### PR TITLE
You no longer get mining speed on IceMeta

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -38,6 +38,7 @@
 	var/poweralm = TRUE
 	var/lightswitch = TRUE
 	var/vacuum = null //yogs- yellow vacuum lights
+	var/mining_speed = FALSE
 
 	var/requires_power = TRUE
 	var/always_unpowered = FALSE	// This gets overridden to 1 for space in area/Initialize(mapload).

--- a/code/game/area/areas/mining.dm
+++ b/code/game/area/areas/mining.dm
@@ -7,6 +7,7 @@
 	ambient_buzz = 'sound/ambience/magma.ogg'
 	
 	ambient_buzz_vol = 10
+	mining_speed = TRUE
 
 /area/mine/explored
 	name = "Mine"
@@ -110,6 +111,7 @@
 	flags_1 = NONE
 	area_flags = FLORA_ALLOWED
 	ambient_buzz = 'sound/ambience/magma.ogg'
+	mining_speed = TRUE
 
 /area/lavaland/surface
 	name = "Lavaland"
@@ -163,6 +165,7 @@
 	flags_1 = NONE
 	area_flags = FLORA_ALLOWED
 	blob_allowed = FALSE
+	mining_speed = TRUE
 
 /area/icemoon/top_layer
 	name = "Icemoon Surface"

--- a/code/game/area/areas/ruins/_ruins.dm
+++ b/code/game/area/areas/ruins/_ruins.dm
@@ -7,6 +7,7 @@
 	hidden = FALSE
 	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
 	ambience_index = AMBIENCE_RUINS
+	mining_speed = TRUE
 
 
 /area/ruin/unpowered

--- a/code/game/area/areas/ruins/space.dm
+++ b/code/game/area/areas/ruins/space.dm
@@ -3,6 +3,7 @@
 /area/ruin/space
 	has_gravity = FALSE
 	blob_allowed = FALSE //Nope, no winning in space as a blob. Gotta eat the station.
+	mining_speed = FALSE
 
 /area/ruin/space/has_grav
 	has_gravity = STANDARD_GRAVITY
@@ -27,6 +28,7 @@
 	ambient_music_index = AMBIENCE_SPACE
 	ambient_buzz = null
 	sound_environment = SOUND_AREA_SPACE
+	mining_speed = FALSE
 
 /////////////
 

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -44,6 +44,7 @@
 		add_movespeed_modifier(MOVESPEED_ID_LIVING_TURF_SPEEDMOD, TRUE, 100, override = TRUE, multiplicative_slowdown = T.slowdown)
 	else
 		remove_movespeed_modifier(MOVESPEED_ID_LIVING_TURF_SPEEDMOD)
+	update_move_intent_slowdown()
 
 /mob/living/proc/update_pull_movespeed()
 	if(pulling && isliving(pulling))

--- a/yogstation/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/human_movement.dm
@@ -10,10 +10,9 @@
 	if(!player_turf || ! is_mining_level(player_turf.z)) // If we can't get the turf, assume it's not on mining.
 		return ..()
 
-	if(is_mining_level(player_turf.z)) // for icemoon 
-		var/area/player_area = get_area(src)
-		if(!player_area.mining_speed)
-			return ..()
+	var/area/player_area = get_area(src)
+	if(!player_area.mining_speed)
+		return ..()
 
 	var/mod = 0
 	if(m_intent == MOVE_INTENT_WALK)

--- a/yogstation/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/human_movement.dm
@@ -5,9 +5,15 @@
 		update_movespeed()
 
 /mob/living/carbon/human/update_move_intent_slowdown()
-	var/turf/T = get_turf(src)
-	if(!T || !is_mining_level(T.z)) // If we can't get the turf, assume it's not on mining.
+	var/turf/player_turf = get_turf(src)
+
+	if(!player_turf || ! is_mining_level(player_turf.z)) // If we can't get the turf, assume it's not on mining.
 		return ..()
+
+	if(is_mining_level(player_turf.z)) // for icemoon 
+		var/area/player_area = get_area(src)
+		if(!player_area.mining_speed)
+			return ..()
 
 	var/mod = 0
 	if(m_intent == MOVE_INTENT_WALK)

--- a/yogstation/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/yogstation/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -10,11 +10,10 @@
 	if(!player_turf || ! is_mining_level(player_turf.z)) // If we can't get the turf, assume it's not on mining.
 		return ..()
 
-	if(is_mining_level(player_turf.z)) // for icemoon 
-		var/area/player_area = get_area(src)
-		if(!player_area.mining_speed)
-			return ..()
-
+	var/area/player_area = get_area(src)
+	if(!player_area.mining_speed)
+		return ..()
+		
 	var/mod = 0
 	if(m_intent == MOVE_INTENT_WALK)
 		mod = CONFIG_GET(number/movedelay/walk_delay) / 1.5 // 4

--- a/yogstation/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/yogstation/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -5,9 +5,15 @@
 		update_movespeed()
 
 /mob/living/silicon/robot/update_move_intent_slowdown()
-	var/turf/T = get_turf(src)
-	if(!T || !is_mining_level(T.z)) // If we can't get the turf, assume it's not on mining.
+	var/turf/player_turf = get_turf(src)
+
+	if(!player_turf || ! is_mining_level(player_turf.z)) // If we can't get the turf, assume it's not on mining.
 		return ..()
+
+	if(is_mining_level(player_turf.z)) // for icemoon 
+		var/area/player_area = get_area(src)
+		if(!player_area.mining_speed)
+			return ..()
 
 	var/mod = 0
 	if(m_intent == MOVE_INTENT_WALK)


### PR DESCRIPTION
# Document the changes in your pull request
Removes the mining speed from station areas, you still get it when youre outside of the station on an icemoon area but will no longer get it on the station.

Currently miner items still perform exactly the same as before, this doesn't change any of that, if someone wants that changed you can use some of the code here to figure it out, but I'm not bothered by that really.

# Why is this good for the game?
Keeps the speed in line with other maps, was annoying for players like myself, I know I personally have discussed this issue with Ned innumerable times and we both agree that this is the best solution to the problem.

I feel this speed in general is better for our server, and having a map that meaninglessly decides to disobey that was silly.

# Changelog
:cl:  
tweak: No more superspeed on icemeta
/:cl:
