### PR TITLE
Mood healing now based on satiety instead (-rng bonus)

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -63,10 +63,12 @@
 	name = get_visible_name()
 
 	if(stat != DEAD)// heal 0.2hp per second to organic limbs (they are self repairing by virtue of being organic)
-		if(prob(50))
+		if(prob(50) && bruteloss)//50/50 to heal brute or burn, but won't heal a damage type if you don't have it
 			heal_bodypart_damage(0.2, 0, 0, TRUE, BODYPART_ORGANIC)
-		else
+		else if(fireloss)
 			heal_bodypart_damage(0, 0.2, 0, TRUE, BODYPART_ORGANIC)
+		else
+			heal_bodypart_damage(0.2, 0, 0, TRUE, BODYPART_ORGANIC)
 		return 1
 
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -62,7 +62,7 @@
 	//Update our name based on whether our face is obscured/disfigured
 	name = get_visible_name()
 
-	if(stat != DEAD)// heal 0.2hp per second if you have 7 or more mood(I feel pretty good)
+	if(stat != DEAD)// heal 0.2hp per second to organic limbs (they are self repairing by virtue of being organic)
 		if(prob(50))
 			heal_bodypart_damage(0.2, 0, 0, TRUE, BODYPART_ORGANIC)
 		else

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -63,12 +63,13 @@
 	name = get_visible_name()
 
 	if(stat != DEAD)// heal 0.2hp per second to organic limbs (they are self repairing by virtue of being organic)
-		if(prob(50) && bruteloss)//50/50 to heal brute or burn, but won't heal a damage type if you don't have it
-			heal_bodypart_damage(0.2, 0, 0, TRUE, BODYPART_ORGANIC)
-		else if(fireloss)
-			heal_bodypart_damage(0, 0.2, 0, TRUE, BODYPART_ORGANIC)
-		else
-			heal_bodypart_damage(0.2, 0, 0, TRUE, BODYPART_ORGANIC)
+		if(HAS_TRAIT(src, TRAIT_NOHUNGER) || satiety > NUTRITION_LEVEL_FED)//either if they don't have hunger at all, or if they're fed enough
+			if(prob(50) && bruteloss)//50/50 to heal brute or burn, but won't heal a damage type if you don't have it
+				heal_bodypart_damage(0.2, 0, 0, TRUE, BODYPART_ORGANIC)
+			else if(fireloss)
+				heal_bodypart_damage(0, 0.2, 0, TRUE, BODYPART_ORGANIC)
+			else
+				heal_bodypart_damage(0.2, 0, 0, TRUE, BODYPART_ORGANIC)
 		return 1
 
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -63,7 +63,7 @@
 	name = get_visible_name()
 
 	if(stat != DEAD)// heal 0.2hp per second to organic limbs (they are self repairing by virtue of being organic)
-		if(HAS_TRAIT(src, TRAIT_NOHUNGER) || nutrition > NUTRITION_LEVEL_FED)//either if they don't have hunger at all, or if they're fed enough
+		if(HAS_TRAIT(src, TRAIT_NOHUNGER) || (nutrition > NUTRITION_LEVEL_FED && satiety > 80))//either if they don't have hunger at all, or if they're fed enough
 			if(prob(50) && bruteloss)//50/50 to heal brute or burn, but won't heal a damage type if you don't have it
 				heal_bodypart_damage(0.2, 0, 0, TRUE, BODYPART_ORGANIC)
 			else if(fireloss)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -63,7 +63,7 @@
 	name = get_visible_name()
 
 	if(stat != DEAD)// heal 0.2hp per second to organic limbs (they are self repairing by virtue of being organic)
-		if(HAS_TRAIT(src, TRAIT_NOHUNGER) || satiety > NUTRITION_LEVEL_FED)//either if they don't have hunger at all, or if they're fed enough
+		if(HAS_TRAIT(src, TRAIT_NOHUNGER) || nutrition > NUTRITION_LEVEL_FED)//either if they don't have hunger at all, or if they're fed enough
 			if(prob(50) && bruteloss)//50/50 to heal brute or burn, but won't heal a damage type if you don't have it
 				heal_bodypart_damage(0.2, 0, 0, TRUE, BODYPART_ORGANIC)
 			else if(fireloss)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -62,14 +62,11 @@
 	//Update our name based on whether our face is obscured/disfigured
 	name = get_visible_name()
 
-	if(stat != DEAD)
-		var/datum/component/mood/moody = GetComponent(/datum/component/mood)
-		if(moody && moody.mood_level >= 7) // heal 0.2hp per second if you have 7 or more mood(I feel pretty good)
-			if(prob(50))
-				if(prob(50))
-					heal_bodypart_damage(0.4, 0, 0, TRUE, BODYPART_ORGANIC)
-				else
-					heal_bodypart_damage(0, 0.4, 0, TRUE, BODYPART_ORGANIC)
+	if(stat != DEAD)// heal 0.2hp per second if you have 7 or more mood(I feel pretty good)
+		if(prob(50))
+			heal_bodypart_damage(0.2, 0, 0, TRUE, BODYPART_ORGANIC)
+		else
+			heal_bodypart_damage(0, 0.2, 0, TRUE, BODYPART_ORGANIC)
 		return 1
 
 


### PR DESCRIPTION
Mood shouldn't have bonuses tied solely to it
this also indirectly nerfs robotic limbs which have proven to be too strong

also, changes it to be a 100% chance per tick to heal rather than 50%, but cuts the healing in half

:cl:  
tweak: passive good mood organic limb healing now requires being full instead of mood
tweak: passive organic limb healing now has a 100% chance per tick, but heals half as much
/:cl:
