### PR TITLE
Failed Cyborg Shoves No Longer Push Them Back Two Tiles

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -67,6 +67,9 @@
 			cell = null
 			update_icons()
 			diag_hud_set_borgcell()
+			return TRUE
+	else if(!opened)
+		..()
 
 /mob/living/silicon/robot/fire_act()
 	if(!on_fire) //Silicons don't gain stacks from hotspots, but hotspots can ignite them

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -67,8 +67,7 @@
 			cell = null
 			update_icons()
 			diag_hud_set_borgcell()
-			return TRUE
-	else if(!opened)
+	if(!opened)
 		..()
 
 /mob/living/silicon/robot/fire_act()

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -46,6 +46,15 @@
 	adjustBruteLoss(run_armor(damage/2, BRUTE, MELEE)) // Cyborgs receive half damage plus armor.
 	return
 
+/mob/living/silicon/robot/attack_hulk(mob/living/carbon/human/user, does_attack_animation = 0)
+	. = ..()
+	if(.) // Successfully punched.
+		spark_system.start()
+		spawn(0)
+			step_away(src,user,15)
+			sleep(0.3 SECONDS)
+			step_away(src,user,15)
+
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /mob/living/silicon/robot/attack_hand(mob/living/carbon/human/user)
 	add_fingerprint(user)
@@ -58,14 +67,6 @@
 			cell = null
 			update_icons()
 			diag_hud_set_borgcell()
-
-	if(!opened)
-		if(..()) // hulk attack
-			spark_system.start()
-			spawn(0)
-				step_away(src,user,15)
-				sleep(0.3 SECONDS)
-				step_away(src,user,15)
 
 /mob/living/silicon/robot/fire_act()
 	if(!on_fire) //Silicons don't gain stacks from hotspots, but hotspots can ignite them

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -67,6 +67,7 @@
 			cell = null
 			update_icons()
 			diag_hud_set_borgcell()
+
 	if(!opened)
 		..()
 


### PR DESCRIPTION
# Document the changes in your pull request
"Failed" cyborg shoves no longer pushes them back twice as if it was from a hulk punch.

# Changelog
:cl:  
bugfix: Failed cyborg shoves no longer push them back two tiles.
bugfix: Hulk punches on cyborgs now properly pushes them back two tiles.
/:cl:
