### PR TITLE
Give the gas analyzer ability to scan turf next to the user

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -608,6 +608,14 @@ GENE SCANNER
 	add_fingerprint(user)
 	scangasses(user)			//yogs start: Makes the gas scanning able to be used elseware
 
+/obj/item/analyzer/afterattack(atom/target as obj, mob/user, proximity)
+	if(!proximity)
+		return
+	add_fingerprint(user)
+	if(istype(target, /turf))
+		var/turf/U = get_turf(target)
+		atmosanalyzer_scan(user, U)
+
 /obj/item/proc/scangasses(mob/user)
 	var/list/combined_msg = list()
 	//yogs stop


### PR DESCRIPTION


# Document the changes in your pull request
Give the gas analyzer ability to scan turf next to the user

# Why is this good for the game?
No longer have to enter harazadous area to scan the turf

# Wiki Documentation
document of change

# Changelog


:cl:  
rscadd: Give the gas analyzer ability to scan turf next to the user

/:cl:
