### PR TITLE
Janiborg's Cleaning is Toggleable and is an Item

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -694,6 +694,36 @@
 	SStgui.close_uis(cooking)
 	return ..()
 
+/obj/item/borg/floor_autocleaner
+	name = "floor autocleaner"
+	desc = "Automatically cleans the floor under you!"
+	icon = 'icons/obj/vehicles.dmi'
+	icon_state = "upgrade"
+	item_flags = NOBLUDGEON
+	var/toggled = FALSE
+
+/obj/item/borg/floor_autocleaner/attack_self(mob/user, modifiers)
+	if(!issilicon(user))
+		return FALSE
+
+	toggled = !toggled
+	if(toggled)
+		user.AddElement(/datum/element/cleaning)
+		user.balloon_alert(user, "cleaning enabled")
+	else
+		user.RemoveElement(/datum/element/cleaning)
+		user.balloon_alert(user, "cleaning disabled")
+
+/obj/item/borg/floor_autocleaner/cyborg_equip(mob/user)
+	if(toggled)
+		user.AddElement(/datum/element/cleaning)
+		user.balloon_alert(user, "cleaning enabled")
+	
+/obj/item/borg/floor_autocleaner/cyborg_unequip(mob/user)
+	if(toggled)
+		user.RemoveElement(/datum/element/cleaning)
+		user.balloon_alert(user, "cleaning disabled")
+
 /**********************************************************************
 						HUD/SIGHT things
 ***********************************************************************/

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -27,6 +27,12 @@
 	return
 
 /**
+  * Parent proc - triggers when an item/module is equipped from a cyborg.
+  */
+/obj/item/proc/cyborg_equip(mob/user)
+	return
+
+/**
   * Finds the first available slot and attemps to put item item_module in it.
   *
   * Arguments
@@ -77,6 +83,7 @@
 	item_module.mouse_opacity = initial(item_module.mouse_opacity)
 	item_module.layer = ABOVE_HUD_LAYER
 	item_module.plane = ABOVE_HUD_PLANE
+	item_module.cyborg_equip(src)
 	item_module.forceMove(src)
 
 	if(istype(item_module, /obj/item/borg/sight))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1176,16 +1176,10 @@
 	else
 		status_flags &= ~CANPUSH
 
-	if(module.clean_on_move)
-		AddElement(/datum/element/cleaning)
-	else
-		RemoveElement(/datum/element/cleaning)
-
 	hat_offset = module.hat_offset
 
 	magpulse = module.magpulsing
 	updatename()
-
 
 /mob/living/silicon/robot/proc/place_on_head(obj/item/new_hat)
 	if(hat)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -29,7 +29,6 @@
 
 	var/can_be_pushed = TRUE
 	var/magpulsing = FALSE
-	var/clean_on_move = FALSE
 
 	var/did_feedback = FALSE
 
@@ -469,7 +468,8 @@
 		/obj/item/paint/paint_remover,
 		/obj/item/lightreplacer/cyborg,
 		/obj/item/holosign_creator/janibarrier,
-		/obj/item/reagent_containers/spray/cyborg_drying)
+		/obj/item/reagent_containers/spray/cyborg_drying,
+		/obj/item/borg/floor_autocleaner)
 	radio_channels = list(RADIO_CHANNEL_SERVICE)
 	emag_modules = list(/obj/item/reagent_containers/spray/cyborg_lube)
 	ratvar_modules = list(
@@ -478,7 +478,6 @@
 	cyborg_base_icon = "janitor"
 	moduleselect_icon = "janitor"
 	hat_offset = -5
-	clean_on_move = TRUE
 
 /obj/item/reagent_containers/spray/cyborg_drying
 	name = "drying agent spray"


### PR DESCRIPTION
# Document the changes in your pull request
Janiborgs no longer automatically cleans the floor under them (even if they're dead)!
Janiborgs start with an item called "floor autocleaner" that replaces their automatic cleaning ability which is togglable. 
It only works if it is an equipped module.

# Why is this good for the game?
Reduces the odds of floor art being removed by a passing Janiborg and requires them to invest more (taking an equipped module slot) to keep their space cleaner tier of cleaning. Also, it makes sense that dead Janiborgs don't clean the floor under them.

# Wiki Documentation
Janiborgs no longer automatically clean when moving over things.
New item that they start with called "floor autocleaner": Toggleable & must be one of the three equipped module to work.

# Changelog
:cl:  
rscadd: Janiborgs start with a "floor autocleaner" item that mimics their automatic cleaning, except it is toggleable and requires it to be equipped to work.  
rscdel: Janiborgs no longer automatically clean things when moving things.
/:cl:
