### PR TITLE
[BOX, META, GAX, ASTEROID] Nukes under window firelocks across all maps, as god intended.

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -162,23 +162,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"abH" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Chemistry Desk";
-	req_access_txt = "33"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "chemistry_shutters";
-	name = "Chemistry shutters"
-	},
-/turf/open/floor/plating,
-/area/medical/chemistry)
 "abK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -764,6 +747,9 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"agA" = (
+/turf/open/floor/plating,
+/area/medical/storage/backroom)
 "agB" = (
 /turf/closed/wall,
 /area/medical/genetics/cloning)
@@ -1324,6 +1310,20 @@
 "alJ" = (
 /turf/closed/wall,
 /area/medical/medbay/aft)
+"alK" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "alL" = (
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_a)
@@ -1682,15 +1682,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos/pumproom)
-"aoz" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/curtain,
-/turf/open/floor/plating,
-/area/medical/storage/backroom)
 "aoA" = (
 /obj/structure/window{
 	dir = 8
@@ -1870,6 +1861,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"aqw" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/crew_quarters/fitness)
 "aqx" = (
 /obj/structure/sign/warning/pods,
 /turf/closed/wall/r_wall,
@@ -2937,20 +2932,6 @@
 /obj/effect/landmark/start/scientist,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"azU" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "chemistry_shutters";
-	name = "Chemistry shutters"
-	},
-/turf/open/floor/plating,
-/area/security/checkpoint/medical)
 "azV" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -3621,6 +3602,16 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
+"aEy" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ai_monitored/security/armory)
 "aEA" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable{
@@ -3659,6 +3650,13 @@
 "aEU" = (
 /turf/open/floor/grass,
 /area/maintenance/port/fore)
+"aEW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/warden)
 "aEX" = (
 /obj/machinery/light{
 	dir = 8
@@ -5577,14 +5575,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_a)
-"aXL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/medical/storage)
 "aXP" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -6977,16 +6967,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"btB" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/genetics/cloning)
 "btU" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line{
@@ -7695,6 +7675,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"bHt" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "chemistry_shutters";
+	name = "Chemistry shutters"
+	},
+/turf/open/floor/plating,
+/area/security/checkpoint/medical)
 "bIa" = (
 /obj/effect/turf_decal/sand,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -7833,6 +7821,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/mechbay)
+"bJC" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "bJD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -8636,24 +8631,6 @@
 /obj/item/shard,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"bYU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "bZf" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plasteel/dark,
@@ -9026,6 +9003,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"cdv" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "cdH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -9121,6 +9108,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"cff" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/main)
 "cfj" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 4
@@ -10165,6 +10156,12 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"cuo" = (
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "cut" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -12011,6 +12008,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cYU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/security/armory)
 "cZd" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -12384,16 +12391,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
-"deB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "deC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -12416,6 +12413,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"dfd" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "dft" = (
 /obj/structure/displaycase/labcage,
 /obj/effect/turf_decal/stripes/line{
@@ -13334,24 +13338,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"dwB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "dwW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -13387,6 +13373,10 @@
 /obj/machinery/atmospherics/miner/n2o,
 /turf/open/floor/engine/n2o,
 /area/engine/atmos/distro)
+"dxr" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/medical/genetics)
 "dxv" = (
 /obj/structure/table/wood,
 /obj/item/clothing/ears/headphones{
@@ -14538,6 +14528,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"dQg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "surgery_shutters";
+	name = "Surgery Shutters"
+	},
+/turf/open/floor/plating,
+/area/medical/surgery)
 "dQp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15774,20 +15772,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"eiP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/storage/eva)
 "eiS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -17498,20 +17482,6 @@
 /mob/living/simple_animal/cow/betsy,
 /turf/open/floor/grass,
 /area/maintenance/starboard/aft)
-"eID" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "psych";
-	name = "psychiatrist shutters"
-	},
-/turf/open/floor/plating,
-/area/medical/psych)
 "eIE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -17883,6 +17853,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"eOr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "eOB" = (
 /obj/machinery/light{
 	dir = 1
@@ -18348,24 +18328,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"eTQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "eUd" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
@@ -19092,6 +19054,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/server)
+"ffH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/security/warden)
 "ffP" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
@@ -19176,6 +19151,10 @@
 /obj/machinery/computer/slot_machine,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"fgU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ai_monitored/storage/eva)
 "fgW" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/item/storage/lockbox/vialbox/blood,
@@ -19468,6 +19447,16 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"fle" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/storage/eva)
 "fln" = (
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/plasteel,
@@ -19503,20 +19492,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"fmr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/security/armory)
 "fmw" = (
 /obj/machinery/light{
 	dir = 8
@@ -19680,20 +19655,6 @@
 "fpN" = (
 /turf/closed/wall/r_wall,
 /area/engine/atmos/pumproom)
-"fqa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/security/armory)
 "fqd" = (
 /obj/structure/sign/map/right{
 	pixel_y = -32
@@ -20321,26 +20282,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"fCK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "fCN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -21413,21 +21354,6 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
-"fTX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "fUb" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Vacant Office A";
@@ -25309,27 +25235,17 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
-"hhM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "hhU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
 /turf/open/floor/plasteel/white,
 /area/science/nanite)
+"hhX" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced/tinted/shutter,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/ai_upload)
 "hig" = (
 /obj/effect/turf_decal/sand,
 /mob/living/carbon/monkey/punpun,
@@ -26049,17 +25965,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"htb" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop_ext"
-	},
-/turf/open/floor/plating,
-/area/clerk)
 "htl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -26465,16 +26370,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"hAb" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/lobby)
 "hAe" = (
 /obj/machinery/modular_computer/console/preset/command/rd{
 	dir = 1
@@ -27653,22 +27548,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_b)
-"hSC" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/storage/eva)
 "hSJ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/delivery,
@@ -27705,20 +27584,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/wood,
 /area/maintenance/starboard/fore)
-"hTD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/warden)
 "hTE" = (
 /obj/structure/table/wood,
 /turf/open/floor/grass,
@@ -27859,6 +27724,18 @@
 "hWr" = (
 /turf/open/floor/plating/ice,
 /area/space/nearstation)
+"hWt" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/brig)
 "hWI" = (
 /obj/effect/spawner/lootdrop/trashbin,
 /turf/open/floor/white{
@@ -28128,6 +28005,14 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
+"ibL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ai_monitored/storage/eva)
 "ibT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -28480,16 +28365,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"ihQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/central)
 "iia" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes,
@@ -29143,14 +29018,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"isf" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/medical/genetics)
 "iss" = (
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/tcoms)
@@ -30193,20 +30060,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"iKC" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "iKH" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Escape Podbay"
@@ -30233,18 +30086,6 @@
 	},
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/aisat_interior)
-"iLo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "surgery_shutters";
-	name = "Surgery Shutters"
-	},
-/turf/open/floor/plating,
-/area/medical/surgery)
 "iLz" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
@@ -30519,18 +30360,6 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
-"iPU" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/preopen{
-	id = "chemistry_shutters";
-	name = "Chemistry shutters"
-	},
-/turf/open/floor/plating,
-/area/medical/chemistry)
 "iQl" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -31692,6 +31521,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"jfT" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "jfV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -32954,6 +32797,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"jzS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/brig)
 "jzW" = (
 /obj/machinery/light{
 	dir = 8
@@ -34584,6 +34441,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"kar" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rnd";
+	name = "research lab shutters"
+	},
+/turf/open/floor/plating,
+/area/science/lab)
 "kaD" = (
 /obj/structure/chair/comfy/brown{
 	dir = 1
@@ -35390,6 +35255,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"koO" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "kpf" = (
 /obj/machinery/computer/cargo{
 	dir = 1
@@ -36286,16 +36161,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"kEy" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/sleeper)
 "kEU" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/laserproof,
@@ -37094,6 +36959,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"kTV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "kUc" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /turf/open/floor/plasteel,
@@ -37887,18 +37761,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"ljd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rnd";
-	name = "research lab shutters"
-	},
-/turf/open/floor/plating,
-/area/science/lab)
 "ljk" = (
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel/dark,
@@ -38021,6 +37883,16 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"lly" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "llL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -39326,19 +39198,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"lLw" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
 "lLR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -40466,6 +40325,22 @@
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"maZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/storage/eva)
 "mbj" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -40496,6 +40371,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"mca" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/genetics/cloning)
 "mcg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -40763,21 +40642,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"mfI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "mfW" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/eighties,
@@ -40963,6 +40827,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
+"miU" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/curtain,
+/turf/open/floor/plating,
+/area/medical/storage/backroom)
 "miV" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -41421,6 +41290,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
+"mpq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/storage)
 "mpv" = (
 /obj/machinery/telecomms/server/presets/command,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -41993,22 +41866,21 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"mzu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-4"
+"mzr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8
 	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	dir = 1;
+	freq = 1400;
+	location = "Engineering"
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
+/obj/structure/plasticflaps{
+	opacity = 1
 	},
 /turf/open/floor/plating,
-/area/security/brig)
+/area/engine/engineering)
 "mzv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -42368,6 +42240,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"mFb" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "mFe" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -42597,21 +42480,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"mIn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "mIz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -43367,14 +43235,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"mTb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/ai_monitored/storage/eva)
 "mTu" = (
 /obj/machinery/computer/bounty{
 	dir = 1
@@ -43409,6 +43269,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"mTH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ai_monitored/storage/eva)
 "mTK" = (
 /obj/machinery/computer/med_data,
 /turf/open/floor/plasteel/grimy,
@@ -44350,14 +44218,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"nhn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/courtroom)
 "nhQ" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
@@ -44730,17 +44590,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"nlX" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "nma" = (
 /obj/machinery/door/airlock/security{
 	name = "Interrogation";
@@ -45087,16 +44936,6 @@
 /obj/effect/decal/remains/human,
 /turf/open/floor/plating/asteroid,
 /area/space/nearstation)
-"nte" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/medical/medbay/central)
 "ntf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -46558,20 +46397,6 @@
 /obj/item/clothing/shoes/sandal,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"nSo" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ai_monitored/security/armory)
 "nSp" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -46919,14 +46744,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"nWw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/sleeper)
 "nWx" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -47021,20 +46838,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"nYG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "nYQ" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -48655,6 +48458,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"oBj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable,
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "oBn" = (
 /obj/structure/closet/l3closet,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
@@ -48844,6 +48659,14 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/space/has_grav/listeningstation)
+"oEc" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rnd";
+	name = "research lab shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/science/lab)
 "oEg" = (
 /obj/structure/table/glass,
 /obj/item/flashlight/lamp{
@@ -49915,22 +49738,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"oTM" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
 "oTN" = (
 /obj/machinery/light,
 /turf/open/floor/carpet/black,
@@ -50091,6 +49898,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"oXj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/storage/eva)
 "oXo" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -50102,6 +49916,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
+"oXy" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/courtroom)
 "oXC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -50259,6 +50077,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"oZS" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "chemistry_shutters";
+	name = "Chemistry shutters"
+	},
+/turf/open/floor/plating,
+/area/medical/chemistry)
 "pam" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -50455,31 +50281,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/aft)
-"pcX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
 "pcZ" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot_red,
@@ -50947,16 +50748,6 @@
 /mob/living/simple_animal/sheep,
 /turf/open/floor/grass,
 /area/maintenance/starboard/fore)
-"pkM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/courtroom)
 "pkP" = (
 /obj/machinery/light{
 	dir = 1
@@ -51190,17 +50981,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"pnI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/ai_monitored/storage/eva)
 "pnO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -51759,14 +51539,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"pvG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/virology)
 "pvM" = (
 /obj/machinery/light{
 	dir = 1
@@ -52050,16 +51822,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"pzv" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "pzB" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 1;
@@ -52131,6 +51893,25 @@
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
+"pAZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "pBd" = (
 /obj/effect/turf_decal/trimline/white/corner{
 	dir = 4
@@ -52581,35 +52362,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"pJz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/brig)
 "pJB" = (
 /turf/open/floor/plating/asteroid/snow,
 /area/space/nearstation)
-"pJJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/cmo)
 "pJO" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -53177,14 +52932,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
-"pTs" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/checkpoint/auxiliary)
 "pTu" = (
 /obj/structure/sign/poster/contraband/random,
 /turf/closed/wall/r_wall,
@@ -53729,6 +53476,16 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
+"pZW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/ai_monitored/security/armory)
 "pZY" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
@@ -53987,21 +53744,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"qeK" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/brig)
 "qeX" = (
 /obj/structure/girder,
 /obj/machinery/door/firedoor/border_only{
@@ -54419,6 +54161,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing/chamber)
+"qmx" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/checkpoint/auxiliary)
 "qmB" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -54522,6 +54268,10 @@
 /obj/structure/chair/stool,
 /turf/open/floor/mineral/titanium,
 /area/teleporter)
+"qol" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/cmo)
 "qop" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -54713,14 +54463,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
-"qrD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/medical/medbay/aft)
 "qrG" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 8
@@ -54756,17 +54498,6 @@
 /obj/item/camera_film,
 /turf/open/floor/wood,
 /area/vacant_room)
-"qrY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/warden)
 "qsa" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/cable/yellow{
@@ -56609,14 +56340,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"qYL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
 "qYO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56660,16 +56383,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"raa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/quartermaster/miningdock)
 "rav" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56844,16 +56557,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"rcH" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/courtroom)
 "rcL" = (
 /obj/machinery/camera{
 	c_tag = "Chapel East";
@@ -56990,6 +56693,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
+"rej" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "psych";
+	name = "psychiatrist shutters"
+	},
+/turf/open/floor/plating,
+/area/medical/psych)
 "reo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -57477,27 +57188,6 @@
 /obj/structure/displaycase/cmo,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/cmo)
-"rkJ" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 1;
-	freq = 1400;
-	location = "Engineering"
-	},
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "rkL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59239,6 +58929,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"rMv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "rMw" = (
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/plating,
@@ -59341,6 +59045,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"rOq" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Chemistry Desk";
+	req_access_txt = "33"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "chemistry_shutters";
+	name = "Chemistry shutters"
+	},
+/turf/open/floor/plating,
+/area/medical/chemistry)
 "rOt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -59686,22 +59403,6 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"rSW" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig)
 "rTe" = (
 /obj/machinery/camera{
 	c_tag = "Brig Entrance";
@@ -60471,14 +60172,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"scr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/security/checkpoint/medical)
 "scs" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Two"
@@ -60943,6 +60636,15 @@
 	},
 /turf/open/floor/plating/asteroid,
 /area/ruin/powered)
+"slo" = (
+/obj/machinery/door/window/southleft{
+	req_access_txt = "36"
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "giftshop"
+	},
+/turf/open/floor/plating,
+/area/clerk)
 "slv" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -62269,6 +61971,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"sFJ" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop_ext"
+	},
+/turf/open/floor/plating,
+/area/clerk)
 "sFQ" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 4
@@ -62418,20 +62127,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"sHW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "chemistry_shutters";
-	name = "Chemistry shutters"
-	},
-/turf/open/floor/plating,
-/area/medical/chemistry)
 "sIe" = (
 /obj/item/coin/antagtoken,
 /obj/structure/table/wood,
@@ -63375,6 +63070,16 @@
 	dir = 1
 	},
 /area/crew_quarters/heads/chief)
+"sVY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/security/warden)
 "sWf" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -64095,6 +63800,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"thC" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/sleeper)
 "thE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -65054,14 +64763,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
-"txy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/medical/sleeper)
 "txF" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -65973,6 +65674,24 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"tNw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
+"tNA" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/medbay/central)
 "tNJ" = (
 /obj/item/kirbyplants/random,
 /obj/structure/extinguisher_cabinet{
@@ -67890,6 +67609,10 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"uqD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/genetics)
 "uqF" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/dark,
@@ -68273,15 +67996,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"uyJ" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/spawner/structure/window/reinforced/tinted/shutter,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/ai_upload)
 "uyQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -69201,14 +68915,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"uPA" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/fitness)
 "uPI" = (
 /obj/machinery/light{
 	dir = 4
@@ -69457,22 +69163,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/locker)
-"uVq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
 "uVV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -71255,19 +70945,6 @@
 /obj/item/taperecorder,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
-"vyZ" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/window/southleft{
-	req_access_txt = "36"
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "giftshop"
-	},
-/turf/open/floor/plating,
-/area/clerk)
 "vzg" = (
 /obj/item/flashlight/lantern/jade{
 	on = 1
@@ -71917,26 +71594,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"vMO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/ai_monitored/storage/eva)
 "vMP" = (
 /obj/item/reagent_containers/food/snacks/store/cheesewheel/parmesan,
 /obj/item/reagent_containers/food/snacks/store/cheesewheel/parmesan,
@@ -72287,6 +71944,10 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/janitor)
+"vSE" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/security/courtroom)
 "vSQ" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
@@ -73885,23 +73546,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"wrB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/warden)
 "wrE" = (
 /obj/machinery/light{
 	dir = 1
@@ -74862,6 +74506,17 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wDL" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/brig)
 "wDO" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -75498,14 +75153,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"wNB" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/genetics)
 "wNI" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/toilet/locker";
@@ -76337,14 +75984,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"wZi" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/main)
 "wZx" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
@@ -78042,17 +77681,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"xEK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/storage/eva)
 "xFq" = (
 /obj/machinery/light{
 	dir = 1
@@ -78151,6 +77779,10 @@
 /obj/item/pen/blue,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/cmo)
+"xHl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/medbay/aft)
 "xHE" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -78257,6 +77889,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
+"xIM" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "xIS" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4
@@ -78615,6 +78258,10 @@
 /obj/item/shard,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
+"xNG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/quartermaster/miningdock)
 "xNI" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -89459,9 +89106,9 @@ aao
 lkU
 aao
 aID
-deB
-deB
-deB
+hkh
+hkh
+hkh
 aID
 aID
 wEd
@@ -90234,7 +89881,7 @@ aUZ
 gic
 sVi
 iPy
-pTs
+qmx
 ygW
 jJX
 xRH
@@ -90748,7 +90395,7 @@ fgA
 oiu
 qfK
 cdp
-pTs
+qmx
 ygW
 jJX
 evL
@@ -97437,12 +97084,12 @@ fUF
 igy
 lXY
 ajM
-lLw
-lLw
-lLw
-lLw
-lLw
-oTM
+bJC
+bJC
+bJC
+bJC
+bJC
+cdv
 ajM
 aJI
 aJI
@@ -99546,7 +99193,7 @@ vjp
 evG
 vWi
 nwY
-qYL
+xNG
 gCC
 kLP
 pIb
@@ -99796,14 +99443,14 @@ viT
 asJ
 uHB
 aaQ
-raa
+xNG
 rdJ
 aaQ
 axn
 qLZ
 apr
 xIo
-qYL
+xNG
 iqF
 qqZ
 pIb
@@ -100317,7 +99964,7 @@ lkE
 wou
 axn
 mYf
-qYL
+xNG
 acr
 pZQ
 pIb
@@ -105446,20 +105093,20 @@ bhQ
 rtZ
 bpM
 mJK
-hAb
-hAb
+pBO
+pBO
 bpM
 fAb
 rtZ
-nte
-ihQ
+tNA
+tNA
 gSo
 aNb
 aNb
 aNb
-kEy
-kEy
-kEy
+thC
+thC
+thC
 wOY
 wOY
 wOY
@@ -105717,7 +105364,7 @@ puD
 hKm
 oEg
 qtz
-aXL
+mpq
 aBJ
 xBu
 nCN
@@ -105891,7 +105538,7 @@ aFr
 ayi
 iXr
 cLe
-nhn
+oXy
 rft
 rft
 mab
@@ -106148,7 +105795,7 @@ aFr
 cAW
 bep
 oFB
-nhn
+oXy
 rft
 rft
 mab
@@ -106405,7 +106052,7 @@ eQv
 gOU
 ayi
 ayi
-nhn
+oXy
 rft
 nlm
 dVp
@@ -106482,13 +106129,13 @@ bKy
 ahl
 akC
 hAm
-nWw
+thC
 ajS
 brj
 fFU
 aGX
 qtf
-aXL
+mpq
 xum
 twv
 ihh
@@ -106739,7 +106386,7 @@ cuU
 vwK
 txN
 rHl
-txy
+thC
 rWu
 brj
 ppp
@@ -106919,7 +106566,7 @@ eQv
 lKL
 ayi
 sxT
-nhn
+oXy
 rft
 hmD
 xoY
@@ -106996,7 +106643,7 @@ gHR
 tIp
 epm
 eup
-nWw
+thC
 dqI
 brj
 oxg
@@ -107176,7 +106823,7 @@ sov
 ykz
 dix
 bep
-nhn
+oXy
 rft
 rft
 ayi
@@ -107433,7 +107080,7 @@ gbo
 ayi
 fUp
 wMY
-nhn
+oXy
 rft
 rft
 xXv
@@ -107500,7 +107147,7 @@ oIN
 dKF
 nPl
 aHs
-sHW
+oZS
 hiL
 jPa
 aHs
@@ -107688,11 +107335,11 @@ aFr
 aFr
 aFr
 sNV
-pkM
-pkM
+oXy
+oXy
 aFr
-rcH
-rcH
+vSE
+vSE
 wZZ
 aFr
 tAj
@@ -108270,7 +107917,7 @@ owe
 cUm
 ipS
 onL
-iPU
+oZS
 tBT
 eUk
 qOt
@@ -108784,13 +108431,13 @@ poL
 ieg
 wAe
 bLx
-iPU
+oZS
 pEU
 ahA
 yfX
 aIC
 vgi
-iPU
+oZS
 gJC
 akC
 tLY
@@ -108965,7 +108612,7 @@ cvn
 wbw
 srW
 vms
-mzu
+oBj
 lUQ
 aZW
 llu
@@ -109047,7 +108694,7 @@ ahA
 ahA
 ahA
 nmq
-abH
+rOq
 wrS
 akC
 cAz
@@ -109222,7 +108869,7 @@ qQt
 ydt
 jrb
 jdm
-eTQ
+jfT
 vob
 iEJ
 eBC
@@ -109479,7 +109126,7 @@ aeE
 xfO
 ebS
 btt
-qeK
+wDL
 lUQ
 aZW
 kvX
@@ -109557,9 +109204,9 @@ bYa
 dSD
 aZJ
 aZJ
-azU
-azU
-azU
+bHt
+bHt
+bHt
 aZJ
 aZJ
 eQk
@@ -109719,7 +109366,7 @@ aJG
 lWt
 cTw
 kEU
-nSo
+aEy
 son
 gbZ
 cxp
@@ -109768,7 +109415,7 @@ eSm
 eii
 dlw
 hjo
-htb
+sFJ
 nSA
 aiZ
 nRE
@@ -109812,7 +109459,7 @@ poL
 xlW
 myr
 tJR
-scr
+qNy
 vwI
 lYR
 tQr
@@ -109823,7 +109470,7 @@ qWm
 ttV
 bCj
 rig
-iLo
+dQg
 bqt
 wjC
 ooE
@@ -109976,7 +109623,7 @@ aJG
 nlT
 aJG
 iAZ
-fqa
+cYU
 mQH
 hMt
 daI
@@ -109993,7 +109640,7 @@ jXT
 iSG
 mWK
 kOl
-rSW
+hWt
 lUQ
 aZW
 plT
@@ -110025,7 +109672,7 @@ paS
 bfs
 qDJ
 bfs
-htb
+sFJ
 nSA
 aiZ
 xPn
@@ -110080,7 +109727,7 @@ sQg
 kLx
 akC
 uvW
-iLo
+dQg
 xfb
 aSS
 bWS
@@ -110233,7 +109880,7 @@ aJG
 gdH
 aJG
 rcS
-fmr
+pZW
 aJG
 hMt
 xKy
@@ -110250,7 +109897,7 @@ qQt
 ggP
 jrb
 jdm
-pJz
+jzS
 lUQ
 aZW
 qiR
@@ -110282,7 +109929,7 @@ yaD
 bfs
 rii
 rii
-vyZ
+slo
 wMU
 aiZ
 cpg
@@ -110326,7 +109973,7 @@ poL
 xlW
 dZL
 tGC
-scr
+qNy
 ebY
 wss
 qTG
@@ -110337,7 +109984,7 @@ mhv
 xKY
 akC
 uvW
-iLo
+dQg
 tCo
 neA
 hgR
@@ -110507,7 +110154,7 @@ aeE
 xfO
 ebS
 btt
-qeK
+wDL
 lUQ
 aZW
 qiR
@@ -110594,7 +110241,7 @@ nyk
 taH
 adB
 mDG
-iLo
+dQg
 xfb
 aSS
 lGp
@@ -110747,7 +110394,7 @@ jBf
 oIh
 aJG
 uaZ
-hTD
+sVY
 mPP
 ogN
 gyp
@@ -110846,7 +110493,7 @@ eRS
 nQe
 gYM
 xOT
-pJJ
+qol
 iIl
 cHM
 fcq
@@ -111004,7 +110651,7 @@ aJG
 nbO
 aJG
 kMO
-wrB
+ffH
 fPN
 fPN
 fPN
@@ -111021,7 +110668,7 @@ qoc
 nfv
 ezN
 oEI
-rSW
+hWt
 lUQ
 aZW
 iJh
@@ -111053,7 +110700,7 @@ hpC
 sun
 rii
 aEi
-htb
+sFJ
 ljU
 aiZ
 ecv
@@ -111261,7 +110908,7 @@ mRd
 qNu
 jIH
 jyH
-qrY
+aEW
 gjp
 hBu
 rbK
@@ -111278,7 +110925,7 @@ qQt
 pMD
 jrb
 jdm
-eTQ
+jfT
 lUQ
 aZW
 tNt
@@ -111360,7 +111007,7 @@ hyW
 sWY
 kHp
 skw
-pJJ
+qol
 jfM
 opB
 krt
@@ -111407,12 +111054,12 @@ iYt
 ghp
 iJC
 iYt
-pzv
+cuo
 jMH
 jMH
 kVK
 fIS
-pzv
+cuo
 aHh
 qUt
 paN
@@ -111535,7 +111182,7 @@ oPv
 xfO
 rWN
 btt
-hhM
+xIM
 eRe
 duM
 fyZ
@@ -111617,7 +111264,7 @@ xOD
 uOZ
 xOD
 fbq
-pJJ
+qol
 sXq
 taH
 jbG
@@ -111775,7 +111422,7 @@ luo
 uRg
 fvZ
 teg
-wZi
+cff
 qqR
 wAB
 rPv
@@ -111874,7 +111521,7 @@ ciJ
 nfO
 ciJ
 hMu
-pJJ
+qol
 pjM
 taH
 rEK
@@ -112135,7 +111782,7 @@ aqH
 mNR
 taH
 jbG
-wOM
+agA
 ebX
 oIA
 hod
@@ -112289,7 +111936,7 @@ hDa
 hDa
 hDa
 bQH
-wZi
+cff
 lOe
 ayu
 umb
@@ -112392,7 +112039,7 @@ aqH
 sXq
 taH
 jbG
-aoz
+miU
 dNc
 qHO
 vAX
@@ -112546,7 +112193,7 @@ fSR
 agT
 xPF
 oWu
-wZi
+cff
 lOe
 qLm
 bei
@@ -112649,7 +112296,7 @@ aqH
 sXq
 taH
 jbG
-aoz
+miU
 dzr
 gOS
 juq
@@ -112906,7 +112553,7 @@ aqH
 sXq
 taH
 jbG
-aoz
+miU
 brL
 xrr
 mSH
@@ -113093,7 +112740,7 @@ ucA
 ucA
 muX
 ucA
-mTb
+fgU
 hPJ
 mhp
 hLn
@@ -113153,13 +112800,13 @@ aWC
 rJv
 efW
 tJR
-qrD
+xHl
 csT
 qsq
 qcV
 uSy
 vXh
-qrD
+xHl
 sXq
 taH
 jbG
@@ -113350,7 +112997,7 @@ ucA
 ucA
 bgi
 ucA
-mTb
+fgU
 tWu
 cxq
 alm
@@ -113599,11 +113246,11 @@ ayZ
 ina
 nsf
 oGi
-hSC
-eiP
+fle
+mTH
 prI
-eiP
-xEK
+mTH
+ibL
 jHg
 wQy
 hYM
@@ -113667,13 +113314,13 @@ uAR
 rJv
 dZL
 tGC
-qrD
+xHl
 gVJ
 wNb
 fGt
 rGx
 jbo
-qrD
+xHl
 sXq
 taH
 xyJ
@@ -113860,11 +113507,11 @@ rGp
 hZH
 hGt
 vKO
-vMO
+maZ
 mdv
 rpC
 ucA
-mTb
+fgU
 wlb
 aCf
 amm
@@ -114117,7 +113764,7 @@ kJL
 kPo
 rQy
 gjs
-pnI
+oXj
 kPo
 rjy
 rGp
@@ -114612,9 +114259,9 @@ nma
 ajQ
 ajQ
 aTD
-uVq
+eOr
 xpC
-pcX
+pAZ
 aqF
 aqF
 aqF
@@ -114715,9 +114362,9 @@ aPX
 aPX
 aPX
 aVN
-eID
+rej
 ovp
-eID
+rej
 aVN
 aVN
 vNv
@@ -114888,7 +114535,7 @@ kGv
 aKk
 aKk
 aKk
-uPA
+aqw
 uKb
 aoC
 cdt
@@ -115145,7 +114792,7 @@ nRw
 gRa
 avf
 iah
-uPA
+aqw
 sfA
 tMx
 aGv
@@ -115916,7 +115563,7 @@ jdb
 aFa
 gvf
 aKk
-uPA
+aqw
 nBv
 kxx
 aly
@@ -115980,7 +115627,7 @@ uAR
 rJv
 qSe
 vnk
-isf
+uqD
 wZf
 kuM
 jgT
@@ -115992,9 +115639,9 @@ nDt
 cKB
 agB
 agB
-btB
-btB
-btB
+mca
+mca
+mca
 aPy
 std
 vCY
@@ -116010,7 +115657,7 @@ ajz
 eIi
 xNJ
 xyY
-pvG
+jpA
 tcz
 egT
 jpA
@@ -116173,7 +115820,7 @@ kGv
 aKk
 aKk
 wKv
-uPA
+aqw
 aCS
 aBm
 amy
@@ -116237,7 +115884,7 @@ aWC
 rJv
 qSe
 vnk
-isf
+uqD
 ubJ
 mVu
 vFa
@@ -116267,7 +115914,7 @@ ajz
 xMo
 sxG
 fbM
-pvG
+jpA
 nxT
 xOh
 dtv
@@ -116500,7 +116147,7 @@ vXe
 vXe
 uoN
 jPk
-wNB
+dxr
 fbQ
 hOn
 bRb
@@ -116781,7 +116428,7 @@ ajz
 cAm
 tdI
 fbM
-pvG
+jpA
 iSM
 egT
 jpA
@@ -117038,7 +116685,7 @@ ajz
 dci
 uBy
 vtL
-pvG
+jpA
 nUK
 rrm
 hYr
@@ -118271,7 +117918,7 @@ hwH
 lhs
 gon
 aAA
-ljd
+oEc
 mnJ
 arE
 arE
@@ -118297,7 +117944,7 @@ aXo
 gjy
 aGL
 aAA
-nlX
+dfd
 bPc
 ogK
 aoJ
@@ -118528,7 +118175,7 @@ hwH
 nVR
 vtV
 pbT
-ljd
+oEc
 uyS
 sRd
 aBH
@@ -118552,9 +118199,9 @@ lVU
 iRg
 xiC
 xvq
-uyJ
+hhX
 aAA
-nYG
+lly
 bPc
 eMv
 cCz
@@ -118785,7 +118432,7 @@ nVR
 keF
 gon
 aAA
-ljd
+oEc
 cvv
 rqx
 arE
@@ -118811,7 +118458,7 @@ wSF
 nKJ
 aGL
 aAA
-nYG
+lly
 bPc
 aHh
 cCz
@@ -119042,7 +118689,7 @@ xZV
 xZV
 xZV
 xZV
-ljd
+kar
 vWJ
 pBs
 wGZ
@@ -119068,7 +118715,7 @@ nTH
 bvk
 xwA
 aAA
-nYG
+lly
 bPc
 aHh
 aoJ
@@ -119325,7 +118972,7 @@ aXo
 gjy
 aGL
 aAA
-iKC
+koO
 vhW
 aHh
 aoJ
@@ -121633,7 +121280,7 @@ wrl
 xgJ
 ruw
 aJj
-rkJ
+mzr
 aJj
 pwX
 aJj
@@ -122135,8 +121782,8 @@ fBs
 fFj
 oJT
 gLw
-fCK
-mfI
+tNw
+kTV
 aPn
 aPn
 aJj
@@ -122391,7 +122038,7 @@ drR
 pBw
 iZv
 xkI
-mIn
+mFb
 nwm
 vql
 ePw
@@ -122648,7 +122295,7 @@ drR
 kZY
 fFj
 xkI
-bYU
+rMv
 sYU
 vId
 aYF
@@ -123425,7 +123072,7 @@ ule
 jFD
 iVY
 sVU
-fTX
+mFb
 pSy
 dzM
 jkI
@@ -123682,7 +123329,7 @@ csp
 vsN
 ule
 vOi
-dwB
+alK
 hUL
 uUo
 rDw

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -594,19 +594,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"anH" = (
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 32
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "aoe" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
@@ -2538,19 +2525,14 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"bmM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
+"bmm" = (
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = "medpriv_shutters";
-	name = "Privacy Shutters"
+	id = "surgery_shutters";
+	name = "Surgery Shutters"
 	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/medical/storage)
+/area/medical/sleeper)
 "bnk" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -5607,17 +5589,6 @@
 /obj/machinery/rnd/production/techfab/department/service,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"cMD" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/execution/transfer)
 "cMQ" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -7761,17 +7732,6 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/chapel/office)
-"dQz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/engine/engine_smes)
 "dQN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -8928,6 +8888,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"epx" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/execution/transfer)
 "epM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -14494,6 +14461,13 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"gVI" = (
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 32
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "gWg" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -14602,17 +14576,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"gZR" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/engine/engine_smes)
 "hae" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
@@ -16470,6 +16433,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"hSO" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/engine_smes)
 "hSV" = (
 /obj/machinery/door/airlock{
 	name = "Unit B"
@@ -17418,6 +17388,10 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/aft)
+"irT" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ai_monitored/secondarydatacore)
 "isd" = (
 /mob/living/simple_animal/bot/cleanbot/medical{
 	on = 0
@@ -18497,6 +18471,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"iTp" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "cmo";
+	name = "CMO office shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/cmo)
 "iTX" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -20531,6 +20514,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/science/lab)
+"jXZ" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/execution/transfer)
 "jYF" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
@@ -20839,14 +20827,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"kjq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/sleeper)
 "kjt" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -25141,16 +25121,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"mpp" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/medical/sleeper)
 "mpq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25901,6 +25871,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"mJX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "medpriv_shutters";
+	name = "Privacy Shutters"
+	},
+/turf/open/floor/plating,
+/area/medical/storage)
 "mKe" = (
 /obj/effect/turf_decal/siding/wideplating{
 	dir = 10
@@ -29106,19 +29085,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/storage/satellite/teleporter)
-"oqd" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "cmo";
-	name = "CMO office shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/cmo)
 "oqg" = (
 /obj/effect/turf_decal/siding/wideplating/corner,
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -29764,6 +29730,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"oJs" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engine_smes)
 "oJy" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
@@ -29973,18 +29946,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"oOL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "medpriv_shutters";
-	name = "Privacy Shutters"
-	},
-/turf/open/floor/plating,
-/area/medical/storage)
 "oOX" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -35065,16 +35026,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"rnX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "rom" = (
 /obj/machinery/light_switch{
 	pixel_x = 24
@@ -35943,16 +35894,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"rGC" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/sleeper)
 "rGM" = (
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/grass,
@@ -38577,6 +38518,10 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"sUQ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "sUS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -39632,18 +39577,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"txq" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "surgery_shutters";
-	name = "Surgery Shutters"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/sleeper)
 "tyq" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -41410,16 +41343,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"uvK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/secondarydatacore)
 "uvN" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -45715,19 +45638,6 @@
 	},
 /turf/open/floor/engine/co2,
 /area/engine/atmos/distro)
-"wye" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/execution/transfer)
 "wyg" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
@@ -67586,9 +67496,9 @@ iVM
 iBt
 iBt
 iBt
-wye
+epx
 lqm
-cMD
+jXZ
 wNW
 tkl
 vRP
@@ -71195,7 +71105,7 @@ pyH
 bmk
 jDg
 xXU
-dQz
+oJs
 neP
 lZu
 xLG
@@ -71966,7 +71876,7 @@ pyH
 tBB
 lmp
 bXk
-gZR
+hSO
 aUd
 xrG
 oNX
@@ -72224,21 +72134,21 @@ mbK
 sUS
 gfV
 aDT
-rnX
-rnX
-rnX
+sUQ
+sUQ
+sUQ
 tjr
-anH
+gVI
 bKD
-rnX
+sUQ
 tjr
-rnX
+sUQ
 cAC
-rnX
+sUQ
 tjr
-rnX
-rnX
-rnX
+sUQ
+sUQ
+sUQ
 eFb
 vaN
 vaN
@@ -77369,7 +77279,7 @@ yeM
 daM
 oew
 nOU
-oOL
+gnc
 iwJ
 efh
 rYG
@@ -77883,7 +77793,7 @@ kIT
 rWu
 qGM
 sfB
-bmM
+mJX
 ohM
 kjt
 szZ
@@ -78654,7 +78564,7 @@ uBP
 weE
 asv
 kqo
-txq
+bmm
 pZb
 uBc
 lxh
@@ -79952,7 +79862,7 @@ arc
 wIq
 ocY
 hFP
-kjq
+rYG
 hae
 kmr
 kJb
@@ -80453,7 +80363,7 @@ cUp
 vKM
 eZo
 nJZ
-oqd
+iTp
 aLB
 xcG
 ecM
@@ -80711,12 +80621,12 @@ and
 kSL
 mUL
 dog
-mpp
-rGC
+rYG
+rYG
 kGI
 kxu
-rGC
-mpp
+rYG
+rYG
 fqH
 fqH
 fqH
@@ -82287,7 +82197,7 @@ nYY
 dpf
 dpf
 dpf
-uvK
+irT
 dpf
 gFn
 dpf

--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -31,6 +31,36 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"aaP" = (
+/obj/structure/table/reinforced,
+/obj/item/pen,
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/machinery/door/window/eastright{
+	dir = 2;
+	name = "Research and Development Desk";
+	req_one_access_txt = "7;29"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "research_shutters";
+	name = "research shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/item/deskbell/preset/sci{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "aaU" = (
 /turf/open/floor/plasteel,
 /area/mine/eva_secondary)
@@ -1283,16 +1313,6 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/top_layer/outdoors)
-"ava" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/medical/genetics/cloning)
 "avk" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/nitrous_input{
 	dir = 1
@@ -1834,20 +1854,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"aCj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "robotics_shutters";
-	name = "robotics shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/science/robotics/lab)
 "aCo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -2330,21 +2336,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"aKX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "council blast";
-	name = "Council Blast Doors"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/bridge)
 "aLa" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating{
@@ -2706,6 +2697,17 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"aPF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "aPO" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/field/generator,
@@ -2839,24 +2841,6 @@
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/solar/starboard/fore)
-"aRe" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "hosprivacy";
-	name = "privacy shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
 "aRk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -4453,20 +4437,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"bpi" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemistry_shutters";
-	name = "chemistry shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/medical/chemistry)
 "bpk" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -5289,6 +5259,17 @@
 "bBP" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/hop)
+"bBW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "hosprivacy";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "bBY" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -5802,24 +5783,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"bKM" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Research Lab Maintenance";
-	req_one_access_txt = "7;29"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/science/central)
 "bKX" = (
 /obj/item/radio/intercom{
 	pixel_y = 21
@@ -6949,6 +6912,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/range)
+"cbY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "rdprivacy";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hor)
 "ccf" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/green/filled/corner/lower,
@@ -7317,6 +7292,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"chv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "council blast";
+	name = "Council Blast Doors"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "chB" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/firedoor/border_only{
@@ -8016,21 +8002,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
-"ctt" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "cmoprivacy";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/cmo)
 "ctB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -8224,6 +8195,14 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"cvV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "research_shutters";
+	name = "research shutters"
+	},
+/turf/open/floor/plating,
+/area/science/lab)
 "cvZ" = (
 /obj/structure/table,
 /obj/item/nanite_scanner,
@@ -8557,18 +8536,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"cBy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemistry_shutters";
-	name = "chemistry shutters"
-	},
-/turf/open/floor/plating,
-/area/medical/chemistry)
 "cBC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -9270,21 +9237,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"cLz" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "hosprivacy";
-	name = "privacy shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
 "cMj" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
@@ -9657,6 +9609,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"cSm" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "briglockdown";
+	name = "brig shutters"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "cSZ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -9804,30 +9767,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cUe" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "cmoprivacy";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/holosign/surgery{
-	id = "surgery_cmo"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/cmo)
 "cUk" = (
 /obj/machinery/door/morgue{
 	name = "Private Study";
@@ -10182,6 +10121,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"cZv" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "rdprivacy";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hor)
 "cZx" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/wood,
@@ -12923,6 +12873,14 @@
 /obj/docking_port/stationary/public_mining_dock,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
+"dPN" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "psych";
+	name = "psychiatrist shutters"
+	},
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/medical/psych)
 "dPS" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig";
@@ -14073,21 +14031,6 @@
 /obj/item/aiModule/supplied/freeform,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"eiN" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "rdprivacy";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hor)
 "eiT" = (
 /obj/machinery/button/door{
 	id = "prisonereducation";
@@ -14490,21 +14433,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
-"epa" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/preopen{
-	id = "cmoprivacy";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/cmo)
 "epc" = (
 /obj/structure/sign/warning/biohazard{
 	pixel_x = -32
@@ -15612,21 +15540,6 @@
 /obj/effect/turf_decal/trimline/chemorange/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"eGE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "detective_shutters";
-	name = "detective's office shutters"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/security/detectives_office)
 "eGG" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
@@ -16778,6 +16691,14 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"fci" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "lawyer_shutters";
+	name = "law office shutters"
+	},
+/turf/open/floor/plating,
+/area/lawoffice)
 "fcp" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 4
@@ -17231,6 +17152,17 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port/aft)
+"fiw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "detective_shutters";
+	name = "detective's office shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/detectives_office)
 "fiL" = (
 /obj/machinery/air_sensor{
 	id_tag = "n2_sensor"
@@ -17262,6 +17194,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"fjf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "council blast";
+	name = "Council Blast Doors"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "fjl" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12;5;39;6"
@@ -17315,20 +17264,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
-"fkz" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "psych";
-	name = "psychiatrist shutters"
-	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/medical/psych)
 "fkE" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -21465,6 +21400,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"gqz" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "gqO" = (
 /obj/effect/turf_decal/tile/blue/opposingcorners{
 	dir = 8
@@ -21543,27 +21489,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"grS" = (
-/obj/machinery/button/door{
-	id = "chemistry_shutters";
-	name = "chemistry shutters control";
-	pixel_x = 24;
-	pixel_y = 24;
-	req_access_txt = "5; 33"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemistry_shutters";
-	name = "chemistry shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/medical/chemistry)
 "gsh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -22141,21 +22066,6 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"gAN" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "corporate_privacy";
-	name = "showroom shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/bridge/showroom/corporate)
 "gAS" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/loading_area{
@@ -23904,6 +23814,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
+"gWd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "hosprivacy";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "gWi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -23960,6 +23884,14 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/solar/port/fore)
+"gXD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chemistry_shutters_2";
+	name = "chemistry shutters"
+	},
+/turf/open/floor/plating,
+/area/medical/chemistry)
 "gXM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -24233,21 +24165,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"hcW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/machinery/door/poddoor/preopen{
-	id = "rdprivacy";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hor)
 "hdb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -25126,21 +25043,6 @@
 /obj/machinery/telecomms/server/presets/medical,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"hrh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "hrp" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -27500,21 +27402,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"ich" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/machinery/door/poddoor/preopen{
-	id = "briglockdown";
-	name = "brig shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "icj" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -28656,21 +28543,6 @@
 /obj/structure/bodycontainer/morgue,
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"iun" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "detective_shutters";
-	name = "detective's office shutters"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/security/detectives_office)
 "iuw" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Launch Room Access";
@@ -29786,24 +29658,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"iJn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "council blast";
-	name = "Council Blast Doors"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/bridge)
 "iJv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -30064,21 +29918,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"iMP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/security/brig)
 "iMQ" = (
 /obj/structure/destructible/cult/tome,
 /obj/machinery/newscaster{
@@ -30557,6 +30396,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"iTF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "toxins_blastdoor";
+	name = "biohazard containment door"
+	},
+/turf/open/floor/plating,
+/area/science/mixing)
 "iTK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -31015,6 +30862,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"jar" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/machinery/door/poddoor/preopen{
+	id = "rdprivacy";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hor)
 "jau" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -32858,6 +32714,17 @@
 /obj/machinery/vending/robotics,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"jAi" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "jAk" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light_switch{
@@ -32906,6 +32773,37 @@
 	},
 /turf/open/floor/plating,
 /area/medical/storage)
+"jBg" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastright{
+	name = "Research and Development Desk";
+	req_one_access_txt = "7;29"
+	},
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/pen,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "research_shutters_2";
+	name = "research shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/item/deskbell/preset/sci{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "jBl" = (
 /obj/effect/turf_decal/trimline/blue/filled/end{
 	dir = 4
@@ -33037,6 +32935,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"jDE" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "jDJ" = (
 /obj/machinery/disposal/bin{
 	pixel_x = 5
@@ -33425,6 +33338,26 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"jJq" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "cmoprivacy";
+	name = "privacy shutter"
+	},
+/obj/machinery/holosign/surgery{
+	id = "surgery_cmo"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/cmo)
 "jJC" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -33771,25 +33704,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jNQ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/security/brig)
 "jNW" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -34158,24 +34072,6 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"jTB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "rdprivacy";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hor)
 "jTD" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -37086,6 +36982,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"kKH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "corporate_privacy";
+	name = "showroom shutters"
+	},
+/turf/open/floor/plating,
+/area/bridge/showroom/corporate)
 "kKQ" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -37611,6 +37516,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"kVe" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "council blast";
+	name = "Council Blast Doors"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "kVi" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/decal/cleanable/dirt,
@@ -38056,37 +37972,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"ldR" = (
-/obj/structure/table/reinforced,
-/obj/item/pen,
-/obj/machinery/door/window/eastright{
-	name = "Robotics Desk";
-	req_one_access_txt = "29;75"
-	},
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "robotics_shutters";
-	name = "robotics shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/item/deskbell/preset/robotics{
-	pixel_x = -8;
-	pixel_y = -4
-	},
-/turf/open/floor/plating,
-/area/science/robotics/lab)
 "ldU" = (
 /turf/closed/wall,
 /area/science/robotics/mechbay)
@@ -38279,36 +38164,6 @@
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"lgt" = (
-/obj/structure/table/reinforced,
-/obj/item/pen,
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/machinery/door/window/eastright{
-	dir = 2;
-	name = "Research and Development Desk";
-	req_one_access_txt = "7;29"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "research_shutters";
-	name = "research shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/item/deskbell/preset/sci{
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/turf/open/floor/plating,
-/area/science/lab)
 "lgH" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -38981,6 +38836,14 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
+"lpq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "robotics_shutters";
+	name = "robotics shutters"
+	},
+/turf/open/floor/plating,
+/area/science/robotics/mechbay)
 "lpD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -41561,24 +41424,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"maP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "rdprivacy";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hor)
 "maT" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/plasteel/cafeteria{
@@ -42108,22 +41953,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"mhX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "miy" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -44554,6 +44383,14 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"mQZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "telelab";
+	name = "test chamber blast door"
+	},
+/turf/open/floor/plating,
+/area/science/explab)
 "mRq" = (
 /obj/structure/sign/poster/random{
 	pixel_y = -32
@@ -46008,6 +45845,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"nmr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "hosprivacy";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "nmJ" = (
 /obj/machinery/computer/secure_data,
 /obj/structure/cable/yellow{
@@ -47751,20 +47599,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"nMT" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "research_shutters_2";
-	name = "research shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/science/lab)
 "nNa" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/freezer,
@@ -48036,20 +47870,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"nQG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemistry_shutters_2";
-	name = "chemistry shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/medical/chemistry)
 "nQS" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -48682,6 +48502,21 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/security/physician)
+"oax" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "rdprivacy";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hor)
 "oaz" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall,
@@ -50227,24 +50062,6 @@
 /obj/machinery/vending/wardrobe/sig_wardrobe,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"ovy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "hosprivacy";
-	name = "privacy shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
 "ovL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -50727,23 +50544,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"oEl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "cmoprivacy";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/cmo)
 "oEF" = (
 /obj/structure/sign/directions/evac,
 /turf/closed/wall,
@@ -51788,6 +51588,21 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"oXB" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Research Lab Maintenance";
+	req_one_access_txt = "7;29"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/maintenance/department/science/central)
 "oXC" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/structure/chair/office/dark{
@@ -52141,6 +51956,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"pcn" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chemistry_shutters";
+	name = "chemistry shutters"
+	},
+/turf/open/floor/plating,
+/area/medical/chemistry)
 "pcz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/light_switch{
@@ -52249,20 +52072,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"pfD" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "telelab";
-	name = "test chamber blast door"
-	},
-/turf/open/floor/plating,
-/area/science/explab)
 "pfP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -52681,6 +52490,20 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"pkU" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "hosprivacy";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hos)
 "pkW" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
@@ -53392,21 +53215,6 @@
 /obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"pvs" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/security/brig)
 "pvw" = (
 /obj/structure/chair/comfy/brown,
 /obj/effect/landmark/start/librarian,
@@ -55372,24 +55180,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
-"qbJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "council blast";
-	name = "Council Blast Doors"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/bridge)
 "qcg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -55414,6 +55204,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"qcy" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "council blast";
+	name = "Council Blast Doors"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "qcJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55742,7 +55546,7 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"qhx" = (
+"qhj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
@@ -55750,12 +55554,6 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "hop";
 	name = "privacy shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
@@ -55877,6 +55675,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"qjo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/machinery/door/poddoor/preopen{
+	id = "briglockdown";
+	name = "brig shutters"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "qjt" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
@@ -56323,19 +56130,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/central)
-"qpN" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "corporate_privacy";
-	name = "showroom shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/bridge/showroom/corporate)
 "qpW" = (
 /obj/structure/transit_tube/diagonal,
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
@@ -59654,18 +59448,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"rng" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "research_shutters";
-	name = "research shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/science/lab)
 "rni" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -60111,20 +59893,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"rvI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "research_shutters";
-	name = "research shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/science/lab)
 "rvN" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
@@ -60430,6 +60198,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"rAA" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/medical/genetics/cloning)
 "rAH" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -60899,19 +60671,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/security/warden)
-"rIM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow,
-/obj/machinery/door/poddoor/preopen{
-	id = "hop";
-	name = "privacy shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hop)
 "rIP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -60961,18 +60720,6 @@
 /obj/item/hand_labeler,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
-"rJu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "robotics_shutters";
-	name = "robotics shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/science/robotics/mechbay)
 "rKg" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -61519,37 +61266,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"rRB" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastright{
-	name = "Research and Development Desk";
-	req_one_access_txt = "7;29"
-	},
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/folder/white{
-	pixel_x = 4;
-	pixel_y = -3
-	},
-/obj/item/pen,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "research_shutters_2";
-	name = "research shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/item/deskbell/preset/sci{
-	pixel_x = -7;
-	pixel_y = -3
-	},
-/turf/open/floor/plating,
-/area/science/lab)
 "rRU" = (
 /obj/effect/landmark/stationroom/box/testingsite,
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
@@ -62880,6 +62596,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"sme" = (
+/obj/machinery/button/door{
+	id = "chemistry_shutters";
+	name = "chemistry shutters control";
+	pixel_x = 24;
+	pixel_y = 24;
+	req_access_txt = "5; 33"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chemistry_shutters";
+	name = "chemistry shutters"
+	},
+/turf/open/floor/plating,
+/area/medical/chemistry)
 "smi" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -63415,6 +63146,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"stG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "cmoprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/cmo)
 "stM" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -65135,6 +64877,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
+"sRg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "research_shutters_2";
+	name = "research shutters"
+	},
+/turf/open/floor/plating,
+/area/science/lab)
 "sRl" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -66377,6 +66127,14 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"tiV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "robotics_shutters";
+	name = "robotics shutters"
+	},
+/turf/open/floor/plating,
+/area/science/robotics/lab)
 "tiZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -66448,20 +66206,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
-"tjq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "toxins_blastdoor";
-	name = "biohazard containment door"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/science/mixing)
 "tjL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -68225,6 +67969,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"tKY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/machinery/door/poddoor/preopen{
+	id = "hop";
+	name = "privacy shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hop)
 "tLc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
@@ -69543,21 +69296,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"ufX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "council blast";
-	name = "Council Blast Doors"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/bridge)
 "ugb" = (
 /obj/structure/rack,
 /obj/item/clothing/under/color/blue,
@@ -71388,6 +71126,20 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"uFJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "rdprivacy";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hor)
 "uFN" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -72981,24 +72733,6 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"vbu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "rdprivacy";
-	name = "privacy shutter"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hor)
 "vby" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/door/airlock/maintenance{
@@ -73882,6 +73616,37 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/top_layer/outdoors)
+"vpV" = (
+/obj/structure/table/reinforced,
+/obj/item/pen,
+/obj/machinery/door/window/eastright{
+	name = "Robotics Desk";
+	req_one_access_txt = "29;75"
+	},
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/item/folder/white{
+	pixel_x = 4;
+	pixel_y = -3
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "robotics_shutters";
+	name = "robotics shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/item/deskbell/preset/robotics{
+	pixel_x = -8;
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "vpY" = (
 /obj/structure/sink{
 	dir = 8;
@@ -75776,23 +75541,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"vRl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "briglockdown";
-	name = "brig shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "vRv" = (
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/command)
@@ -76857,6 +76605,17 @@
 /obj/machinery/computer/libraryconsole/bookmanagement,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"wgD" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "cmoprivacy";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/cmo)
 "wgE" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -77135,18 +76894,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"wjZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemistry_shutters";
-	name = "chemistry shutters"
-	},
-/turf/open/floor/plating,
-/area/medical/chemistry)
 "wkf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -78144,6 +77891,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"wxO" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "wxZ" = (
 /obj/machinery/camera{
 	c_tag = "Research Director's Office";
@@ -81694,18 +81453,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"xwJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "lawyer_shutters";
-	name = "law office shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/lawoffice)
 "xwT" = (
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
@@ -82295,6 +82042,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"xDb" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "council blast";
+	name = "Council Blast Doors"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "xDj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -83748,6 +83509,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"xVX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "detective_shutters";
+	name = "detective's office shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/detectives_office)
 "xWa" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
@@ -84490,27 +84262,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/security/main)
-"ygA" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "council blast";
-	name = "Council Blast Doors"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/bridge)
 "ygD" = (
 /obj/machinery/hydroponics/soil,
 /obj/structure/window/reinforced,
@@ -84828,21 +84579,6 @@
 /obj/structure/displaycase/trophy,
 /turf/open/floor/wood,
 /area/library)
-"ylp" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "hosprivacy";
-	name = "privacy shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hos)
 "ylr" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -107908,7 +107644,7 @@ tyM
 nCD
 sYq
 sYq
-qhx
+qhj
 sYq
 sYq
 puz
@@ -108201,14 +107937,14 @@ uZt
 cBY
 cBY
 cBY
-oEl
+wgD
 eyB
 aQN
 cBY
 cBY
 lWJ
 lWJ
-ava
+rAA
 hvo
 lWJ
 lWJ
@@ -108219,7 +107955,7 @@ glx
 lxx
 oDM
 ete
-fkz
+dPN
 oDM
 oDM
 oDM
@@ -108427,7 +108163,7 @@ fKP
 gbE
 sVf
 gnb
-rIM
+tKY
 eoO
 uia
 uxI
@@ -108969,7 +108705,7 @@ jer
 mgB
 qdA
 nTH
-epa
+wgD
 dCO
 mCm
 oqY
@@ -109226,7 +108962,7 @@ eBG
 rOi
 cWz
 nTH
-cUe
+jJq
 saW
 hSc
 ehK
@@ -109455,7 +109191,7 @@ mTR
 ibB
 qEA
 jJb
-rIM
+tKY
 bjk
 eUW
 kvD
@@ -109483,7 +109219,7 @@ dzl
 xgw
 hMk
 nTH
-ctt
+stG
 ybi
 fBT
 sTb
@@ -109681,7 +109417,7 @@ wBi
 tCW
 ebU
 fYc
-pvs
+gqz
 vHY
 gdm
 hOd
@@ -109938,7 +109674,7 @@ pMo
 bMM
 xtg
 aMg
-jNQ
+jDE
 gCL
 dLa
 cbL
@@ -110195,7 +109931,7 @@ bEY
 fra
 gjE
 jPy
-iMP
+aPF
 wAE
 gvW
 uDV
@@ -110506,7 +110242,7 @@ nyg
 mHl
 oaE
 bwY
-wjZ
+pcn
 dmM
 cdh
 obl
@@ -110709,7 +110445,7 @@ bEY
 tCW
 goo
 fYc
-pvs
+gqz
 wAE
 vLp
 rOq
@@ -110966,7 +110702,7 @@ oXi
 ucy
 jVT
 aMg
-jNQ
+jDE
 gCL
 uFN
 mar
@@ -111010,7 +110746,7 @@ eqF
 vKA
 rYC
 pgg
-qpN
+kKH
 cnB
 tqZ
 sJM
@@ -111223,7 +110959,7 @@ bEY
 fra
 gjE
 vFZ
-iMP
+aPF
 wAE
 vAL
 nzl
@@ -111277,7 +111013,7 @@ lnA
 lsm
 qTz
 buT
-cBy
+pcn
 jHW
 tbr
 pRN
@@ -111519,7 +111255,7 @@ uNQ
 wGO
 sBH
 lmz
-gAN
+aSz
 uoi
 wen
 mTm
@@ -111535,14 +111271,14 @@ hUC
 nbv
 sEn
 diI
-grS
+sme
 diI
-bpi
+pcn
 diI
 diI
 pjm
 mSV
-nQG
+gXD
 diI
 vZL
 aLw
@@ -111737,7 +111473,7 @@ bEY
 tCW
 dCD
 fYc
-pvs
+gqz
 wAE
 vAL
 mar
@@ -111770,7 +111506,7 @@ gjd
 azD
 ngX
 dyo
-aKX
+kVe
 iSn
 xBT
 syX
@@ -111994,7 +111730,7 @@ oXi
 fgn
 dzJ
 aMg
-jNQ
+jDE
 gCL
 vAL
 xst
@@ -112027,7 +111763,7 @@ gjd
 sCT
 xXN
 bhR
-qbJ
+qcy
 iSn
 xBT
 uKd
@@ -112038,7 +111774,7 @@ xJv
 rSY
 vAJ
 ecX
-qpN
+kKH
 cnB
 gQG
 bsG
@@ -112251,7 +111987,7 @@ bEY
 fra
 gjE
 rJn
-iMP
+aPF
 wAE
 ocJ
 tgJ
@@ -112284,7 +112020,7 @@ lYQ
 bRb
 dMK
 bAT
-ygA
+fjf
 kot
 wOS
 gUe
@@ -112295,7 +112031,7 @@ oGn
 wen
 yaj
 tUK
-qpN
+kKH
 cnB
 mgS
 rHU
@@ -112541,7 +112277,7 @@ gjd
 nZE
 aYm
 llW
-iJn
+xDb
 iSn
 cmS
 nln
@@ -112552,7 +112288,7 @@ hpJ
 xxk
 gYY
 xkF
-qpN
+kKH
 cnB
 arX
 fvo
@@ -112798,7 +112534,7 @@ gjd
 pVC
 ngX
 hOH
-ufX
+chv
 iSn
 cmS
 syX
@@ -112820,9 +112556,9 @@ sgT
 qfZ
 iXP
 eTy
-rvI
+cvV
 eTy
-rvI
+cvV
 eTy
 eTy
 iaQ
@@ -113061,7 +112797,7 @@ hRE
 usg
 nKI
 ozD
-gAN
+aSz
 tTn
 aDM
 hdh
@@ -113082,9 +112818,9 @@ skl
 nah
 pyK
 eTy
-nMT
-rRB
-nMT
+sRg
+jBg
+sRg
 eTy
 tfV
 pex
@@ -113097,8 +112833,8 @@ iNJ
 ilv
 tSS
 rwe
-aCj
-ldR
+tiV
+vpV
 wAR
 pWo
 kXB
@@ -113353,7 +113089,7 @@ dkB
 reY
 xOM
 tSS
-rJu
+lpq
 gIl
 mCV
 kFB
@@ -113537,9 +113273,9 @@ rts
 ulr
 ulr
 qin
-vRl
+cSm
 sWn
-ich
+qjo
 xFO
 lGg
 bPR
@@ -113580,7 +113316,7 @@ sFz
 cYh
 wXs
 cmZ
-qpN
+kKH
 cnB
 oxp
 sJM
@@ -113847,7 +113583,7 @@ dMk
 jgC
 pBx
 wEN
-rng
+cvV
 sQa
 xvV
 fvn
@@ -114104,7 +113840,7 @@ vCR
 vIf
 nRU
 gIM
-lgt
+aaP
 cJp
 nzr
 cYs
@@ -114361,7 +114097,7 @@ rvN
 sYG
 bLe
 whk
-rng
+cvV
 fBF
 jDJ
 vLX
@@ -114370,7 +114106,7 @@ hEF
 jpb
 iKL
 ccJ
-bKM
+oXB
 rCZ
 uoH
 mII
@@ -114805,7 +114541,7 @@ vQf
 kgZ
 nbR
 qVx
-ylp
+bBW
 jvj
 mUU
 rVe
@@ -115062,7 +114798,7 @@ xzA
 wtY
 nNc
 yfb
-aRe
+gWd
 byB
 ffl
 viO
@@ -115576,7 +115312,7 @@ iZS
 lGc
 xWe
 iNO
-ovy
+pkU
 byB
 lUE
 jka
@@ -115589,7 +115325,7 @@ tQZ
 suD
 cZS
 bEY
-eGE
+xVX
 caw
 nkY
 xtP
@@ -115833,7 +115569,7 @@ wyb
 agB
 mZK
 aVT
-cLz
+nmr
 wWA
 hdU
 kry
@@ -115859,7 +115595,7 @@ cje
 rEY
 knV
 xOS
-xwJ
+fci
 jMN
 oBV
 nuf
@@ -116103,7 +115839,7 @@ xvh
 suD
 sOC
 bEY
-iun
+fiw
 rOB
 cvq
 tIm
@@ -116169,17 +115905,17 @@ oSv
 ohu
 kIs
 edl
-maP
-jTB
-jTB
-hcW
+oax
+cbY
+cbY
+jar
 vLD
 iaj
 iaj
 ihu
-tjq
+iTF
 bMk
-tjq
+iTF
 ihu
 dnc
 dnc
@@ -116373,7 +116109,7 @@ qJX
 eYO
 qJX
 iYn
-xwJ
+fci
 dNc
 aqj
 bvA
@@ -116426,7 +116162,7 @@ tdO
 trI
 sDu
 xAN
-vbu
+uFJ
 lEw
 xHB
 xNU
@@ -116683,7 +116419,7 @@ pSM
 iwS
 sBR
 cGi
-eiN
+cZv
 xfT
 wRv
 dyT
@@ -120276,8 +120012,8 @@ rTH
 krH
 lXG
 lXG
-pfD
-pfD
+mQZ
+mQZ
 lXG
 iIG
 lXG
@@ -124865,7 +124601,7 @@ lSY
 lNk
 nzP
 lfM
-hrh
+jAi
 kaX
 sYa
 pwM
@@ -125122,7 +124858,7 @@ jJf
 gKJ
 aNK
 hSI
-mhX
+wxO
 pfB
 uRy
 mIG

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -2914,6 +2914,16 @@
 "avy" = (
 /turf/closed/wall/r_wall,
 /area/engine/atmos/mix)
+"avA" = (
+/obj/structure/grille,
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/window{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "avC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -3797,11 +3807,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"aCe" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig)
 "aCh" = (
 /obj/structure/musician/piano{
 	icon_state = "piano";
@@ -4344,21 +4349,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"aEX" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig)
 "aFc" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -6872,20 +6862,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"aWP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "heads_meeting";
-	name = "privacy shutters"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/bridge/meeting_room)
 "aXb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10631,14 +10607,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
-"bBZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/turf/open/floor/plating,
-/area/engine/atmos/foyer)
 "bCf" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -11252,6 +11220,21 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"bIh" = (
+/obj/machinery/status_display/evac,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "bIv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -12753,26 +12736,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"bXs" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 4;
-	freq = 1400;
-	location = "Atmospherics"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/atmos/foyer)
 "bXx" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -16092,6 +16055,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"cRC" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "surgery_shutters";
+	name = "Surgery Shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/surgery)
 "cRM" = (
 /obj/machinery/light{
 	dir = 8
@@ -17399,26 +17370,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"dsj" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "viropen";
-	name = "Monkey Pen Shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/medical/virology)
 "dss" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -17538,26 +17489,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"dvb" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/southright{
-	name = "Research and Development Desk";
-	req_access_txt = "7"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rnd";
-	name = "research lab shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/item/deskbell/preset/sci{
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
 "dvd" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -18041,6 +17972,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
+"dDw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/sleeper)
 "dDy" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -19336,33 +19271,6 @@
 	},
 /turf/open/floor/mech_bay_recharge_floor,
 /area/science/robotics/mechbay)
-"edL" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastright{
-	base_state = "left";
-	dir = 8;
-	icon_state = "left";
-	name = "Robotics Desk";
-	req_one_access_txt = "29;75"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "robotics2";
-	name = "robotics lab shutters"
-	},
-/obj/item/folder/white,
-/obj/item/pen,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/item/deskbell/preset/robotics{
-	pixel_x = 9;
-	pixel_y = -4
-	},
-/turf/open/floor/plating,
-/area/science/robotics/lab)
 "edT" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Quartermaster";
@@ -19503,6 +19411,10 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"egh" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "egk" = (
 /obj/machinery/modular_computer/console/preset/curator{
 	dir = 4
@@ -20735,10 +20647,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"eBX" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "eCa" = (
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
@@ -22181,13 +22089,6 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"fdQ" = (
-/obj/structure/grille,
-/obj/structure/window{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "fdU" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/stripes/line{
@@ -23267,14 +23168,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"fwe" = (
-/obj/structure/grille,
-/obj/structure/window{
-	dir = 1
-	},
-/obj/structure/window,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "fwi" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -23553,6 +23446,14 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"fCc" = (
+/obj/structure/grille,
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/window,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "fCx" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil/random,
@@ -23850,16 +23751,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"fHt" = (
-/obj/structure/grille,
-/obj/structure/window{
-	dir = 4
-	},
-/obj/structure/window{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "fHC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -24175,6 +24066,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
+"fLf" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "chemistry_shutters";
+	name = "Chemistry shutters"
+	},
+/turf/open/floor/plating,
+/area/medical/chemistry)
 "fLl" = (
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
@@ -25095,6 +24994,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"gfu" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "viropen";
+	name = "Monkey Pen Shutters"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/medical/virology)
 "gfL" = (
 /obj/machinery/door/airlock{
 	name = "Custodial Closet";
@@ -25386,21 +25294,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"gnq" = (
-/obj/machinery/status_display/evac,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/bridge)
 "gnD" = (
 /obj/structure/table,
 /obj/item/radio/off,
@@ -29211,14 +29104,6 @@
 /obj/item/clothing/under/color/lightpurple,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"hLh" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rnd";
-	name = "research lab shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/lab)
 "hLI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
@@ -29286,6 +29171,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hOj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/main)
 "hOn" = (
 /obj/effect/turf_decal/bot_red,
 /obj/structure/rack,
@@ -30025,17 +29914,6 @@
 /obj/effect/landmark/stationroom/box/hydroponics,
 /turf/template_noop,
 /area/hydroponics)
-"iav" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "iaJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/eastleft{
@@ -30101,6 +29979,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"ibq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/warning/securearea{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/security/main)
 "ibw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westright{
@@ -31071,14 +30956,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"isB" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "surgery_shutters";
-	name = "Surgery Shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/surgery)
 "isH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31155,6 +31032,16 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"itQ" = (
+/obj/structure/grille,
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "iuY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -31630,16 +31517,6 @@
 "iEt" = (
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"iEN" = (
-/obj/structure/grille,
-/obj/structure/window{
-	dir = 8
-	},
-/obj/structure/window{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "iEY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -32783,6 +32660,20 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
+"iZJ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "viropen";
+	name = "Monkey Pen Shutters"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/medical/virology)
 "iZL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -34057,6 +33948,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"jzs" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "heads_meeting";
+	name = "privacy shutters"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/bridge/meeting_room)
 "jzw" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -34331,13 +34236,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jFM" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/cloth_curtain{
-	color = "#99ccff"
-	},
-/turf/open/floor/plating,
-/area/medical/sleeper)
 "jFQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -34635,6 +34533,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"jLY" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/medical/medbay/lobby)
 "jMv" = (
 /turf/closed/wall,
 /area/crew_quarters/theatre)
@@ -34660,23 +34562,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"jNI" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/engine/atmos/foyer)
 "jNQ" = (
 /obj/structure/cloth_curtain{
 	color = "#99ccff";
@@ -36083,14 +35968,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"krm" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "psych";
-	name = "psychiatrist shutters"
-	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/medical/psych)
 "krt" = (
 /obj/structure/cloth_curtain{
 	color = "#99ccff"
@@ -36311,13 +36188,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"kyw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/securearea{
-	pixel_x = -32
-	},
-/turf/open/floor/plating,
-/area/security/main)
 "kyA" = (
 /obj/machinery/camera{
 	c_tag = "MiniSat  Antechamber";
@@ -37777,6 +37647,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
+"ldU" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hop";
+	name = "Privacy Shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hop)
 "ldW" = (
 /turf/template_noop,
 /area/maintenance/aft)
@@ -38114,6 +37995,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"liZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos/foyer)
 "lja" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
@@ -39086,14 +38974,6 @@
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
-"lCK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "chemistry_shutters";
-	name = "Chemistry shutters"
-	},
-/turf/open/floor/plating,
-/area/medical/chemistry)
 "lCW" = (
 /obj/machinery/light_switch{
 	pixel_x = 27
@@ -42182,6 +42062,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"mKZ" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "briggate";
+	name = "security blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "mLd" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -42414,6 +42305,17 @@
 /obj/effect/landmark/start/shaft_miner,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"mOK" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "mOU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -42876,6 +42778,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"mXr" = (
+/obj/structure/grille,
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "mXv" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
@@ -42964,6 +42873,10 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"mZs" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/atmos/foyer)
 "mZw" = (
 /obj/machinery/light{
 	dir = 4
@@ -43600,14 +43513,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"nlA" = (
-/obj/structure/grille,
-/obj/structure/window,
-/obj/structure/window{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "nlC" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/cable{
@@ -43964,6 +43869,17 @@
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"nsn" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "heads_meeting";
+	name = "privacy shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/bridge/meeting_room)
 "nsx" = (
 /obj/machinery/door/airlock/research{
 	name = "Robotics Lab";
@@ -44060,6 +43976,20 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
+"ntL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "ntR" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
@@ -44568,10 +44498,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"nEu" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ai_monitored/security/armory)
 "nEv" = (
 /obj/machinery/camera{
 	c_tag = "Construction Area";
@@ -46198,6 +46124,10 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plating,
 /area/engine/atmos/distro)
+"ooh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ai_monitored/security/armory)
 "ooi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46585,10 +46515,6 @@
 /obj/effect/landmark/stationroom/box/testingsite,
 /turf/open/space/basic,
 /area/space)
-"ouW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/main)
 "ouY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -48662,17 +48588,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/aft)
-"piW" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "briggate";
-	name = "security blast door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "pjc" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff";
@@ -49821,17 +49736,6 @@
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"pCn" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "pCF" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -50360,6 +50264,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"pQd" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hop";
+	name = "Privacy Shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hop)
 "pQe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -50745,18 +50663,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"pWI" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rnd2";
-	name = "research lab shutters"
-	},
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/science/lab)
 "pWK" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -51498,6 +51404,26 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"qku" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/southright{
+	name = "Research and Development Desk";
+	req_access_txt = "7"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rnd";
+	name = "research lab shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/item/deskbell/preset/sci{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "qkB" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -51604,16 +51530,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"qlM" = (
-/obj/structure/grille,
-/obj/structure/window{
-	dir = 8
-	},
-/obj/structure/window{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "qlP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -51749,6 +51665,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"qoj" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "psych";
+	name = "psychiatrist shutters"
+	},
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/medical/psych)
 "qot" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/reagent_dispensers/fueltank,
@@ -52914,14 +52838,6 @@
 /obj/item/storage/belt/utility,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"qLO" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "psych";
-	name = "psychiatrist shutters"
-	},
-/turf/open/floor/plating,
-/area/medical/psych)
 "qLP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -53249,6 +53165,11 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
+/area/medical/sleeper)
+"qRq" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/medical/sleeper)
 "qRK" = (
 /obj/structure/table/wood,
@@ -54306,6 +54227,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
+"rmz" = (
+/obj/structure/grille,
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "rmD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -54361,6 +54292,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"rod" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/cloth_curtain{
+	color = "#99ccff"
+	},
+/turf/open/floor/plating,
+/area/medical/sleeper)
 "ron" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -54520,17 +54458,6 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
-"rrs" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hop";
-	name = "Privacy Shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hop)
 "rry" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -54850,17 +54777,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"rxY" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/bridge)
 "ryf" = (
 /obj/structure/sign/departments/minsky/research/research,
 /turf/closed/wall/r_wall,
@@ -54928,6 +54844,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"rzC" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rnd";
+	name = "research lab shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/lab)
 "rAb" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/components/binary/pump/layer2{
@@ -55842,6 +55766,14 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"rRh" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rnd2";
+	name = "research lab shutters"
+	},
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/science/lab)
 "rRj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -57890,6 +57822,33 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"sGX" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	dir = 8;
+	icon_state = "left";
+	name = "Robotics Desk";
+	req_one_access_txt = "29;75"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "robotics2";
+	name = "robotics lab shutters"
+	},
+/obj/item/folder/white,
+/obj/item/pen,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/item/deskbell/preset/robotics{
+	pixel_x = 9;
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "sGY" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /mob/living/carbon/monkey{
@@ -58796,11 +58755,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"sZg" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/sleeper)
 "sZn" = (
 /obj/structure/table/wood,
 /obj/item/stamp/captain{
@@ -59184,6 +59138,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"tgX" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/brig)
 "tgY" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -59807,10 +59776,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"ttT" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/medical/medbay/lobby)
 "tup" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -60234,6 +60199,17 @@
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
 /area/medical/sleeper)
+"tDw" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "tDD" = (
 /obj/machinery/camera{
 	c_tag = "Head of Personnel's Office";
@@ -60278,23 +60254,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
-"tEa" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "heads_meeting";
-	name = "privacy shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/bridge/meeting_room)
 "tEp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"tEr" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop_ext"
+	},
+/turf/open/floor/plating,
+/area/clerk)
 "tEx" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/wood,
@@ -60335,20 +60307,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"tFF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "heads_meeting";
-	name = "privacy shutters"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/bridge/meeting_room)
 "tFM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -60474,6 +60432,20 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"tHI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "heads_meeting";
+	name = "privacy shutters"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/bridge/meeting_room)
 "tHJ" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Port";
@@ -62901,6 +62873,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"uFr" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "psych";
+	name = "psychiatrist shutters"
+	},
+/turf/open/floor/plating,
+/area/medical/psych)
 "uFy" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4;
@@ -63085,6 +63065,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"uIP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "uIQ" = (
 /obj/structure/table/wood,
 /obj/item/clothing/glasses/sunglasses,
@@ -63244,6 +63238,14 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"uLV" = (
+/obj/structure/grille,
+/obj/structure/window,
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "uMg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -63638,6 +63640,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"uTe" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engine/atmos/foyer)
 "uTh" = (
 /turf/closed/wall,
 /area/security/execution/transfer)
@@ -64351,20 +64370,6 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"vgy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/bridge)
 "vhz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -64475,10 +64480,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"vjG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/atmos/foyer)
 "vke" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
@@ -64550,13 +64551,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
-"vlb" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop_ext"
-	},
-/turf/open/floor/plating,
-/area/clerk)
 "vli" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -64804,6 +64798,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"vpa" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/brig)
 "vpm" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -68213,13 +68212,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"wBE" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/atmos/foyer)
 "wBI" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -68308,6 +68300,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"wEi" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
+	},
+/turf/open/floor/plating,
+/area/engine/atmos/foyer)
 "wEo" = (
 /turf/open/floor/engine/co2,
 /area/engine/atmos/distro)
@@ -68714,10 +68714,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"wNl" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/sleeper)
 "wNq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -69165,6 +69161,17 @@
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
+"wXu" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "wXw" = (
 /obj/machinery/light{
 	dir = 4
@@ -69933,6 +69940,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
+"xpa" = (
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	dir = 4;
+	freq = 1400;
+	location = "Atmospherics"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos/foyer)
 "xpf" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
@@ -70164,20 +70191,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"xsG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/bridge)
 "xsP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -70218,20 +70231,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"xuT" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hop";
-	name = "Privacy Shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hop)
 "xuX" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -71607,21 +71606,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"xWw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "viropen";
-	name = "Monkey Pen Shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/medical/virology)
 "xWF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -91081,7 +91065,7 @@ aPA
 hfy
 hfy
 sLs
-iEN
+itQ
 cnh
 nxy
 aaa
@@ -91338,7 +91322,7 @@ aPA
 hfy
 hfy
 hfy
-fwe
+fCc
 jGC
 aZE
 bPj
@@ -91595,7 +91579,7 @@ aPA
 hfy
 hfy
 hfy
-nlA
+uLV
 jGC
 aZE
 mwa
@@ -91850,9 +91834,9 @@ aPA
 aPA
 aPA
 aPA
-fHt
-qlM
-fdQ
+avA
+rmz
+mXr
 dBb
 aZE
 xBU
@@ -98529,9 +98513,9 @@ jAv
 dLQ
 aZM
 aZM
-tEa
-aWP
-tFF
+nsn
+jzs
+tHI
 aZM
 aZM
 aZM
@@ -99054,8 +99038,8 @@ nkd
 bmr
 bmr
 qPS
-rrs
-xuT
+ldU
+pQd
 qov
 bmr
 bmr
@@ -99519,10 +99503,10 @@ xlp
 agj
 wpl
 qQn
-aCe
+vpa
 afL
 aez
-pCn
+tDw
 uZB
 tcK
 kUv
@@ -99779,7 +99763,7 @@ wqV
 jaI
 amu
 alx
-aEX
+tgX
 tsu
 vDP
 dtL
@@ -100033,10 +100017,10 @@ nWg
 agj
 wHG
 qQn
-aCe
+vpa
 aqn
 rxB
-iav
+wXu
 tsu
 aKE
 kUv
@@ -100547,10 +100531,10 @@ rrC
 agj
 mKD
 qQn
-aCe
+vpa
 afL
 uWQ
-pCn
+tDw
 tsu
 aKE
 fYZ
@@ -100807,7 +100791,7 @@ dmd
 isT
 amu
 alx
-aEX
+tgX
 tsu
 anQ
 lhG
@@ -100833,7 +100817,7 @@ bOS
 ewR
 aJq
 qdd
-rxY
+mOK
 lyo
 vnU
 ngJ
@@ -101061,10 +101045,10 @@ naR
 uFo
 ajH
 wbI
-aCe
+vpa
 aqn
 rxB
-iav
+wXu
 tsu
 anz
 gLV
@@ -101090,7 +101074,7 @@ bOS
 wRq
 wWH
 qdd
-xsG
+uIP
 fpR
 hRj
 hRj
@@ -101347,7 +101331,7 @@ lFZ
 cif
 dAf
 qdd
-gnq
+bIh
 fqI
 exk
 hRj
@@ -101562,7 +101546,7 @@ llj
 epj
 svu
 vkr
-nEu
+ooh
 aly
 aeq
 aiB
@@ -101575,10 +101559,10 @@ ewO
 mKD
 lLO
 qQn
-aCe
+vpa
 afL
 cRY
-pCn
+tDw
 tsu
 anz
 geQ
@@ -101604,7 +101588,7 @@ aJq
 aLY
 dCj
 qdd
-xsG
+uIP
 fqV
 fJb
 lLe
@@ -101819,7 +101803,7 @@ adl
 bbx
 adl
 uLE
-nEu
+ooh
 alB
 aeP
 rlK
@@ -101835,7 +101819,7 @@ nhR
 lfZ
 aDF
 alx
-aEX
+tgX
 tsu
 anz
 fYZ
@@ -101861,7 +101845,7 @@ aJq
 cTw
 dCp
 qdd
-xsG
+uIP
 xEH
 lvm
 oXR
@@ -102089,10 +102073,10 @@ nrd
 ous
 lLO
 qQn
-aCe
+vpa
 aqn
 rxB
-iav
+wXu
 tsu
 aKI
 qlS
@@ -102118,7 +102102,7 @@ aJq
 cUP
 dDm
 qdd
-xsG
+uIP
 xLu
 fJS
 hRj
@@ -102375,7 +102359,7 @@ aJq
 aMa
 aNw
 qdd
-xsG
+uIP
 leO
 iXt
 nvA
@@ -102632,7 +102616,7 @@ aJq
 aLZ
 aNv
 qdd
-xsG
+uIP
 iQH
 vke
 dyd
@@ -102847,7 +102831,7 @@ adl
 ahM
 adl
 kDS
-nEu
+ooh
 mnj
 aEx
 aFF
@@ -102860,7 +102844,7 @@ pyO
 pFh
 dJb
 png
-aCe
+vpa
 amZ
 aGc
 joH
@@ -102889,7 +102873,7 @@ ihn
 aMc
 aNy
 qdd
-gnq
+bIh
 bWK
 exk
 jTD
@@ -102928,10 +102912,10 @@ mdG
 bzs
 sXH
 sXH
-bXs
-jNI
+xpa
+uTe
 oaA
-bBZ
+wEi
 sXH
 iYj
 qmg
@@ -103104,7 +103088,7 @@ adl
 adl
 svu
 jjk
-nEu
+ooh
 oED
 alE
 aGK
@@ -103120,7 +103104,7 @@ rFm
 agj
 aDL
 aGh
-piW
+mKZ
 tsu
 eKU
 ght
@@ -103146,7 +103130,7 @@ bOS
 bVS
 hOb
 qdd
-xsG
+uIP
 ifL
 hRj
 hRj
@@ -103361,7 +103345,7 @@ adl
 hMM
 wtN
 iMJ
-nEu
+ooh
 jUA
 aeM
 nSl
@@ -103403,7 +103387,7 @@ bOS
 vDS
 aJq
 qdd
-vgy
+ntL
 izI
 hjG
 fnb
@@ -103879,7 +103863,7 @@ aEp
 aEu
 aEv
 age
-kyw
+ibq
 wBD
 lqw
 skM
@@ -104136,7 +104120,7 @@ aEv
 aEv
 rUt
 gmt
-ouW
+hOj
 cHo
 wLy
 jYd
@@ -104145,7 +104129,7 @@ dWG
 jDj
 ayB
 dae
-aCe
+vpa
 lMk
 nNR
 aiX
@@ -104650,7 +104634,7 @@ aEv
 aEv
 acT
 aoH
-ouW
+hOj
 thk
 eut
 ahH
@@ -104659,7 +104643,7 @@ adR
 xpf
 qLJ
 cun
-aCe
+vpa
 kRb
 amo
 aiX
@@ -104983,10 +104967,10 @@ xgI
 eEO
 nBp
 nBp
-vjG
-vjG
+mZs
+mZs
 bLT
-wBE
+liZ
 sXH
 sXH
 sXH
@@ -105198,7 +105182,7 @@ woA
 cSk
 oYe
 dDt
-vlb
+tEr
 vDS
 aJq
 qdd
@@ -105455,7 +105439,7 @@ crX
 cSk
 fjo
 uTy
-vlb
+tEr
 vDS
 aJq
 qdd
@@ -105712,7 +105696,7 @@ eil
 cSk
 wjX
 uhC
-vlb
+tEr
 qTf
 aJq
 qdd
@@ -106483,7 +106467,7 @@ ayG
 inx
 awb
 bol
-vlb
+tEr
 daW
 cSf
 cSf
@@ -108302,19 +108286,19 @@ bfF
 bfF
 fFS
 huX
-lCK
-lCK
+fLf
+fLf
 bfF
 bjZ
 sIO
 uQd
-wNl
+dDw
 mhE
 oLD
 bZg
 vlU
 vEC
-jFM
+rod
 rMl
 gtj
 xvp
@@ -108822,13 +108806,13 @@ hbQ
 dUl
 ogm
 wSj
-wNl
+dDw
 xuX
 sha
 bDR
 ven
 vrL
-jFM
+rod
 ecl
 hWO
 pUL
@@ -109075,11 +109059,11 @@ brO
 oHK
 rJo
 smm
-ttT
+jLY
 exQ
 aBB
 qWO
-wNl
+dDw
 sIY
 sha
 bDR
@@ -109583,7 +109567,7 @@ qQV
 aYV
 aYV
 duH
-ttT
+jLY
 nSQ
 cWT
 stz
@@ -109840,7 +109824,7 @@ qQV
 aYV
 aYV
 duH
-ttT
+jLY
 nSQ
 cWT
 ajv
@@ -110097,7 +110081,7 @@ qQV
 qfN
 aYV
 duH
-ttT
+jLY
 nSQ
 cWT
 aqO
@@ -110107,13 +110091,13 @@ gtC
 fvz
 kub
 qcv
-wNl
+dDw
 gYW
 hRR
 bDR
 shN
 nAj
-sZg
+qRq
 kpp
 mFt
 iTq
@@ -110364,7 +110348,7 @@ gtC
 xIf
 kub
 qcv
-wNl
+dDw
 tPE
 tvO
 bDR
@@ -110617,7 +110601,7 @@ xyQ
 pDq
 vMp
 wtY
-ttT
+jLY
 aww
 kub
 blt
@@ -110878,7 +110862,7 @@ krO
 lLT
 pjc
 hLI
-wNl
+dDw
 dZg
 vDT
 dHB
@@ -111392,7 +111376,7 @@ sny
 vIx
 kub
 hQW
-isB
+cRC
 piE
 deu
 djz
@@ -111649,7 +111633,7 @@ lcC
 guV
 cXg
 hQW
-isB
+cRC
 gRR
 rHs
 wpp
@@ -111658,7 +111642,7 @@ ees
 gGi
 mqs
 iZf
-qLO
+uFr
 jyi
 bDB
 gjv
@@ -111906,7 +111890,7 @@ cKt
 nEH
 rTC
 hQW
-isB
+cRC
 lYv
 aiD
 vqa
@@ -111915,7 +111899,7 @@ pfg
 lMy
 hzV
 krt
-qLO
+uFr
 lUn
 faj
 uWK
@@ -112163,7 +112147,7 @@ lcC
 nfk
 kub
 hLI
-isB
+cRC
 ggM
 jsg
 duJ
@@ -112173,15 +112157,15 @@ lMy
 xOf
 dhS
 aDR
-krm
+qoj
 wwp
-krm
+qoj
 aDR
 aDR
 jxu
 jxu
-dsj
-xWw
+iZJ
+gfu
 bNd
 vzb
 tCd
@@ -119871,7 +119855,7 @@ bfV
 bfV
 box
 lEQ
-edL
+sGX
 box
 box
 wTW
@@ -121149,7 +121133,7 @@ aYV
 aYV
 vLR
 vhG
-hLh
+rzC
 pAi
 qed
 blI
@@ -121406,14 +121390,14 @@ aYV
 aYV
 vLR
 uIE
-dvb
+qku
 ulN
 biW
 blK
 bnp
 boA
 anO
-pWI
+rRh
 wTW
 qMc
 bvJ
@@ -121663,7 +121647,7 @@ aYV
 bdv
 sMz
 aNr
-hLh
+rzC
 ulg
 biW
 blJ
@@ -121713,9 +121697,9 @@ cOe
 cNW
 cOe
 cNW
-eBX
-eBX
-eBX
+egh
+egh
+egh
 cNW
 aaf
 aaf
@@ -121969,7 +121953,7 @@ fXS
 cOe
 gpq
 cOe
-eBX
+egh
 iKq
 iKq
 cCG
@@ -122184,7 +122168,7 @@ blL
 biW
 bnh
 ggC
-pWI
+rRh
 teq
 nyu
 bvK
@@ -122226,7 +122210,7 @@ fXS
 cOe
 gpq
 cOe
-eBX
+egh
 iKq
 iKq
 iKq
@@ -122483,7 +122467,7 @@ fXS
 chH
 cNW
 cOe
-eBX
+egh
 iKq
 iKq
 iKq

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -1215,21 +1215,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/misc_lab)
-"ahU" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "aic" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/fore/secondary)
@@ -1807,25 +1792,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/processing)
-"amR" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/security/brig)
 "amW" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "testlab";
@@ -3831,6 +3797,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"aCe" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/brig)
 "aCh" = (
 /obj/structure/musician/piano{
 	icon_state = "piano";
@@ -4373,6 +4344,21 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"aEX" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/security/brig)
 "aFc" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -4693,18 +4679,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"aHA" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "briggate";
-	name = "security blast door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "aHB" = (
 /obj/structure/flora/junglebush,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -6898,6 +6872,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"aWP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "heads_meeting";
+	name = "privacy shutters"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/bridge/meeting_room)
 "aXb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8151,18 +8139,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"bhC" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rnd";
-	name = "research lab shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/science/lab)
 "bhE" = (
 /obj/structure/table/glass,
 /obj/structure/window/reinforced{
@@ -10104,29 +10080,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"byS" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/engine/atmos/foyer)
 "byZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -10678,6 +10631,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
+"bBZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
+	},
+/turf/open/floor/plating,
+/area/engine/atmos/foyer)
 "bCf" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -12792,6 +12753,26 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"bXs" = (
+/obj/structure/plasticflaps{
+	opacity = 1
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=4";
+	dir = 4;
+	freq = 1400;
+	location = "Atmospherics"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos/foyer)
 "bXx" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -14476,17 +14457,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"csF" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop_ext"
-	},
-/turf/open/floor/plating,
-/area/clerk)
 "csP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -14579,14 +14549,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ctM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/security/armory)
 "ctR" = (
 /turf/open/floor/engine/n2,
 /area/engine/atmos/distro)
@@ -14936,23 +14898,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"czW" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hop";
-	name = "Privacy Shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hop)
 "cAt" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Primary Tool Storage"
@@ -16526,19 +16471,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/space/basic,
 /area/space/nearstation)
-"cYB" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/atmos/foyer)
 "cZu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -17160,18 +17092,6 @@
 /obj/item/caution,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"dms" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "psych";
-	name = "psychiatrist shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/medical/psych)
 "dmu" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Lounge"
@@ -17224,17 +17144,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"dmR" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/cloth_curtain{
-	color = "#99ccff"
-	},
-/turf/open/floor/plating,
-/area/medical/sleeper)
 "dmV" = (
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/grimy,
@@ -17629,6 +17538,26 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"dvb" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/southright{
+	name = "Research and Development Desk";
+	req_access_txt = "7"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rnd";
+	name = "research lab shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/item/deskbell/preset/sci{
+	pixel_x = 8;
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel/white,
+/area/science/lab)
 "dvd" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -18355,21 +18284,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"dHZ" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "dId" = (
 /obj/machinery/light,
 /obj/structure/tank_dispenser,
@@ -19077,26 +18991,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"dVQ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/southright{
-	name = "Research and Development Desk";
-	req_access_txt = "7"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "rnd";
-	name = "research lab shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/item/deskbell/preset/sci{
-	pixel_x = 8;
-	pixel_y = 7
-	},
-/turf/open/floor/plating,
-/area/science/lab)
 "dVT" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -19773,26 +19667,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"ejp" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "hop";
-	name = "Privacy Shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/heads/hop)
 "ejC" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -20861,6 +20735,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"eBX" = (
+/obj/effect/spawner/structure/window/reinforced/tinted,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "eCa" = (
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
@@ -22303,6 +22181,13 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fdQ" = (
+/obj/structure/grille,
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "fdU" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/stripes/line{
@@ -22776,15 +22661,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"flM" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/sleeper)
 "fme" = (
 /obj/machinery/air_sensor/atmos/mix_tank,
 /turf/open/floor/engine/vacuum,
@@ -23089,14 +22965,6 @@
 /obj/item/hfr_box/corner,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"frB" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "frD" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -23399,6 +23267,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"fwe" = (
+/obj/structure/grille,
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/window,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "fwi" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -23974,6 +23850,16 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"fHt" = (
+/obj/structure/grille,
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/window{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "fHC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -25500,6 +25386,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"gnq" = (
+/obj/machinery/status_display/evac,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "gnD" = (
 /obj/structure/table,
 /obj/item/radio/off,
@@ -25799,20 +25700,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"gtP" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "psych";
-	name = "psychiatrist shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/medical/psych)
 "gtZ" = (
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel/dark,
@@ -25860,26 +25747,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"guI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "heads_meeting";
-	name = "privacy shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/bridge/meeting_room)
 "guJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -27104,15 +26971,6 @@
 	},
 /turf/open/space,
 /area/solar/port/aft)
-"gUI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/security/brig)
 "gUN" = (
 /obj/machinery/requests_console{
 	department = "Security";
@@ -27690,26 +27548,6 @@
 /obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"hez" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "heads_meeting";
-	name = "privacy shutters"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/bridge/meeting_room)
 "hfb" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -29373,6 +29211,14 @@
 /obj/item/clothing/under/color/lightpurple,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"hLh" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "rnd";
+	name = "research lab shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/lab)
 "hLI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
@@ -30179,6 +30025,17 @@
 /obj/effect/landmark/stationroom/box/hydroponics,
 /turf/template_noop,
 /area/hydroponics)
+"iav" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "iaJ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/brigdoor/eastleft{
@@ -31214,6 +31071,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"isB" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "surgery_shutters";
+	name = "Surgery Shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/surgery)
 "isH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31731,16 +31596,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"iDS" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "iDY" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -31775,6 +31630,16 @@
 "iEt" = (
 /turf/open/floor/plasteel,
 /area/escapepodbay)
+"iEN" = (
+/obj/structure/grille,
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "iEY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -32888,14 +32753,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos/foyer)
-"iYI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/medical/sleeper)
 "iZf" = (
 /obj/structure/bed,
 /obj/structure/cloth_curtain{
@@ -34172,14 +34029,6 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"jyw" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/medical/medbay/lobby)
 "jyK" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -34482,6 +34331,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"jFM" = (
+/obj/effect/spawner/structure/window,
+/obj/structure/cloth_curtain{
+	color = "#99ccff"
+	},
+/turf/open/floor/plating,
+/area/medical/sleeper)
 "jFQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -34779,14 +34635,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"jMd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/ai_monitored/security/armory)
 "jMv" = (
 /turf/closed/wall,
 /area/crew_quarters/theatre)
@@ -34812,6 +34660,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"jNI" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "atmos";
+	name = "Atmospherics Blast Door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engine/atmos/foyer)
 "jNQ" = (
 /obj/structure/cloth_curtain{
 	color = "#99ccff";
@@ -36218,6 +36083,14 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"krm" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "psych";
+	name = "psychiatrist shutters"
+	},
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/medical/psych)
 "krt" = (
 /obj/structure/cloth_curtain{
 	color = "#99ccff"
@@ -36438,6 +36311,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"kyw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/sign/warning/securearea{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/security/main)
 "kyA" = (
 /obj/machinery/camera{
 	c_tag = "MiniSat  Antechamber";
@@ -36993,22 +36873,6 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/secondarydatacore)
-"kJK" = (
-/obj/structure/grille,
-/obj/structure/window{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/window{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "kKq" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -38500,22 +38364,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"lmH" = (
-/obj/structure/grille,
-/obj/structure/window{
-	dir = 8
-	},
-/obj/structure/window{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "lmI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -38729,14 +38577,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/security/main)
-"lqG" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
 /area/security/main)
 "lrb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -39246,6 +39086,14 @@
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"lCK" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "chemistry_shutters";
+	name = "Chemistry shutters"
+	},
+/turf/open/floor/plating,
+/area/medical/chemistry)
 "lCW" = (
 /obj/machinery/light_switch{
 	pixel_x = 27
@@ -40397,20 +40245,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"maV" = (
-/obj/structure/grille,
-/obj/structure/window{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/window{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "mbf" = (
 /obj/machinery/vending/wallmed{
 	pixel_y = 29
@@ -40475,30 +40309,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"mck" = (
-/obj/structure/grille,
-/obj/structure/window{
-	dir = 1
-	},
-/obj/structure/window,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"mco" = (
-/obj/structure/grille,
-/obj/structure/window,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/window{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "mcw" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only,
@@ -40735,30 +40545,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"mgH" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/medical/medbay/lobby)
 "mgJ" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"mhm" = (
-/obj/structure/grille,
-/obj/structure/window{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "mhB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -43809,6 +43600,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
+"nlA" = (
+/obj/structure/grille,
+/obj/structure/window,
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "nlC" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/cable{
@@ -44285,20 +44084,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"nuK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "chemistry_shutters";
-	name = "Chemistry shutters"
-	},
-/turf/open/floor/plating,
-/area/medical/chemistry)
 "nuL" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
@@ -44783,6 +44568,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nEu" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ai_monitored/security/armory)
 "nEv" = (
 /obj/machinery/camera{
 	c_tag = "Construction Area";
@@ -45589,20 +45378,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"nWs" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "chemistry_shutters";
-	name = "Chemistry shutters"
-	},
-/turf/open/floor/plating,
-/area/medical/chemistry)
 "nWA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -46810,6 +46585,10 @@
 /obj/effect/landmark/stationroom/box/testingsite,
 /turf/open/space/basic,
 /area/space)
+"ouW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/main)
 "ouY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -48031,21 +47810,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"oSt" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/bridge)
 "oSN" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
@@ -48462,15 +48226,6 @@
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
-"pck" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/security/brig)
 "pcF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -48893,14 +48648,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"piL" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/sleeper)
 "piV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -48915,6 +48662,17 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/aft)
+"piW" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "briggate";
+	name = "security blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "pjc" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff";
@@ -48971,17 +48729,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"pkH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/securearea{
-	pixel_x = -32
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/security/main)
 "pkU" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -50074,6 +49821,17 @@
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"pCn" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
 "pCF" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -51846,6 +51604,16 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"qlM" = (
+/obj/structure/grille,
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "qlP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -52457,14 +52225,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"qzz" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/medical/medbay/lobby)
 "qAb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -53154,6 +52914,14 @@
 /obj/item/storage/belt/utility,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"qLO" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "psych";
+	name = "psychiatrist shutters"
+	},
+/turf/open/floor/plating,
+/area/medical/psych)
 "qLP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -54752,6 +54520,17 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
+"rrs" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hop";
+	name = "Privacy Shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hop)
 "rry" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -55071,6 +54850,17 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"rxY" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "ryf" = (
 /obj/structure/sign/departments/minsky/research/research,
 /turf/closed/wall/r_wall,
@@ -56501,20 +56291,6 @@
 "rZt" = (
 /turf/closed/wall,
 /area/medical/paramedic)
-"rZO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/atmos/foyer)
 "rZU" = (
 /obj/machinery/light{
 	dir = 8;
@@ -59020,6 +58796,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"sZg" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/sleeper)
 "sZn" = (
 /obj/structure/table/wood,
 /obj/item/stamp/captain{
@@ -59134,32 +58915,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
-"taW" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=4";
-	dir = 4;
-	freq = 1400;
-	location = "Atmospherics"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/preopen{
-	id = "atmos";
-	name = "Atmospherics Blast Door"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos/foyer)
 "taZ" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -60052,6 +59807,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"ttT" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/medical/medbay/lobby)
 "tup" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -60519,6 +60278,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
+"tEa" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "heads_meeting";
+	name = "privacy shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/bridge/meeting_room)
 "tEp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -60565,6 +60335,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"tFF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "heads_meeting";
+	name = "privacy shutters"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/bridge/meeting_room)
 "tFM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -61834,18 +61618,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"udf" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "surgery_shutters";
-	name = "Surgery Shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/surgery)
 "udl" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -62050,18 +61822,6 @@
 "uiF" = (
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/entry)
-"uiJ" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "surgery_shutters";
-	name = "Surgery Shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/surgery)
 "uiV" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -62312,23 +62072,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"unk" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "heads_meeting";
-	name = "privacy shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/bridge/meeting_room)
 "unB" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -62667,24 +62410,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"uvd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/bridge)
 "uvE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -63345,16 +63070,6 @@
 /obj/effect/turf_decal/trimline/purple/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"uIH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/atmos/foyer)
 "uIL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -64636,6 +64351,20 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"vgy" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "vhz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -64746,24 +64475,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"vjE" = (
+"vjG" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /turf/open/floor/plating,
-/area/bridge)
+/area/engine/atmos/foyer)
 "vke" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
@@ -64835,6 +64550,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
+"vlb" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop_ext"
+	},
+/turf/open/floor/plating,
+/area/clerk)
 "vli" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -68491,6 +68213,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"wBE" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/atmos/foyer)
 "wBI" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -68985,6 +68714,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"wNl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/medical/sleeper)
 "wNq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -69167,25 +68900,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"wRI" = (
-/obj/machinery/status_display/evac,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/bridge)
 "wRK" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -70178,20 +69892,6 @@
 /obj/structure/closet/secure_closet/warden,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"xnn" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "psych";
-	name = "psychiatrist shutters"
-	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/medical/psych)
 "xnF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -70464,6 +70164,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"xsG" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/bridge)
 "xsP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -70504,6 +70218,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"xuT" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "hop";
+	name = "Privacy Shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/heads/hop)
 "xuX" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -91353,7 +91081,7 @@ aPA
 hfy
 hfy
 sLs
-maV
+iEN
 cnh
 nxy
 aaa
@@ -91610,7 +91338,7 @@ aPA
 hfy
 hfy
 hfy
-mck
+fwe
 jGC
 aZE
 bPj
@@ -91867,7 +91595,7 @@ aPA
 hfy
 hfy
 hfy
-mco
+nlA
 jGC
 aZE
 mwa
@@ -92122,9 +91850,9 @@ aPA
 aPA
 aPA
 aPA
-kJK
-lmH
-mhm
+fHt
+qlM
+fdQ
 dBb
 aZE
 xBU
@@ -98801,9 +98529,9 @@ jAv
 dLQ
 aZM
 aZM
-unk
-guI
-hez
+tEa
+aWP
+tFF
 aZM
 aZM
 aZM
@@ -99326,8 +99054,8 @@ nkd
 bmr
 bmr
 qPS
-czW
-ejp
+rrs
+xuT
 qov
 bmr
 bmr
@@ -99791,10 +99519,10 @@ xlp
 agj
 wpl
 qQn
-gUI
+aCe
 afL
 aez
-ahU
+pCn
 uZB
 tcK
 kUv
@@ -100051,7 +99779,7 @@ wqV
 jaI
 amu
 alx
-amR
+aEX
 tsu
 vDP
 dtL
@@ -100305,10 +100033,10 @@ nWg
 agj
 wHG
 qQn
-gUI
+aCe
 aqn
 rxB
-dHZ
+iav
 tsu
 aKE
 kUv
@@ -100819,10 +100547,10 @@ rrC
 agj
 mKD
 qQn
-pck
+aCe
 afL
 uWQ
-ahU
+pCn
 tsu
 aKE
 fYZ
@@ -101079,7 +100807,7 @@ dmd
 isT
 amu
 alx
-amR
+aEX
 tsu
 anQ
 lhG
@@ -101105,7 +100833,7 @@ bOS
 ewR
 aJq
 qdd
-oSt
+rxY
 lyo
 vnU
 ngJ
@@ -101333,10 +101061,10 @@ naR
 uFo
 ajH
 wbI
-pck
+aCe
 aqn
 rxB
-dHZ
+iav
 tsu
 anz
 gLV
@@ -101362,7 +101090,7 @@ bOS
 wRq
 wWH
 qdd
-vjE
+xsG
 fpR
 hRj
 hRj
@@ -101619,7 +101347,7 @@ lFZ
 cif
 dAf
 qdd
-wRI
+gnq
 fqI
 exk
 hRj
@@ -101834,7 +101562,7 @@ llj
 epj
 svu
 vkr
-jMd
+nEu
 aly
 aeq
 aiB
@@ -101847,10 +101575,10 @@ ewO
 mKD
 lLO
 qQn
-pck
+aCe
 afL
 cRY
-ahU
+pCn
 tsu
 anz
 geQ
@@ -101876,7 +101604,7 @@ aJq
 aLY
 dCj
 qdd
-vjE
+xsG
 fqV
 fJb
 lLe
@@ -102091,7 +101819,7 @@ adl
 bbx
 adl
 uLE
-jMd
+nEu
 alB
 aeP
 rlK
@@ -102107,7 +101835,7 @@ nhR
 lfZ
 aDF
 alx
-amR
+aEX
 tsu
 anz
 fYZ
@@ -102133,7 +101861,7 @@ aJq
 cTw
 dCp
 qdd
-vjE
+xsG
 xEH
 lvm
 oXR
@@ -102361,10 +102089,10 @@ nrd
 ous
 lLO
 qQn
-pck
+aCe
 aqn
 rxB
-dHZ
+iav
 tsu
 aKI
 qlS
@@ -102390,7 +102118,7 @@ aJq
 cUP
 dDm
 qdd
-vjE
+xsG
 xLu
 fJS
 hRj
@@ -102647,7 +102375,7 @@ aJq
 aMa
 aNw
 qdd
-vjE
+xsG
 leO
 iXt
 nvA
@@ -102904,7 +102632,7 @@ aJq
 aLZ
 aNv
 qdd
-vjE
+xsG
 iQH
 vke
 dyd
@@ -103119,7 +102847,7 @@ adl
 ahM
 adl
 kDS
-ctM
+nEu
 mnj
 aEx
 aFF
@@ -103132,7 +102860,7 @@ pyO
 pFh
 dJb
 png
-gUI
+aCe
 amZ
 aGc
 joH
@@ -103161,7 +102889,7 @@ ihn
 aMc
 aNy
 qdd
-wRI
+gnq
 bWK
 exk
 jTD
@@ -103200,10 +102928,10 @@ mdG
 bzs
 sXH
 sXH
-taW
-byS
+bXs
+jNI
 oaA
-rZO
+bBZ
 sXH
 iYj
 qmg
@@ -103376,7 +103104,7 @@ adl
 adl
 svu
 jjk
-ctM
+nEu
 oED
 alE
 aGK
@@ -103392,7 +103120,7 @@ rFm
 agj
 aDL
 aGh
-aHA
+piW
 tsu
 eKU
 ght
@@ -103418,7 +103146,7 @@ bOS
 bVS
 hOb
 qdd
-vjE
+xsG
 ifL
 hRj
 hRj
@@ -103633,7 +103361,7 @@ adl
 hMM
 wtN
 iMJ
-ctM
+nEu
 jUA
 aeM
 nSl
@@ -103675,7 +103403,7 @@ bOS
 vDS
 aJq
 qdd
-uvd
+vgy
 izI
 hjG
 fnb
@@ -104151,7 +103879,7 @@ aEp
 aEu
 aEv
 age
-pkH
+kyw
 wBD
 lqw
 skM
@@ -104408,7 +104136,7 @@ aEv
 aEv
 rUt
 gmt
-lqG
+ouW
 cHo
 wLy
 jYd
@@ -104417,7 +104145,7 @@ dWG
 jDj
 ayB
 dae
-gUI
+aCe
 lMk
 nNR
 aiX
@@ -104922,7 +104650,7 @@ aEv
 aEv
 acT
 aoH
-lqG
+ouW
 thk
 eut
 ahH
@@ -104931,7 +104659,7 @@ adR
 xpf
 qLJ
 cun
-gUI
+aCe
 kRb
 amo
 aiX
@@ -105255,10 +104983,10 @@ xgI
 eEO
 nBp
 nBp
-uIH
-uIH
+vjG
+vjG
 bLT
-cYB
+wBE
 sXH
 sXH
 sXH
@@ -105470,7 +105198,7 @@ woA
 cSk
 oYe
 dDt
-csF
+vlb
 vDS
 aJq
 qdd
@@ -105727,7 +105455,7 @@ crX
 cSk
 fjo
 uTy
-csF
+vlb
 vDS
 aJq
 qdd
@@ -105984,7 +105712,7 @@ eil
 cSk
 wjX
 uhC
-csF
+vlb
 qTf
 aJq
 qdd
@@ -106755,7 +106483,7 @@ ayG
 inx
 awb
 bol
-csF
+vlb
 daW
 cSf
 cSf
@@ -108574,19 +108302,19 @@ bfF
 bfF
 fFS
 huX
-nuK
-nWs
+lCK
+lCK
 bfF
 bjZ
 sIO
 uQd
-piL
+wNl
 mhE
 oLD
 bZg
 vlU
 vEC
-dmR
+jFM
 rMl
 gtj
 xvp
@@ -109094,13 +108822,13 @@ hbQ
 dUl
 ogm
 wSj
-piL
+wNl
 xuX
 sha
 bDR
 ven
 vrL
-dmR
+jFM
 ecl
 hWO
 pUL
@@ -109347,11 +109075,11 @@ brO
 oHK
 rJo
 smm
-qzz
+ttT
 exQ
 aBB
 qWO
-iYI
+wNl
 sIY
 sha
 bDR
@@ -109855,7 +109583,7 @@ qQV
 aYV
 aYV
 duH
-mgH
+ttT
 nSQ
 cWT
 stz
@@ -110112,7 +109840,7 @@ qQV
 aYV
 aYV
 duH
-mgH
+ttT
 nSQ
 cWT
 ajv
@@ -110369,7 +110097,7 @@ qQV
 qfN
 aYV
 duH
-mgH
+ttT
 nSQ
 cWT
 aqO
@@ -110379,13 +110107,13 @@ gtC
 fvz
 kub
 qcv
-iYI
+wNl
 gYW
 hRR
 bDR
 shN
 nAj
-flM
+sZg
 kpp
 mFt
 iTq
@@ -110636,7 +110364,7 @@ gtC
 xIf
 kub
 qcv
-iYI
+wNl
 tPE
 tvO
 bDR
@@ -110889,7 +110617,7 @@ xyQ
 pDq
 vMp
 wtY
-jyw
+ttT
 aww
 kub
 blt
@@ -111150,7 +110878,7 @@ krO
 lLT
 pjc
 hLI
-piL
+wNl
 dZg
 vDT
 dHB
@@ -111664,7 +111392,7 @@ sny
 vIx
 kub
 hQW
-uiJ
+isB
 piE
 deu
 djz
@@ -111921,7 +111649,7 @@ lcC
 guV
 cXg
 hQW
-udf
+isB
 gRR
 rHs
 wpp
@@ -111930,7 +111658,7 @@ ees
 gGi
 mqs
 iZf
-dms
+qLO
 jyi
 bDB
 gjv
@@ -112178,7 +111906,7 @@ cKt
 nEH
 rTC
 hQW
-udf
+isB
 lYv
 aiD
 vqa
@@ -112187,7 +111915,7 @@ pfg
 lMy
 hzV
 krt
-dms
+qLO
 lUn
 faj
 uWK
@@ -112435,7 +112163,7 @@ lcC
 nfk
 kub
 hLI
-udf
+isB
 ggM
 jsg
 duJ
@@ -112445,9 +112173,9 @@ lMy
 xOf
 dhS
 aDR
-gtP
+krm
 wwp
-xnn
+krm
 aDR
 aDR
 jxu
@@ -121421,7 +121149,7 @@ aYV
 aYV
 vLR
 vhG
-bhC
+hLh
 pAi
 qed
 blI
@@ -121678,7 +121406,7 @@ aYV
 aYV
 vLR
 uIE
-dVQ
+dvb
 ulN
 biW
 blK
@@ -121935,7 +121663,7 @@ aYV
 bdv
 sMz
 aNr
-bhC
+hLh
 ulg
 biW
 blJ
@@ -121985,9 +121713,9 @@ cOe
 cNW
 cOe
 cNW
-iDS
-iDS
-iDS
+eBX
+eBX
+eBX
 cNW
 aaf
 aaf
@@ -122241,7 +121969,7 @@ fXS
 cOe
 gpq
 cOe
-frB
+eBX
 iKq
 iKq
 cCG
@@ -122498,7 +122226,7 @@ fXS
 cOe
 gpq
 cOe
-frB
+eBX
 iKq
 iKq
 iKq
@@ -122755,7 +122483,7 @@ fXS
 chH
 cNW
 cOe
-frB
+eBX
 iKq
 iKq
 iKq


### PR DESCRIPTION
# Document the changes in your pull request

redo of a series of PRs I did before, but they all died due to me deleting my fork.  biome wanted this.

# Why is this good for the game?
pleases the headcoder, adds consistency 

# Changelog

:cl:  cark
mapping: kills under-window firelocks across all maps, making them consistent with each other and themselves.
/:cl:
