### PR TITLE
Fixed x-ray bolts causing toxin damage to rad-immune species when embedded

### DIFF
--- a/code/modules/projectiles/ammunition/reusable/arrow.dm
+++ b/code/modules/projectiles/ammunition/reusable/arrow.dm
@@ -562,6 +562,10 @@
 	projectile_type = /obj/item/projectile/energy/arrow/xray
 	tick_damage_type = TOX
 
+/obj/item/ammo_casing/reusable/arrow/energy/xray/embed_tick(target, mob/living/carbon/human/embedde, obj/item/bodypart/part)
+	tick_damage = HAS_TRAIT(embedde, TRAIT_RADIMMUNE) ? 0 : initial(tick_damage)
+	return ..()
+
 /obj/item/ammo_casing/reusable/arrow/energy/shock
 	name = "shock bolt"
 	desc = "An arrow made from hardlight. This one shocks the victim with harmless energy capable of stunning them."


### PR DESCRIPTION
# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:    
bugfix: fixed x-ray bolts causing toxin damage to rad-immune species when embedded
/:cl:
