### PR TITLE
Hecata necromancy objective # reduced

### DIFF
--- a/code/modules/antagonists/bloodsuckers/bloodsucker_objectives.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsucker_objectives.dm
@@ -389,7 +389,7 @@
 	name = "necromance"
 
 /datum/objective/bloodsucker/necromance/New()
-	target_amount = rand(5,6)
+	target_amount = rand(4,5)
 	..()
 
 

--- a/code/modules/antagonists/bloodsuckers/bloodsucker_objectives.dm
+++ b/code/modules/antagonists/bloodsuckers/bloodsucker_objectives.dm
@@ -389,7 +389,7 @@
 	name = "necromance"
 
 /datum/objective/bloodsucker/necromance/New()
-	target_amount = rand(6,8)
+	target_amount = rand(5,6)
 	..()
 
 


### PR DESCRIPTION
You have to necromance 4-5 people instead of 7-8.

Encouraged murderbone too much at high levels even though it is not needed what so ever, as each person revived does not need to be unique.

Other clan objectives are also laughably easy so until they're tuned this will be easier as well for now.

Good for game because people wait until they're level 8 to go on a murderbone spree instead of using necromancy throughout the whole round to get their objective complete, like they're supposed to do.

# Changelog

:cl:  
tweak: Hecata Bloodsuckers need to revive 4-5 people rather than 7-8
/:cl:
