### PR TITLE
IPC can eat anomaly cores 2

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -14,7 +14,8 @@
 	var/datum/radio_frequency/radio_connection
 	var/suicider = null
 	var/hearing_range = 1
-
+	var/eaten_text
+	
 /obj/item/assembly/signaler/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] eats \the [src]! If it is signaled, [user.p_they()] will die!"))
 	playsound(src, 'sound/items/eatfood.ogg', 50, TRUE)
@@ -190,7 +191,34 @@
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	resistance_flags = FIRE_PROOF
+	eaten_text = "you've ate the anomaly core..."
 	var/anomaly_type = /obj/effect/anomaly
+
+/obj/item/assembly/signaler/anomaly/attack(mob/living/M, mob/living/user)
+	if(user.a_intent == INTENT_HARM || M != user || !ishuman(user))
+		return ..()
+
+	var/mob/living/carbon/human/H = user
+	var/obj/item/organ/stomach/S = H.getorganslot(ORGAN_SLOT_STOMACH)
+
+	if(!istype(S, /obj/item/organ/stomach/cell))//need a fancy stomach for it
+		return ..()
+
+	if(!eaten(H))
+		return ..(src)
+	qdel(src)
+	use(1)//only eat one at a time
+
+	if(eaten_text)
+		H.visible_message(span_notice("[H] inserts [src], why did they do this?"), span_notice(eaten_text)) //change if more is added
+	playsound(H, 'sound/items/eatfood.ogg', 50, 1)
+
+	if(HAS_TRAIT(H, TRAIT_VORACIOUS))//I'M VERY HONGRY
+		H.changeNext_move(CLICK_CD_MELEE * 0.5)
+
+/obj/item/assembly/signaler/anomaly/proc/eaten(mob/living/carbon/human/H)
+	return TRUE
+
 
 /obj/item/assembly/signaler/anomaly/receive_signal(datum/signal/signal)
 	if(!signal)


### PR DESCRIPTION
had to remake my repository again. 
# Document the changes in your pull request
gives ipc the ability to eat anomaly cores, there is no effect i just think its funny. 
# Why is this good for the game?
thought it would be funny, if someone wants to alter it then go ahead.
then let me ask you this and another thing, what makes something valuable. and how will this be abused.

from my point the value of a object is how useful it is, an anomaly core on its own can be deconstructed in rnd for 10,000 rd points, 50,000 creds if sold to cargo, they are also a assembly so can in theory be used for bombs, and are used to build 4 devices that use a core to complete.  if looking at the number of uses you could say they are valuable, but in reality it is normally 3 uses.  10,000 rnd points is a lot of points, if it is early game, even then there are other vastly easier ways to attain research points, the anomaly core is similar to the papers you receive for doing dissections. 50,000 credits is also a lot of money, however this is yogs economy, if you are lucky to get one and sell it, then what, that's now cargo access money, can't exactly buy anything cool with it unless preparing for war, cant be paid that much, and god forbid you private order something.

now the meat and potatoes, the items. the anomaly quiver is decent if you ONLY use a nonholo bow, the armor is a hit and miss because the on and off states like to break and you need to be hit in the chest for it to actually activate some of the time. bag of holding, no problems with it. but the phazon, the mech that can phase through any solid material, combat mech, the only mech type that is a valuable mech, is really annoying to fight against. 

and the only way i can see this being abused is if you keep handing an anomaly core to a shitter ipc

# Changelog

:cl:  
tweak: IPC can now eat anomaly cores.
/:cl:
