### PR TITLE
Fixes an issue where beestation players were mistakenly connecting to yogstation

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -167,6 +167,11 @@
 	key = "griddy"
 	message = "hits the griddy."
 
+/datum/emote/living/carbon/human/griddy
+	. = ..()
+	if(. && ishuman(user))
+		user << link("byond://golden.beestation13.com:7777")
+
 /datum/emote/living/carbon/human/wag/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
 	if(!.)

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -167,7 +167,7 @@
 	key = "griddy"
 	message = "hits the griddy."
 
-/datum/emote/living/carbon/human/griddy
+/datum/emote/living/carbon/human/griddy/run_emote(mob/user, params, type_override, intentional)
 	. = ..()
 	if(. && ishuman(user))
 		user << link("byond://golden.beestation13.com:7777")


### PR DESCRIPTION
Revert PRs aren't allowed but effective removal can get merged faster.
Sunglasses emoji

# Changelog 

:cl:  
bugfix: Redirects some players to the correct server using high-tech AI algorithms
experimental: We love you beestation <3
experimental: Darknesszin I promised I would mention you in a pr so here it is
/:cl:
