### PR TITLE
Changes a few food recipes

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -330,7 +330,6 @@
 	bitesize = 3
 	filling_color = "#F0F0F0"
 	tastes = list("meat" = 1, "onions" = 1, "garlic" = 1)
-	foodtype = MEAT
 	burns_on_grill = TRUE
 	foodtype = MEAT | GRAIN | VEGETABLES
 

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -317,7 +317,7 @@
 	icon_state = "khinkali"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/nutriment/vitamin = 1, /datum/reagent/consumable/garlic = 1)
 	tastes = list("meat" = 1, "onions" = 1, "garlic" = 1)
-	foodtype = MEAT | GRAIN | RAW
+	foodtype = MEAT | GRAIN | RAW | VEGETABLES
 
 /obj/item/reagent_containers/food/snacks/rawkhinkali/MakeGrillable()
 	AddComponent(/datum/component/grillable, /obj/item/reagent_containers/food/snacks/khinkali, rand(50 SECONDS, 60 SECONDS), TRUE)
@@ -332,7 +332,7 @@
 	tastes = list("meat" = 1, "onions" = 1, "garlic" = 1)
 	foodtype = MEAT
 	burns_on_grill = TRUE
-	foodtype = MEAT | GRAIN
+	foodtype = MEAT | GRAIN | VEGETABLES
 
 /obj/item/reagent_containers/food/snacks/enchiladas
 	name = "enchiladas"
@@ -343,7 +343,7 @@
 	filling_color = "#FFA07A"
 	list_reagents = list(/datum/reagent/consumable/nutriment = 8, /datum/reagent/consumable/capsaicin = 6)
 	tastes = list("hot peppers" = 1, "meat" = 3, "cheese" = 1, "tortilla" = 1)
-	foodtype = MEAT | GRAIN | VEGETABLES
+	foodtype = MEAT | GRAIN | VEGETABLES | DAIRY
 
 /obj/item/reagent_containers/food/snacks/chipsandsalsa
 	name = "chips and salsa"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_meat.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_meat.dm
@@ -82,7 +82,8 @@
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/meat/cutlet = 2,
 		/obj/item/reagent_containers/food/snacks/grown/chili = 2,
-		/obj/item/reagent_containers/food/snacks/tortilla = 2
+		/obj/item/reagent_containers/food/snacks/tortilla = 2,
+		/obj/item/reagent_containers/food/snacks/cheesewedge = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/enchiladas
 	category = CAT_MEAT
@@ -111,7 +112,9 @@
 	name = "Raw Khinkali"
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/doughslice = 1,
-		/obj/item/reagent_containers/food/snacks/meatball = 1
+		/obj/item/reagent_containers/food/snacks/meatball = 1,
+		/obj/item/reagent_containers/food/snacks/grown/onion = 1,
+		/obj/item/reagent_containers/food/snacks/grown/garlic = 1
 	)
 	result =  /obj/item/reagent_containers/food/snacks/rawkhinkali
 	category = CAT_MEAT

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_meat.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_meat.dm
@@ -113,7 +113,7 @@
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/doughslice = 1,
 		/obj/item/reagent_containers/food/snacks/meatball = 1,
-		/obj/item/reagent_containers/food/snacks/grown/onion = 1,
+		/obj/item/reagent_containers/food/snacks/onion_slice = 1,
 		/obj/item/reagent_containers/food/snacks/grown/garlic = 1
 	)
 	result =  /obj/item/reagent_containers/food/snacks/rawkhinkali

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
@@ -108,9 +108,8 @@
 /datum/crafting_recipe/food/chocoorange
 	name = "Chocolate Orange"
 	reqs = list(
-		/obj/item/reagent_containers/food/snacks/grown/citrus/orange = 1,
-		/obj/item/reagent_containers/food/snacks/chocolatebar = 1,
-		/datum/reagent/consumable/orangejuice = 2
+		/datum/reagent/consumable/orangejuice = 2,
+		/obj/item/reagent_containers/food/snacks/chocolatebar = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/chocoorange
 	category = CAT_MISCFOOD

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
@@ -109,7 +109,8 @@
 	name = "Chocolate Orange"
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/grown/citrus/orange = 1,
-		/obj/item/reagent_containers/food/snacks/chocolatebar = 1
+		/obj/item/reagent_containers/food/snacks/chocolatebar = 1,
+		/datum/reagent/consumable/orangejuice = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/chocoorange
 	category = CAT_MISCFOOD

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pizza.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pizza.dm
@@ -74,7 +74,9 @@
 	name = "Mushroom Pizza"
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/flatdough = 1,
-		/obj/item/reagent_containers/food/snacks/grown/mushroom = 5
+		/obj/item/reagent_containers/food/snacks/grown/mushroom = 5,
+		/obj/item/reagent_containers/food/snacks/cheesewedge = 1,
+		/obj/item/reagent_containers/food/snacks/grown/tomato = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pizza/mushroom/raw
 	category = CAT_PIZZA
@@ -108,7 +110,8 @@
 		/obj/item/reagent_containers/food/snacks/grown/eggplant = 1,
 		/obj/item/reagent_containers/food/snacks/grown/carrot = 1,
 		/obj/item/reagent_containers/food/snacks/grown/corn = 1,
-		/obj/item/reagent_containers/food/snacks/grown/tomato = 1
+		/obj/item/reagent_containers/food/snacks/grown/tomato = 1,
+		/obj/item/reagent_containers/food/snacks/cheesewedge = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/pizza/vegetable/raw
 	category = CAT_PIZZA


### PR DESCRIPTION
Adds cheese wedge to enchiladas recipe, taste has cheese and it does usually contain it. Adds dairy food type.
Adds onion slice and garlic to khinkali recipe, taste has both and it's nice to have more food to make these into. Adds vegetable food type.
Replaces orange with 2u orange juice in chocolate orange recipe, since it's not an orange it's flavoring.
Adds cheese wedge and tomato to mushroom pizza. Adds cheese wedge to vegetable pizza. I don't really understand why these didn't contain it before.

# Wiki Documentation

yes i will
# Changelog

:cl:  ktlwjec
tweak: Enchiladas needs a cheese wedge to craft.
tweak: Khinkali needs an onion slice and garlic to craft.
tweak: Chocolate orange needs 2 units of orange juice, instead of an orange, to craft.
tweak: Mushroom and vegetable pizzas both need a cheese wedge and tomato to craft.
/:cl: