### PR TITLE
Quivers can now hold bolts

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -833,6 +833,7 @@
 	STR.max_combined_w_class = 20
 	STR.display_numerical_stacking = TRUE
 	STR.set_holdable(list(
+		/obj/item/ammo_casing/caseless/bolts,
 		/obj/item/ammo_casing/reusable/arrow,
 		/obj/item/stand_arrow,
 		/obj/item/throwing_star/magspear


### PR DESCRIPTION
# Document the changes in your pull request
to make the makeshift gauss rifle more viable by ammo storage
updates quiver to now hold bolts.
# Changelog
:cl:  
tweak: quivers can now hold bolts
/:cl:
