### PR TITLE
Makes the Pride Jackets donator items in addition to coming from clothesmates

### DIFF
--- a/yogstation/code/modules/donor/unique_donator_items.dm
+++ b/yogstation/code/modules/donor/unique_donator_items.dm
@@ -502,6 +502,15 @@ Uncomment this and use atomproccall as necessary, then copypaste the output into
 /datum/donator_gear/orca_dress
 	name = "creator's dress"
 	unlock_path = /obj/item/clothing/suit/yogs/keiki
+/datum/donator_gear/pridejacket
+	name = "pride jacket"
+	unlock_path = /obj/item/clothing/suit/jacket/pride
+/datum/donator_gear/mlm
+	name = "MLM pride jacket"
+	unlock_path = /obj/item/clothing/suit/jacket/pride/mlm
+/datum/donator_gear/lesbian
+	name = "lesbian pride jacket"
+	unlock_path = /obj/item/clothing/suit/jacket/pride/lesbian
 /datum/donator_gear/oreo
 	name = "Black and white sneakers"
 	unlock_path = /obj/item/clothing/shoes/yogs/trainers


### PR DESCRIPTION
# Document the changes in your pull request

The pride hoodie as it exists was an idea I had for a unique donator item locked to myself, specifically the MLM version.  I had cuackles sprite it, and then the great unique item crackdown happened.  I recall someone at some point asking me if I was okay with the hoodie being made public and new ones made with it.  I said yes under the impression they would be accessible as donor items (not exclusively donor but donors could take them).  I might be pulling that interaction out of my ass though.

I have no issue with these existing I just want donors to be able to easily access them :)

# Why is this good for the game?
adds more gay

# Wiki Documentation

if there is a list of donor items anywhere these need to go there

# Changelog

:cl:  cark
tweak: donors can take pride hoodies as a donor item now 
/:cl:
