### PR TITLE
Medical Cyborg Alien Tools Upgrade

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -905,7 +905,7 @@
 	R.module.basic_modules += CS
 	R.module.add_module(CS, FALSE, TRUE)
 
-/obj/item/borg/upgrade/aliensurgerykit
+/obj/item/borg/upgrade/alien_surgerykit
 	name = "medical cyborg alien surgical kit"
 	desc = "An upgrade for medical cyborgs which replaces their advanced surgical tools with the alien versions of them."
 	icon_state = "cyborg_upgrade5"
@@ -928,7 +928,7 @@
 	)
 
 // Replaces the cyborg's advanced surgery tools with the alien verison of those tools.
-/obj/item/borg/upgrade/aliensurgerykit/action(mob/living/silicon/robot/R, user = usr)
+/obj/item/borg/upgrade/alien_surgerykit/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if(!.)
 		return FALSE
@@ -951,7 +951,7 @@
 		R.module.basic_modules += added_item
 		R.module.add_module(added_item, FALSE, TRUE)
 
-/obj/item/borg/upgrade/aliensurgerykit/deactivate(mob/living/silicon/robot/R, user = usr)
+/obj/item/borg/upgrade/alien_surgerykit/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if(!.)
 		return FALSE

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -927,7 +927,7 @@
 		/obj/item/cautery/alien
 	)
 
-// Replaces the cyborg's advanced surgery tools with the alien verison of those tools.
+// Replaces the cyborg's advanced surgery tools with the alien verison of those tools. Requires prerequisite surgery kit.
 /obj/item/borg/upgrade/alien_surgerykit/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if(!.)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -905,6 +905,69 @@
 	R.module.basic_modules += CS
 	R.module.add_module(CS, FALSE, TRUE)
 
+/obj/item/borg/upgrade/aliensurgerykit
+	name = "medical cyborg alien surgical kit"
+	desc = "An upgrade for medical cyborgs which replaces their advanced surgical tools with the alien versions of them."
+	icon_state = "cyborg_upgrade5"
+	require_module = TRUE
+	module_types = list(/obj/item/robot_module/medical)
+	module_flags = BORG_MODULE_MEDICAL
+	prerequisite_upgrades = list(/obj/item/borg/upgrade/surgerykit)
+	var/list/items_to_remove = list( // From surgery kit prerequisite.
+		/obj/item/scalpel/advanced,
+		/obj/item/retractor/advanced,
+		/obj/item/cautery/advanced
+	)
+	var/list/items_to_add = list(
+		/obj/item/scalpel/alien,
+		/obj/item/hemostat/alien,
+		/obj/item/retractor/alien,
+		/obj/item/circular_saw/alien,
+		/obj/item/surgicaldrill/alien,
+		/obj/item/cautery/alien
+	)
+
+// Replaces the cyborg's advanced surgery tools with the alien verison of those tools.
+/obj/item/borg/upgrade/aliensurgerykit/action(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	// Remove all items with the exact item type in `items_to_remove`.
+	for(var/obj/item/item_module in R.module.modules)
+		for(var/item_type_to_remove in items_to_remove)
+			if(item_module.type == item_type_to_remove)
+				R.module.remove_module(item_module, TRUE)
+
+	// Checks if they have any of the added items already. If so, inform and return.
+	for(var/item_type_to_check in items_to_add)
+		if(is_type_in_list(item_type_to_check, R.module.modules))
+			to_chat(user, span_warning("This cyborg is already equipped with an alien surgical kit."))
+			return FALSE
+
+	// Gives the items from `items_to_add`.
+	for(var/item_type_to_add in items_to_add)
+		var/added_item = new item_type_to_add(R.module)
+		R.module.basic_modules += added_item
+		R.module.add_module(added_item, FALSE, TRUE)
+
+/obj/item/borg/upgrade/aliensurgerykit/deactivate(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(!.)
+		return FALSE
+
+	// Remove all items with the exact item type in `items_to_add`.
+	for(var/obj/item/item_module in R.module.modules)
+		for(var/item_type_to_remove in items_to_add)
+			if(item_module.type == item_type_to_remove)
+				R.module.remove_module(item_module, TRUE)
+
+	// Give the items from `items_to_remove`.
+	for(var/item_type_to_add in items_to_remove)
+		var/added_item = new item_type_to_add(R.module)
+		R.module.basic_modules += added_item
+		R.module.add_module(added_item, FALSE, TRUE)
+
 /obj/item/borg/upgrade/ai
 	name = "B.O.R.I.S. module"
 	desc = "Bluespace Optimized Remote Intelligence Synchronization. An uplink device which takes the place of an MMI in cyborg endoskeletons, creating a robotic shell controlled by an AI."

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -905,6 +905,16 @@
 	construction_time = 140
 	category = list("Cyborg Upgrade Modules")
 
+/datum/design/borg_upgrade_surgerykit_alien
+	name = "Cyborg Upgrade (Alien Surgical Kit)"
+	id = "borg_upgrade_surgerykit_alien"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/alien_surgerykit
+	/// Combined materials of all 6 alien surgical tools.
+	materials = list(/datum/material/iron = 28000, /datum/material/silver = 11000, /datum/material/plasma = 3000, /datum/material/titanium = 9000)
+	construction_time = 14 SECONDS
+	category = list("Cyborg Upgrade Modules")
+
 /datum/design/borg_upgrade_analyzer
 	name = "Cyborg Upgrade (Advanced Analyzer)"
 	id = "borg_upgrade_analyzer"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -356,10 +356,18 @@
 
 /datum/techweb_node/cyborg_upg_surgkit
 	id = "cyborg_upg_surgkit"
-	display_name = "Cyborg Upgrade: Medical Advanced Medical Tools"
-	description = "Advanced Surgical Kit and Advanced Health Scanner upgrade design for medical cyborgs."
+	display_name = "Cyborg Upgrade: Advanced Medical Tools"
+	description = "Advanced medical tool upgrades for cyborgs."
 	prereq_ids = list("cyborg_upg_med", "exp_tools")
 	design_ids = list("borg_upgrade_surgerykit", "borg_upgrade_analyzer")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
+
+/datum/techweb_node/cyborg_upg_surgkit_alien
+	id = "cyborg_upg_surgkit_alien"
+	display_name = "Cyborg Upgrade: Alien Medical Tools"
+	description = "Alien medical tool upgrades for cyborgs."
+	prereq_ids = list("cyborg_upg_surgkit", "alien_bio")
+	design_ids = list("borg_upgrade_surgerykit_alien")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 
 /datum/techweb_node/ai

--- a/code/modules/research/techweb/layout.dm
+++ b/code/modules/research/techweb/layout.dm
@@ -463,6 +463,10 @@
 	ui_x = 416
 	ui_y = -160
 
+/datum/techweb_node/cyborg_upg_surgkit_alien
+	ui_x = 480
+	ui_y = -160
+
 /datum/techweb_node/cyber_organs_upgraded
 	ui_x = 416
 	ui_y = -96


### PR DESCRIPTION
# Document the changes in your pull request
A new upgrade for medical cyborgs to install that replaces their advanced surgery tools with the alien surgery tools. It requires the advanced surgery tool upgrade as a prerequisite upgrade. It costs: 28000 iron (14 sheets), 11000 silver (5.5 sheets), 3000 plasma (1.5 sheets), and 9000 titanium (4.5 sheets).

A new techweb node called "Cyborg Upgrade: Alien Medical Tools" is added. It costs 1000 general points and requires two prerequisite techweb nodes: "Cyborg Upgrade: Advanced Medical Tools" and "Alien Biological Tools".

Changes the description of "Cyborg Upgrade: Advanced Medical Tools" techweb node to be more general to match all the other techweb nodes.

Changes the name of "Cyborg Upgrade: Medical Advanced Medical Tools" to ""Cyborg Upgrade: Advanced Medical Tools" as there was an unnecessary word ("Medical") in it.

# Why is this good for the game?
No reason why cyborgs are excluded from getting alien tools when humans can print them out at the nearest medical protolathe when it is researched. Gives people who care about medical a reason to bring alien tech to Research instead of not. Progression (if it ever gets researched). 

# Wiki Documentation
New techweb node: "Cyborg Upgrade: Alien Medical Tools" costing 1000 points and locked behind "Cyborg Upgrade: Advanced Medical Tools" and "Alien Biological Tools".

New upgrade for mediborgs: "medical cyborg alien surgical kit" costing 28000 iron, 11000 silver, 3000 plasma, and 9000 titanium. 
Description: "An upgrade for medical cyborgs which replaces their advanced surgical tools with the alien versions of them."

# Changelog

:cl:  
rscadd: A new upgrade for medical cyborgs that replaces their advanced surgery tools with alien surgery tools. Requires the prerequisite upgrade of advanced surgery tools to install.
rscadd: A techweb node called "Cyborg Upgrade: Alien Medical Tools" costing 1000 general points. Locked behind "Cyborg Upgrade: Advanced Medical Tools" and "Alien Biological Tools".
tweak: Makes the description of "Cyborg Upgrade: Advanced Medical Tools" to be more general like every other techweb.
spellcheck: "Cyborg Upgrade: Medical Advanced Medical Tools" -> "Cyborg Upgrade: Advanced Medical Tools"
/:cl:
