### PR TITLE
Increase pill number to 7 in pentetic acid pill bottle

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -702,7 +702,7 @@
 	desc = "Contains pills to expunge radiation and toxins."
 
 /obj/item/storage/pill_bottle/penacid/PopulateContents()
-	for(var/i in 1 to 3)
+	for(var/i in 1 to 7)
 		new /obj/item/reagent_containers/pill/penacid(src)
 
 


### PR DESCRIPTION

# Document the changes in your pull request
Increase pill number to 7 in pentetic acid pill bottle

# Why is this good for the game?
Why does it only have 3, why not full bottle? Someone probally ate most of it while shipping it to the station



# Wiki Documentation
pentetic acid pill bottle now has 7 pills maximum

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: pentetic acid pill bottle now has 7 pills maximum
/:cl:
