### PR TITLE
Cyborg Remote Monitoring Program Now Displays Cyborg's Location

### DIFF
--- a/code/modules/modular_computers/file_system/programs/science/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/science/borg_monitor.dm
@@ -98,12 +98,11 @@
 			shell = TRUE
 
 		var/area/A = get_area(R)
-		var/turf/T = get_turf(R)
 		var/list/cyborg_data = list(
 			name = R.name,
 			integ = round((R.health + 100) / 2), //mob heath is -100 to 100, we want to scale that to 0 - 100
 			locked_down = R.lockcharge,
-			locstring = "[A.name] ([T.x], [T.y])",
+			locstring = "[A.name]",
 			status = R.stat,
 			shell_discon = shell,
 			charge = R.cell ? round(R.cell.percent()) : null,

--- a/code/modules/modular_computers/file_system/programs/science/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/science/borg_monitor.dm
@@ -101,6 +101,7 @@
 			name = R.name,
 			integ = round((R.health + 100) / 2), //mob heath is -100 to 100, we want to scale that to 0 - 100
 			locked_down = R.lockcharge,
+			locstring = "[A.name] ([T.x], [T.y])",
 			status = R.stat,
 			shell_discon = shell,
 			charge = R.cell ? round(R.cell.percent()) : null,

--- a/code/modules/modular_computers/file_system/programs/science/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/science/borg_monitor.dm
@@ -97,6 +97,8 @@
 		if(R.shell && !R.ckey)
 			shell = TRUE
 
+		var/area/A = get_area(R)
+		var/turf/T = get_turf(R)
 		var/list/cyborg_data = list(
 			name = R.name,
 			integ = round((R.health + 100) / 2), //mob heath is -100 to 100, we want to scale that to 0 - 100

--- a/tgui/packages/tgui/interfaces/NtosCyborgRemoteMonitor.js
+++ b/tgui/packages/tgui/interfaces/NtosCyborgRemoteMonitor.js
@@ -114,6 +114,11 @@ export const NtosCyborgRemoteMonitorContent = (props, context) => {
                                     : "Nominal"}
                             </Box>
                           </LabeledList.Item>
+                          <LabeledList.Item label="Location">
+                            <Box>
+                              {cyborg.locstring}
+                            </Box>
+                          </LabeledList.Item>
                           <LabeledList.Item label="Condition">
                             <Box color={cyborg.integ <= 25
                               ? 'bad'


### PR DESCRIPTION
# Document the changes in your pull request
Cyborg Remote Monitoring program now displays the area name and coordinates of listed cyborgs.

![image](https://github.com/yogstation13/Yogstation/assets/30399783/05d6b530-baa7-4fb8-b896-90143a832bc8)


# Why is this good for the game?
Gives roboticists something to do/pay attention to (and a reason to download the program). Makes the Cyborg Remote Monitoring program more unique from the robotics console in terms of information.

# Changelog
:cl:  
rscadd: The Cyborg Remote Monitoring program now displays the area name and coordinates of any listed cyborgs.
/:cl:
