### PR TITLE
roaming herd of pencil holders

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -1216,7 +1216,10 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/item/pen,
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = 5;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "akY" = (
@@ -1264,7 +1267,6 @@
 	pixel_x = 1;
 	pixel_y = 9
 	},
-/obj/item/pen/red,
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
 	},
@@ -1649,7 +1651,10 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/item/pen,
+/obj/item/storage/pencil_holder/crew{
+	pixel_y = -4;
+	pixel_x = -5
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aoq" = (
@@ -17032,6 +17037,10 @@
 	id = "atmos";
 	name = "Atmospherics Blast Door"
 	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = -10;
+	pixel_y = 12
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "eBg" = (
@@ -21283,6 +21292,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
+/obj/item/storage/pencil_holder/crew/creative,
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
 "fSR" = (
@@ -27092,6 +27102,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"hMa" = (
+/obj/structure/table/wood,
+/obj/item/storage/pencil_holder/crew,
+/turf/open/floor/carpet/blue,
+/area/bridge/meeting_room)
 "hMd" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -29148,6 +29163,10 @@
 	pixel_x = 9;
 	pixel_y = 8
 	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = 8;
+	pixel_y = -4
+	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "iuq" = (
@@ -30260,6 +30279,9 @@
 "iOo" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck,
+/obj/item/storage/pencil_holder/crew{
+	pixel_y = 10
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "iOr" = (
@@ -32124,6 +32146,10 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 8
 	},
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = -8;
+	pixel_y = 12
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "jnJ" = (
@@ -33273,6 +33299,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"jHC" = (
+/obj/structure/table/wood,
+/obj/item/storage/pencil_holder/crew/fancy,
+/turf/open/floor/carpet/blue,
+/area/bridge/meeting_room)
 "jHG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -36805,6 +36836,10 @@
 	pixel_x = 8;
 	pixel_y = -5
 	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = -10;
+	pixel_y = 12
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "kQS" = (
@@ -36839,6 +36874,9 @@
 /obj/structure/table/wood,
 /obj/item/folder/blue,
 /obj/item/stamp/captain,
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_y = 12
+	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
 "kRi" = (
@@ -43514,6 +43552,10 @@
 	pixel_x = 8;
 	pixel_y = -4
 	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = -12;
+	pixel_y = 1
+	},
 /turf/open/floor/plasteel,
 /area/security/warden)
 "mXM" = (
@@ -45053,8 +45095,6 @@
 /area/crew_quarters/fitness)
 "nvK" = (
 /obj/structure/table/wood,
-/obj/item/pen/fountain,
-/obj/item/pen/blue,
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -45062,6 +45102,17 @@
 /obj/item/deskbell/preset/library{
 	pixel_x = -8;
 	pixel_y = -4
+	},
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/obj/item/storage/pencil_holder/crew/creative{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = 8
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -48013,7 +48064,6 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/item/pen,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -48025,6 +48075,10 @@
 /obj/item/deskbell/preset/xenobio{
 	pixel_x = 9;
 	pixel_y = -5
+	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = -10;
+	pixel_y = 12
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -50697,6 +50751,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = 10
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "pkj" = (
@@ -53067,6 +53124,9 @@
 /obj/item/deskbell/preset/hop{
 	pixel_x = -6;
 	pixel_y = -5
+	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_y = 9
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
@@ -63959,6 +64019,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"tjP" = (
+/obj/structure/table/wood,
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = -10;
+	pixel_y = 12
+	},
+/turf/open/floor/wood,
+/area/vacant_room)
 "tkm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -66782,6 +66850,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = -10;
+	pixel_y = 12
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "uet" = (
@@ -68371,6 +68443,10 @@
 /obj/item/deskbell/preset/engi{
 	pixel_x = 8;
 	pixel_y = -3
+	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = -10;
+	pixel_y = 12
 	},
 /turf/open/floor/plating,
 /area/engine/foyer)
@@ -70278,12 +70354,20 @@
 "vpt" = (
 /obj/structure/table,
 /obj/item/toy/figure/rd,
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = -8;
+	pixel_y = 12
+	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
 "vql" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/yellow,
 /obj/item/stamp/ce,
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_y = 10;
+	pixel_x = 10
+	},
 /turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
@@ -75005,6 +75089,10 @@
 	pixel_y = 3
 	},
 /obj/item/phone/banana,
+/obj/item/storage/pencil_holder/crew/creative{
+	pixel_x = 8;
+	pixel_y = 12
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "wLM" = (
@@ -77565,6 +77653,10 @@
 "xBV" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/deputy,
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = -8;
+	pixel_y = 12
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "xCc" = (
@@ -77776,7 +77868,13 @@
 	pixel_x = -2;
 	pixel_y = 5
 	},
-/obj/item/pen/blue,
+/obj/item/pen/blue{
+	pixel_x = -1
+	},
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_y = 10;
+	pixel_x = 10
+	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/cmo)
 "xHl" = (
@@ -77880,6 +77978,10 @@
 /obj/item/deskbell/preset/supply{
 	pixel_x = 7;
 	pixel_y = 6
+	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_y = -2;
+	pixel_x = 9
 	},
 /turf/open/floor/plating,
 /area/quartermaster/office)
@@ -100181,7 +100283,7 @@ bxL
 aGM
 oLY
 wFU
-fAC
+hMa
 wzz
 glU
 ssK
@@ -100438,7 +100540,7 @@ bxL
 aGM
 igI
 fAC
-fAC
+jHC
 jWJ
 dcX
 ssK
@@ -100695,7 +100797,7 @@ bxL
 aGM
 onW
 tzn
-fAC
+hMa
 bkf
 gpL
 ssK
@@ -120207,7 +120309,7 @@ hqO
 ajF
 jPS
 aGE
-ajF
+tjP
 uWo
 amx
 hoZ

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -9905,6 +9905,7 @@
 	pixel_y = -2;
 	req_access_txt = "5"
 	},
+/obj/item/storage/pencil_holder/crew,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "eLA" = (
@@ -12879,6 +12880,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"gfu" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/westleft{
+	dir = 2;
+	name = "Cargo Desk";
+	req_access_txt = "31"
+	},
+/obj/item/deskbell/preset/supply{
+	pixel_x = 8;
+	pixel_y = 9
+	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = 5;
+	pixel_y = -4
+	},
+/turf/open/floor/plating,
+/area/quartermaster/office)
 "gfF" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -15847,6 +15865,14 @@
 "hBI" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = 8;
+	pixel_y = 10
+	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = 8;
+	pixel_y = 4
+	},
 /turf/open/floor/carpet/exoticblue,
 /area/bridge/meeting_room)
 "hBV" = (
@@ -16996,6 +17022,7 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
+/obj/item/storage/pencil_holder/crew/fancy,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "ihC" = (
@@ -20681,6 +20708,9 @@
 /obj/structure/table/glass,
 /obj/item/folder/white,
 /obj/item/stamp/cmo,
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_y = 12
+	},
 /turf/open/floor/carpet/exoticblue,
 /area/crew_quarters/heads/cmo)
 "kdW" = (
@@ -25510,6 +25540,10 @@
 	departmentType = 5;
 	name = "Head of Security RC";
 	pixel_x = -32
+	},
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = 8;
+	pixel_y = 10
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
@@ -30724,6 +30758,7 @@
 	pixel_x = 8;
 	pixel_y = -3
 	},
+/obj/item/storage/pencil_holder/crew,
 /turf/open/floor/plating,
 /area/engine/foyer)
 "pjL" = (
@@ -35218,6 +35253,10 @@
 	department = "Research Director";
 	name = "Research Director's Fax Machine"
 	},
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = -10;
+	pixel_y = 12
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "rrG" = (
@@ -35275,6 +35314,10 @@
 	pixel_x = 9;
 	pixel_y = 8
 	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = -10;
+	pixel_y = 12
+	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
 "rsT" = (
@@ -35330,6 +35373,9 @@
 /obj/item/folder/yellow,
 /obj/item/paper/monitorkey,
 /obj/item/stamp/ce,
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_y = 12
+	},
 /turf/open/floor/carpet/orange,
 /area/crew_quarters/heads/chief)
 "rtB" = (
@@ -35693,6 +35739,10 @@
 	},
 /obj/item/reagent_containers/food/snacks/baguette,
 /obj/item/toy/dummy,
+/obj/item/storage/pencil_holder/crew/creative{
+	pixel_x = -8;
+	pixel_y = 12
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "rCa" = (
@@ -37013,6 +37063,10 @@
 	},
 /obj/item/folder/blue,
 /obj/item/stamp/hop,
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = -8;
+	pixel_y = -4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "slR" = (
@@ -38211,6 +38265,10 @@
 /obj/item/deskbell/preset/sci{
 	pixel_x = 7;
 	pixel_y = -3
+	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = -10;
+	pixel_y = 12
 	},
 /turf/open/floor/plating,
 /area/science/lab)
@@ -40320,14 +40378,20 @@
 /area/solar/port/aft)
 "tSm" = (
 /obj/structure/table/wood,
-/obj/item/pen/red,
-/obj/item/pen/blue{
-	pixel_x = 5;
-	pixel_y = 5
-	},
 /obj/item/deskbell/preset/library{
 	pixel_x = -9;
 	pixel_y = -3
+	},
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/obj/item/storage/pencil_holder/crew/creative{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = 8
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -43830,7 +43894,7 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/obj/item/pen,
+/obj/item/storage/pencil_holder/crew,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "vDA" = (
@@ -45596,6 +45660,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/item/storage/pencil_holder/crew,
 /turf/open/floor/plating,
 /area/security/brig)
 "wxf" = (
@@ -47046,6 +47111,7 @@
 	pixel_x = 10;
 	pixel_y = -3
 	},
+/obj/item/storage/pencil_holder/crew,
 /turf/open/floor/plating,
 /area/security/warden)
 "xhD" = (
@@ -47115,6 +47181,10 @@
 /obj/item/hand_tele{
 	pixel_x = 2;
 	pixel_y = -2
+	},
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = -8;
+	pixel_y = -4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
@@ -77301,7 +77371,7 @@ uwH
 jHK
 ivt
 jaW
-nzG
+gfu
 lFh
 qhL
 nkP

--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -59,6 +59,7 @@
 	pixel_x = 8;
 	pixel_y = 7
 	},
+/obj/item/storage/pencil_holder/crew,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "aaU" = (
@@ -3612,6 +3613,10 @@
 /obj/machinery/status_display/supply{
 	pixel_x = 32
 	},
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = -8;
+	pixel_y = 10
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bcx" = (
@@ -3988,6 +3993,10 @@
 /obj/item/folder/white{
 	pixel_x = 4;
 	pixel_y = -3
+	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = 8;
+	pixel_y = 10
 	},
 /turf/open/floor/carpet,
 /area/bridge)
@@ -33580,6 +33589,10 @@
 	},
 /obj/item/pen,
 /obj/effect/turf_decal/delivery,
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = 8;
+	pixel_y = 10
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "jLX" = (
@@ -37289,6 +37302,17 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = 8;
+	pixel_y = 12
+	},
+/obj/item/storage/pencil_holder/crew/creative{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = 8
+	},
 /turf/open/floor/wood,
 /area/library)
 "kQA" = (
@@ -38577,6 +38601,10 @@
 "llW" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = -8;
+	pixel_y = 10
+	},
 /turf/open/floor/carpet,
 /area/bridge)
 "llX" = (
@@ -38983,6 +39011,10 @@
 /obj/item/reagent_containers/food/snacks/pie/cream,
 /obj/machinery/airalarm{
 	pixel_y = 24
+	},
+/obj/item/storage/pencil_holder/crew/creative{
+	pixel_x = -8;
+	pixel_y = 11
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
@@ -42537,6 +42569,9 @@
 /obj/item/stamp/hop{
 	pixel_x = -4;
 	pixel_y = 4
+	},
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = 8
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
@@ -50272,6 +50307,10 @@
 	pixel_y = -4
 	},
 /obj/item/pen,
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = -5;
+	pixel_y = -9
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "ozK" = (
@@ -50501,6 +50540,7 @@
 	pixel_x = -3;
 	pixel_y = 5
 	},
+/obj/item/storage/pencil_holder/crew,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "oDr" = (
@@ -52150,6 +52190,7 @@
 	pixel_x = -8;
 	pixel_y = -3
 	},
+/obj/item/storage/pencil_holder/crew,
 /turf/open/floor/plating,
 /area/engine/foyer)
 "phd" = (
@@ -53638,6 +53679,10 @@
 /obj/structure/window/reinforced,
 /obj/item/radio/intercom{
 	pixel_x = 27
+	},
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = -8;
+	pixel_y = 10
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
@@ -57517,6 +57562,10 @@
 	name = "Chief Medical Officer RC";
 	pixel_y = 32
 	},
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = -8;
+	pixel_y = 10
+	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/cmo)
 "qHT" = (
@@ -59486,6 +59535,7 @@
 	pixel_x = 10;
 	pixel_y = -3
 	},
+/obj/item/storage/pencil_holder/crew,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "rnr" = (
@@ -60468,6 +60518,9 @@
 /obj/item/deskbell/preset/med{
 	pixel_x = 9;
 	pixel_y = 8
+	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_y = 12
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -62369,6 +62422,10 @@
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
 /obj/item/paper/monitorkey,
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = -8;
+	pixel_y = 10
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "shB" = (
@@ -62496,6 +62553,10 @@
 /obj/item/cartridge/signal/toxins{
 	pixel_x = 4;
 	pixel_y = 6
+	},
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = -8;
+	pixel_y = 10
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -62900,6 +62961,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/item/storage/pencil_holder/crew/creative,
 /turf/open/floor/plasteel/vaporwave,
 /area/storage/art)
 "srj" = (
@@ -65251,6 +65313,7 @@
 	pixel_x = -7;
 	pixel_y = -3
 	},
+/obj/item/storage/pencil_holder/crew,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "sWw" = (
@@ -71960,6 +72023,7 @@
 	pixel_x = 8;
 	pixel_y = 9
 	},
+/obj/item/storage/pencil_holder/crew,
 /turf/open/floor/plating,
 /area/engine/atmos)
 "uPS" = (
@@ -73644,6 +73708,10 @@
 /obj/item/deskbell/preset/robotics{
 	pixel_x = -8;
 	pixel_y = -4
+	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = -5;
+	pixel_y = -9
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -77710,6 +77778,9 @@
 	desc = "Supposedly a direct line to Nanotrasen Central Command. It's not even plugged in.";
 	pixel_x = -3;
 	pixel_y = -5
+	},
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = 8
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -2199,6 +2199,7 @@
 	persistence_id = "public";
 	pixel_x = -32
 	},
+/obj/item/storage/pencil_holder/crew/creative,
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
 "aqd" = (
@@ -7657,6 +7658,10 @@
 "bdX" = (
 /obj/item/folder/blue,
 /obj/structure/table/wood,
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = -8;
+	pixel_y = 10
+	},
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
 "bea" = (
@@ -9105,9 +9110,11 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/item/pen,
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -10914,14 +10921,20 @@
 "bFb" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood,
-/obj/item/pen/blue{
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/obj/item/pen/red,
 /obj/item/deskbell/preset/library{
 	pixel_x = -9;
 	pixel_y = -3
+	},
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_y = 12;
+	pixel_x = 8
+	},
+/obj/item/storage/pencil_holder/crew/creative{
+	pixel_x = 8;
+	pixel_y = 6
+	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = 8
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -27020,6 +27033,10 @@
 	pixel_x = 8;
 	pixel_y = -3
 	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = -6;
+	pixel_y = -10
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "gYb" = (
@@ -28350,6 +28367,7 @@
 	dir = 4
 	},
 /obj/structure/table/glass,
+/obj/item/storage/pencil_holder/crew/fancy,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/cmo)
 "hwu" = (
@@ -35419,6 +35437,9 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "khj" = (
@@ -35587,6 +35608,10 @@
 	},
 /obj/item/pen,
 /obj/structure/table/wood,
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_y = 10;
+	pixel_x = 8
+	},
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
 "kjt" = (
@@ -45456,6 +45481,9 @@
 	pixel_x = -7;
 	pixel_y = 8
 	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/foyer)
 "oaC" = (
@@ -47543,6 +47571,9 @@
 /obj/item/folder/yellow,
 /obj/item/pen/red,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_y = 12
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "oNV" = (
@@ -47928,6 +47959,7 @@
 /obj/structure/table/wood,
 /obj/item/instrument/piano_synth,
 /obj/effect/decal/cleanable/dirt,
+/obj/item/storage/pencil_holder/crew,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "oXp" = (
@@ -51422,6 +51454,9 @@
 	pixel_x = 8;
 	pixel_y = 7
 	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = 8
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "qkB" = (
@@ -53341,9 +53376,11 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/item/pen,
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -54211,6 +54248,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2
 	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = 8
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "rlK" = (
@@ -54687,6 +54727,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_y = 12
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
@@ -55445,6 +55488,9 @@
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_y = 12
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "rKJ" = (
@@ -57204,6 +57250,10 @@
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
+	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_y = 10;
+	pixel_x = -8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
@@ -61149,6 +61199,9 @@
 	pixel_x = 32;
 	pixel_y = -3
 	},
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_y = 12
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "tUz" = (
@@ -61490,6 +61543,9 @@
 /obj/item/deskbell/preset/robotics{
 	pixel_x = 9;
 	pixel_y = 8
+	},
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -62317,6 +62373,9 @@
 /obj/item/hand_tele,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_y = 12
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "utp" = (
@@ -65741,6 +65800,10 @@
 	pixel_y = 8;
 	req_access_txt = "47"
 	},
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = -8;
+	pixel_y = 10
+	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
 "vGM" = (
@@ -68475,6 +68538,10 @@
 	},
 /obj/effect/turf_decal/tile/random{
 	dir = 8
+	},
+/obj/item/storage/pencil_holder/crew/creative{
+	pixel_x = 6;
+	pixel_y = 13
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)


### PR DESCRIPTION
# Document the changes in your pull request
adds pencil holders to station maps. as a general rule:

calligraphy holders are located in chain of command or high on the chain (cmo,ce,qm) and in the library.
crayon holders are located in the theaters, art rooms, and library.
pencil holders are at least one at each department's reception desk, library, and chain of command meeting room.

# Why is this good for the game?
to robust my #19876 pr, didn't realize it doesn't spawn a lot of pens to the maint loot table, also to kind of make it easier for mappers to place then hunting down the pens they want. 

# Changelog

:cl:  
mapping: adds pencil holders to station maps
/:cl:
