### PR TITLE
Makes IAA unable to buy the cloaker belt because nigh-true invisibility + anything that stuns instantly is very cringe and I died to it.

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1433,7 +1433,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A tactical belt that renders the wearer invisible while active. Has a short charge that is refilled in darkness; only charges when in use."
 	item = /obj/item/storage/belt/military/shadowcloak
 	cost = 10
-	exclude_modes = list(/datum/game_mode/nuclear)
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/traitor/internal_affairs)
 
 /datum/uplink_item/stealthy_tools/nuclearshadowcloak
 	name = "Cloaker Belt"


### PR DESCRIPTION
# Document the changes in your pull request

the ability for any IAA member to buy a belt that just makes them nigh invisible and walk up to you with CQC and roundend you without you even being able to see them is not a fun gameplay mechanic.

# Wiki Documentation

if excluded gamemodes are listed for uplink items, this'd need to be there

# Changelog

:cl:  cark
tweak: IAA can no longer buy cloaker belts
/:cl:
