### PR TITLE
Fixes objective name having a typo in it

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1426,7 +1426,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 		return
 	var/chosen_pet = rand(1, possible_pets.len)
 	pet = locate(possible_pets[chosen_pet]) in GLOB.mob_living_list
-	name = "Kill [pet.name]]"
+	name = "Kill [pet.name]"
 	explanation_text = "Assassinate the important animal, [pet.name]."
 	return pet
 


### PR DESCRIPTION
# Document the changes in your pull request
Pet names don't need a ] after them

# Changelog

:cl:  
spellcheck: fixed pet kill objective name typo
/:cl:
