### PR TITLE
Makes the admin rad goat not crash the server with 9,000,000,000 rad goats

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -397,18 +397,19 @@
 		log_game("[key_name(S.key)] was made into a radioactive goat by radiation anomaly at [AREACOORD(T)].")
 
 /obj/effect/anomaly/radiation/detonate()
-	if(spawn_goat)//only spawn the goat once, when the anomaly explodes
-		INVOKE_ASYNC(src, PROC_REF(makegoat))
 	INVOKE_ASYNC(src, PROC_REF(rad_Spin))
-	QDEL_IN(src, 1)
 
-/obj/effect/anomaly/radiation/proc/rad_Spin()
+/obj/effect/anomaly/radiation/proc/rad_Spin(increment = 1)
+	if(increment > 100)
+		if(spawn_goat)//only spawn the goat once, when the anomaly explodes
+			INVOKE_ASYNC(src, PROC_REF(makegoat))
+		qdel(src)
 	radiation_pulse(src, 5000, 7)
 	var/turf/T = get_turf(src)
-	for(var/i=1 to 100)
-		var/angle = i * 10
-		T.fire_nuclear_particle(angle)
-		sleep(0.7)
+	var/angle = increment * 10
+	T.fire_nuclear_particle(angle)
+	addtimer(CALLBACK(src, PROC_REF(rad_Spin), increment + 1), 0.7)
+		
 
 /obj/effect/anomaly/radiation/process(delta_time)
 	anomalyEffect(delta_time)

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -400,6 +400,7 @@
 	if(spawn_goat)//only spawn the goat once, when the anomaly explodes
 		INVOKE_ASYNC(src, PROC_REF(makegoat))
 	INVOKE_ASYNC(src, PROC_REF(rad_Spin))
+	QDEL_IN(src, 1)
 
 /obj/effect/anomaly/radiation/proc/rad_Spin()
 	radiation_pulse(src, 5000, 7)
@@ -414,6 +415,5 @@
 	if(death_time < world.time)
 		if(loc)
 			detonate()
-			addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(qdel), src), 150)
 
 #undef ANOMALY_MOVECHANCE

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -397,6 +397,8 @@
 		log_game("[key_name(S.key)] was made into a radioactive goat by radiation anomaly at [AREACOORD(T)].")
 
 /obj/effect/anomaly/radiation/detonate()
+	if(spawn_goat)//only spawn the goat once, when the anomaly explodes
+		INVOKE_ASYNC(src, PROC_REF(makegoat))
 	INVOKE_ASYNC(src, PROC_REF(rad_Spin))
 
 /obj/effect/anomaly/radiation/proc/rad_Spin()
@@ -411,8 +413,6 @@
 	anomalyEffect(delta_time)
 	if(death_time < world.time)
 		if(loc)
-			if(spawn_goat)
-				INVOKE_ASYNC(src, PROC_REF(makegoat))
 			detonate()
 			addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(qdel), src), 150)
 

--- a/code/modules/spells/spell_types/conjure/rad_goat.dm
+++ b/code/modules/spells/spell_types/conjure/rad_goat.dm
@@ -6,7 +6,7 @@
 	sound = 'sound/weapons/resonator_fire.ogg'
 
 	school = SCHOOL_CONJURATION
-	cooldown_time = 1 MINUTE //it lasts 90 seconds
+	cooldown_time = 1 MINUTES //it lasts 90 seconds
 
 	invocation_type = INVOCATION_SHOUT
 	invocation = "UNGA"

--- a/code/modules/spells/spell_types/conjure/rad_goat.dm
+++ b/code/modules/spells/spell_types/conjure/rad_goat.dm
@@ -1,12 +1,12 @@
 /datum/action/cooldown/spell/conjure/radiation_anomaly
 	name = "Spawn Radiation Anomaly"
-	desc = "Spawn a radiation anomaly, summon your brothers!"
+	desc = "Spawn a radiation anomaly!"
 	button_icon = 'icons/obj/projectiles.dmi'
 	button_icon_state = "radiation_anomaly"
 	sound = 'sound/weapons/resonator_fire.ogg'
 
 	school = SCHOOL_CONJURATION
-	cooldown_time = 10 SECONDS
+	cooldown_time = 1 MINUTE //it lasts 90 seconds
 
 	invocation_type = INVOCATION_SHOUT
 	invocation = "UNGA"
@@ -19,6 +19,5 @@
 	if(!istype(summoned_object, /obj/effect/anomaly/radiation))
 		return
 	var/obj/effect/anomaly/radiation/anomaly = summoned_object
-	anomaly.spawn_goat = TRUE
 	owner.visible_message(span_notice("You see the radiation anomaly emerges from the [owner]."), span_notice("The radiation anomaly emerges from your body."))
 	notify_ghosts("The Radioactive Goat has spawned a radiation anomaly!", source = anomaly, action = NOTIFY_ORBIT, flashwindow = FALSE, header = "Radiation Anomaly Spawned!")


### PR DESCRIPTION
An admin rad goat can spawn anomalies that spawn an additional rad goat every single TICK, this ability has a 10 second cooldown
those goats spawned by the anomaly also can spawn their own anomalies that spawn goats

you can see how that might get out of hand quickly

:cl:  
tweak: Rad goats can no longer crash the server using unlimited goat works
/:cl:
