### PR TITLE
Someone forgot that not all borgs have an MMI

### DIFF
--- a/code/modules/mob/living/silicon/robot/laws.dm
+++ b/code/modules/mob/living/silicon/robot/laws.dm
@@ -66,7 +66,7 @@
 		else
 			temp = master.zeroth
 
-		if(!mmi.syndicate_mmi)
+		if(!mmi?.syndicate_mmi)
 			laws.zeroth = temp
 
 		laws.inherent.len = master.inherent.len
@@ -98,7 +98,7 @@
 
 /mob/living/silicon/robot/set_zeroth_law(law, law_borg, announce = TRUE)
 	laws_sanity_check()
-	if(mmi.syndicate_mmi)
+	if(mmi?.syndicate_mmi)
 		syndiemmi_override()
 		to_chat(src, span_warning("Lawset change detected. Syndicate override engaged."))
 		return
@@ -106,7 +106,7 @@
 
 /mob/living/silicon/robot/clear_zeroth_law(force, announce = TRUE)
 	laws_sanity_check()
-	if(mmi.syndicate_mmi)
+	if(mmi?.syndicate_mmi)
 		syndiemmi_override()
 		to_chat(src, span_warning("Lawset change detected. Syndicate override engaged."))
 		return


### PR DESCRIPTION
# Document the changes in your pull request
Shells don't have an mmi, so a shell wouldn't lawsync lol

# Why is this good for the game?
Shell having different laws than the AI is a can of worms that should not be opened

# Changelog

:cl:  
bugfix: fixed AI shell lawsync not working
/:cl:
