### PR TITLE
Nerfs bluespace harvester

### DIFF
--- a/code/modules/goals/station_goals/bluespace_tap.dm
+++ b/code/modules/goals/station_goals/bluespace_tap.dm
@@ -226,7 +226,7 @@
 	var/emagged = FALSE
 
 	/// Cooldown to prevent spamming portal spawns without an emag
-	COOLDOWN_DELCARE(emergency_shutdown)
+	COOLDOWN_DECLARE(emergency_shutdown)
 
 /obj/machinery/power/bluespace_tap/New()
 	..()


### PR DESCRIPTION
# Document the changes in your pull request

Building a small room in space to farm points while flooding space with hostile mobs is likely not intended, so spawning an anomaly triggers a cooldown.

# Changelog

:cl:  
tweak: bluespace harvester now has a 10 minute cooldown after spawning a portal when not emagged
/:cl:
