### PR TITLE
Locks Worldbreaker behind hijack and glorious death only

### DIFF
--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -162,7 +162,7 @@
 	It is not uncommon for Preterni that have consumed it to be crushed under the weight of their own ever-growing skin. The weight will also prevent use of conventional vehicles."
 	cost = 20
 	player_minimum = 25 //basically a fuckin megafauna
-	include_objectives = list(/datum/objective/hijack) //too much collateral damage with it's AOEs
+	include_objectives = list(/datum/objective/hijack, /datum/objective/martyr, /datum/objective/nuclear) //too much collateral damage with it's AOEs
 	item = /obj/item/book/granter/martial/worldbreaker
 	manufacturer = /datum/corporation/traitor/vahlen
 	restricted_species = list("preternis")

--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -162,6 +162,7 @@
 	It is not uncommon for Preterni that have consumed it to be crushed under the weight of their own ever-growing skin. The weight will also prevent use of conventional vehicles."
 	cost = 20
 	player_minimum = 25 //basically a fuckin megafauna
+	include_objectives = list(/datum/objective/hijack) //too much collateral damage with it's AOEs
 	item = /obj/item/book/granter/martial/worldbreaker
 	manufacturer = /datum/corporation/traitor/vahlen
 	restricted_species = list("preternis")


### PR DESCRIPTION
Only hijack and martyr traitors are exempt from murderbone rules
This martial art does so much aoe that you're damn close to just murderboning everyone
sort of an issue when it comes to admin ruling, so it's being locked behind those

also lets nukies still have it if an admin decides to every species swap nukies into preterni for some reason

:cl:  
tweak: Locks Worldbreaker behind hijack and glorious death
/:cl:
