### PR TITLE
Syndicate Listening Post - Slight Tweaks that May or May Not Be An ided PR but I Do Not Give A Shit

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -1853,7 +1853,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/window/reinforced/survival_pod,
 /obj/item/paper{
-	info = "It is the decision of the Lieutenant, and the Lieutenant alone, on when the Self Destruct should be activated."
+	info = "It is the decision of the Lieutenant, and the Lieutenant alone, on when the Self Destruct should be activated. If they are not available, decision-making falls to the junior agent."
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/tile/red/fourcorners,

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -1005,7 +1005,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/warehouse)
 "iu" = (
-/obj/structure/closet/wardrobe/black,
+/obj/structure/closet/wardrobe/black{
+	anchored = 1
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ruin/space/has_grav/listeningstation/quarters)
 "iz" = (
@@ -1368,9 +1370,6 @@
 /obj/item/paper_bin,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/warehouse)
-"oq" = (
-/turf/closed/mineral/gibtonite,
-/area/ruin/space/has_grav/listeningstation)
 "ou" = (
 /turf/open/floor/engine/o2,
 /area/ruin/space/has_grav/listeningstation/engineering)
@@ -1831,9 +1830,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/window/reinforced/survival_pod,
 /obj/machinery/door/firedoor/border_only,
-/obj/item/paper{
-	info = "In order to help increase the power of your onboard self-destruct, the asteroid selected has extremely high gibtonite concentration. If you do decide to mine, take a scanner with you to avoid the impromptu evaporation of the base."
-	},
 /obj/effect/turf_decal/tile/red/fourcorners,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/hallway)
@@ -1856,7 +1852,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/window/reinforced/survival_pod,
 /obj/item/paper{
-	info = "Both recon agents are required to reach a consensus on use of the Emergency Self Destruct before it is used."
+	info = "It is the decision of the Lieutenant, and the Lieutenant alone, on when the Self Destruct should be activated."
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/tile/red/fourcorners,
@@ -3674,7 +3670,7 @@ NO
 NO
 NO
 NO
-oq
+NO
 yN
 zg
 aC
@@ -3766,12 +3762,12 @@ aD
 fL
 KS
 yN
-oq
+NO
 NO
 as
 as
 as
-oq
+NO
 NO
 uy
 uy
@@ -4194,7 +4190,7 @@ NO
 NO
 NO
 NO
-oq
+NO
 bn
 bn
 Dk
@@ -4244,7 +4240,7 @@ Nl
 bx
 bw
 bn
-oq
+NO
 NO
 as
 as

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -1536,6 +1536,7 @@
 /obj/item/computer_hardware/hard_drive/portable/super,
 /obj/item/reagent_containers/glass/bottle/mannitol,
 /obj/item/clothing/head/helmet,
+/obj/item/bombcore/training,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/warehouse)
 "sR" = (


### PR DESCRIPTION
# Document the changes in your pull request

Removes Gibtonite from the listening post asteroid

Adds a dummy payload to rig up 'self destruct if someone dies' mechanisms without dying

Anchors the uniform lockers (CAYENNE)

# Why is this good for the game?

Listening Post gibtonite was meant for self destruct not funny space people (yes it's an ided but still), rest is QOL

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
mapping: The Syndicate has stopped throwing their supposedly important listening stations into gibtonite-filled shithole rocks, and has also supplied a few extra supplies.
/:cl:
