### PR TITLE
energy armor is now 66% more effective against stun batons. stun batons no longer apply confusion.

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -33,6 +33,8 @@
 	var/preload_cell_type
 	///used for passive discharge
 	var/cell_last_used = 0
+	///armor penetration
+	var/stam_penetration = -40
 
 /obj/item/melee/baton/get_cell()
 	return cell
@@ -211,7 +213,7 @@
 			return FALSE
 
 	var/obj/item/bodypart/affecting = L.get_bodypart(user? user.zone_selected : BODY_ZONE_CHEST)
-	var/armor_block = L.run_armor_check(affecting, ENERGY) //check armor on the limb because that's where we are slapping...
+	var/armor_block = L.run_armor_check(affecting, ENERGY, null, null, stam_penetration) //check armor on the limb because that's where we are slapping...
 	L.apply_damage(stamina_damage, STAMINA, BODY_ZONE_CHEST, armor_block) //...then deal damage to chest so we can't do the old hit-a-disabled-limb-200-times thing, batons are electrical not directed.
 	
 	
@@ -224,11 +226,9 @@
 		else
 			L.Paralyze(stunforce)
 		L.adjust_jitter(20 SECONDS)
-		L.adjust_confusion(8 SECONDS)
 		L.apply_effect(EFFECT_STUTTER, stunforce)
 	else if(current_stamina_damage > 70)
 		L.adjust_jitter(10 SECONDS)
-		L.adjust_confusion(8 SECONDS)
 		L.apply_effect(EFFECT_STUTTER, stunforce)
 	else if(current_stamina_damage >= 20)
 		L.adjust_jitter(5 SECONDS)


### PR DESCRIPTION
# Document the changes in your pull request

Stun batons now have -40 armor penetration to the stamina damage it causes.
stun batons no longer apply confusion. they already down in 2 hits, why the hell do they need this?
this means armor polish will now be able to tank 3 stun baton hits
this means heretic armor will now be able to tank 8-9 hits, so that they can actually use their damn blade instead of getting hit 3 times by a baton and then dying.
this buffs antag armor to fair better against the best melee weapon that security has without buffing crew armor too much.

telebatons not affected as they use melee armor in their calculations
reflective vest not affected because it does not cover head or legs

# Wiki Documentation

say it has an AP of -40 (the stamina damage) on the guide to combat

# Changelog

:cl:  
tweak: stun batons now have a negative AP of -40 (on the stamina damage)
tweak: stun batons no longer apply confusion
/:cl:
