### PR TITLE
HFR reaction rate is now based on damper instead of constrictor

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -211,7 +211,7 @@
 		return
 
 	// Phew. Lets calculate what this means in practice.
-	var/reaction_rate = clamp((power_level * 0.5) * (500 / magnetic_constrictor) * delta_time, 0.05, 30) // constrictor controls reaction rate instead of fuel injection
+	var/reaction_rate = clamp((power_level * 0.5) * (500 / current_damper+1) * delta_time, 0.05, 30) // constrictor controls reaction rate instead of fuel injection
 	switch(power_level)
 		if(3,4)
 			reaction_rate = clamp(reaction_rate * heat_output * 5e-4, 0, reaction_rate)


### PR DESCRIPTION
constrictor already has its purpose as in controlling the energy for optimal heat generation so no need for it to affect the reaction rate because at some point HFR will heat up too much that you need constrictor to minimize the heat generation so coolant can effectively cool it but this process will reduce reaction rate resulting in less gas produced which isnt really nice

damper is used for destabilizing reaction so i think its more suitable here for controlling the reaction rate

# Document the changes in your pull request

HFR reaction rate is now based on damper instead of constrictor


# Wiki Documentation
HFR reaction rate is now based on damper instead of constrictor

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: HFR reaction rate is now based on damper instead of constrictor
/:cl:
