### PR TITLE
Pulsing Mech Fabricator's WIRE_ZAP No Longer Reaches Through Reality to Break Your Limbs

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -160,7 +160,7 @@
 	var/datum/wound/blunt/severe/break_it = new
 	///Picks limb to break. People with less limbs have a chance of it grapping at air
 	var/obj/item/bodypart/bone = C.get_bodypart(pick(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG))
-	if(bone)
+	if(bone && Adjacent(user))
 		to_chat(C,span_userdanger("The manipulator arms grapple after your [bone.name], attempting to break its bone!"))
 		break_it.apply_wound(bone)
 		bone.receive_damage(brute=50, updating_health=TRUE)


### PR DESCRIPTION
# Document the changes in your pull request
Pulsing a mech fabricator's WIRE_ZAP now requires you to be adjacent to it in order for it to break your limbs.

# Why is this good for the game?
Oversight. Likely was not intentional for the zap wire to break your limbs while you're far away or behind walls/windows.

# Changelog
:cl:  
bugfix: Pulsing Mech Fabricator's WIRE_ZAP no longer breaks your limbs unless you are adjacent to it as intended.
/:cl:
