### PR TITLE
Translation Matrix Design Bugfix + Corrects Typo

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -266,7 +266,7 @@
 /// Contains both common and rarer languages.
 /obj/item/borg/upgrade/language/expanded
 	name = "advanced translation matrix upgrade"
-	desc = "Increases the translation matrix to include an even wider variety in langauges."
+	desc = "Increases the translation matrix to include an even wider variety in languages."
 	blacklisted_upgrades = list(/obj/item/borg/upgrade/language/omni)
 	languages = list(
 		/datum/language/bonespeak,

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -782,7 +782,7 @@
 	name = "Cyborg Upgrade (Translation Matrix)"
 	id = "borg_upgrade_language"
 	build_type = MECHFAB
-	build_path = /obj/item/borg/upgrade/language
+	build_path = /obj/item/borg/upgrade/language/normal
 	materials = list(/datum/material/iron = 10000, /datum/material/glass = 6000, /datum/material/plasma = 5000)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")


### PR DESCRIPTION
# Document the changes in your pull request
Fixes typo and makes Cyborg Upgrade (Translation Matrix) design print the correct upgrade.

# Changelog
:cl:  
bugfix: "Cyborg Upgrade (Translation Matrix)" design now prints the correct upgrade.
spellcheck: langauges -> languages
/:cl:
