### PR TITLE
Electrolyzer now process more gas

### DIFF
--- a/code/game/machinery/electrolyzer.dm
+++ b/code/game/machinery/electrolyzer.dm
@@ -105,7 +105,7 @@
 		removed.adjust_moles(/datum/gas/oxygen, proportion / 2)
 		removed.adjust_moles(/datum/gas/hydrogen, proportion)
 	if(removed.get_moles(/datum/gas/hypernoblium))
-		proportion = min(removed.get_moles(/datum/gas/hypernoblium), (delta_time * workingPower)) // up to 48 moles at a time
+		proportion = min(removed.get_moles(/datum/gas/hypernoblium), (delta_time * workingPower)) // up to 8 moles at a time
 		removed.adjust_moles(/datum/gas/hypernoblium, -proportion)
 		removed.adjust_moles(/datum/gas/antinoblium, proportion)
 	env.merge(removed) //put back the new gases in the turf

--- a/code/game/machinery/electrolyzer.dm
+++ b/code/game/machinery/electrolyzer.dm
@@ -100,12 +100,12 @@
 
 	var/proportion = 0
 	if(removed.get_moles(/datum/gas/water_vapor))
-		proportion = min(removed.get_moles(/datum/gas/water_vapor), (3 * delta_time * workingPower)) //Works to max 12 moles at a time.
+		proportion = min(removed.get_moles(/datum/gas/water_vapor), (3 * delta_time * workingPower)) //Works to max 240 moles at a time.
 		removed.adjust_moles(/datum/gas/water_vapor, -proportion)
 		removed.adjust_moles(/datum/gas/oxygen, proportion / 2)
 		removed.adjust_moles(/datum/gas/hydrogen, proportion)
 	if(removed.get_moles(/datum/gas/hypernoblium))
-		proportion = min(removed.get_moles(/datum/gas/hypernoblium), (delta_time * workingPower)) // up to 4 moles at a time
+		proportion = min(removed.get_moles(/datum/gas/hypernoblium), (delta_time * workingPower)) // up to 80 moles at a time
 		removed.adjust_moles(/datum/gas/hypernoblium, -proportion)
 		removed.adjust_moles(/datum/gas/antinoblium, proportion)
 	env.merge(removed) //put back the new gases in the turf
@@ -143,7 +143,7 @@
 		cap += M.rating
 		charge_rate = initial(charge_rate)*M.rating
 
-	workingPower = lasers / 2 //used in the amount of moles processed
+	workingPower = lasers * 10 //used in the amount of moles processed
 
 	efficiency = (cap + 1) * 0.5 //used in the amount of charge in power cell uses
 

--- a/code/game/machinery/electrolyzer.dm
+++ b/code/game/machinery/electrolyzer.dm
@@ -100,12 +100,12 @@
 
 	var/proportion = 0
 	if(removed.get_moles(/datum/gas/water_vapor))
-		proportion = min(removed.get_moles(/datum/gas/water_vapor), (3 * delta_time * workingPower)) //Works to max 240 moles at a time.
+		proportion = min(removed.get_moles(/datum/gas/water_vapor), (3 * delta_time * workingPower)) //Works to max 48 moles at a time.
 		removed.adjust_moles(/datum/gas/water_vapor, -proportion)
 		removed.adjust_moles(/datum/gas/oxygen, proportion / 2)
 		removed.adjust_moles(/datum/gas/hydrogen, proportion)
 	if(removed.get_moles(/datum/gas/hypernoblium))
-		proportion = min(removed.get_moles(/datum/gas/hypernoblium), (delta_time * workingPower)) // up to 80 moles at a time
+		proportion = min(removed.get_moles(/datum/gas/hypernoblium), (delta_time * workingPower)) // up to 48 moles at a time
 		removed.adjust_moles(/datum/gas/hypernoblium, -proportion)
 		removed.adjust_moles(/datum/gas/antinoblium, proportion)
 	env.merge(removed) //put back the new gases in the turf
@@ -143,7 +143,7 @@
 		cap += M.rating
 		charge_rate = initial(charge_rate)*M.rating
 
-	workingPower = lasers * 10 //used in the amount of moles processed
+	workingPower = lasers * 2 //used in the amount of moles processed
 
 	efficiency = (cap + 1) * 0.5 //used in the amount of charge in power cell uses
 


### PR DESCRIPTION
before there was a bug that increaseed the amount of gas that is electrolyzed even when you put less gas in the electrolyzer, the bug was fixed resulting in less gas electrolyzed because the electrolyzer now only take in maximum of 12 moles of water and 4 moles of hypernob at tier4. This PR buffs electrolyzer to take more water upto 48 moles and hypernob upto 8 moles at tier4 just like before the bugfix

# Document the changes in your pull request

Electrolyzer now process more gas (Upto 48 moles of water and 8 moles of hypernob at tier4)

# Wiki doc
in doc of changes




# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: Electrolyzer now process more gas (Upto 48 moles of water and 8 moles of hypernob at tier4)
/:cl:
