### PR TITLE
Engiborg Gripper Can Pick Up Conveyor Belts + Conveyor Belts Switches

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -855,5 +855,7 @@
 		/obj/item/electronics,
 		/obj/item/wallframe,
 		/obj/item/stock_parts,
-		/obj/item/tank/internals
+		/obj/item/tank/internals,
+		/obj/item/conveyor_switch_construct,
+		/obj/item/stack/conveyor
 	)


### PR DESCRIPTION
# Document the changes in your pull request
Engineering Cyborg's gripper can now pick up conveyor belts and conveyor belt switches. More things to help build with.

# Changelog

:cl:  
rscadd: Engineering Cyborg's gripper can pick up conveyor belts and conveyor belt switches.
/:cl:
