### PR TITLE
Holy light medbot + antimagic

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -68,7 +68,7 @@
 
 #define STATUS_EFFECT_DIAMONDSKIN /datum/status_effect/diamondskin //Increases heat and pressure resistance
 
-#define STATUS_EFFECT_ANTIMAGIC /datum/status_effect/antimagic //temporary antimagic
+#define STATUS_EFFECT_HOLYLIGHT_ANTIMAGIC /datum/status_effect/holylight_antimagic //long-term temporary antimagic that makes you blue
 
 /////////////
 // DEBUFFS //

--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -68,6 +68,8 @@
 
 #define STATUS_EFFECT_DIAMONDSKIN /datum/status_effect/diamondskin //Increases heat and pressure resistance
 
+#define STATUS_EFFECT_ANTIMAGIC /datum/status_effect/antimagic //temporary antimagic
+
 /////////////
 // DEBUFFS //
 /////////////

--- a/code/datums/status_effects/buffs/buffs.dm
+++ b/code/datums/status_effects/buffs/buffs.dm
@@ -700,9 +700,9 @@
 	alert_type = /atom/movable/screen/alert/status_effect/holylight_antimagic
 
 /atom/movable/screen/alert/status_effect/holylight_antimagic
-	name = "Diamond skin"
-	desc = "Your skin is infused with diamonds, making you more resistant to heat and pressure."
-	icon_state = "shadow_mend" //i'm a coder, not a spriter
+	name = "Holy suffusion"
+	desc = "Your being is suffused with holy light that repels vile magics."
+	icon_state = "slime_rainbowshield" //i'm a coder, not a spriter
 
 /datum/status_effect/holylight_antimagic/on_apply()
 	ADD_TRAIT(owner, TRAIT_ANTIMAGIC, type)

--- a/code/datums/status_effects/buffs/buffs.dm
+++ b/code/datums/status_effects/buffs/buffs.dm
@@ -692,31 +692,23 @@
 		H.physiology.pressure_mod /= 0.5
 		H.physiology.heat_mod /= 0.5
 	
-/datum/status_effect/antimagic
+/datum/status_effect/holylight_antimagic
 	id = "antimagic"
 	duration = 2 MINUTES
 	tick_interval = 0
 	status_type = STATUS_EFFECT_REFRESH
-	alert_type = /atom/movable/screen/alert/status_effect/antimagic
+	alert_type = /atom/movable/screen/alert/status_effect/holylight_antimagic
 
-/atom/movable/screen/alert/status_effect/antimagic
+/atom/movable/screen/alert/status_effect/holylight_antimagic
 	name = "Diamond skin"
 	desc = "Your skin is infused with diamonds, making you more resistant to heat and pressure."
 	icon_state = "shadow_mend" //i'm a coder, not a spriter
 
-/datum/status_effect/antimagic/on_apply()
-	. = ..()
-	if(.)
-		if(ishuman(owner))
-			var/mob/living/carbon/human/H = owner
-			H.AddComponent(/datum/component/anti_magic, TRUE, TRUE, FALSE, null, null, FALSE)
-			H.add_atom_colour(GLOB.freon_color_matrix, TEMPORARY_COLOUR_PRIORITY)
+/datum/status_effect/holylight_antimagic/on_apply()
+	ADD_TRAIT(owner, TRAIT_ANTIMAGIC, type)
+	owner.add_atom_colour(GLOB.freon_color_matrix, TEMPORARY_COLOUR_PRIORITY)
 
-/datum/status_effect/antimagic/on_remove()
-	if(ishuman(owner))
-		var/mob/living/carbon/human/H = owner
-		var/datum/component/anti_magic/antimagic = H.GetComponent(/datum/component/anti_magic)
-		if(antimagic)
-			antimagic.RemoveComponent()
-		H.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY)
+/datum/status_effect/holylight_antimagic/on_remove()
+	REMOVE_TRAIT(owner, TRAIT_ANTIMAGIC, type)
+	owner.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY)
 

--- a/code/datums/status_effects/buffs/buffs.dm
+++ b/code/datums/status_effects/buffs/buffs.dm
@@ -693,7 +693,7 @@
 		H.physiology.heat_mod /= 0.5
 	
 /datum/status_effect/holylight_antimagic
-	id = "antimagic"
+	id = "holy antimagic"
 	duration = 2 MINUTES
 	tick_interval = 0
 	status_type = STATUS_EFFECT_REFRESH

--- a/code/datums/status_effects/buffs/buffs.dm
+++ b/code/datums/status_effects/buffs/buffs.dm
@@ -691,3 +691,32 @@
 		var/mob/living/carbon/human/H = owner
 		H.physiology.pressure_mod /= 0.5
 		H.physiology.heat_mod /= 0.5
+	
+/datum/status_effect/antimagic
+	id = "antimagic"
+	duration = 2 MINUTES
+	tick_interval = 0
+	status_type = STATUS_EFFECT_REFRESH
+	alert_type = /atom/movable/screen/alert/status_effect/antimagic
+
+/atom/movable/screen/alert/status_effect/antimagic
+	name = "Diamond skin"
+	desc = "Your skin is infused with diamonds, making you more resistant to heat and pressure."
+	icon_state = "shadow_mend" //i'm a coder, not a spriter
+
+/datum/status_effect/antimagic/on_apply()
+	. = ..()
+	if(.)
+		if(ishuman(owner))
+			var/mob/living/carbon/human/H = owner
+			H.AddComponent(/datum/component/anti_magic, TRUE, TRUE, FALSE, null, null, FALSE)
+			H.add_atom_colour(GLOB.freon_color_matrix, TEMPORARY_COLOUR_PRIORITY)
+
+/datum/status_effect/antimagic/on_remove()
+	if(ishuman(owner))
+		var/mob/living/carbon/human/H = owner
+		var/datum/component/anti_magic/antimagic = H.GetComponent(/datum/component/anti_magic)
+		if(antimagic)
+			antimagic.RemoveComponent()
+		H.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY)
+

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -68,6 +68,7 @@
 	var/treatment_virus = /datum/reagent/medicine/spaceacillin
 	var/treat_virus = 1 //If on, the bot will attempt to treat viral infections, curing them if possible.
 	var/shut_up = 0 //self explanatory :)
+	var/holy = FALSE //if it injects holy water
 
 /mob/living/simple_animal/bot/medbot/mysterious
 	name = "\improper Mysterious Medibot"
@@ -658,6 +659,9 @@
 				else
 					patient.reagents.add_reagent(reagent_id,injection_amount)
 					log_combat(src, patient, "injected", "internal synthesizer", "[reagent_id]:[injection_amount]")
+					if(holy)
+						patient.reagents.add_reagent(/datum/reagent/water/holywater ,injection_amount)
+						log_combat(src, patient, "injected", "internal synthesizer", "[/datum/reagent/water/holywater]:[injection_amount]")
 				C.visible_message(span_danger("[src] injects [patient] with its syringe!"), \
 					span_userdanger("[src] injects you with its syringe!"))
 			else

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -689,7 +689,7 @@
 	man_to_revive.revive(TRUE)
 	if(was_dead) // aheal needs downside
 		man_to_revive.adjustCloneLoss(75) // can be slowly healed with the rod of asclepius anyways
-	man_to_revive.apply_status_effect(STATUS_EFFECT_ANTIMAGIC)	
+	man_to_revive.apply_status_effect(STATUS_EFFECT_HOLYLIGHT_ANTIMAGIC)	
 	to_chat(man_to_revive, span_userdanger("As you rise anew, you forget all that had previously harmed you!"))
 	man_to_revive.emote("smile")
 	man_to_revive.visible_message(span_notice("[man_to_revive] rises, reborn in the Holy Light!"))

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -607,8 +607,11 @@
 
 /datum/religion_rites/medibot/invoke_effect(mob/living/user, atom/movable/religious_tool)
 	var/altar_turf = get_turf(religious_tool)
-	var/atom/newitem = new /mob/living/simple_animal/bot/medbot (altar_turf)
+	var/mob/living/simple_animal/bot/medbot/newitem = new (altar_turf)
 	newitem.name = "\improper Holy Medibot"
+	newitem.add_atom_colour(GLOB.freon_color_matrix, TEMPORARY_COLOUR_PRIORITY)
+	newitem.holy = TRUE
+	newitem.AddComponent(/datum/component/anti_magic, TRUE, TRUE, FALSE, null, null, FALSE)
 	playsound(altar_turf, 'sound/magic/staff_healing.ogg', 50, TRUE)
 	return TRUE
 
@@ -686,7 +689,7 @@
 	man_to_revive.revive(TRUE)
 	if(was_dead) // aheal needs downside
 		man_to_revive.adjustCloneLoss(75) // can be slowly healed with the rod of asclepius anyways
-	man_to_revive.add_atom_colour(GLOB.freon_color_matrix, TEMPORARY_COLOUR_PRIORITY)
+	man_to_revive.apply_status_effect(STATUS_EFFECT_ANTIMAGIC)	
 	to_chat(man_to_revive, span_userdanger("As you rise anew, you forget all that had previously harmed you!"))
 	man_to_revive.emote("smile")
 	man_to_revive.visible_message(span_notice("[man_to_revive] rises, reborn in the Holy Light!"))


### PR DESCRIPTION
only merge after #20178

The problem is that medbots are currently anti-synergistic and there's nothing special about them when robotics can mass produce them faster than you
When the other PR is merged, this'll make them heal slightly more than regular medbots as well as not steal potential favour from the chaplain

As a side effect, holy medbots will be far more useful against something like clockies, assuming the chap can make them

Also makes the holy revival rite a little funnier in that it gives temporary antimagic, the idea being they're still suffused with the power that revived them for the time being

:cl:  
tweak: Holy medbots have antimagic and also inject holy water
tweak: Holy revival rite gives 2 minutes of antimagic
/:cl:
