### PR TITLE
space syndicate derelict loot changes

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/syndicate_derelict_station.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_derelict_station.dmm
@@ -229,6 +229,17 @@
 /obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/airless,
 /area/ruin/space/has_grav/syndiederelict/hydroponics)
+"ec" = (
+/obj/machinery/airalarm/syndicate{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/closet/crate/secure/gear,
+/obj/item/gun/ballistic/automatic/c20r/ultrasecure,
+/obj/item/ammo_box/magazine/smgm45,
+/obj/item/melee/transforming/energy/sword,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/syndiederelict/virology)
 "eE" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -2102,18 +2113,6 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/ruin/space/has_grav/syndiederelict/solars)
-"Oh" = (
-/obj/machinery/airalarm/syndicate{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/closet/crate/secure/gear,
-/obj/item/gun/ballistic/automatic/c20r/ultrasecure,
-/obj/item/gun/ballistic/automatic/c20r/ultrasecure,
-/obj/item/ammo_box/magazine/smgm45,
-/obj/item/ammo_box/magazine/smgm45,
-/turf/open/floor/plasteel/airless,
-/area/ruin/space/has_grav/syndiederelict/virology)
 "Ol" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 1
@@ -3030,7 +3029,7 @@ QU
 xQ
 Ya
 Wm
-Oh
+ec
 UL
 Yf
 Yf

--- a/_maps/RandomRuins/SpaceRuins/syndicate_derelict_station.dmm
+++ b/_maps/RandomRuins/SpaceRuins/syndicate_derelict_station.dmm
@@ -306,7 +306,7 @@
 	},
 /obj/machinery/power/apc/syndicate{
 	name = "Syndicate Derelict Kitchen";
-	pixel_y = -24;
+	pixel_y = -23;
 	start_charge = 0
 	},
 /obj/machinery/light/broken,
@@ -501,10 +501,10 @@
 	tilted = 1
 	},
 /obj/machinery/power/apc/syndicate{
-	name = "Syndicate Derelict Hydroponics";
 	dir = 1;
-	start_charge = 0;
-	pixel_y = 24
+	name = "Syndicate Derelict Hydroponics";
+	pixel_y = 23;
+	start_charge = 0
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -551,7 +551,7 @@
 	},
 /obj/machinery/power/apc/syndicate{
 	name = "Syndicate Derelict Hallway";
-	pixel_y = -24;
+	pixel_y = -23;
 	start_charge = 0
 	},
 /obj/effect/mob_spawn/human/corpse/nanotrasensoldier,
@@ -1109,9 +1109,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc/syndicate{
-	name = "Syndicate Derelict Engineering";
-	pixel_x = -24;
 	dir = 8;
+	name = "Syndicate Derelict Engineering";
+	pixel_x = -25;
 	start_charge = 0
 	},
 /obj/effect/mob_spawn/human/syndicate_derelict_engineer{
@@ -2031,9 +2031,9 @@
 /obj/item/shard,
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/power/apc/syndicate{
-	name = "Syndicate Derelict Research Wing";
-	pixel_x = -24;
 	dir = 8;
+	name = "Syndicate Derelict Research Wing";
+	pixel_x = -25;
 	start_charge = 0
 	},
 /turf/open/floor/plating/broken/three,
@@ -2102,6 +2102,18 @@
 /obj/structure/cable,
 /turf/open/space/basic,
 /area/ruin/space/has_grav/syndiederelict/solars)
+"Oh" = (
+/obj/machinery/airalarm/syndicate{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/closet/crate/secure/gear,
+/obj/item/gun/ballistic/automatic/c20r/ultrasecure,
+/obj/item/gun/ballistic/automatic/c20r/ultrasecure,
+/obj/item/ammo_box/magazine/smgm45,
+/obj/item/ammo_box/magazine/smgm45,
+/turf/open/floor/plasteel/airless,
+/area/ruin/space/has_grav/syndiederelict/virology)
 "Ol" = (
 /obj/structure/window/plasma/reinforced{
 	dir = 1
@@ -2287,9 +2299,9 @@
 	dir = 5
 	},
 /obj/machinery/power/apc/syndicate{
-	name = "Syndicate Derelict Virology";
-	pixel_x = -24;
 	dir = 8;
+	name = "Syndicate Derelict Virology";
+	pixel_x = -25;
 	start_charge = 0
 	},
 /obj/effect/decal/cleanable/blood/footprints,
@@ -2507,7 +2519,7 @@
 "Xg" = (
 /obj/machinery/power/apc/syndicate{
 	name = "Syndicate Derelict Medbay";
-	pixel_y = -24;
+	pixel_y = -23;
 	start_charge = 0
 	},
 /obj/structure/cable/yellow{
@@ -2534,16 +2546,6 @@
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/plasteel/airless/broken/three,
 /area/ruin/space/has_grav/syndiederelict/research)
-"XA" = (
-/obj/machinery/airalarm/syndicate{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/closet/crate/secure/gear,
-/obj/item/melee/transforming/energy/sword,
-/obj/item/melee/transforming/energy/sword,
-/turf/open/floor/plasteel/airless,
-/area/ruin/space/has_grav/syndiederelict/virology)
 "XC" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -3028,7 +3030,7 @@ QU
 xQ
 Ya
 Wm
-XA
+Oh
 UL
 Yf
 Yf

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -709,3 +709,4 @@
 	id = /obj/item/card/id/syndicate
 	l_pocket = /obj/item/flashlight
 	r_pocket = /obj/item/kitchen/knife/combat/survival
+	implants = list(/obj/item/implant/weapons_auth)

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -78,6 +78,9 @@
 	mag_display_ammo = TRUE
 	empty_indicator = TRUE
 
+/obj/item/gun/ballistic/automatic/c20r/ultrasecure
+	pin = /obj/item/firing_pin/fucked
+
 /obj/item/gun/ballistic/automatic/c20r/unrestricted
 	pin = /obj/item/firing_pin
 


### PR DESCRIPTION
Replaces one of the energy swords locked in a crate on the syndicate space derelict with an ultrasecure c20r SMG and 1 magazine for it. Prevents making a makeshift double esword from just the contents on board, and slightly reduces the loot pinata effectiveness of the station without weakening the occupants (and possibly strengthening them).

# Wiki Documentation

if this is kept on wiki, say that one of the energy swords on the space syndicate derelict is replaced with a ultrasecure c20r SMG and a magazine only usable by syndis.

# Changelog

:cl:  
tweak: One of the energy swords locked inside a crate on the syndicate space derelict is replaced with a ultrasecure c20r SMG that self destruct upon use/tamper by non syndicates.
/:cl:
