### PR TITLE
Spawns less clock cult at low pop

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -140,8 +140,8 @@ Credit where due:
 	antag_flag = ROLE_SERVANT_OF_RATVAR
 	false_report_weight = 10
 	required_players = 24
-	required_enemies = 4
-	recommended_enemies = 4
+	required_enemies = 3
+	recommended_enemies = 3
 	enemy_minimum_age = 14
 	protected_jobs = list("AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Brig Physician") //Silicons can eventually be converted //Yogs: Added Brig Physician
 	restricted_jobs = list("Chaplain", "Captain")
@@ -161,13 +161,13 @@ Credit where due:
 		restricted_jobs += protected_jobs
 	if(CONFIG_GET(flag/protect_assistant_from_antagonist))
 		restricted_jobs += "Assistant"
-	var/starter_servants = 4 //Guaranteed four servants
+	var/starter_servants = required_enemies
 	var/number_players = num_players()
 	roundstart_player_count = number_players
-	if(number_players > 30) //plus one servant for every additional 10 players above 30
+	if(number_players > 30) //plus one servant for every additional 8 players above 30
 		number_players -= 30
-		starter_servants += round(number_players / 10)
-	starter_servants = min(starter_servants, 8) //max 8 servants (that sould only happen with a ton of players)
+		starter_servants += round(number_players / 8)
+	starter_servants = min(starter_servants, 8) //max 8 servants (that should only happen with a ton of players)
 	while(starter_servants)
 		var/datum/mind/servant = antag_pick(antag_candidates)
 		servants_to_serve += servant


### PR DESCRIPTION
# Why is this good for the game?
Rather than making clock cult rarer by making the population lock more restrictive, simply reduces the number of clock cult when it's low pop to avoid stomping so much

:cl:  
tweak: Spawns 3 clockcult + 1 for every 8 players over 30 instead of 4 + 1 for every 10
/:cl:
