### PR TITLE
Changes some crafting recipes so they dont explode you when made (lol)

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_soup.dm
+++ b/code/modules/food_and_drinks/food/snacks_soup.dm
@@ -71,7 +71,7 @@
 	desc = "Not very funny."
 	icon_state = "clownstears"
 	bonus_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/banana = 5, /datum/reagent/consumable/nutriment/vitamin = 8, /datum/reagent/consumable/clownstears = 10)
-	list_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/banana = 5, /datum/reagent/water = 5, /datum/reagent/consumable/nutriment/vitamin = 8, /datum/reagent/consumable/clownstears = 10)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 4, /datum/reagent/consumable/banana = 5, /datum/reagent/lube = 5, /datum/reagent/consumable/nutriment/vitamin = 8, /datum/reagent/consumable/clownstears = 10)
 	tastes = list("a bad joke" = 1)
 	foodtype = FRUIT | SUGAR
 

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
@@ -189,7 +189,6 @@
 		/obj/item/reagent_containers/food/snacks/grown/apple = 1,
 		/obj/item/reagent_containers/food/snacks/grown/citrus/orange = 1,
 		/obj/item/reagent_containers/food/snacks/grown/citrus/lemon = 1,
-		/obj/item/reagent_containers/food/snacks/grown/banana = 1,
 		/obj/item/reagent_containers/food/snacks/grown/ambrosia = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/melonfruitbowl

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_salad.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_salad.dm
@@ -52,11 +52,9 @@
 	name = "Jungle Salad"
 	reqs = list(
 		/obj/item/reagent_containers/glass/bowl = 1,
-		/obj/item/reagent_containers/food/snacks/grown/apple = 1,
-		/obj/item/reagent_containers/food/snacks/grown/grapes = 1,
-		/obj/item/reagent_containers/food/snacks/grown/banana = 2,
-		/obj/item/reagent_containers/food/snacks/watermelonslice = 2
-
+		/obj/item/reagent_containers/food/snacks/grown/apple = 2,
+		/obj/item/reagent_containers/food/snacks/grown/grapes = 2,
+		/obj/item/reagent_containers/food/snacks/grown/banana = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/salad/jungle
 	category = CAT_SALAD

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_soup.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_soup.dm
@@ -26,7 +26,7 @@
 /datum/crafting_recipe/food/clownstears
 	name = "Clown's Tears"
 	reqs = list(
-		/datum/reagent/water = 10,
+		/datum/reagent/lube = 10,
 		/obj/item/reagent_containers/glass/bowl = 1,
 		/obj/item/reagent_containers/food/snacks/grown/banana = 1,
 		/obj/item/stack/ore/bananium = 1


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/65437 clown's tears
https://github.com/tgstation/tgstation/pull/67929 jungle salad
and melon fruit bowl changed (see changelog). All three mix potassium in bananas + water/watermelon and just blow you up which is hilarious but stupid.

Closes #19504 


# Wiki Documentation
yes i am wiki i will change it

:cl:  Ktlwjec, carshalash
tweak: Melon Fruit Bowl no longer uses banana.
tweak: Jungle Salad is crafted with 2 apples and 2 grapes (instead of 1), and no bananas.
tweak: Clown's Tears uses lube instead of water.
/:cl: