### PR TITLE
[s] Fixes issues with PDA failsafe

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -29,6 +29,8 @@ GLOBAL_LIST_EMPTY(uplinks)
 	var/hidden_crystals = 0
 	var/unlock_note
 	var/unlock_code
+	/// Set to true if failsafe_code should blow up the device
+	var/has_failsafe = FALSE
 	var/failsafe_code
 	var/debug = FALSE
 	var/compact_mode = FALSE
@@ -353,7 +355,7 @@ GLOBAL_LIST_EMPTY(uplinks)
 		return L
 
 /datum/component/uplink/proc/failsafe()
-	if(!parent)
+	if(!parent || !has_failsafe)
 		return
 	var/turf/T = get_turf(parent)
 	if(!T)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1731,6 +1731,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/device_tools/failsafe/spawn_item(spawn_path, mob/user, datum/component/uplink/U)
 	if(!U)
 		return
+	U.has_failsafe = TRUE
 	U.failsafe_code = U.generate_code()
 	var/code = "[islist(U.failsafe_code) ? english_list(U.failsafe_code) : U.failsafe_code]"
 	to_chat(user, span_warning("The new failsafe code for this uplink is now : [code]."))


### PR DESCRIPTION
# Document the changes in your pull request

Fixes an issues where entering a ringtone that gets trimmed to empty string causes the failsafe to explode if the failsafe has not been bought.

# Changelog

:cl:  
bugfix: fixed security being able to sacrifice assistants to determine if a PDA has an uplink
/:cl:
