### PR TITLE
BRPED Upgrade for Engineering Cyborg

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -44,13 +44,17 @@
 				to_chat(user, "This upgrade was already applied to this cyborg!")
 				return FALSE
 	if(prerequisite_upgrades && prerequisite_upgrades.len > 0)
-		for(var/upgrade_type in prerequisite_upgrades) // Janky, only because is_type_in_list() doesn't work.
+		var/list/unsatisfied_prereq_types = prerequisite_upgrades.Copy()
+		for(var/upgrade_type in unsatisfied_prereq_types)
 			for(var/obj/item/borg/upgrade/installed_upgrade in R.upgrades)
 				if(upgrade_type == installed_upgrade.type)
-					var/obj/item/borg/upgrade/temp_upgrade = new upgrade_type()
-					to_chat(R, "Upgrade error! Upgrade requires [initial(temp_upgrade.name)] first!")
-					to_chat(user, "This upgrade requires the prerequisite upgrade, [initial(temp_upgrade.name)]!")
-					return FALSE
+					unsatisfied_prereq_types -= upgrade_type
+		if(unsatisfied_prereq_types.len > 0) // Didn't meet all of the prerequisites.
+			var/first_upgrade_type = unsatisfied_prereq_types[1]
+			var/obj/item/borg/upgrade/temp_upgrade = new first_upgrade_type()
+			to_chat(R, "Upgrade error! Upgrade requires [initial(temp_upgrade.name)] first!") // Hint of what upgrade to add next.
+			to_chat(user, "This upgrade requires the prerequisite upgrade, [initial(temp_upgrade.name)]!")
+			return FALSE
 	if(blacklisted_upgrades && blacklisted_upgrades.len > 0)
 		for(var/upgrade_type in blacklisted_upgrades)
 			for(var/obj/item/borg/upgrade/installed_upgrade in R.upgrades)
@@ -63,8 +67,13 @@
 
 /// Called when upgrade is removed from the cyborg.
 /obj/item/borg/upgrade/proc/deactivate(mob/living/silicon/robot/R, user = usr)
-	if(!(src in R.upgrades))
+	if(!(src in R.upgrades)) // This upgrade should still be in the list when this proc is called.
 		return FALSE
+	for(var/obj/item/borg/upgrade/I in R.upgrades)
+		if(!I.prerequisite_upgrades)
+			continue
+		if(is_type_in_list(src, I.prerequisite_upgrades))
+			I.forceMove(get_turf(R)) // Will deactivate all upgrades that use this as a prerequisite.
 	return TRUE
 
 /obj/item/borg/upgrade/rename
@@ -992,12 +1001,56 @@
 	R.module.add_module(RPED, FALSE, TRUE)
 
 /obj/item/borg/upgrade/rped/deactivate(mob/living/silicon/robot/R, user = usr)
+	. = ..() // If BRPED upgrade is in, this will deactivate it too.
+	if(!.)
+		return FALSE
+
+	for(var/obj/item/storage/part_replacer/cyborg/RPED in R.module.modules)
+		RPED.emptyStorage()
+		R.module.remove_module(RPED, TRUE)
+
+/obj/item/borg/upgrade/brped
+	name = "engineering cyborg BRPED"
+	desc = "A bluespace rapid part exchange device for the engineering cyborg."
+	icon = 'icons/obj/storage.dmi'
+	icon_state = "BS_RPED"
+	require_module = TRUE
+	module_types = list(/obj/item/robot_module/engineering, /obj/item/robot_module/saboteur)
+	module_flags = BORG_MODULE_ENGINEERING
+	prerequisite_upgrades = list(/obj/item/borg/upgrade/rped)
+
+/// Gives the cyborg a bluespace rapid part exchange device (BRPED) if they had the previous RPED upgrade.
+/obj/item/borg/upgrade/brped/action(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	var/obj/item/storage/part_replacer/bluespace/cyborg/BRPED = locate() in R.module.modules
+	if(BRPED)
+		to_chat(user, span_warning("This cyborg is already equipped with a BRPED module."))
+		return FALSE
+
+	for(var/obj/item/storage/part_replacer/cyborg/RPED in R.module.modules)
+		RPED.emptyStorage()
+		R.module.remove_module(RPED, TRUE)
+
+	BRPED = new(R.module)
+	R.module.basic_modules += BRPED
+	R.module.add_module(BRPED, FALSE, TRUE)
+
+/obj/item/borg/upgrade/brped/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if(!.)
 		return FALSE
 	
-	for(var/obj/item/storage/part_replacer/cyborg/RPED in R.module.modules)
-		R.module.remove_module(RPED, TRUE)
+	for(var/obj/item/storage/part_replacer/bluespace/cyborg/BRPED in R.module.modules)
+		BRPED.emptyStorage()
+		R.module.remove_module(BRPED, TRUE)
+
+	var/obj/item/storage/part_replacer/cyborg/RPED = locate() in R.module.modules // Give back the prerequisite item.
+	RPED = new(R.module)
+	R.module.basic_modules += RPED
+	R.module.add_module(RPED, FALSE, TRUE)
 
 /obj/item/borg/upgrade/plasmacutter
 	name = "mining cyborg plasma cutter"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -970,6 +970,15 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
+/datum/design/borg_upgrade_brped
+	name = "Cyborg Upgrade (BRPED)"
+	id = "borg_upgrade_brped"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/brped
+	materials = list(/datum/material/iron = 15000, /datum/material/glass = 5000, /datum/material/silver = 2500)
+	construction_time = 12 SECONDS
+	category = list("Cyborg Upgrade Modules")
+
 /datum/design/borg_upgrade_broomer
 	name = "Cyborg Upgrade (Experimental Push Broom)"
 	id = "borg_upgrade_broomer"

--- a/code/modules/research/stock_parts.dm
+++ b/code/modules/research/stock_parts.dm
@@ -104,12 +104,16 @@ If you create T5+ please take a pass at gene_modder.dm [L40]. Max_values MUST fi
 		new /obj/item/stock_parts/matter_bin(src)
 
 /obj/item/storage/part_replacer/cyborg
-	name = "rapid part exchange device"
-	desc = "Special mechanical module made to store, sort, and apply standard machine parts."
+	name = "cyborg rapid part exchange device"
+	desc = "A special mechanical module made to store, sort, and apply standard machine parts."
 	icon_state = "borgrped"
 	item_state = "RPED"
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
+
+/obj/item/storage/part_replacer/bluespace/cyborg
+	name = "cyborg bluespace rapid part exchange device"
+	desc = "A bluespace-variant of the special mechanical module made to store, sort, and apply standard machine parts."
 
 /proc/cmp_rped_sort(obj/item/A, obj/item/B)
 	return B.get_part_rating() - A.get_part_rating()

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -342,8 +342,8 @@
 	id = "adv_cyborg_upg_util"
 	display_name = "Cyborg Upgrades: Advanced Utility"
 	description = "Advanced utility upgrades for cyborgs."
-	prereq_ids = list("cyborg_upg_util", "exp_tools") // Experimental tools should cover everything with all of its prereqs.
-	design_ids = list("borg_upgrade_engi_advancedtools", "borg_upgrade_holofan")
+	prereq_ids = list("cyborg_upg_util", "practical_bluespace", "exp_tools") // Experimental tools covers tools & holofan. Bluespace covers BRPED.
+	design_ids = list("borg_upgrade_engi_advancedtools", "borg_upgrade_holofan", "borg_upgrade_brped")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 
 /datum/techweb_node/cyborg_upg_med


### PR DESCRIPTION
# Document the changes in your pull request
Adds a bluespace variant of the RPED upgrade for engineering cyborg. Requires RPED upgrade to be installed first.
Same cost as a handheld BRPED: 15000 metal (7.5 sheets), 5000 glass (2.5 sheets), 2500 silver (1.25 sheets).

Locked behind Cyborg. Adv. Utility Upgrades.
Cyborg. Adv. Utility Upgrades now has additional prerequisite node of Applied Bluespace Research.

Bug fix where parts in cyborg RPED disappear into the void (get deleted) when removed instead of dropping to floor.
Bug fix where being a prerequisite upgrade functioned like a blacklist (not it mattered since no upgrades were using it at the time).
Cyborg RPED(s) start with "cyborg" to note it is the cyborg version.

# Wiki Documentation
New upgrade for Cyborg Upgrades. 
- Name: "engineering cyborg BRPED". 
- Description: "A bluespace rapid part exchange device for the engineering cyborg."
- Requires RPED upgrade to be installed first before this upgrade can installed.

New item & prereq node for Cyborg. Adv. Utility Upgrades. 
- Design name: "Cyborg Upgrade (BRPED)"
- Cost: 15000 metal (7.5 sheets), 5000 glass (2.5 sheets), 2500 silver (1.25 sheets).
- Required prereq node: "Applied Bluespace Research"

# Changelog
:cl:  
rscadd: A new upgrade for engineering cyborgs have been added that gives them a BRPED. It requires the RPED upgrade to be installed first as a prerequisite.
bugfix: Prerequisite upgrades for cyborg upgrades properly function as intended.
bugfix: On deactivation, Cyborg RPED drop all parts onto the floor instead of disappearing into the void.
tweak: "Cyborg Upgrades: Advanced Utility" now also requires the "Applied Bluespace Research" techweb node as a prerequisite.
spellcheck: Cyborg RPED's name starts with "cyborg" to note it is the cyborg version.
/:cl:
