### PR TITLE
Hecata necromancy works slower on mindshielded non-vassals

### DIFF
--- a/code/modules/antagonists/bloodsuckers/powers/targeted/hecata.dm
+++ b/code/modules/antagonists/bloodsuckers/powers/targeted/hecata.dm
@@ -63,9 +63,9 @@
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = user.mind.has_antag_datum(/datum/antagonist/bloodsucker)
 	if(target.stat == DEAD && user.Adjacent(target))
 		owner.balloon_alert(owner, "attempting to revive...")
-		if(HAS_TRAIT(target, TRAIT_MINDSHIELD) || IS_VASSAL(target)) //if they aren't already a vassal and they have a mindshield
-			owner.balloon_alert(owner, "mindshield detected, this will take a little longer...")
-			if(!do_after(user, 12 SECONDS, target))
+		if(HAS_TRAIT(target, TRAIT_MINDSHIELD) && !IS_VASSAL(target)) //if they aren't already a vassal and they have a mindshield
+			owner.balloon_alert(owner, "mindshield detected, this will take longer...")
+			if(!do_after(user, 18 SECONDS, target))
 				return FALSE
 		else
 			if(!do_after(user, 6 SECONDS, target))

--- a/code/modules/antagonists/bloodsuckers/powers/targeted/hecata.dm
+++ b/code/modules/antagonists/bloodsuckers/powers/targeted/hecata.dm
@@ -19,7 +19,7 @@
 /datum/action/cooldown/bloodsucker/targeted/hecata/necromancy
 	name = "Necromancy"
 	button_icon_state = "power_necromancy"
-	desc = "Raise the dead as temporary vassals, or revive a dead vassal as a zombie permanently. Temporary vassals last longer as this ability ranks up."
+	desc = "Raise the dead as temporary vassals, or revive a dead vassal as a zombie permanently. Temporary vassals last longer as this ability ranks up. Mindshielded people will take far longer to necromance."
 	power_explanation = "Necromancy:\n\
 		Click on a corpse in order to attempt to resurrect them.\n\
 		Non-vassals will become temporary zombies that will follow your orders. Dead vassals are also turned, but last permanently.\n\

--- a/code/modules/antagonists/bloodsuckers/powers/targeted/hecata.dm
+++ b/code/modules/antagonists/bloodsuckers/powers/targeted/hecata.dm
@@ -63,8 +63,13 @@
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = user.mind.has_antag_datum(/datum/antagonist/bloodsucker)
 	if(target.stat == DEAD && user.Adjacent(target))
 		owner.balloon_alert(owner, "attempting to revive...")
-		if(!do_after(user, 6 SECONDS, target))
-			return FALSE
+		if(HAS_TRAIT(target, TRAIT_MINDSHIELD) || IS_VASSAL(target)) //if they aren't already a vassal and they have a mindshield
+			owner.balloon_alert(owner, "mindshield detected, this will take a little longer...")
+			if(!do_after(user, 12 SECONDS, target))
+				return FALSE
+		else
+			if(!do_after(user, 6 SECONDS, target))
+				return FALSE
 		if(IS_VASSAL(target))
 			power_activated_sucessfully()
 			owner.balloon_alert(owner, "we revive [target]!")


### PR DESCRIPTION
Bloodsucker Hecata clan necromancy now takes 18 seconds to complete rather than 6 seconds if the target is mindshielded and is not already a vassal. Taking secoffs and such as your temporary zombie vassals will be a bit more hard and time consuming while still permitting it.

You can put in the wiki that Hecata necromancy takes 3x as long to complete if the target is a mindshielded non-vassal.

# Changelog

:cl:  
tweak: Hecata bloodsuckers take 3x as long (18 seconds) to necromance mindshielded non vassals.
/:cl:
