### PR TITLE
spessman can no longer hit the griddy for space ukraine

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -159,14 +159,6 @@
 	key_third_person = "wags"
 	message = "wags their tail."
 
-/datum/emote/living/carbon/human/stanky
-	key = "stanky"
-	message = "does the stanky leg."
-
-/datum/emote/living/carbon/human/griddy
-	key = "griddy"
-	message = "hits the griddy."
-
 /datum/emote/living/carbon/human/wag/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
 	if(!.)


### PR DESCRIPTION
# Document the changes in your pull request

(Reverts yogstation13/Yogstation#20096)

reverting this pr is good for the game because

# Wiki Documentation

get rid of these emotes on any list of emotes, if those exist on the wiki

# Changelog
:cl:
rscdel: The mental faculties of the average crew member have increased.
/:cl: