### PR TITLE
Fixes runtime when the infiltrator checks if it can spawn too early

### DIFF
--- a/yogstation/code/modules/events/infiltrators.dm
+++ b/yogstation/code/modules/events/infiltrators.dm
@@ -12,6 +12,8 @@
 
 /datum/round_event_control/infiltrators/canSpawnEvent(players_amt, gamemode)
 	. = ..()
+	if(!.)
+		return .
 	if(SSshuttle.emergency.mode != SHUTTLE_RECALL && SSshuttle.emergency.mode != SHUTTLE_IDLE) // Don't send infiltrators if the shuttle is coming!
 		return FALSE
 	var/datum/station_state/current_state = new /datum/station_state()


### PR DESCRIPTION
# Document the changes in your pull request

`GLOB.start_state` might not have been initialized by the time an event attempts to spawn

# Changelog


:cl:  
bugfix: fixed a runtime when checking if infiltrators can spawn too early in the round
/:cl:
