### PR TITLE
Worldbreaker balance tweaks

### DIFF
--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -265,7 +265,7 @@
 			new /obj/effect/temp_visual/dragon_swoop/bubblegum(telegraph)
 
 	var/jumpspeed = 4 - user.cached_multiplicative_slowdown
-	jumpspeed = clamp(jumpspeed, 0.5, 4)
+	jumpspeed = clamp(jumpspeed, 0.75, 4)
 
 	user.throw_at(target, 15, jumpspeed, user, FALSE, TRUE, callback = CALLBACK(src, PROC_REF(leap_end), user))
 	user.Immobilize(1 SECONDS, ignore_canstun = TRUE) //to prevent cancelling the leap

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -492,7 +492,7 @@
 		var/damage = 10
 		if(isstructure(obstruction) || ismecha(obstruction))
 			damage += 5
-		if(obstruction == target)
+		if(get_turf(obstruction) == get_turf(target))
 			damage *= 3
 		obstruction.take_damage(damage, sound_effect = FALSE) //reduced sound from hitting LOTS of things
 

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -617,13 +617,13 @@
 
 	combined_msg +=  "[span_notice("Leap")]: \
 	Your disarm is instead a leap that deals damage, staggers, and knocks everything back within a radius. \
-	Landing on someone will do extra damage. Has a cooldown that gets longer with more plates grown."
+	Landing on someone will do extra damage. The cooldown is longer if heavy and only starts when you land."
 	
 	combined_msg +=  "[span_notice("Clasp")]: Your grab is far stronger. \
 	Instead of grabbing someone, you will pick them up and be able to throw them."
 
 	combined_msg +=  "[span_notice("Pummel")]: Your harm intent pummels a small area dealing damage, knocking back, and staggering. \
-	The target takes three times as much damage."
+	The targets in the middle take notably more damage."
 
 	combined_msg +=  "[span_notice("Worldstomp")]: After a delay, create a giant shockwave that deals damage to all mobs within a radius. \
 	The shockwave will knock back and stagger all mobs in a larger radius. Objects and structures within the extended radius will be thrown or damaged respectively. \

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -256,7 +256,7 @@
 		return
 	if(!target)
 		return
-	COOLDOWN_START(src, next_leap, COOLDOWN_LEAP * 2)//should last longer than the leap, but just in case
+	COOLDOWN_START(src, next_leap, COOLDOWN_LEAP * 3)//should last longer than the leap, but just in case
 
 	//telegraph ripped entirely from bubblegum charge
 	if(heavy)
@@ -265,7 +265,7 @@
 			new /obj/effect/temp_visual/dragon_swoop/bubblegum(telegraph)
 
 	var/jumpspeed = 4 - user.cached_multiplicative_slowdown
-	jumpspeed = clamp(jumpspeed, 1, 4)
+	jumpspeed = clamp(jumpspeed, 0.5, 4)
 
 	user.throw_at(target, 15, jumpspeed, user, FALSE, TRUE, callback = CALLBACK(src, PROC_REF(leap_end), user))
 	user.Immobilize(1 SECONDS, ignore_canstun = TRUE) //to prevent cancelling the leap

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -302,7 +302,7 @@
 		if(isitem(obstruction))
 			push_away(user, obstruction)
 			continue
-		if(!isstructure(obstruction) && !ismachinery(obstruction))
+		if(!isstructure(obstruction) && !ismachinery(obstruction) && !ismecha(obstruction))
 			continue
 		var/damage = 5
 		if(obstruction.loc == user.loc)
@@ -487,10 +487,10 @@
 		if(isitem(obstruction))
 			push_away(user, obstruction)
 			continue
-		if(!isstructure(obstruction) && !ismachinery(obstruction))
+		if(!isstructure(obstruction) && !ismachinery(obstruction) && !ismecha(obstruction))
 			continue
 		var/damage = 10
-		if(isstructure(obstruction))
+		if(isstructure(obstruction) || ismecha(obstruction))
 			damage += 5
 		if(obstruction == target)
 			damage *= 3
@@ -568,10 +568,10 @@
 	for(var/obj/item/I in range(actual_range, owner))
 		linked_martial.push_away(owner, I, 2)
 	for(var/obj/obstruction in range(actual_range/2, owner))
-		if(!isstructure(obstruction) && !ismachinery(obstruction))
+		if(!isstructure(obstruction) && !ismachinery(obstruction) && !ismecha(obstruction))
 			continue
 		var/damage = 10
-		if(isstructure(obstruction)) //less damage to machinery because machinery is actually important, and if it was 20 or higher it would 100% break all lights within range
+		if(isstructure(obstruction) || ismecha(obstruction)) //less damage to machinery because machinery is actually important, and if it was 20 or higher it would 100% break all lights within range
 			damage += 15 + (plates * 3)
 		obstruction.take_damage(damage) //we WANT this one to be loud
 

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -20,7 +20,7 @@
 
 #define THROW_MOBDMG 5 //the damage dealt per object impacted during a throw
 #define THROW_OBJDMG 500 //Total amount of structure damage that can be done
-#define COOLDOWN_GRAB 0.8 SECONDS //basically just to prevent infinite stunlock spam
+#define COOLDOWN_GRAB 1.2 SECONDS //basically just to prevent infinite stunlock spam
 
 /datum/martial_art/worldbreaker
 	name = "Worldbreaker"
@@ -350,6 +350,7 @@
 		F.name = "worldbreaker"
 		victim.density = FALSE
 		victim.visible_message(span_warning("[user] grabs [victim] and lifts [victim.p_them()] off the ground!"))
+		victim.Stun(1 SECONDS) //so the user has time to aim their throw
 		to_chat(victim, span_userdanger("[user] grapples you and lifts you up into the air! Resist [user.p_their()] grip!"))
 		victim.forceMove(Z)
 		F.buckle_mob(target)


### PR DESCRIPTION
With it being hijack locked soon, i'm giving it a few tweaks

The ideas for these changes are 
make plates more impactful, without giving them that much more effective health
let them keep going even when getting low, but make sure they're slow
iron out some of the less enjoyable parts of leap (weird scaling cooldown) while still having it scale based on plates
make pummel actually worth using as a main attack ability instead of relying entirely on throw

:cl:  
tweak: Worldbreaker tweaks
tweak: throw only does damage upon collision, not upon throwing
tweak: grabbing now stuns for a very short time to allow for aiming
tweak: pummel does 20 damage instead of 15
tweak: pummel has regular attack cooldown instead of slower (preterni no longer attack slower)
tweak: plates have 25 health instead of 15
tweak: can only have 3 plates over armour cap instead of 5
tweak: plates take 1/4 damage from non brute and burn rather than 1/3
tweak: plates give more slowdown
tweak: leap cooldown no longer scales directly with number of plates, instead just takes 1 second longer if heavy
tweak: leap speed now directly scales with movespeed (meaning outside sources of movespeed will increase it)
tweak: leap cooldown only starts once you land, rather than when you start jumping
tweak: now gives softcrit immunity
tweak: no longer gives damage slowdown resistance
tweak: never takes damage from being thrown into a wall
bugfix: attacks can now hurt mechs
/:cl:
