### PR TITLE
Disables the gas station lavaland ruin

### DIFF
--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -452,6 +452,7 @@
 	suffix = "lavaland_surface_gas_station.dmm"
 	allow_duplicates = FALSE
 	cost = 10
+	unpickable = TRUE
 
 /datum/map_template/ruin/lavaland/king_goat_boss
 	name = "King Goat Boss Ruin"


### PR DESCRIPTION
# Document the changes in your pull request

disables gas station ruin on lavaland, requested by molti

# Why is this good for the game?
rarely used, usually just a miner loot pinata, takes up space on lavaland

# Changelog

:cl:  cark
mapping: disabled lavaland gas station
/:cl:
