### PR TITLE
Other idea holy light

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -70,6 +70,8 @@
 
 #define STATUS_EFFECT_HOLYLIGHT_ANTIMAGIC /datum/status_effect/holylight_antimagic //long-term temporary antimagic that makes you blue
 
+#define STATUS_EFFECT_HOLYLIGHT_HEALBOOST /datum/status_effect/holylight_healboost //long-term temporary antimagic that makes you blue
+
 /////////////
 // DEBUFFS //
 /////////////

--- a/code/datums/components/heal_react.dm
+++ b/code/datums/components/heal_react.dm
@@ -19,7 +19,7 @@
 
 /datum/component/heal_react/boost
 	///multiplicitive boost to incoming healing
-	var/boost_amount = 0.2
+	var/boost_amount = 0.5
 	///types of damage this will effect
 	var/list/applies_to = list(BRUTE,BURN,TOX,OXY,CLONE,STAMINA)
 	///internal check for if we are being healed by ourselves, no double dipping

--- a/code/datums/components/heal_react.dm
+++ b/code/datums/components/heal_react.dm
@@ -19,7 +19,7 @@
 
 /datum/component/heal_react/boost
 	///multiplicitive boost to incoming healing
-	var/boost_amount = 0.5
+	var/boost_amount = 1
 	///types of damage this will effect
 	var/list/applies_to = list(BRUTE,BURN,TOX,OXY,CLONE,STAMINA)
 	///internal check for if we are being healed by ourselves, no double dipping

--- a/code/datums/status_effects/buffs/buffs.dm
+++ b/code/datums/status_effects/buffs/buffs.dm
@@ -694,6 +694,7 @@
 		H.physiology.pressure_mod /= 0.5
 		H.physiology.heat_mod /= 0.5
 	
+//holy light specific buffs
 /datum/status_effect/holylight_antimagic
 	id = "holy antimagic"
 	duration = 2 MINUTES
@@ -714,3 +715,22 @@
 	REMOVE_TRAIT(owner, TRAIT_ANTIMAGIC, type)
 	owner.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY)
 
+/datum/status_effect/holylight_healboost
+	id = "holy healboost"
+	duration = 30 SECONDS
+	tick_interval = 0
+	status_type = STATUS_EFFECT_REFRESH
+	alert_type = /atom/movable/screen/alert/status_effect/holylight_healboost
+	examine_text = span_notice("They are glowing with an internal holy light.")
+
+/atom/movable/screen/alert/status_effect/holylight_healboost
+	name = "Blessing of light"
+	desc = "Your being is suffused with holy light that accelerates healing."
+	icon_state = "regenerative_core" //again, i'm a coder, not a spriter
+
+/datum/status_effect/holylight_healboost/on_apply()
+	owner.AddComponent(/datum/component/heal_react/boost/holylight)
+
+/datum/status_effect/holylight_healboost/on_remove()
+	var/datum/component/heal_react/boost/holylight/healing = owner.GetComponent(/datum/component/heal_react/boost/holylight)
+	healing?.RemoveComponent()

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -660,8 +660,7 @@
 					patient.reagents.add_reagent(reagent_id,injection_amount)
 					log_combat(src, patient, "injected", "internal synthesizer", "[reagent_id]:[injection_amount]")
 					if(holy)
-						patient.reagents.add_reagent(/datum/reagent/water/holywater ,injection_amount)
-						log_combat(src, patient, "injected", "internal synthesizer", "[/datum/reagent/water/holywater]:[injection_amount]")
+						patient.apply_status_effect(STATUS_EFFECT_HOLYLIGHT_HEALBOOST)	
 				C.visible_message(span_danger("[src] injects [patient] with its syringe!"), \
 					span_userdanger("[src] injects you with its syringe!"))
 			else

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -214,11 +214,9 @@
 
 /datum/reagent/water/holywater/on_mob_metabolize(mob/living/L)
 	..()
-	GLOB.religious_sect.holy_water_start(L)
 	ADD_TRAIT(L, TRAIT_HOLY, type)
 
 /datum/reagent/water/holywater/on_mob_end_metabolize(mob/living/L)
-	GLOB.religious_sect.holy_water_end(L)
 	REMOVE_TRAIT(L, TRAIT_HOLY, type)
 	..()
 

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -418,7 +418,7 @@
 /datum/religion_sect/holylight
 	name = "Holy Light"
 	desc = "A sect dedicated to healing."
-	convert_opener = "Welcome to the Holy Light, disciple. <br>Your bible will now bless people. Blessed people will receive increased healing, and generate favor when they do."
+	convert_opener = "Welcome to the Holy Light, disciple. <br>Healing people with your bible will increase further healing given to them for a short time, providing favor based on the amount healed."
 	alignment = ALIGNMENT_GOOD // literally the only good sect besides default lol
 	rites_list = list(/datum/religion_rites/medibot, /datum/religion_rites/holysight, /datum/religion_rites/healrod, /datum/religion_rites/holyrevival)
 	altar_icon_state = "convertaltar-heal"

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -418,7 +418,7 @@
 /datum/religion_sect/holylight
 	name = "Holy Light"
 	desc = "A sect dedicated to healing."
-	convert_opener = "Welcome to the Holy Light, disciple. <br>Your holy water will now bless people with improved healing, which provides favor. Additionally, your bible heal is significantly stronger, at the cost of favor and an increased cooldown."
+	convert_opener = "Welcome to the Holy Light, disciple. <br>Your bible will now bless people with improved healing, which provides favor."
 	alignment = ALIGNMENT_GOOD // literally the only good sect besides default lol
 	rites_list = list(/datum/religion_rites/medibot, /datum/religion_rites/holysight, /datum/religion_rites/healrod, /datum/religion_rites/holyrevival)
 	altar_icon_state = "convertaltar-heal"

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -441,7 +441,7 @@
 		return FALSE
 
 	var/mob/living/carbon/human/H = L
-	var/heal_amt = 15 //no chance to mess up and applies a buff that increases healing, so it heals less than default
+	var/heal_amt = 10 //no chance to mess up and applies a buff that significantly increases healing, so it heals less than default
 
 	if(H.getBruteLoss() > 0 || H.getFireLoss() > 0)
 		H.apply_status_effect(STATUS_EFFECT_HOLYLIGHT_HEALBOOST)	

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -448,7 +448,7 @@
 		H.heal_overall_damage(heal_amt, heal_amt, 0, BODYPART_ANY)
 		H.update_damage_overlays()
 
-		COOLDOWN_START(src, last_heal, 12 SECONDS)
+		COOLDOWN_START(src, last_heal, 10 SECONDS)
 		H.visible_message(span_notice("[user] heals [H] with the power of [GLOB.deity]!"))
 		to_chat(H, span_boldnotice("May the power of [GLOB.deity] compel you to be healed!"))
 		playsound(user, 'sound/magic/staff_healing.ogg', 25, TRUE, -1)

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -418,7 +418,7 @@
 /datum/religion_sect/holylight
 	name = "Holy Light"
 	desc = "A sect dedicated to healing."
-	convert_opener = "Welcome to the Holy Light, disciple. <br>Your bible will now bless people with improved healing, which provides favor."
+	convert_opener = "Welcome to the Holy Light, disciple. <br>Your bible will now bless people. Blessed people will receive increased healing, and generate favor when they do."
 	alignment = ALIGNMENT_GOOD // literally the only good sect besides default lol
 	rites_list = list(/datum/religion_rites/medibot, /datum/religion_rites/holysight, /datum/religion_rites/healrod, /datum/religion_rites/holyrevival)
 	altar_icon_state = "convertaltar-heal"

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -99,10 +99,6 @@
 		SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "blessing", /datum/mood_event/blessing)
 	return FALSE
 
-/datum/religion_sect/proc/holy_water_start(mob/living/L)
-
-/datum/religion_sect/proc/holy_water_end(mob/living/L)
-
 /datum/religion_sect/puritanism
 	name = "Puritanism (Default)"
 	desc = "Nothing special."
@@ -445,35 +441,17 @@
 		return FALSE
 
 	var/mob/living/carbon/human/H = L
-	var/heal_amt = 40 //double healing, no chance to mess up, and shorter cooldown than default
-	var/heal_cost = 40
+	var/heal_amt = 15 //no chance to mess up and applies a buff that increases healing, so it heals less than default
 
 	if(H.getBruteLoss() > 0 || H.getFireLoss() > 0)
-		var/amount_healed = (heal_amt * 2) + min(H.getBruteLoss() - heal_amt, 0) + min(H.getFireLoss() - heal_amt, 0)
-		heal_cost *= amount_healed/heal_amt
-		if(L.GetComponent(/datum/component/heal_react/boost/holylight)) //we don't heal any more with holy water, but we do get a small favor boost from it
-			heal_amt *= 0.8
-			heal_cost *= 0.15
-
-		if(favor < heal_cost)
-			user.balloon_alert(user, "not enough favor!")
-			return FALSE
-
+		H.apply_status_effect(STATUS_EFFECT_HOLYLIGHT_HEALBOOST)	
 		H.heal_overall_damage(heal_amt, heal_amt, 0, BODYPART_ANY)
 		H.update_damage_overlays()
 
 		COOLDOWN_START(src, last_heal, 12 SECONDS)
-		adjust_favor(-heal_cost, user)
 		H.visible_message(span_notice("[user] heals [H] with the power of [GLOB.deity]!"))
 		to_chat(H, span_boldnotice("May the power of [GLOB.deity] compel you to be healed!"))
 		playsound(user, 'sound/magic/staff_healing.ogg', 25, TRUE, -1)
 		SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "blessing", /datum/mood_event/blessing)
 		return TRUE
 	return FALSE
-
-/datum/religion_sect/holylight/holy_water_start(mob/living/L)
-	L.AddComponent(/datum/component/heal_react/boost/holylight)
-
-/datum/religion_sect/holylight/holy_water_end(mob/living/L)
-	var/datum/component/heal_react/boost/holylight/healing = L.GetComponent(/datum/component/heal_react/boost/holylight)
-	healing?.RemoveComponent()


### PR DESCRIPTION
# Why is this good for the game?

- Holy Light relying on holy water to generate favour removes the agency from the chaplain, as they're either forced to inject people with holy water against their will, or give the holy water to medical KNOWING they're never going to use it.
- This still forces them to rely on other sources of healing as the bible has very little healing on it's own, even when accounting for the heal boost.
- It being a direct action means medical can let them into medbay to actively help, without just fully healing the injured people, taking their job away from them
- It being tied to a chemical means it could very easily be abused by some people that have a penchant for taking lots of various chemicals to become effectively immortal via chem healing, this can't happen when it's tied solely to the bible and unreliable medbots.
- Holy Light is focused on Holy Light rather than Holy Water

:cl:  
rscdel: Holy Light water no longer applies a heal boost
rscadd: Holy Light bible now applies a 30 second duration heal boost
tweak: Holy Light bible now heals for 10 instead of 40 with a 10 second cooldown instead of 12 and has no favor cost
tweak: Holy Light heal boost now increases by 100% (200% in chapel) instead of 20% (40% in chapel)
tweak: Holy Light medbot applies the heal boost status effect instead of injecting holy water
/:cl:
