### PR TITLE
instant unwrench when total mole below 0.01

### DIFF
--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -214,7 +214,7 @@ GLOBAL_LIST_EMPTY(pipeimages)
 		if(empty_mixes == device_type)
 			empty_pipe = TRUE
 			
-	if(!(int_air.total_moles() > 1))
+	if(!(int_air.total_moles() > MINIMUM_MOLE_COUNT && internal_pressure > 2*ONE_ATMOSPHERE))
 		empty_pipe = TRUE
 
 	if(!empty_pipe)

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -214,7 +214,7 @@ GLOBAL_LIST_EMPTY(pipeimages)
 		if(empty_mixes == device_type)
 			empty_pipe = TRUE
 			
-	if(!(int_air.total_moles() > 0))
+	if(!(int_air.total_moles() > 1))
 		empty_pipe = TRUE
 
 	if(!empty_pipe)

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -214,7 +214,7 @@ GLOBAL_LIST_EMPTY(pipeimages)
 		if(empty_mixes == device_type)
 			empty_pipe = TRUE
 			
-	if(!(int_air.total_moles() > MINIMUM_MOLE_COUNT && internal_pressure > 2*ONE_ATMOSPHERE))
+	if(!(int_air.total_moles() > MINIMUM_MOLE_COUNT || unsafe_wrenching))
 		empty_pipe = TRUE
 
 	if(!empty_pipe)


### PR DESCRIPTION
for some reason when you attempt to remove pipe when total mole is at 0 it wont do the instant-unwrench because it still detect some trace 0.00000000000001 mole left so yeah

# Document the changes in your pull request

instant unwrench when total mole below 0.01

# Wiki Documentation
in document of change

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: instant unwrench when total mole below 1
/:cl:
