### PR TITLE
you can now normally sell sm sliver to cargo instead having to wait for the bounty

### DIFF
--- a/code/modules/cargo/bounties/engineering.dm
+++ b/code/modules/cargo/bounties/engineering.dm
@@ -71,10 +71,3 @@
 	reward = 7500
 	required_count = 3
 	wanted_types = list(/obj/item/fireaxe/metal_h2_axe)
-
-/datum/bounty/item/supermatter_silver
-	name = "Supermatter Silvers"
-	description = "Nanotrasen engineering team wants to build a new supermatter engine. Ship them 2 supermatter silvers."
-	reward = 50000
-	required_count = 2
-	wanted_types = list(/obj/item/nuke_core/supermatter_sliver)

--- a/code/modules/cargo/bounty.dm
+++ b/code/modules/cargo/bounty.dm
@@ -198,7 +198,6 @@ GLOBAL_LIST_EMPTY(bounties_list_syndicate)
 	var/list/low_priority_strict_type_list = list(  /datum/bounty/item/alien_organs,
 													/datum/bounty/item/syndicate_documents,
 													/datum/bounty/item/adamantine,
-													/datum/bounty/item/supermatter_silver,
 													/datum/bounty/more_bounties)
 
 	for(var/low_priority_bounty in low_priority_strict_type_list)

--- a/code/modules/cargo/exports/tools.dm
+++ b/code/modules/cargo/exports/tools.dm
@@ -160,3 +160,8 @@
 	cost = 80000 // the outcome of something gone devestatingly wrong, but hey drinks on me
 	unit_name = "stage 6 singularity shard"
 	export_types = list(/obj/item/singularity_shard/stage6)
+
+/datum/export/supermatter_silver
+	cost = 25000 // good job kid,you are doing the god's work
+	unit_name = "supermatter silver shard"
+	export_types = list(/obj/item/nuke_core/supermatter_sliver)

--- a/code/modules/cargo/exports/tools.dm
+++ b/code/modules/cargo/exports/tools.dm
@@ -162,6 +162,6 @@
 	export_types = list(/obj/item/singularity_shard/stage6)
 
 /datum/export/supermatter_silver
-	cost = 25000 // good job kid,you are doing the god's work
+	cost = 30000 // good job kid,you are doing the god's work
 	unit_name = "supermatter silver shard"
 	export_types = list(/obj/item/nuke_core/supermatter_sliver)

--- a/code/modules/cargo/exports/tools.dm
+++ b/code/modules/cargo/exports/tools.dm
@@ -161,7 +161,7 @@
 	unit_name = "stage 6 singularity shard"
 	export_types = list(/obj/item/singularity_shard/stage6)
 
-/datum/export/supermatter_silver
+/datum/export/supermatter_sliver
 	cost = 30000 // good job kid, you are doing the god's work
 	unit_name = "supermatter sliver"
 	export_types = list(/obj/item/nuke_core/supermatter_sliver)

--- a/code/modules/cargo/exports/tools.dm
+++ b/code/modules/cargo/exports/tools.dm
@@ -162,6 +162,6 @@
 	export_types = list(/obj/item/singularity_shard/stage6)
 
 /datum/export/supermatter_silver
-	cost = 30000 // good job kid,you are doing the god's work
-	unit_name = "supermatter silver shard"
+	cost = 30000 // good job kid, you are doing the god's work
+	unit_name = "supermatter silver"
 	export_types = list(/obj/item/nuke_core/supermatter_sliver)

--- a/code/modules/cargo/exports/tools.dm
+++ b/code/modules/cargo/exports/tools.dm
@@ -163,5 +163,5 @@
 
 /datum/export/supermatter_silver
 	cost = 30000 // good job kid, you are doing the god's work
-	unit_name = "supermatter silver"
+	unit_name = "supermatter sliver"
 	export_types = list(/obj/item/nuke_core/supermatter_sliver)


### PR DESCRIPTION
sm slivers take times and efforts to make and pretty dangerous to handle without care so would be a nice way to make money for cargo as you all wanted cargo dependency

# Document the changes in your pull request
you can now normally sell sm slivers to cargo
sm slivers bounty is no more



# Wiki Documentation
you can now normally sell sm silvers to cargo
sm silvers bounty is no more

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: you can now normally sell sm slivers to cargo
rscdel: sm slivers bounty is no more
/:cl:
