### PR TITLE
Heretic worm ascension contract abillity cooldown reduced

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -578,7 +578,7 @@
 	button_icon_state = "worm_contract"
 
 	school = SCHOOL_FORBIDDEN
-	cooldown_time = 30 SECONDS
+	cooldown_time = 5 SECONDS
 
 	invocation_type = INVOCATION_NONE
 	spell_requirements = NONE

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -578,7 +578,7 @@
 	button_icon_state = "worm_contract"
 
 	school = SCHOOL_FORBIDDEN
-	cooldown_time = 5 SECONDS
+	cooldown_time = 15 SECONDS
 
 	invocation_type = INVOCATION_NONE
 	spell_requirements = NONE


### PR DESCRIPTION
# Document the changes in your pull request
Heretic worm ascension abillity has had its cooldown reduced from 30 to 15 seconds
this is good because you often get stuck as the worm cause you cannot go through your own body.
every other heretic ascension heals you and makes you almost invincible, while as the worm you need to constantly be killing and eating people's arms to regenerate health.
this will just let the worm be able to survive more.


# Wiki Documentation
wiki doesn't have the worm contract abillity on it

# Changelog


:cl:  
tweak: Heretic worm ascension abillity to contract has had its cooldown reduced to 15 seconds
/:cl:
