### PR TITLE
Undoes an unintentional nerf to ethereal brute mod

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -10,7 +10,7 @@
 	mutantstomach = /obj/item/organ/stomach/ethereal
 	exotic_blood = /datum/reagent/consumable/liquidelectricity //Liquid Electricity. fuck you think of something better gamer
 	siemens_coeff = 0.5 //They thrive on energy
-	brutemod = 1.5 //Don't rupture their membranes
+	brutemod = 1.25 //Don't rupture their membranes
 	burnmod = 0.8 //Bodies are resilient to heat and energy
 	heatmod = 0.5 //Bodies are resilient to heat and energy
 	coldmod = 2.0 //Don't extinguish the stars


### PR DESCRIPTION
When removing the variable brute mod from ethereals in #19698 it made their default brute mod 1.5 rather than 1.25 as their spec_life was setting it to 1.25 while the initial value is 1.5

This reverts that unintended nerf

:cl:  
bugfix: Fixes ethereal brute mod being 1.5 rather than 1.25 like intended
/:cl:
