### PR TITLE
Nerfs cult shield

### DIFF
--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -938,7 +938,7 @@ GLOBAL_VAR_INIT(curselimit, 0)
 	w_class = WEIGHT_CLASS_BULKY
 	attack_verb = list("bumped", "prodded")
 	hitsound = 'sound/weapons/smash.ogg'
-	var/illusions = 5
+	var/illusions = 2
 
 /obj/item/shield/mirror/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(iscultist(owner))


### PR DESCRIPTION

# Document the changes in your pull request

Nerfs cult shield by making it spawn less ghosts when hit, because cult does not need it and the ghost can damage you.

No idea if this will work


# Why is this good for the game?
Because bloodcult is unfair and stupidly OP

# Wiki Documentation

I dont think it mentions the amount of illusions it spawn, but if it does, change it to 2

# Changelog


:cl:  

tweak: Lowers the amount of illusions the cult shield can spawn to 2
/:cl:
