### PR TITLE
Mood isn't optional

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -73,15 +73,9 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		var/client/client = client_or_prefs
 		prefs = client.prefs
 
-	// If moods are globally enabled, or this guy does indeed have his mood pref set to Enabled
-	var/ismoody = (!CONFIG_GET(flag/disable_human_mood) || (prefs.read_preference(/datum/preference/toggle/mood_enabled)))
-
 	for (var/quirk_name in quirks)
 		var/datum/quirk/quirk = SSquirks.quirks[quirk_name]
 		if (isnull(quirk))
-			continue
-
-		if (initial(quirk.mood_quirk) && !ismoody)
 			continue
 
 		// Returns error string, FALSE if quirk is okay to have

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -137,9 +137,12 @@
 	for(var/a in antag_datums)	//Makes sure all antag datums effects are applied in the new body
 		var/datum/antagonist/A = a
 		A.on_body_transfer(old_current, current)
-	if(iscarbon(new_character))
+	if(iscarbon(new_character) && !new_character.GetComponent(/datum/component/mood))
 		var/mob/living/carbon/C = new_character
 		C.last_mind = src
+	if(ishuman(new_character))
+		var/mob/living/carbon/human/H = C
+		H.AddComponent(/datum/component/mood)
 	transfer_martial_arts(new_character)
 	transfer_parasites()
 	RegisterSignal(new_character, COMSIG_GLOB_MOB_DEATH, PROC_REF(set_death_time))

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -137,13 +137,13 @@
 	for(var/a in antag_datums)	//Makes sure all antag datums effects are applied in the new body
 		var/datum/antagonist/A = a
 		A.on_body_transfer(old_current, current)
-	if(iscarbon(new_character) && !new_character.GetComponent(/datum/component/mood))
+	if(iscarbon(new_character))
 		var/mob/living/carbon/C = new_character
 		C.last_mind = src
-	if(ishuman(new_character))
-		var/mob/living/carbon/human/H = C
-		H.AddComponent(/datum/component/mood)
-	transfer_martial_arts(new_character)
+		if(ishuman(new_character) && !new_character.GetComponent(/datum/component/mood))
+			var/mob/living/carbon/human/H = C
+			H.AddComponent(/datum/component/mood)
+		transfer_martial_arts(new_character)
 	transfer_parasites()
 	RegisterSignal(new_character, COMSIG_GLOB_MOB_DEATH, PROC_REF(set_death_time))
 	if(accent_name)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -112,19 +112,7 @@
 
 /datum/mind/proc/transfer_to(mob/new_character, force_key_move = 0)
 	original_character = null
-	var/mood_was_enabled = FALSE//Yogs -- Mood Preferences
-	if(current)	// remove ourself from our old body's mind variable
-		// Yogs start -- Mood preferences
-		if(current.client && current.client.prefs.read_preference(/datum/preference/toggle/mood_enabled))
-			mood_was_enabled = TRUE
-		else if(ishuman(current) && CONFIG_GET(flag/disable_human_mood))
-			var/mob/living/carbon/human/H = current
-			if(H.mood_enabled)
-				mood_was_enabled = TRUE
-				var/datum/component/mood/c = H.GetComponent(/datum/component/mood)
-				if(c)
-					c.RemoveComponent()
-		// Yogs End
+	if(current)
 		current.mind = null
 		UnregisterSignal(current, COMSIG_GLOB_MOB_DEATH)
 		UnregisterSignal(current, COMSIG_MOB_SAY)
@@ -152,11 +140,6 @@
 	if(iscarbon(new_character))
 		var/mob/living/carbon/C = new_character
 		C.last_mind = src
-		// Yogs start -- Mood preferences
-		if(ishuman(new_character) && mood_was_enabled && !new_character.GetComponent(/datum/component/mood))
-			var/mob/living/carbon/human/H = C
-			H.AddComponent(/datum/component/mood)
-		// Yogs End
 	transfer_martial_arts(new_character)
 	transfer_parasites()
 	RegisterSignal(new_character, COMSIG_GLOB_MOB_DEATH, PROC_REF(set_death_time))

--- a/code/modules/antagonists/creep/creep.dm
+++ b/code/modules/antagonists/creep/creep.dm
@@ -71,22 +71,6 @@
 		qdel(trauma)
 	. = ..()
 
-/datum/antagonist/obsessed/apply_innate_effects(mob/living/mob_override)
-	var/mob/living/M = mob_override || owner.current
-	if(M && ishuman(M) && !M.GetComponent(/datum/component/mood))
-		to_chat(owner, span_danger("You feel more aware of your condition, mood has been enabled!"))
-		M.AddComponent(/datum/component/mood) //you fool you absolute buffoon to think you could escape
-
-/datum/antagonist/obsessed/remove_innate_effects(mob/living/mob_override)
-	. = ..()
-	var/mob/living/M = mob_override || owner.current
-	var/mob/living/carbon/human/H = M
-	if(H && !H.mood_enabled)
-		var/datum/component/C = M.GetComponent(/datum/component/mood)
-		if(C) //we cannot be too sure they may have somehow removed it
-			to_chat(owner, span_danger("Your need for mental fitness vanishes alongside the voices, mood has been disabled."))
-			C.RemoveComponent()
-
 /datum/antagonist/obsessed/proc/forge_objectives(datum/mind/obsessionmind)
 	var/list/objectives_left = list("spendtime", "polaroid", "hug")
 	var/datum/quirk/family_heirloom/family_heirloom

--- a/code/modules/client/preferences/middleware/quirks.dm
+++ b/code/modules/client/preferences/middleware/quirks.dm
@@ -16,9 +16,6 @@
 	data["selected_quirks"] = get_selected_quirks()
 	data["locked_quirks"] = get_locked_quirks()
 
-	// If moods are globally enabled, or this guy does indeed have his mood pref set to Enabled
-	data["mood_enabled"] = (!CONFIG_GET(flag/disable_human_mood) || (user.client?.prefs.read_preference(/datum/preference/toggle/mood_enabled)))
-
 	return data
 
 /datum/preference_middleware/quirks/get_ui_data(mob/user)
@@ -28,9 +25,6 @@
 		tainted = FALSE
 		data["selected_quirks"] = get_selected_quirks()
 		data["locked_quirks"] = get_locked_quirks()
-	
-	// If moods are globally enabled, or this guy does indeed have his mood pref set to Enabled
-	data["mood_enabled"] = (!CONFIG_GET(flag/disable_human_mood) || (user.client?.prefs.read_preference(/datum/preference/toggle/mood_enabled)))
 
 	return data
 

--- a/code/modules/client/preferences/migrations/legacy_mood_migration.dm
+++ b/code/modules/client/preferences/migrations/legacy_mood_migration.dm
@@ -1,3 +1,2 @@
 /datum/preferences/proc/migrate_yog_legacy_toggles(savefile/savefile)
 	write_preference(GLOB.preference_entries[/datum/preference/toggle/quiet_mode], yogtoggles & 1<<0)
-	write_preference(GLOB.preference_entries[/datum/preference/toggle/mood_enabled], yogtoggles & 1<<1)

--- a/code/modules/client/preferences/mood_enabling.dm
+++ b/code/modules/client/preferences/mood_enabling.dm
@@ -1,5 +1,0 @@
-/datum/preference/toggle/mood_enabled
-	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
-	savefile_key = "pref_mood"
-	savefile_identifier = PREFERENCE_PLAYER
-

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1488,16 +1488,15 @@ GLOBAL_LIST_EMPTY(features_by_species)
 					. += (health_deficiency / 50) ** 2.58
 				else
 					. += (health_deficiency / 100) + 5
-		if(CONFIG_GET(flag/disable_human_mood) && !H.mood_enabled) // Yogs -- Mood as preference
-			if(!HAS_TRAIT(H, TRAIT_NOHUNGER))
-				var/hungry = (500 - H.nutrition) / 5 //So overeat would be 100 and default level would be 80
-				if((hungry >= 70) && !flight) //Being hungry will still allow you to use a flightsuit/wings.
-					. += hungry / 50
-			else if(isethereal(H))
-				var/datum/species/ethereal/E = H.dna.species
-				var/charge = E.get_charge(H)
-				if(charge <= ETHEREAL_CHARGE_NORMAL)
-					. += 1.5 * (1 - charge / 100)
+		if(!HAS_TRAIT(H, TRAIT_NOHUNGER))
+			var/hungry = (500 - H.nutrition) / 5 //So overeat would be 100 and default level would be 80
+			if((hungry >= 70) && !flight) //Being hungry will still allow you to use a flightsuit/wings.
+				. += hungry / 50
+		else if(isethereal(H))
+			var/datum/species/ethereal/E = H.dna.species
+			var/charge = E.get_charge(H)
+			if(charge <= ETHEREAL_CHARGE_NORMAL)
+				. += 1.5 * (1 - charge / 100)
 
 		//Moving in high gravity is very slow (Flying too)
 		if(gravity > STANDARD_GRAVITY)

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -175,7 +175,7 @@
 
 /datum/species/human/felinid/spec_life(mob/living/carbon/human/H)
 	. = ..()
-	if((H.client && H.client.prefs.read_preference(/datum/preference/toggle/mood_tail_wagging)) && !is_wagging_tail() && H.mood_enabled)
+	if((H.client && H.client.prefs.read_preference(/datum/preference/toggle/mood_tail_wagging)) && !is_wagging_tail())
 		var/datum/component/mood/mood = H.GetComponent(/datum/component/mood)
 		if(!istype(mood) || !(mood.shown_mood >= MOOD_LEVEL_HAPPY2)) 
 			return

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -86,7 +86,7 @@
 
 /datum/species/lizard/spec_life(mob/living/carbon/human/H)
 	. = ..()
-	if((H.client && H.client.prefs.read_preference(/datum/preference/toggle/mood_tail_wagging)) && !is_wagging_tail() && H.mood_enabled)
+	if((H.client && H.client.prefs.read_preference(/datum/preference/toggle/mood_tail_wagging)) && !is_wagging_tail())
 		var/datum/component/mood/mood = H.GetComponent(/datum/component/mood)
 		if(!istype(mood) || !(mood.shown_mood >= MOOD_LEVEL_HAPPY2)) 
 			return

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -661,9 +661,6 @@ MICE_ROUNDSTART 5
 ## This used to be named traits, hence the config name, but it handles quirks, not the other kind of trait!
 ROUNDSTART_TRAITS
 
-## Uncomment to disable human moods.
-DISABLE_HUMAN_MOOD
-
 ## Enable night shifts ##
 #ENABLE_NIGHT_SHIFTS
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
@@ -181,11 +181,6 @@ export const QuirksPage = (props, context) => {
             return lock_reason;
           }
 
-          if (quirk.mood && !data.mood_enabled)
-          {
-            return "This quirk requires mood to be enabled in your game options.";
-          }
-
           if (
             quirk.value > 0
           ) {

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
@@ -164,7 +164,6 @@ export type PreferencesMenuData = {
   overflow_role: string;
   selected_quirks: string[];
   locked_quirks: Record<string, string>;
-  mood_enabled: BooleanLike;
 
   antag_bans?: string[];
   antag_days_left?: Record<string, number>;

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/legacy_yog_toggles.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/legacy_yog_toggles.tsx
@@ -6,10 +6,3 @@ export const quiet_mode: FeatureToggle = {
   description: "You cannot be chosen as an antagonist or antagonist target.",
   component: CheckboxInput,
 };
-
-export const pref_mood: FeatureToggle = {
-  name: "Enable mood",
-  category: "GAMEPLAY",
-  description: "Enable the mood system.",
-  component: CheckboxInput,
-};

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2068,7 +2068,6 @@
 #include "code\modules\client\preferences\items.dm"
 #include "code\modules\client\preferences\jobless_role.dm"
 #include "code\modules\client\preferences\mood.dm"
-#include "code\modules\client\preferences\mood_enabling.dm"
 #include "code\modules\client\preferences\names.dm"
 #include "code\modules\client\preferences\ooc.dm"
 #include "code\modules\client\preferences\parallax.dm"

--- a/yogstation/code/controllers/subsystem/processing/quirks.dm
+++ b/yogstation/code/controllers/subsystem/processing/quirks.dm
@@ -1,8 +1,5 @@
 /datum/controller/subsystem/processing/quirks/proc/checkquirks(mob/living/user,client/cli) // Returns true when the player isn't trying to fuckin scum the mood pref stuff to exploit
 	var/mob/living/carbon/human/U = user
-	U.mood_enabled = cli.prefs.read_preference(/datum/preference/toggle/mood_enabled) // Marks whether this player had moods enabled in preferences at the time of spawning (helps prevent exploitation)
-	
-	var/ismoody = (!CONFIG_GET(flag/disable_human_mood) || (cli.prefs.read_preference(/datum/preference/toggle/mood_enabled))) // If moods are globally enabled, or this guy does indeed have his mood pref set to Enabled
 	
 	var/points = 0;
 	var/good_quirks = 0;
@@ -10,10 +7,6 @@
 	for(var/V in cli.prefs.all_quirks)
 		var/datum/quirk/Q = quirks[V]
 		if(Q)
-			if(initial(Q.mood_quirk) && !ismoody)
-				to_chat(cli, span_danger("You cannot have the quirk '[V]' with mood disabled! You shall receive no quirks this round."))
-				message_admins("[key_name(cli)] just tried to exploit the mood pref system to get bonus points for their quirks.")
-				return FALSE
 			points += initial(Q.value)
 			if(initial(Q.value) > 0)
 				good_quirks += 1

--- a/yogstation/code/controllers/subsystem/processing/quirks.dm
+++ b/yogstation/code/controllers/subsystem/processing/quirks.dm
@@ -1,6 +1,5 @@
 /datum/controller/subsystem/processing/quirks/proc/checkquirks(mob/living/user,client/cli) // Returns true when the player isn't trying to fuckin scum the mood pref stuff to exploit
-	var/mob/living/carbon/human/U = user
-	
+
 	var/points = 0;
 	var/good_quirks = 0;
 

--- a/yogstation/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/human_defines.dm
@@ -1,3 +1,2 @@
 /mob/living/carbon/human
 	var/gender_ambiguous = 0 //if something goes wrong during gender reassignment this generates a line in examine
-	var/mood_enabled = FALSE // Marks whether this player had moods enabled in preferences at the time of spawning (helps prevent exploitation)


### PR DESCRIPTION
# Why is this good for the game
it adds a layer of mechanics that can be further developed and iterated upon
when it's disabled by everyone, there's no reason to make it better

:cl:  
rscdel: removes mood preference
/:cl:
