### PR TITLE
Fixes runtime in gender preferences I think

### DIFF
--- a/code/modules/client/preferences/gender.dm
+++ b/code/modules/client/preferences/gender.dm
@@ -11,14 +11,14 @@
 
 	var/datum/species/species_type = preferences.read_preference(/datum/preference/choiced/species)
 	
-	if(!species_type.sexes || (AGENDER in initial(species_type.species_traits)))
-		return list(PLURAL)
+	if(!initial(species_type.sexes) || (AGENDER in initial(species_type.species_traits)))
+		return PLURAL
 	else if(FGENDER in initial(species_type.species_traits))
-		return list(FEMALE)
+		return FEMALE
 	else if(MGENDER in initial(species_type.species_traits))
-		return list(MALE)
+		return MALE
 
-	return list(MALE, FEMALE, PLURAL)
+	return pick(list(MALE, FEMALE, PLURAL))
 
 /datum/preference/choiced/gender/apply_to_human(mob/living/carbon/human/target, value)
 	var/datum/species/S = target.dna.species


### PR DESCRIPTION
# Document the changes in your pull request

Pretty sure the initial is required to read from a typepath, and `create_informed_default_value` expects a single value, not a list

# Changelog

:cl:  
bugfix: fixed a couple errors with the gender selector
/:cl:
