### PR TITLE
Increase bs harvester safe level and emag tweak

### DIFF
--- a/code/modules/goals/station_goals/bluespace_tap.dm
+++ b/code/modules/goals/station_goals/bluespace_tap.dm
@@ -2,7 +2,7 @@
 #define BLUESPACE_TAP_POINT_GOAL 45000 // Yogs
 /datum/station_goal/bluespace_tap
 	name = "Bluespace Harvester"
-	var/goal = BLUESPACE_TAP_POINT_GOAL // Yogs 
+	var/goal = BLUESPACE_TAP_POINT_GOAL // Yogs
 
 /datum/station_goal/bluespace_tap/get_report()
 	return {"<b>Bluespace Harvester Experiment</b><br>

--- a/code/modules/goals/station_goals/bluespace_tap.dm
+++ b/code/modules/goals/station_goals/bluespace_tap.dm
@@ -222,7 +222,7 @@
 	/// Amount of points to give per mining level
 	var/base_points = 100
 	/// How high the machine can be run before it starts having a chance for dimension breaches.
-	var/safe_levels = 13
+	var/safe_levels = 15
 	var/emagged = FALSE
 
 /obj/machinery/power/bluespace_tap/New()

--- a/code/modules/goals/station_goals/bluespace_tap.dm
+++ b/code/modules/goals/station_goals/bluespace_tap.dm
@@ -410,6 +410,7 @@
 /obj/machinery/power/bluespace_tap/emag_act(mob/user, obj/item/card/emag/emag_card)
 	if(emagged)
 		return FALSE
+	safe_levels = 10
 	emagged = TRUE
 	do_sparks(5, FALSE, src)
 	if(user)

--- a/code/modules/goals/station_goals/bluespace_tap.dm
+++ b/code/modules/goals/station_goals/bluespace_tap.dm
@@ -410,7 +410,7 @@
 /obj/machinery/power/bluespace_tap/emag_act(mob/user, obj/item/card/emag/emag_card)
 	if(emagged)
 		return FALSE
-	safe_levels = 10
+	safe_levels = 5
 	emagged = TRUE
 	do_sparks(5, FALSE, src)
 	if(user)

--- a/code/modules/goals/station_goals/bluespace_tap.dm
+++ b/code/modules/goals/station_goals/bluespace_tap.dm
@@ -2,7 +2,7 @@
 #define BLUESPACE_TAP_POINT_GOAL 45000 // Yogs
 /datum/station_goal/bluespace_tap
 	name = "Bluespace Harvester"
-	var/goal = BLUESPACE_TAP_POINT_GOAL // Yogs
+	var/goal = BLUESPACE_TAP_POINT_GOAL // Yogs 
 
 /datum/station_goal/bluespace_tap/get_report()
 	return {"<b>Bluespace Harvester Experiment</b><br>

--- a/code/modules/goals/station_goals/bluespace_tap.dm
+++ b/code/modules/goals/station_goals/bluespace_tap.dm
@@ -222,7 +222,7 @@
 	/// Amount of points to give per mining level
 	var/base_points = 100
 	/// How high the machine can be run before it starts having a chance for dimension breaches.
-	var/safe_levels = 10
+	var/safe_levels = 13
 	var/emagged = FALSE
 
 /obj/machinery/power/bluespace_tap/New()


### PR DESCRIPTION

# Document the changes in your pull request
increase bs harvester safe level from 10 to 15
emagging bs harvester will reduce safe level to 5

# Why is this good for the game?
Make it harder to spawn monsters, so less chaotic in one round for normal bs harvester and traitors can easily bring chaotic by emagging bs harvester



# Wiki Documentation
Document of changes to bs harvester

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: increase bs harvester safe level from 10 to 15
tweak: emagging bs harvester will reduce safe level to 5
/:cl:
