### PR TITLE
Space syndicate listening post loot changes

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -1183,24 +1183,6 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
 /area/ruin/space/has_grav/listeningstation)
-"kv" = (
-/obj/structure/closet/syndicate{
-	req_access_txt = "150"
-	},
-/obj/item/ammo_box/magazine/m10mm,
-/obj/item/crowbar/red,
-/obj/item/clothing/head/HoS/beret/syndicate,
-/obj/item/clothing/head/HoS/syndicate{
-	desc = "A black cap fit for a Syndicate recon officer."
-	},
-/obj/item/binoculars,
-/obj/item/clothing/under/syndicate,
-/obj/item/clothing/under/syndicate/combat,
-/obj/item/clothing/under/syndicate/camo,
-/obj/effect/decal/cleanable/dirt,
-/obj/item/suppressor,
-/turf/open/floor/plasteel/grimy,
-/area/ruin/space/has_grav/listeningstation/quarters)
 "kw" = (
 /obj/item/circuitboard/machine/holopad,
 /obj/item/stock_parts/capacitor,
@@ -1247,6 +1229,20 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation/airlock)
+"kR" = (
+/obj/structure/closet/syndicate{
+	req_access_txt = "150"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/ammo_box/a357,
+/obj/item/crowbar/red,
+/obj/item/clothing/head/HoS/beret/syndicate,
+/obj/item/binoculars,
+/obj/item/clothing/under/syndicate,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/clothing/under/syndicate/camo,
+/turf/open/floor/plasteel/grimy,
+/area/ruin/space/has_grav/listeningstation/quarters)
 "kW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1787,6 +1783,21 @@
 /obj/effect/turf_decal/tile/red/half/contrasted,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/telecomms)
+"we" = (
+/obj/structure/closet/syndicate{
+	req_access_txt = "150"
+	},
+/obj/item/ammo_box/magazine/m10mm,
+/obj/item/crowbar/red,
+/obj/item/clothing/head/HoS/beret/syndicate,
+/obj/item/binoculars,
+/obj/item/clothing/under/syndicate,
+/obj/item/clothing/under/syndicate/combat,
+/obj/item/clothing/under/syndicate/camo,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/suppressor,
+/turf/open/floor/plasteel/grimy,
+/area/ruin/space/has_grav/listeningstation/quarters)
 "wj" = (
 /obj/machinery/light{
 	dir = 8
@@ -1801,9 +1812,9 @@
 	name = "Cayenne II's bed"
 	},
 /mob/living/simple_animal/hostile/carp{
+	desc = "A descendant of the legendary Cayenne, a failed Syndicate experiment in weaponized space carp technology, it now serves as a lovable mascot.";
 	faction = list("Syndicate");
-	name = "Cayenne II";
-	desc = "A descendant of the legendary Cayenne, a failed Syndicate experiment in weaponized space carp technology, it now serves as a lovable mascot."
+	name = "Cayenne II"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/listeningstation/quarters)
@@ -1976,18 +1987,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/hallway)
-"zW" = (
-/obj/effect/mob_spawn/human/lavaland_syndicate/comms/space{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/no_erp{
-	desc = "This poster reminds the crew that Eroticism, Rape and Pornography are banned on Syndicate stations.";
-	pixel_y = -32
-	},
-/obj/item/bedsheet/syndie,
-/obj/structure/bed,
-/turf/open/floor/plasteel/grimy,
-/area/ruin/space/has_grav/listeningstation/quarters)
 "Ag" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/red/half/contrasted,
@@ -2251,6 +2250,18 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation/engineering)
+"He" = (
+/obj/structure/sign/poster/official/no_erp{
+	desc = "This poster reminds the crew that Eroticism, Rape and Pornography are banned on Syndicate stations.";
+	pixel_y = -32
+	},
+/obj/item/bedsheet/syndie,
+/obj/structure/bed,
+/obj/effect/mob_spawn/human/lavaland_syndicate/comms/space/lieutenant{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/space/has_grav/listeningstation/quarters)
 "Hy" = (
 /obj/machinery/computer/med_data/syndie{
 	dir = 8;
@@ -3887,7 +3898,7 @@ aY
 wW
 ba
 vQ
-kv
+we
 az
 NO
 "}
@@ -4127,7 +4138,7 @@ wW
 wW
 sB
 pO
-kv
+kR
 as
 NO
 "}
@@ -4167,7 +4178,7 @@ OV
 Su
 tH
 ah
-zW
+He
 az
 NO
 "}

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -71,6 +71,9 @@
 	if (current_skin)
 		. += "It can be spun with <b>alt+click</b>"
 
+/obj/item/gun/ballistic/revolver/ultrasecure
+	pin = /obj/item/firing_pin/fucked
+
 /obj/item/gun/ballistic/revolver/detective
 	name = "\improper Colt Detective Special"
 	desc = "A classic, if not outdated, law enforcement firearm. Uses .38 special rounds."

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -145,10 +145,18 @@
 	outfit = /datum/outfit/lavaland_syndicate/comms
 
 /obj/effect/mob_spawn/human/lavaland_syndicate/comms/space
+	name = "Syndicate Space Comms Agent"
 	short_desc = "You are a syndicate agent, assigned to a small listening post station situated near your hated enemy's top secret research facility: Space Station 13."
-	flavour_text = "Monitor enemy activity as best you can, and try to keep a low profile. Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Collaborate with your partner to disrupt Nanotrasen operations and do not let the base fall into enemy hands!"
+	flavour_text = "Monitor enemy activity as best you can, and try to keep a low profile. Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Collaborate with your partner to disrupt Nanotrasen operations and do not let the base fall into enemy hands! In addition, you are subordinate to your lieutenant should any issues arise."
 	important_info = "DO NOT abandon the base, let it fall into enemy hands, or share your supplies with non-Syndicate personnel."
+	outfit = /datum/outfit/lavaland_syndicate/comms/subordinate
 
+/obj/effect/mob_spawn/human/lavaland_syndicate/comms/space/lieutenant
+	name = "Syndicate Lieutenant Space Comms Agent"
+	short_desc = "You are a syndicate agent, assigned to a small listening post station situated near your hated enemy's top secret research facility: Space Station 13."
+	flavour_text = "Monitor enemy activity as best you can, and try to keep a low profile. Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Collaborate with your partner to disrupt Nanotrasen operations and do not let the base fall into enemy hands! Should any issues arise within the base, you have the final say."
+	important_info = "DO NOT abandon the base, let it fall into enemy hands, or share your supplies with non-Syndicate personnel."
+	outfit = /datum/outfit/lavaland_syndicate/comms/lieutenant
 
 /datum/outfit/lavaland_syndicate/comms
 	name = "Lavaland Syndicate Comms Agent"
@@ -156,6 +164,20 @@
 	mask = /obj/item/clothing/mask/chameleon/gps
 	suit = /obj/item/clothing/suit/armor/vest
 	backpack_contents = list(/obj/item/modular_computer/tablet/preset/syndicate=1)
+
+/datum/outfit/lavaland_syndicate/comms/subordinate
+	name = "Space Syndicate Comms Agent"
+	r_hand = /obj/item/kitchen/knife/combat
+
+/datum/outfit/lavaland_syndicate/comms/lieutenant
+	name = "Space Syndicate Comms Agent Lieutenant"
+	r_hand = /obj/item/melee/transforming/energy/sword/saber
+	head = /obj/item/clothing/head/HoS/syndicate
+	r_pocket = null
+	backpack_contents = list(
+		/obj/item/modular_computer/tablet/preset/syndicate=1,
+		/obj/item/gun/ballistic/revolver/ultrasecure=1,
+		)
 
 /obj/item/clothing/mask/chameleon/gps/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
The space syndicate listening station gets a few changes to make it less of a loot pinata.

There is now one 'Lieutenant' comms agent, and one 'Subordinate' comms agent. In flavor, the lieutenant gets final say on any situations that arise. In gameplay, the two roles have a bit different equipment.

The lieutenant gets a syndi cap (and the two that already existed on board are removed, so the lieutenant has a special hat), keeps their e-sword, and gets an ultrasecure revolver that detonates should any non syndis try to use or tamper with it, rather than a stechkin. Their locker has also appropriately had it's silencer removed and 10mm magazine replaced with a 357 speedloader.

The subordinate has a combat knife rather than an esword (to prevent making a makeshift esword loot pinata), otherwise they're the exact same as comms agents before.

It still has enough loot to make worthwhile raiding (secret docs, 1 esword + 1 stechkin + 1 combat knife should you kill both comms agents), just less.

# Wiki Documentation

if this is kept on wiki, just say that one Space Comms agent is considered the lieutenant with a final say, and gets a revolver rather than a stechkin, and the subordinate has a combat knife instead of an energy sword.

# Changelog

:cl:  
tweak: Space syndicate listening post slight loot tweak. One agent is now considered the superior and has better equipment with an ultra secure pinlock revolver, while their subordinate has a combat knife rather than an energy sword.
/:cl:
