### PR TITLE
Makes photo objectives use minds rather than mobs

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1541,8 +1541,8 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 		return TRUE
 	var/list/all_items = owner.current.get_all_contents()
 	for(var/obj/item/photo/P in all_items)
-		for(var/mob/M in P.picture.mobs_seen)
-			if(M.real_name == target.name)
+		for(var/datum/mind/M in P.picture.minds_seen)
+			if(M == target)
 				return TRUE
 	return FALSE
 

--- a/code/modules/antagonists/creep/creep.dm
+++ b/code/modules/antagonists/creep/creep.dm
@@ -314,7 +314,7 @@
 		for(var/obj/I in all_items) //Check for wanted items
 			if(istype(I, /obj/item/photo))
 				var/obj/item/photo/P = I
-				if(P.picture.mobs_seen.Find(owner.current) && P.picture.mobs_seen.Find(target.current) && !P.picture.dead_seen.Find(target.current))//you are in the picture, they are but they are not dead.
+				if(P.picture.minds_seen.Find(owner) && P.picture.minds_seen.Find(target) && !P.picture.dead_seen.Find(target))//you are in the picture, they are but they are not dead.
 					return TRUE
 	return FALSE
 

--- a/code/modules/photography/_pictures.dm
+++ b/code/modules/photography/_pictures.dm
@@ -1,8 +1,8 @@
 /datum/picture
 	var/picture_name = "picture"
 	var/picture_desc = "This is a picture."
-	var/list/mobs_seen = list()
 	var/list/dead_seen = list()
+	var/list/minds_seen = list()
 	var/caption
 	var/icon/picture_image
 	var/icon/picture_icon
@@ -12,13 +12,13 @@
 	var/logpath						//If the picture has been logged this is the path.
 	var/id							//this var is NOT protected because the worst you can do with this that you couldn't do otherwise is overwrite photos, and photos aren't going to be used as attack logs/investigations anytime soon.
 
-/datum/picture/New(name, desc, mobs_spotted, dead_spotted, image, icon, size_x, size_y, bp, caption_, autogenerate_icon)
+/datum/picture/New(name, desc, minds_spotted, dead_spotted, image, icon, size_x, size_y, bp, caption_, autogenerate_icon)
 	if(!isnull(name))
 		picture_name = name
 	if(!isnull(desc))
 		picture_desc = desc
-	if(!isnull(mobs_spotted))
-		mobs_seen = mobs_spotted
+	if(!isnull(minds_spotted))
+		minds_seen = minds_spotted
 	if(!isnull(dead_spotted))
 		dead_seen = dead_spotted
 	if(!isnull(image))
@@ -175,5 +175,6 @@
 		if(picture_image)
 			P.picture_image.Crop(cropx, cropy, psize_x - cropx, psize_y - cropy)
 		P.regenerate_small_icon()
-	P.mobs_seen = mobs_seen
+	P.minds_seen = minds_seen
+	P.dead_seen = dead_seen
 	return P

--- a/code/modules/photography/camera/camera.dm
+++ b/code/modules/photography/camera/camera.dm
@@ -215,6 +215,7 @@
 	var/list/desc = list("This is a photo of an area of [size_x+1] meters by [size_y+1] meters.")
 	var/list/mobs_spotted = list()
 	var/list/dead_spotted = list()
+	var/list/minds_spotted = list()
 	var/ai_user = isAI(user)
 	var/list/seen
 	var/list/viewlist = (user && user.client)? getviewsize(user.client.view) : getviewsize(world.view)
@@ -235,8 +236,9 @@
 	for(var/i in mobs)
 		var/mob/M = i
 		mobs_spotted += M
+		minds_spotted += M.mind
 		if(M.stat == DEAD)
-			dead_spotted += M
+			dead_spotted += M.mind
 		desc += M.get_photo_description(src)
 
 	var/psize_x = (size_x * 2 + 1) * world.icon_size
@@ -248,7 +250,7 @@
 	temp.Scale(psize_x, psize_y)
 	temp.Blend(get_icon, ICON_OVERLAY)
 
-	var/datum/picture/P = new("picture", desc.Join(" "), mobs_spotted, dead_spotted, temp, null, psize_x, psize_y, blueprints)
+	var/datum/picture/P = new("picture", desc.Join(" "), mobs_spotted, dead_spotted, minds_spotted, temp, null, psize_x, psize_y, blueprints)
 	after_picture(user, P, flag)
 	blending = FALSE
 


### PR DESCRIPTION
# Document the changes in your pull request

Minds are a much better way of identifying someone than mob is
Also fixes bug where photocopying a photo of your dead obsession target counts as them being alive

# Why is this good for the game?
Shouldn't get fucked because you took a photo of someone who was cremated or cloned

# Changelog

:cl:  
bugfix: fixed photos forgetting about people who are cremated
bugfix: fixed photos not recognizing targets who were cloned
bugfix: fixed photos thinking dead people are alive after copying
/:cl:
