### PR TITLE
Hecata clan necromancy reverts you back to your original species after it ends

### DIFF
--- a/code/modules/antagonists/bloodsuckers/powers/targeted/hecata.dm
+++ b/code/modules/antagonists/bloodsuckers/powers/targeted/hecata.dm
@@ -58,7 +58,7 @@
 
 /datum/action/cooldown/bloodsucker/targeted/hecata/necromancy/FireTargetedPower(atom/target_atom)
 	. = ..()
-	var/mob/living/target = target_atom
+	var/mob/living/carbon/target = target_atom
 	var/mob/living/user = owner
 	var/datum/antagonist/bloodsucker/bloodsuckerdatum = user.mind.has_antag_datum(/datum/antagonist/bloodsucker)
 	if(target.stat == DEAD && user.Adjacent(target))
@@ -80,6 +80,7 @@
 			owner.balloon_alert(owner, "their body refuses to react...")
 			DeactivatePower()
 			return
+		var/old_species = target.dna?.species.type
 		zombify(target)
 		bloodsuckerdatum.make_vassal(target)
 		power_activated_sucessfully()
@@ -99,16 +100,16 @@
 				living_time = 14 MINUTES 
 			if(5 to 99)
 				living_time = 17 MINUTES //in general, they don't last long, make the most of them.
-		addtimer(CALLBACK(src, PROC_REF(end_necromance), target), living_time)
+		addtimer(CALLBACK(src, PROC_REF(end_necromance), target, old_species), living_time)
 	else //extra check, but this shouldn't happen
 		owner.balloon_alert(owner, "out of range/not dead.")
 		return FALSE
 	DeactivatePower()
 	
-/datum/action/cooldown/bloodsucker/targeted/hecata/necromancy/proc/end_necromance(mob/living/user)
+/datum/action/cooldown/bloodsucker/targeted/hecata/necromancy/proc/end_necromance(mob/living/user, old_species)
 	user.mind.remove_antag_datum(/datum/antagonist/vassal)
 	to_chat(user, span_warning("You feel the shadows around you weaken, your form falling limp like a puppet cut from its strings!"))
-	user.set_species(/datum/species/krokodil_addict) //they will turn into a fake zombie on death, that still retains blood and isnt so powerful.
+	user.set_species(old_species ? old_species : /datum/species/krokodil_addict) //go back to original species, or lesser zombie if they somehow didn't have one
 	user.death()
 
 /datum/action/cooldown/bloodsucker/targeted/hecata/necromancy/proc/zombify(mob/living/user)


### PR DESCRIPTION
# Document the changes in your pull request

Hecata clan necromancy will now revert you back to your original species when it ends, instead of staying a zombie.

# Why is this good for the game?
<!-- Describe why you think this change is good for the game. -->

Remaining a zombie after the necromancy ends is a bit silly.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: hecata clan necromancy reverts you back to your original species after it ends instead of staying a zombie
/:cl:
