### PR TITLE
Disables the Beach Biodome

### DIFF
--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -13,6 +13,7 @@
 	description = "Seemingly plucked from a tropical destination, this beach is calm and cool, with the salty waves roaring softly in the background. \
 	Comes with a rustic wooden bar and suicidal bartender."
 	suffix = "lavaland_biodome_beach.dmm"
+	unpickable = TRUE
 
 /datum/map_template/ruin/lavaland/biodome/fishing
 	name = "Biodome Fishing Pier"

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -13,7 +13,6 @@
 	description = "Seemingly plucked from a tropical destination, this beach is calm and cool, with the salty waves roaring softly in the background. \
 	Comes with a rustic wooden bar and suicidal bartender."
 	suffix = "lavaland_biodome_beach.dmm"
-	unpickable = TRUE
 
 /datum/map_template/ruin/lavaland/biodome/fishing
 	name = "Biodome Fishing Pier"

--- a/config/lavaruinblacklist.txt
+++ b/config/lavaruinblacklist.txt
@@ -6,7 +6,7 @@
 ##BIODOMES
 #_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter_inn.dmm
-#_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
 _maps/RandomRuins/LavaRuins/lavaland_surface_cube.dmm
 


### PR DESCRIPTION
# Document the changes in your pull request

Disables the beach biodome from being spawned on Lavaland, as per title.

# Why is this good for the game?
Nobody ever uses the ghost roles here, and it takes up far too much space for a unused spot.  I seriously haven't seen anyone spawn here since like 2020.  I toyed briefly with reducing its size but it's honestly far too much of a hassle for a feature nobody will use.

This will allow for ruins that are actually used to have more likelyhood to spawn.


# Wiki Documentation

note that it is disabled on the ruins page

# Changelog

:cl:  cark
mapping: the beach biodome no longer spawns on lavaland
/:cl:
