### PR TITLE
ultrakill martial art is 20 tc again

### DIFF
--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -178,7 +178,7 @@
 	desc = "A module full of forbidden techniques that will make you capable of ultimate bloodshed. \
 			If you install this, it will make you incapable of pushing and pulling. \
 			There are no half-measures, either you succeed or you die."
-	cost = 16
+	cost = 20
 	item = /obj/item/book/granter/martial/ultra_violence
 	restricted_species = list("ipc")
 


### PR DESCRIPTION
Closest comparison to this would be the buster arm as both give you visible tells and cost similar prices, but ultrakill definitely blows the arm out of the water with crit immunity, dashes, infinite guns, and quick easy healing. Worldbreaker is also kind of similar, though honestly I think its weaker while costing 4 more TC.

Just sets it back to being 20 TC like it was when it was first introduced. Discounts are still present, though honestly you don't really need anything else to go with this as it gives you healing, speed, guns, melee damage, and defense all in one.

# Changelog

:cl:  
tweak: Ultrakill martial art is 20 TC again instead of 16
/:cl:
