### PR TITLE
Fixes runtime in engineering payouts

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -149,7 +149,9 @@ SUBSYSTEM_DEF(economy)
 /datum/controller/subsystem/economy/proc/eng_payout()
 	var/engineering_cash = 3000
 	engineering_check.count()
-	var/station_integrity = min(PERCENT(GLOB.start_state.score(engineering_check)), 100)
+	var/station_integrity = 100
+	if(GLOB.start_state)
+		station_integrity = min(PERCENT(GLOB.start_state.score(engineering_check)), 100)
 	station_integrity *= 0.01
 	engineering_cash *= station_integrity
 	if(moneysink)


### PR DESCRIPTION
# Document the changes in your pull request

Engineering payouts can happen before the integrity of the station has been established. This just assumes its at full

# Changelog

:cl:  
bugfix: fixed engineering payouts erroring at the start of the round
/:cl:
