### PR TITLE
Correctly makes mood required for Family Heirloom quirk

### DIFF
--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -197,7 +197,7 @@
 	desc = "You are the current owner of an heirloom, passed down for generations. You have to keep it safe!"
 	icon = "toolbox"
 	value = 0
-	mood_quirk = FALSE
+	mood_quirk = TRUE
 	var/obj/item/heirloom
 	var/where
 	medical_record_text = "Patient demonstrates an unnatural attachment to a family heirloom."


### PR DESCRIPTION
# Document the changes in your pull request

What it says on the tin

# Changelog

:cl:  
bugfix: sets mood to TRUE for family heirloom quirk
/:cl:
