### PR TITLE
Better Syndicate Surgery Duffel Bag Uplink Description

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1909,8 +1909,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/device_tools/surgerybag
 	name = "Syndicate Surgery Duffel Bag"
-	desc = "The Syndicate surgery duffel bag is a toolkit containing all surgery tools, surgical drapes, \
-			a normal MMI, an implant case, a straitjacket, and a muzzle."
+	desc = "A red and black duffel bag containing all surgery tools, a surgical mat, \
+			a normal MMI, an implant case, a straitjacket, and a muzzle. The surgery tools are twice as fast compared to normal surgery tools."
 	manufacturer = /datum/corporation/traitor/vahlen
 	item = /obj/item/storage/backpack/duffelbag/syndie/surgery
 	cost = 2


### PR DESCRIPTION
# Document the changes in your pull request
Changes Syndicate Surgery Duffel Bag's description to be more accurate of its contents.

# Why is this good for the game?
Lets traitors make better informed decisions when purchasing things.

# Wiki Documentation
New description: "A red and black duffel bag containing all surgery tools, a surgical mat, a normal MMI, an implant case, a straitjacket, and a muzzle. The surgery tools are twice as fast compared to normal surgery tools."

# Changelog
:cl:  
tweak: Syndicate Surgery Duffel Bag's description in the Uplink now accurately tells you that the surgery tools have double toolspeed (0.5) and includes a surgical mat.
/:cl:
