### PR TITLE
Disables Boxstation

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -13,8 +13,7 @@ Format:
 	votable (is this map votable)
 
 map yogstation
-	voteweight 0.7
-	votable
+	disabled
 endmap
 
 map yogsmeta


### PR DESCRIPTION
What do you think this PR does

# Wiki Documentation

Move boxstation to out of rotation on the wiki

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
mapping: No more box.
/:cl:
