### PR TITLE
Cargo and HoP winter coats can hold stamps

### DIFF
--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -257,7 +257,7 @@
 	hoodtype = /obj/item/clothing/head/hooded/raincoat
 	flags_inv = HIDEGLOVES|HIDESUITSTORAGE|HIDENECK|HIDEJUMPSUIT
 	alternate_worn_layer = ABOVE_BODY_FRONT_LAYER
-	
+
 /obj/item/clothing/head/hooded/raincoat
 	name = "raincoat hood"
 	desc = "A lightweight but protective hood that will keep all manner of fluids off you."
@@ -335,7 +335,7 @@
 	clothing_flags = THICKMATERIAL
 	flags_inv = HIDEHAIR|HIDEEARS
 	dynamic_hair_suffix = ""
-	
+
 /obj/item/clothing/suit/hooded/bee_costume/authentic
 	name = "bee costume"
 	desc = "Bee the true Queen! Smells like honey..."
@@ -591,6 +591,7 @@
 	armor = list(MELEE = 10, BULLET = 15, LASER = 15, ENERGY = 25, BOMB = 10, BIO = 0, RAD = 0, FIRE = 0, ACID = 35)
 	allowed = list(
 		/obj/item/melee/classic_baton,
+		/obj/item/stamp
 	)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/hop
 
@@ -739,6 +740,7 @@
 	icon_state = "coatcargo"
 	item_state = "coatcargo"
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/cargo
+	allowed = list(/obj/item/stamp)
 
 /obj/item/clothing/head/hooded/winterhood/cargo
 	icon_state = "winterhood_cargo"


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/76267

Something nice, makes sense.

:cl:  Seven
tweak: Stamps are now allowed suit storage items in the hop and cargo wintercoats.
/:cl:
