### PR TITLE
MMI Laws Now Properly Transfer When Becoming a Cyborg

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -295,17 +295,16 @@
 				return
 			if(user.mind.assigned_role == "Roboticist") // RD gets nothing
 				SSachievements.unlock_achievement(/datum/achievement/roboborg, user.client)
-
-			if(M.laws && M.laws.id != DEFAULT_AI_LAWID && M.override_cyborg_laws)
+			
+			if(M.disabled_linksync)
 				aisync = FALSE
 				lawsync = FALSE
-				O.laws = M.laws
-				M.laws.associate(O)
 
 			O.invisibility = 0
-			//Transfer debug settings to new mob
+			// Transferring debug settings to new mob:
 			O.custom_name = created_name
 			O.locked = panel_locked
+
 			if(!aisync)
 				lawsync = FALSE
 				O.set_connected_ai(null)
@@ -313,11 +312,18 @@
 				O.notify_ai(NEW_BORG)
 				if(forced_ai)
 					O.set_connected_ai(forced_ai)
+
 			if(!lawsync)
 				O.lawupdate = 0
-				if(M.laws.id == DEFAULT_AI_LAWID)
-					O.make_laws()
-					to_chat(user,span_warning("Any laws uploaded to this MMI have not been transferred!"))
+
+			if(M.overrides_cyborg_laws && M.laws && !(O.connected_ai && O.lawupdate))
+				O.laws = M.laws
+				M.laws.associate(O)
+
+			// In case there is no law datum:
+			if(!O.laws)
+				O.make_laws()
+				to_chat(user, span_warning("The MMI flashes in alarm and exclaims: \"Safety enabled! Randomized safe lawset generated!\""))
 
 			SSticker.mode.remove_antag_for_borging(BM.mind)
 			if(!istype(M.laws, /datum/ai_laws/ratvar))

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -295,7 +295,7 @@
 				return
 			if(user.mind.assigned_role == "Roboticist") // RD gets nothing
 				SSachievements.unlock_achievement(/datum/achievement/roboborg, user.client)
-			
+
 			if(M.disabled_linksync)
 				aisync = FALSE
 				lawsync = FALSE

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -312,14 +312,11 @@
 				O.notify_ai(NEW_BORG)
 				if(forced_ai)
 					O.set_connected_ai(forced_ai)
-
 			if(!lawsync)
 				O.lawupdate = 0
-
 			if(M.overrides_cyborg_laws && M.laws && !(O.connected_ai && O.lawupdate))
 				O.laws = M.laws
 				M.laws.associate(O)
-
 			// In case there is no law datum:
 			if(!O.laws)
 				O.make_laws()

--- a/code/modules/antagonists/clockcult/clock_items/soul_vessel.dm
+++ b/code/modules/antagonists/clockcult/clock_items/soul_vessel.dm
@@ -23,7 +23,7 @@
 	autoping = FALSE
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	force_replace_ai_name = TRUE
-	override_cyborg_laws = TRUE
+	disabled_linksync = TRUE
 	can_update_laws = TRUE
 
 /obj/item/mmi/posibrain/soul_vessel/Initialize(mapload)

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -12,18 +12,29 @@
 	var/obj/mecha = null //This does not appear to be used outside of reference in mecha.dm.
 	var/obj/item/organ/brain/brain = null //The actual brain
 	var/datum/ai_laws/laws = new()
+	/// If they become an AI, should their name be replaced with the brainmob's `name`?
 	var/force_replace_ai_name = FALSE
-	var/overrides_aicore_laws = TRUE // Whether the laws on the MMI are transferred when it's uploaded as an AI
-	var/override_cyborg_laws = FALSE // Do custom laws uploaded to the MMI get transferred to borgs? If yes the borg will be unlinked and have lawsync disabled.
-	var/can_update_laws = TRUE //Can we use a lawboard to change the laws of this MMI?
-	var/remove_time = 2 SECONDS /// The time to remove the brain or reset the posi brain
+	/// Whether the laws on the MMI are to be transferred when it is uploaded as an AI.
+	var/overrides_aicore_laws = TRUE
+	/// Whether the laws on the MMI are to be transferred when it is inserted into a cyborg.
+	var/overrides_cyborg_laws = TRUE
+	/// If they become a cyborg, should they automatically be unlinked (from any AIs) and lawsync disabled?
+	var/disabled_linksync = FALSE
+	/// Can law modules be used to change the laws of this MMI?
+	var/can_update_laws = TRUE
+	/// How long does it take in seconds to remove the brain / reset the posi-brain?
+	var/remove_time = 2 SECONDS
+	/// Whether the MMI is rebooting after being deconstructed (from a cyborg).
 	var/rebooting = FALSE /// If the MMI is rebooting after being deconstructed
-	var/remove_window = 10 SECONDS /// The window in which someone has to remove the brain to lose memory of being killed as a borg
+	/// How many seconds it takes to fully reboot? If brain is removed during this time, the brain will suffer from memory loss (which also includes their death).
+	var/remove_window = 10 SECONDS
+	/// Reference for timer.
 	var/reboot_timer = null
 	/// Is this a syndicate MMI?
 	var/syndicate_mmi = FALSE
 	/// The human that the enslaved the MMI.
 	var/mob/living/carbon/human/syndicate_master = null
+	/// The welcome message displayed to the brain when they're inserted into the MMI.
 	var/welcome_message = "<b>You are a brain within a Man-Machine Interface.\n\
 	Unless you are slaved as a silicon, you retain crew/antagonist/etc status and should behave as such.\n\
 	Being placed in a mech does not slave you to any laws.</b>"

--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -25,7 +25,7 @@
 	/// How long does it take in seconds to remove the brain / reset the posi-brain?
 	var/remove_time = 2 SECONDS
 	/// Whether the MMI is rebooting after being deconstructed (from a cyborg).
-	var/rebooting = FALSE /// If the MMI is rebooting after being deconstructed
+	var/rebooting = FALSE
 	/// How many seconds it takes to fully reboot? If brain is removed during this time, the brain will suffer from memory loss (which also includes their death).
 	var/remove_window = 10 SECONDS
 	/// Reference for timer.


### PR DESCRIPTION
# Document the changes in your pull request
MMIs can now properly inherit their laws when being transferred into a cyborg.
Autodocs some variables related to MMIs.

# Changelog
:cl:  
bugfix: MMI laws now properly transfer when becoming a cyborg.
/:cl:
