### PR TITLE
Fixed emagged emitters firing strong nuclear particles instead of their intended projectile

### DIFF
--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -454,7 +454,7 @@
 	if(obj_flags & EMAGGED)
 		fuel_consumption *= 2
 
-/obj/machinery/power/emitter/emag_act(mob/user)
+/obj/machinery/power/emitter/particle/emag_act(mob/user)
 	if(..()) // stronger particles
 		projectile_type = /obj/item/projectile/energy/nuclear_particle/strong
 


### PR DESCRIPTION
# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: fixed emagged emitters firing strong nuclear particles instead of their intended projectile
/:cl:
