### PR TITLE
The health scanner can now detect the extent of flesh damage and healing in a burn wound AND Burn wound tweaks

### DIFF
--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -263,7 +263,7 @@
 	else if(istype(I, /obj/item/flashlight/pen/paramedic))
 		uv(I, user)
 
-// people complained about burns not healing on stasis beds, so in addition to checking if it's cured, they also get the special ability to very slowly heal on stasis beds if they have the healing effects stored
+// people complained about burns not healing on stasis beds, so in addition to checking if it's cured, they also get the special ability to very slowly heal on stasis beds if they have the healing effects stored.
 /datum/wound/burn/on_stasis()
 	. = ..()
 	if(flesh_healing > 0)

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -167,14 +167,12 @@
 	. += "Wound Bed Damage: [span_deadsay("[flesh_damage]")]\n"
 	if(flesh_healing > 0)
 		. += "Positive signs of healing in the flesh damage, rate: [span_green("[flesh_healing]%")]\n"
-	else
-		. += "Flesh damage is not exhibiting signs of healing, rate: [span_brass("[flesh_healing]%")]\n"
 
 	if(infestation <= sanitization && flesh_damage <= flesh_healing)
 		. += "[span_green("No further treatment required: Burns will heal shortly.")]"
 	else
 		if(infestation > 0)
-			. += "Current Sanitization Effect: [span_green("[sanitization/infestation]%")]\n"
+			. += "Current Sanitization Effect: [span_brass("[sanitization/infestation]%")]\n"
 			switch(infestation)
 				if(0 to WOUND_INFECTION_MODERATE)
 					. += "Infection Level: Minimal\n"

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -164,13 +164,12 @@
 	. = ..()
 	. += "<div class='ml-3'>"
 
-	. += "Wound Bed Damage: [span_deadsay("[flesh_damage]")]\n"
-	if(flesh_healing > 0)
-		. += "Positive signs of healing in the flesh damage, rate: [span_green("[round(flesh_healing, 0.01)]")]\n"
-
 	if(infestation <= sanitization && flesh_damage <= flesh_healing)
 		. += "[span_green("No further treatment required: Burns will heal shortly.")]"
 	else
+		. += "Wound Bed Damage: [span_deadsay("[flesh_damage]")]\n"
+		if(flesh_healing > 0)
+			. += "Positive signs of healing in the flesh damage, rate: [span_green("[round(flesh_healing, 0.01)]")]\n"
 		if(infestation > 0)
 			. += "Current Sanitization Effect: [span_brass("[clamp(round(sanitization/infestation*100, 1),0,100)]%")]\n"
 			if(sanitization > 0)

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -76,7 +76,8 @@
 		sanitization = max(0, sanitization - (WOUND_BURN_SANITIZATION_RATE * bandage_factor))
 		return
 
-	infestation += infestation_rate
+	if(flesh_damage >= 12.5)
+		infestation += infestation_rate
 
 	switch(infestation)
 		if(0 to WOUND_INFECTION_MODERATE)
@@ -164,18 +165,31 @@
 	. = ..()
 	. += "<div class='ml-3'>"
 
-	if(infestation <= sanitization && flesh_damage <= flesh_healing)
-		. += "No further treatment required: Burns will heal shortly."
+	. += "Estimated duration of treatment while the healing rate is active: [span_deadsay("[flesh_damage]s")]\n"
+	if(flesh_healing > 0)
+		. += "Positive signs of healing in the flesh damage, rate: [span_green("[flesh_healing]%")]\n"
 	else
-		switch(infestation)
-			if(WOUND_INFECTION_MODERATE to WOUND_INFECTION_SEVERE)
-				. += "Infection Level: Moderate\n"
-			if(WOUND_INFECTION_SEVERE to WOUND_INFECTION_CRITICAL)
-				. += "Infection Level: Severe\n"
-			if(WOUND_INFECTION_CRITICAL to WOUND_INFECTION_SEPTIC)
-				. += "Infection Level: <span class='deadsay'>CRITICAL</span>\n"
-			if(WOUND_INFECTION_SEPTIC to INFINITY)
-				. += "Infection Level: <span class='deadsay'>LOSS IMMINENT</span>\n"
+		. += "Flesh damage is not exhibiting signs of healing, rate: [span_brass("[flesh_healing]%")]\n"
+
+	if(infestation <= sanitization && flesh_damage <= flesh_healing)
+		. += "[span_green("No further treatment required: Burns will heal shortly.")]"
+	else
+		if(infestation > 0)
+			switch(infestation)
+				if(0 to WOUND_INFECTION_MODERATE)
+					. += "Infection Level: Minimal\n"
+					. += "Time Untill Next Infection Level: [span_abductor("[DisplayTimeText((WOUND_INFECTION_MODERATE-infestation)/infestation_rate*10)]")]\n"
+				if(WOUND_INFECTION_MODERATE to WOUND_INFECTION_SEVERE)
+					. += "Infection Level: Moderate\n"
+					. += "Time Untill Next Infection Level: [span_abductor("[DisplayTimeText((WOUND_INFECTION_SEVERE-infestation)/infestation_rate*10)]")]\n"
+				if(WOUND_INFECTION_SEVERE to WOUND_INFECTION_CRITICAL)
+					. += "Infection Level: Severe\n"
+					. += "Time Untill Next Infection Level: [span_abductor("[DisplayTimeText((WOUND_INFECTION_CRITICAL-infestation)/infestation_rate*10)]")]\n"
+				if(WOUND_INFECTION_CRITICAL to WOUND_INFECTION_SEPTIC)
+					. += "Infection Level: <span class='deadsay'>CRITICAL</span>\n"
+					. += "Time Untill Next Infection Level: [span_abductor("[DisplayTimeText((WOUND_INFECTION_SEPTIC-infestation)/infestation_rate*10, 0)]")]\n"
+				if(WOUND_INFECTION_SEPTIC to INFINITY)
+					. += "Infection Level: <span class='deadsay'>LOSS IMMINENT</span>\n"
 		if(infestation > sanitization)
 			. += "\tSurgical debridement, antibiotics/sterilizers, or regenerative mesh will rid infection. Paramedic UV penlights are also effective.\n"
 

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -172,7 +172,7 @@
 		. += "[span_green("No further treatment required: Burns will heal shortly.")]"
 	else
 		if(infestation > 0)
-			. += "Current Sanitization Effect: [span_brass("[round(sanitization/infestation, 0.01)]%")]\n"
+			. += "Current Sanitization Effect: [span_brass("[round(sanitization/infestation*100, 0.01)]%")]\n"
 			if(sanitization > 0)
 				. += "[span_green("Sanitization in effect, infection level is decreasing.")]\n"
 			switch(infestation)

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -76,8 +76,7 @@
 		sanitization = max(0, sanitization - (WOUND_BURN_SANITIZATION_RATE * bandage_factor))
 		return
 
-	if(flesh_damage >= 12.5)
-		infestation += infestation_rate
+	infestation += infestation_rate
 
 	switch(infestation)
 		if(0 to WOUND_INFECTION_MODERATE)
@@ -165,7 +164,8 @@
 	. = ..()
 	. += "<div class='ml-3'>"
 
-	. += "Estimated duration of treatment while the healing rate is active: [span_deadsay("[flesh_damage]s")]\n"
+	. += "Wound Bed Damage: [span_deadsay("[flesh_damage]")]\n"
+	. += "Current Sanitization Effect: [span_green("[sanitization/infestation]%")]\n"
 	if(flesh_healing > 0)
 		. += "Positive signs of healing in the flesh damage, rate: [span_green("[flesh_healing]%")]\n"
 	else

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -172,7 +172,7 @@
 		. += "[span_green("No further treatment required: Burns will heal shortly.")]"
 	else
 		if(infestation > 0)
-			. += "Current Sanitization Effect: [span_brass("[round(sanitization/infestation*100, 0.01)]%")]\n"
+			. += "Current Sanitization Effect: [span_brass("[clamp(round(sanitization/infestation*100, 1),0,100)]%")]\n"
 			if(sanitization > 0)
 				. += "[span_green("Sanitization in effect, infection level is decreasing.")]\n"
 			switch(infestation)

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -166,13 +166,13 @@
 
 	. += "Wound Bed Damage: [span_deadsay("[flesh_damage]")]\n"
 	if(flesh_healing > 0)
-		. += "Positive signs of healing in the flesh damage, rate: [span_green("[flesh_healing]%")]\n"
+		. += "Positive signs of healing in the flesh damage, rate: [span_green("[round(flesh_healing, 0.01)]%")]\n"
 
 	if(infestation <= sanitization && flesh_damage <= flesh_healing)
 		. += "[span_green("No further treatment required: Burns will heal shortly.")]"
 	else
 		if(infestation > 0)
-			. += "Current Sanitization Effect: [span_brass("[round(sanitization/infestation)]%")]\n"
+			. += "Current Sanitization Effect: [span_brass("[round(sanitization/infestation, 0.01)]%")]\n"
 			if(sanitization > 0)
 				. += "[span_green("Sanitization in effect, infection level is decreasing.")]\n"
 			switch(infestation)

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -165,7 +165,6 @@
 	. += "<div class='ml-3'>"
 
 	. += "Wound Bed Damage: [span_deadsay("[flesh_damage]")]\n"
-	. += "Current Sanitization Effect: [span_green("[sanitization/infestation]%")]\n"
 	if(flesh_healing > 0)
 		. += "Positive signs of healing in the flesh damage, rate: [span_green("[flesh_healing]%")]\n"
 	else
@@ -175,6 +174,7 @@
 		. += "[span_green("No further treatment required: Burns will heal shortly.")]"
 	else
 		if(infestation > 0)
+			. += "Current Sanitization Effect: [span_green("[sanitization/infestation]%")]\n"
 			switch(infestation)
 				if(0 to WOUND_INFECTION_MODERATE)
 					. += "Infection Level: Minimal\n"

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -178,16 +178,16 @@
 			switch(infestation)
 				if(0 to WOUND_INFECTION_MODERATE)
 					. += "Infection Level: Minimal\n"
-					. += "Time Untill Next Infection Level: [span_abductor("[DisplayTimeText((WOUND_INFECTION_MODERATE-infestation)/infestation_rate*10)]")]\n"
+					. += "Time Until Next Infection Level: [span_abductor("[DisplayTimeText((WOUND_INFECTION_MODERATE-infestation)/infestation_rate*10)]")]\n"
 				if(WOUND_INFECTION_MODERATE to WOUND_INFECTION_SEVERE)
 					. += "Infection Level: Moderate\n"
-					. += "Time Untill Next Infection Level: [span_abductor("[DisplayTimeText((WOUND_INFECTION_SEVERE-infestation)/infestation_rate*10)]")]\n"
+					. += "Time Until Next Infection Level: [span_abductor("[DisplayTimeText((WOUND_INFECTION_SEVERE-infestation)/infestation_rate*10)]")]\n"
 				if(WOUND_INFECTION_SEVERE to WOUND_INFECTION_CRITICAL)
 					. += "Infection Level: Severe\n"
-					. += "Time Untill Next Infection Level: [span_abductor("[DisplayTimeText((WOUND_INFECTION_CRITICAL-infestation)/infestation_rate*10)]")]\n"
+					. += "Time Until Next Infection Level: [span_abductor("[DisplayTimeText((WOUND_INFECTION_CRITICAL-infestation)/infestation_rate*10)]")]\n"
 				if(WOUND_INFECTION_CRITICAL to WOUND_INFECTION_SEPTIC)
 					. += "Infection Level: <span class='deadsay'>CRITICAL</span>\n"
-					. += "Time Untill Next Infection Level: [span_abductor("[DisplayTimeText((WOUND_INFECTION_SEPTIC-infestation)/infestation_rate*10)]")]\n"
+					. += "Time Until Next Infection Level: [span_abductor("[DisplayTimeText((WOUND_INFECTION_SEPTIC-infestation)/infestation_rate*10)]")]\n"
 				if(WOUND_INFECTION_SEPTIC to INFINITY)
 					. += "Infection Level: <span class='deadsay'>LOSS IMMINENT</span>\n"
 		if(infestation > sanitization)

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -172,7 +172,9 @@
 		. += "[span_green("No further treatment required: Burns will heal shortly.")]"
 	else
 		if(infestation > 0)
-			. += "Current Sanitization Effect: [span_brass("[sanitization/infestation]%")]\n"
+			. += "Current Sanitization Effect: [span_brass("[round(sanitization/infestation)]%")]\n"
+			if(sanitization > 0)
+				. += "[span_green("Sanitization in effect, infection level is decreasing.")]\n"
 			switch(infestation)
 				if(0 to WOUND_INFECTION_MODERATE)
 					. += "Infection Level: Minimal\n"
@@ -188,6 +190,8 @@
 					. += "Time Until Next Infection Level: [span_abductor("[DisplayTimeText((WOUND_INFECTION_SEPTIC-infestation)/infestation_rate*10)]")]\n"
 				if(WOUND_INFECTION_SEPTIC to INFINITY)
 					. += "Infection Level: <span class='deadsay'>LOSS IMMINENT</span>\n"
+		else
+			. += "[span_green("No infection detected.")]\n"
 		if(infestation > sanitization)
 			. += "\tSurgical debridement, antibiotics/sterilizers, or regenerative mesh will rid infection. Paramedic UV penlights are also effective.\n"
 

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -166,7 +166,7 @@
 
 	. += "Wound Bed Damage: [span_deadsay("[flesh_damage]")]\n"
 	if(flesh_healing > 0)
-		. += "Positive signs of healing in the flesh damage, rate: [span_green("[round(flesh_healing, 0.01)]%")]\n"
+		. += "Positive signs of healing in the flesh damage, rate: [span_green("[round(flesh_healing, 0.01)]")]\n"
 
 	if(infestation <= sanitization && flesh_damage <= flesh_healing)
 		. += "[span_green("No further treatment required: Burns will heal shortly.")]"

--- a/code/datums/wounds/burns.dm
+++ b/code/datums/wounds/burns.dm
@@ -187,7 +187,7 @@
 					. += "Time Untill Next Infection Level: [span_abductor("[DisplayTimeText((WOUND_INFECTION_CRITICAL-infestation)/infestation_rate*10)]")]\n"
 				if(WOUND_INFECTION_CRITICAL to WOUND_INFECTION_SEPTIC)
 					. += "Infection Level: <span class='deadsay'>CRITICAL</span>\n"
-					. += "Time Untill Next Infection Level: [span_abductor("[DisplayTimeText((WOUND_INFECTION_SEPTIC-infestation)/infestation_rate*10, 0)]")]\n"
+					. += "Time Untill Next Infection Level: [span_abductor("[DisplayTimeText((WOUND_INFECTION_SEPTIC-infestation)/infestation_rate*10)]")]\n"
 				if(WOUND_INFECTION_SEPTIC to INFINITY)
 					. += "Infection Level: <span class='deadsay'>LOSS IMMINENT</span>\n"
 		if(infestation > sanitization)


### PR DESCRIPTION
# Document the changes in your pull request
You can now see the amount flesh damage and healing in a burn wound using health scanner
health scanner now accurately indicates amount of infection in burn wound as well as the percentage of sanitzation/infestation

<details><summary>some visual images</summary>

![v1](https://github.com/yogstation13/Yogstation/assets/89688125/8552ac76-5313-4cdb-b0ee-0316523b5caa)

![v2](https://github.com/yogstation13/Yogstation/assets/89688125/b1be7253-c9fa-4e08-8527-9dc4520ee7bd)

![image](https://github.com/yogstation13/Yogstation/assets/89688125/27c40e2c-d1c4-40d4-8fb3-54941b235ef7)



</details>


# Why is this good for the game?
This helps medical staff determine the estimated healing time for a burn wound and allows them to track the extent of flesh damage to effectively manage the application of regenerative mesh


# Wiki Documentation
document of change to health scanner and medicine

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: You can now see the amount flesh damage and healing in a burn wound using health scanner
tweak: health scanner now accurately indicates amount of infection in burn wound as well as the percentage of sanitzation/infestation
/:cl:
