### PR TITLE
Makes Holy Light Holy Water better to use

### DIFF
--- a/code/datums/components/heal_react.dm
+++ b/code/datums/components/heal_react.dm
@@ -19,7 +19,7 @@
 
 /datum/component/heal_react/boost
 	///multiplicitive boost to incoming healing
-	var/boost_amount = 0.5
+	var/boost_amount = 0.3
 	///types of damage this will effect
 	var/list/applies_to = list(BRUTE,BURN,TOX,OXY,CLONE,STAMINA)
 	///internal check for if we are being healed by ourselves, no double dipping

--- a/code/datums/components/heal_react.dm
+++ b/code/datums/components/heal_react.dm
@@ -19,7 +19,7 @@
 
 /datum/component/heal_react/boost
 	///multiplicitive boost to incoming healing
-	var/boost_amount = 0.2
+	var/boost_amount = 0.5
 	///types of damage this will effect
 	var/list/applies_to = list(BRUTE,BURN,TOX,OXY,CLONE,STAMINA)
 	///internal check for if we are being healed by ourselves, no double dipping

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -265,9 +265,7 @@
 				SSticker.mode.remove_cultist(M.mind, FALSE, TRUE)
 			else if(is_servant_of_ratvar(M))
 				remove_servant_of_ratvar(M)
-			M.remove_status_effect(/datum/status_effect/jitter)
-			M.remove_status_effect(/datum/status_effect/speech/stutter)
-			holder.remove_reagent(type, volume)	// maybe this is a little too perfect and a max() cap on the statuses would be better??
+			holder.remove_reagent(type, volume)
 			return
 	if(ishuman(M) && is_vampire(M) && prob(80)) // Yogs Start
 		var/datum/antagonist/vampire/V = M.mind.has_antag_datum(ANTAG_DATUM_VAMPIRE)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -240,10 +240,9 @@
 			for(var/datum/action/innate/cult/blood_spell/BS in BM.spells)
 				qdel(BS)
 	if(data["misc"] >= 25)		// 10 units, 45 seconds @ metabolism 0.4 units & tick rate 1.8 sec
-		if(iscultist(M) || is_servant_of_ratvar(M))//only cultists get dizzy, stutter, and stronger jitter
-			M.adjust_jitter_up_to(4 SECONDS, 20 SECONDS)
-			M.adjust_stutter_up_to(4 SECONDS, 20 SECONDS)
-			M.set_dizzy_if_lower(10 SECONDS)
+		M.adjust_jitter_up_to(4 SECONDS, 20 SECONDS)//only get fucked if you're injected with it for a long time
+		M.adjust_stutter_up_to(4 SECONDS, 20 SECONDS)
+		M.set_dizzy_if_lower(10 SECONDS)
 		if(iscultist(M) && prob(20))
 			M.say(pick("Av'te Nar'sie","Pa'lid Mors","INO INO ORA ANA","SAT ANA!","Daim'niodeis Arc'iai Le'eones","R'ge Na'sie","Diabo us Vo'iscum","Eld' Mon Nobis"), forced = "holy water")
 			if(prob(10))

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -233,15 +233,17 @@
 	if(!data)
 		data = list("misc" = 1)
 	data["misc"]++
-	M.adjust_jitter_up_to(4 SECONDS, 20 SECONDS)
+	M.set_jitter_if_lower(1 SECONDS)
 	if(iscultist(M))
 		for(var/datum/action/innate/cult/blood_magic/BM in M.actions)
 			to_chat(M, span_cultlarge("Your blood rites falter as holy water scours your body!"))
 			for(var/datum/action/innate/cult/blood_spell/BS in BM.spells)
 				qdel(BS)
 	if(data["misc"] >= 25)		// 10 units, 45 seconds @ metabolism 0.4 units & tick rate 1.8 sec
-		M.adjust_stutter_up_to(4 SECONDS, 20 SECONDS)
-		M.set_dizzy_if_lower(10 SECONDS)
+		if(iscultist(M) || is_servant_of_ratvar(M))//only cultists get dizzy, stutter, and stronger jitter
+			M.adjust_jitter_up_to(4 SECONDS, 20 SECONDS)
+			M.adjust_stutter_up_to(4 SECONDS, 20 SECONDS)
+			M.set_dizzy_if_lower(10 SECONDS)
 		if(iscultist(M) && prob(20))
 			M.say(pick("Av'te Nar'sie","Pa'lid Mors","INO INO ORA ANA","SAT ANA!","Daim'niodeis Arc'iai Le'eones","R'ge Na'sie","Diabo us Vo'iscum","Eld' Mon Nobis"), forced = "holy water")
 			if(prob(10))

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -445,11 +445,9 @@
 		return FALSE
 
 	var/mob/living/carbon/human/H = L
-	var/heal_amt = 40 //double healing, no chance to mess up, and shorter cooldown than default
+	var/heal_amt = 20 //no chance to mess up
 
 	if(H.getBruteLoss() > 0 || H.getFireLoss() > 0)
-		var/amount_healed = (heal_amt * 2) + min(H.getBruteLoss() - heal_amt, 0) + min(H.getFireLoss() - heal_amt, 0)
-
 		H.heal_overall_damage(heal_amt, heal_amt, 0, BODYPART_ANY)
 		H.update_damage_overlays()
 

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -19,7 +19,7 @@
 	var/altar_icon // Changes the Altar of Gods icon
 	var/altar_icon_state // Changes the Altar of Gods icon_state
 	var/list/active_rites // Currently Active (non-deleted) rites
-	var/chapel_buff_coeff = 2
+	var/chapel_buff_coeff = 2.5
 
 /datum/religion_sect/New()
 	. = ..()

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -446,24 +446,14 @@
 
 	var/mob/living/carbon/human/H = L
 	var/heal_amt = 40 //double healing, no chance to mess up, and shorter cooldown than default
-	var/heal_cost = 40
 
 	if(H.getBruteLoss() > 0 || H.getFireLoss() > 0)
 		var/amount_healed = (heal_amt * 2) + min(H.getBruteLoss() - heal_amt, 0) + min(H.getFireLoss() - heal_amt, 0)
-		heal_cost *= amount_healed/heal_amt
-		if(L.GetComponent(/datum/component/heal_react/boost/holylight)) //we don't heal any more with holy water, but we do get a small favor boost from it
-			heal_amt *= 0.8
-			heal_cost *= 0.15
-
-		if(favor < heal_cost)
-			user.balloon_alert(user, "not enough favor!")
-			return FALSE
 
 		H.heal_overall_damage(heal_amt, heal_amt, 0, BODYPART_ANY)
 		H.update_damage_overlays()
 
 		COOLDOWN_START(src, last_heal, 12 SECONDS)
-		adjust_favor(-heal_cost, user)
 		H.visible_message(span_notice("[user] heals [H] with the power of [GLOB.deity]!"))
 		to_chat(H, span_boldnotice("May the power of [GLOB.deity] compel you to be healed!"))
 		playsound(user, 'sound/magic/staff_healing.ogg', 25, TRUE, -1)


### PR DESCRIPTION
# Why is this good for the game?

- It reduces the annoyance that holy water brings, hopefully making regular people not care nearly as much about drinking holy water.
- It doesn't bring back the issue of chaplains just walking around slapping people with a bible as they'll need to give people holy water first for favour. As we know, getting an injured assistant to sit still long enough to drink a holy water isn't exactly an easy task.
- It reduces the on-demand healing of the bible without making it anti-synergistic to the sect.
- It increases the favour gain from holy water, as favour gain is based on amount healed.
- It will be a useful chemical for doctors to use as it'll allow them to heal patients faster.

:cl:  
tweak: Holy water gives far less jitter (gives a lot more after 25 ticks)
tweak: Holy Light water now gives a 30% healing boost (75% in chapel) rather than 20% (40% in chapel)
tweak: Holy Light bible no longer costs favour, but heals 20 instead of 40
/:cl:
