### PR TITLE
Anticitizen

### DIFF
--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -39,6 +39,7 @@
 		"Copy" = 'sound/voice/cpvoicelines/copy.ogg',
 		"Alright, you can go" = 'sound/voice/cpvoicelines/allrightyoucango.ogg',
 		"Backup" = 'sound/voice/cpvoicelines/backup.ogg',
+		"Anticitizen" = 'sound/voice/cpvoicelines/anticitizen.ogg',
 		"Citizen" = 'sound/voice/cpvoicelines/citizen.ogg',
 		"Get down" = 'sound/voice/cpvoicelines/getdown.ogg',
 		"Get out of here" = 'sound/voice/cpvoicelines/getoutofhere.ogg',
@@ -66,7 +67,6 @@
 		"First warning, move away" = 'sound/voice/cpvoicelines/firstwarningmove.ogg',
 		"Sentence delivered" = 'sound/voice/cpvoicelines/sentencedelivered.ogg',
 		"Issuing malcompliant citation" = 'sound/voice/cpvoicelines/issuingmalcompliantcitation.ogg',
-		"Anticitizen" = 'sound/voice/cpvoicelines/anticitizen.ogg',
 		"Apply" = 'sound/voice/cpvoicelines/apply.ogg',
 		"Hehe" = 'sound/voice/cpvoicelines/chuckle.ogg',
 	)

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -47,7 +47,7 @@
 		"Help" = 'sound/voice/cpvoicelines/help.ogg',
 		"Hold it" = 'sound/voice/cpvoicelines/holdit.ogg',
 		"In position" = 'sound/voice/cpvoicelines/inposition.ogg',
-		"I said move along" = 'sound/voice/cpvoicelines/isaidmovealong.ogg',
+		"I said move along" = 'sound/voice/cpvoicelines/isaidmovealong.ogg'
 		"Keep moving" = 'sound/voice/cpvoicelines/keepmoving.ogg',
 		"Lookout" = 'sound/voice/cpvoicelines/Lookout.ogg',
 		"Move along" = 'sound/voice/cpvoicelines/movealong.ogg',

--- a/code/modules/clothing/masks/hailer.dm
+++ b/code/modules/clothing/masks/hailer.dm
@@ -47,7 +47,7 @@
 		"Help" = 'sound/voice/cpvoicelines/help.ogg',
 		"Hold it" = 'sound/voice/cpvoicelines/holdit.ogg',
 		"In position" = 'sound/voice/cpvoicelines/inposition.ogg',
-		"I said move along" = 'sound/voice/cpvoicelines/isaidmovealong.ogg'
+		"I said move along" = 'sound/voice/cpvoicelines/isaidmovealong.ogg',
 		"Keep moving" = 'sound/voice/cpvoicelines/keepmoving.ogg',
 		"Lookout" = 'sound/voice/cpvoicelines/Lookout.ogg',
 		"Move along" = 'sound/voice/cpvoicelines/movealong.ogg',


### PR DESCRIPTION
fix anticitizen line in sechailer speaking citizen instead

the list used the citizen line first making anticitizen line doesnt work so i move it above

# Document the changes in your pull request
Anticitizen line now work in sechailer



# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

bugfix: Anticitizen line now work in sechailer
/:cl:
