### PR TITLE
Optimize appearance overlay encoding for replays

### DIFF
--- a/code/controllers/subsystem/demo.dm
+++ b/code/controllers/subsystem/demo.dm
@@ -300,18 +300,20 @@ SUBSYSTEM_DEF(demo)
 			inted[i] += round(old_list[i] * 255)
 		color_string = jointext(inted, ",")
 	var/overlays_string = "\[]"
-	if(appearance.overlays.len)
+	var/list/appearance_overlays = appearance.overlays
+	if(appearance_overlays.len)
 		var/list/overlays_list = list()
-		for(var/i in 1 to appearance.overlays.len)
-			var/image/overlay = appearance.overlays[i]
+		for(var/i in 1 to appearance_overlays.len)
+			var/image/overlay = appearance_overlays[i]
 			overlays_list += encode_appearance(overlay, appearance, TRUE)
 		overlays_string = "\[[jointext(overlays_list, ",")]]"
 
 	var/underlays_string = "\[]"
-	if(appearance.underlays.len)
+	var/list/appearance_underlays = appearance.underlays
+	if(appearance_underlays.len)
 		var/list/underlays_list = list()
-		for(var/i in 1 to appearance.underlays.len)
-			var/image/underlay = appearance.underlays[i]
+		for(var/i in 1 to appearance_underlays.len)
+			var/image/underlay = appearance_underlays[i]
 			underlays_list += encode_appearance(underlay, appearance, TRUE)
 		underlays_string = "\[[jointext(underlays_list, ",")]]"
 


### PR DESCRIPTION
You may know that doing this kind of caching is usually faster. However in the case of accessing `appearance.overlays` or `appearance.underlays`, it's *much* faster. The reason is because specifically for appearances, BYOND will create a new list, copy your appearances into that list, and then return it, every time you access it. (Note that accessing .overlays on an object will not do this as they have special list types that allow the list to be a "live view" into the list for editing purposes)

warning: I did not test this code.