### PR TITLE
Disables the pet hospital and the medical outpost ruins

### DIFF
--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -91,6 +91,7 @@
 	cost = 5
 	suffix = "lavaland_surface_animal_hospital.dmm"
 	allow_duplicates = FALSE
+	unpickable = TRUE
 
 /datum/map_template/ruin/lavaland/sin
 	cost = 10
@@ -412,6 +413,7 @@
 	suffix = "lavaland_surface_medical.dmm"
 	allow_duplicates = FALSE
 	cost = 15
+	unpickable = TRUE
 
 /datum/map_template/ruin/lavaland/travellingbard
 	name = "Travelling Bard"

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -91,7 +91,6 @@
 	cost = 5
 	suffix = "lavaland_surface_animal_hospital.dmm"
 	allow_duplicates = FALSE
-	unpickable = TRUE
 
 /datum/map_template/ruin/lavaland/sin
 	cost = 10
@@ -413,7 +412,6 @@
 	suffix = "lavaland_surface_medical.dmm"
 	allow_duplicates = FALSE
 	cost = 15
-	unpickable = TRUE
 
 /datum/map_template/ruin/lavaland/travellingbard
 	name = "Travelling Bard"

--- a/config/lavaruinblacklist.txt
+++ b/config/lavaruinblacklist.txt
@@ -30,7 +30,8 @@ _maps/RandomRuins/LavaRuins/lavaland_surface_prisoner_crash.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_ww_vault.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_automated_trade_outpost.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_xeno_nest.dmm
-#_maps/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
+_maps/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
+_maps/RandomRuins/LavaRuins/lavaland_surface_medical.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_survivalpod.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_wwiioutpost.dmm
 #_maps/RandomRuins/LavaRuins/lavaland_surface_tomb.dmm


### PR DESCRIPTION
# Document the changes in your pull request

disables both of the hospital ruins on lavaland. requested by Molti

# Why is this good for the game?
nobody plays these, and when they do its just "rush to station to have fun"
they take up space on lavaland and aren't worth overhauling when the concept isnt fun.

# Wiki Documentation

remove/note unused on ruins wiki page

# Changelog

:cl:  cark
mapping: removes the two hospital ruins on lavaland
/:cl:
