### PR TITLE
hallucination sting now mentions it costs 10 chemicals

### DIFF
--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -240,7 +240,7 @@
 
 /datum/action/changeling/sting/LSD
 	name = "Hallucination Sting"
-	desc = "We cause mass terror to our victim."
+	desc = "We cause mass terror to our victim. Costs 10 chemicals."
 	helptext = "We evolve the ability to sting a target with a powerful hallucinogenic chemical. The target does not notice they have been stung, and the effect occurs after 30 to 60 seconds."
 	button_icon_state = "sting_lsd"
 	sting_icon = "sting_lsd"


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/76354
so all the other stings currently tell you how much they cost except this one (funny)

:cl:  Jolly
tweak: Changeling hallucination sting will now tell you it costs 10 chemicals.
/:cl: