### PR TITLE
daps spellcheck

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -35,7 +35,7 @@
 	key = "dap"
 	key_third_person = "daps"
 	message = "sadly can't find anybody to give daps to, and daps themself. Shameful."
-	message_param = "give daps to %t."
+	message_param = "gives daps to %t."
 	hands_use_check = TRUE
 
 /datum/emote/living/carbon/human/eyebrow


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/77829
should be gives, not give

# Wiki Documentation

yes emotes page

:cl:  tf-4
spellcheck: Fixed a spelling error with the daps emote.
/:cl: