### PR TITLE
Remove clown from bureaucratic error and overflow bureacracy mistake

### DIFF
--- a/code/datums/station_traits/negative_traits.dm
+++ b/code/datums/station_traits/negative_traits.dm
@@ -40,7 +40,7 @@
 	trait_type = STATION_TRAIT_NEGATIVE
 	weight = 5
 	show_in_report = TRUE
-	var/list/jobs_to_use = list("Clown", "Bartender", "Cook", "Botanist", "Cargo Technician", "Mime", "Janitor")
+	var/list/jobs_to_use = list("Bartender", "Cook", "Botanist", "Cargo Technician", "Mime", "Janitor")
 	var/chosen_job
 
 /datum/station_trait/overflow_job_bureacracy/New()

--- a/code/modules/events/bureaucratic_error.dm
+++ b/code/modules/events/bureaucratic_error.dm
@@ -12,4 +12,4 @@
 	priority_announce("A recent bureaucratic error in the Organic Resources Department may result in personnel shortages in some departments and redundant staffing in others.", "Paperwork Mishap Alert")
 
 /datum/round_event/bureaucratic_error/start()
-	SSjob.set_overflow_role(pick(get_all_jobs()))
+	SSjob.set_overflow_role(pick(get_all_jobs() - "Clown"))


### PR DESCRIPTION
# Document the changes in your pull request
Now both the trait and the event will not make clowns overflow, this is good for the game because clown shittery is exponentially proportional to the number of clowns

# Changelog

:cl:  
rscdel: Removed the ability for clowns to be the overflow role
/:cl:
