### PR TITLE
Lets assistant traitors buy his grace

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2481,7 +2481,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	To activate His Grace, simply unlatch Him."
 	item = /obj/item/his_grace
 	cost = 20
-	restricted_roles = list("Chaplain")
+	restricted_roles = list("Chaplain", "Assistant")
 	surplus = 0 //This is a hijack item. Do not add this into surplus.
 
 /datum/uplink_item/role_restricted/horror


### PR DESCRIPTION
In the description it literally says it was recovered from a station overcome by the grey tide, why can't it be bought by assistants already?

# Why is this good for the game?
It's a really cool item and yet it's pretty much never seen because a chaplain will never buy it

:cl:  
tweak: His Grace can be bought by assistants
/:cl:
