### PR TITLE
Cyborgs Can Repair Fire Axe Cabinets & Use R-Glass Properly

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -171,8 +171,9 @@ GLOBAL_LIST_INIT(reinforced_glass_recipes, list ( \
 	return min(round(source.energy / metcost), round(glasource.energy / glacost))
 
 /obj/item/stack/sheet/rglass/cyborg/use(used, transfer = FALSE) // Requires special checks, because it uses two storages
-	source.use_charge(used * metcost)
-	glasource.use_charge(used * glacost)
+	if(source.use_charge(used * metcost) && glasource.use_charge(used * glacost))
+		return TRUE
+	return FALSE
 
 /obj/item/stack/sheet/rglass/cyborg/add(amount)
 	source.add_charge(amount * metcost)

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -34,9 +34,10 @@
 
 /obj/structure/fireaxecabinet/attackby(obj/item/I, mob/user, params)
 	check_deconstruct(I, user)//yogs - deconstructible cabinet
-	if(iscyborg(user) || I.tool_behaviour == TOOL_MULTITOOL)
-		reset_lock(user) //yogs - adds reset option
-	else if(I.tool_behaviour == TOOL_WELDER && user.a_intent == INTENT_HELP && !broken)
+	if(I.tool_behaviour == TOOL_MULTITOOL)
+		reset_lock(user) // Yogs - Adds reset option.
+		return
+	if(I.tool_behaviour == TOOL_WELDER && user.a_intent == INTENT_HELP && !broken)
 		//Repairing light damage with a welder
 		if(obj_integrity < max_integrity)
 			if(!I.tool_start_check(user, amount=2))
@@ -189,6 +190,12 @@
 /obj/structure/fireaxecabinet/attack_ai(mob/user)
 	toggle_lock(user)
 	return
+
+/obj/structure/fireaxecabinet/attack_robot(mob/living/silicon/user)
+	if(user.a_intent == INTENT_HARM) // In the case they still want to try to `reset_lock` instead of `toggle_lock`.
+		reset_lock(user)
+		return
+	. = ..()
 
 /obj/structure/fireaxecabinet/attack_tk(mob/user)
 	toggle_open()//yogs - consolidates opening code


### PR DESCRIPTION
# Document the changes in your pull request
Cyborgs are no longer forced to attempt to `reset_lock` when using any item on any fire axe cabinets; now they can do the same things as humans can when using an item on it such as repairing it with a welder or r-glass.

Cyborgs can now try to `reset_lock` by interacting on harm intent with no module.

Anything that `use` cyborg reinforced glass now properly work. This means they can finally repair fire axe cabinets, set up double-sided reflector, changes solar panels to r-glass, and other interactions.

# Changelog
:cl:  
bugfix: Cyborgs can now repair fire axe cabinets properly.
bugfix: Using cyborg reinforced glass on/for certain structures now work properly.
tweak: Cyborgs can attempt to trigger a fire axe cabinet's alarm by interacting with it on harm intent with no module.
/:cl:
