### PR TITLE
Ultra Violence is now hijack/martyr only

### DIFF
--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -181,6 +181,7 @@
 	cost = 20
 	item = /obj/item/book/granter/martial/ultra_violence
 	restricted_species = list("ipc")
+	include_objectives = list(/datum/objective/hijack, /datum/objective/martyr, /datum/objective/nuclear) // designed around mass murder, no need to use this if you aren't allowed to do that
 
 /datum/uplink_item/stealthy_weapons/camera_flash
 	name = "Camera Flash"


### PR DESCRIPTION
# Document the changes in your pull request

This PR makes the Ultra Violence IPC upgrade only available with hijack or glorious death objectives.

# Why it's good for the game

- Ultra Violence is designed specifically around mass killing, both thematically and mechanically, which doesn't make sense for objectives that don't allow mass murder.
- Security *cannot* stop it with their roundstart equipment, the only other items that are like this are also locked to hijack/martyr or in the process of being locked.
- IPC traitors use this same thing seemingly every time, more variety is always good.

# Wiki Documentation

On the list of syndicate items, add hijack/martyr to required objectives for the version one upgrade module.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: ultra violence is now hijack/martyr only
/:cl:
