### PR TITLE
electrolyzer requirement tweak

### DIFF
--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1376,8 +1376,7 @@
 		/obj/item/stock_parts/capacitor = 1,
 		/obj/item/stack/cable_coil = 3,
 		/obj/item/stack/sheet/glass = 1,
-		/obj/item/stack/sheet/mineral/gold = 1,
-		/obj/item/stack/sheet/mineral/silver = 1)
+		/obj/item/stack/sheet/plasteel = 2)
 
 	needs_anchored = FALSE
 


### PR DESCRIPTION
this machine shouldnt use gold and silver, use plasteel instead like other atmos machines

# Document the changes in your pull request
replaces gold and silver with two plasteels for the requirement of electrolyzer



# Wiki Documentation
changes in document

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: replaces gold and silver with two plasteels for the requirement of electrolyzer
/:cl:
