### PR TITLE
Completely revamps Metas service, taking inspiration from /TG/

### DIFF
--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -3431,14 +3431,21 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "aZn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/door/airlock{
+	name = "Kitchen";
+	req_access_txt = "28"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/turf/open/indestructible/carpet/black,
-/area/clerk)
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/hallway/secondary/service)
 "aZs" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
@@ -9144,17 +9151,12 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cKE" = (
-/obj/structure/table/wood/fancy/black,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/structure/table,
+/obj/machinery/smartfridge/disks{
+	pixel_y = 2
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters{
-	id = "giftshop"
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/plasteel/dark,
-/area/clerk)
+/area/hydroponics)
 "cKH" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/machinery/camera{
@@ -9602,15 +9604,6 @@
 /mob/living/simple_animal/sloth/citrus,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"cSj" = (
-/obj/effect/turf_decal/trimline/green/warning/lower{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "cSm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -9941,15 +9934,19 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cWR" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop_ext"
 	},
-/area/crew_quarters/kitchen)
+/obj/machinery/door/airlock/glass_large{
+	doorOpen = 'sound/machines/defib_success.ogg';
+	name = "Gift Shop"
+	},
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "cWW" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -10747,15 +10744,6 @@
 	luminosity = 2
 	},
 /area/security/nuke_storage)
-"dkk" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_y = 21
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "dkz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11980,17 +11968,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "dBc" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/plantgenes{
+	pixel_y = 6
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "dBf" = (
 /turf/closed/wall,
 /area/science/robotics/lab)
@@ -12011,20 +11994,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "dBp" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 10
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop_ext"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/indestructible/carpet/black,
-/area/clerk)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "dBs" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/bot,
@@ -15417,19 +15392,11 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "eEG" = (
-/obj/machinery/door/airlock{
-	name = "Gift Shop";
-	req_access_txt = "36"
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/clerk)
+/area/crew_quarters/kitchen)
 "eEK" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -15620,9 +15587,15 @@
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "eHU" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "eIe" = (
 /obj/item/candle,
 /obj/machinery/light_switch{
@@ -16250,16 +16223,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "eTj" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/disposalpipe/sorting/mail{
-	sortType = 21
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "eTn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer2{
@@ -19173,21 +19141,17 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "fMy" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/service";
-	dir = 1;
-	name = "Service Hall APC";
-	pixel_y = 23
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
 	},
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/area/crew_quarters/kitchen)
 "fML" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19374,11 +19338,17 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "fPk" = (
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
+/obj/structure/table/wood/fancy/black,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/area/crew_quarters/kitchen)
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters{
+	id = "giftshop"
+	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/clerk)
 "fPo" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser{
@@ -19402,12 +19372,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "fPq" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop_ext"
-	},
-/turf/open/floor/plating,
-/area/clerk)
+/obj/structure/table,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "fPt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -20974,20 +20941,19 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "gkw" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/hydroponicsplants{
+	pixel_x = -3
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+/obj/item/book/manual/wiki/hydroponicsguide{
+	pixel_x = 3;
+	pixel_y = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hydroponics)
 "gkB" = (
 /turf/closed/wall,
 /area/hallway/primary/central)
@@ -25536,11 +25502,6 @@
 /area/chapel/main)
 "hyt" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/eastleft{
-	dir = 1;
-	name = "Kitchen Window";
-	req_access_txt = "28"
-	},
 /obj/item/paper,
 /obj/machinery/door/window/eastleft{
 	dir = 2;
@@ -26040,13 +26001,20 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "hFR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/window/eastleft{
+	dir = 1;
+	name = "Kitchen Window";
+	req_access_txt = "28"
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
-/area/crew_quarters/kitchen)
+/area/hallway/secondary/service)
 "hGA" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -26629,12 +26597,20 @@
 /turf/closed/wall,
 /area/science/xenobiology)
 "hOb" = (
-/obj/structure/table,
-/obj/machinery/smartfridge/disks{
-	pixel_y = 2
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hOd" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -26879,6 +26855,22 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/storage)
+"hRm" = (
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hRr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 4;
@@ -26995,21 +26987,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hTj" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+	dir = 10
 	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "hTm" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/light/small{
@@ -27832,18 +27822,20 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "ikG" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -28302,20 +28294,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "irt" = (
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -29917,20 +29907,19 @@
 /turf/closed/wall,
 /area/security/courtroom)
 "iMH" = (
-/obj/effect/landmark/start/cook,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 8
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "iMQ" = (
 /obj/structure/destructible/cult/tome,
 /obj/machinery/newscaster{
@@ -30644,16 +30633,14 @@
 /turf/open/floor/wood,
 /area/library)
 "iXN" = (
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/hydroponicsplants{
-	pixel_x = -3
-	},
-/obj/item/book/manual/wiki/hydroponicsguide{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	sortType = 21
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -31653,6 +31640,18 @@
 "jlE" = (
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"jlF" = (
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "jlJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -32064,6 +32063,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"jrn" = (
+/obj/structure/table/glass,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "jrJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -33562,6 +33577,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"jLL" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "jLP" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -33909,14 +33931,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"jRa" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "jRd" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/structure/cable{
@@ -34369,12 +34383,12 @@
 /turf/closed/wall/r_wall,
 /area/aisat)
 "jYL" = (
-/obj/structure/table,
-/obj/machinery/plantgenes{
-	pixel_y = 6
+/obj/machinery/smartfridge/drying_rack,
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 6
 	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "jYO" = (
 /obj/structure/table/wood,
 /obj/item/deskbell/preset/library{
@@ -44035,21 +44049,14 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "mNG" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hydroponics)
 "mNN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -45065,18 +45072,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mZy" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "mZK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -45391,9 +45386,12 @@
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
 "ndS" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics)
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop_ext"
+	},
+/turf/open/floor/plating,
+/area/clerk)
 "neg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45695,17 +45693,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"njA" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
-	},
-/obj/structure/sign/map/right{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-right-MS";
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "njU" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -48555,9 +48542,16 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "obf" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/clerk)
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/obj/structure/sign/map/right{
+	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
+	icon_state = "map-right-MS";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "obl" = (
 /obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
 	dir = 8
@@ -49007,18 +49001,6 @@
 /obj/item/gun/ballistic/shotgun/automatic/breaching,
 /turf/open/floor/plasteel,
 /area/security/warden)
-"ogv" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "ogK" = (
 /obj/machinery/light{
 	dir = 8
@@ -49350,11 +49332,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "olY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/clerk)
 "omn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -49759,12 +49739,11 @@
 	},
 /area/security/prison)
 "osp" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 10
+/obj/machinery/processor,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/area/crew_quarters/kitchen)
 "osy" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -50588,20 +50567,18 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "oFF" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hydroponics)
 "oFH" = (
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway - Fore";
@@ -50974,19 +50951,20 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "oNC" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "Serving Hatch"
+/obj/effect/landmark/start/cook,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
-/area/hallway/secondary/service)
+/area/crew_quarters/kitchen)
 "oND" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -57349,20 +57327,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"qGD" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop_ext"
-	},
-/obj/machinery/door/airlock/glass_large{
-	doorOpen = 'sound/machines/defib_success.ogg';
-	name = "Gift Shop"
-	},
-/turf/open/indestructible/carpet/black,
-/area/clerk)
 "qGE" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
@@ -57599,6 +57563,9 @@
 	},
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -58060,21 +58027,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "qQw" = (
-/obj/machinery/door/airlock{
-	name = "Kitchen";
-	req_access_txt = "28"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/hallway/secondary/service)
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "qQQ" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -58308,6 +58268,20 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"qUs" = (
+/obj/structure/table/wood,
+/obj/item/camera,
+/obj/item/camera_film,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/camera{
+	c_tag = "Gift Shop";
+	dir = 4
+	},
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "qUC" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -60646,16 +60620,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "rIb" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -64476,12 +64452,8 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "sMo" = (
@@ -64767,19 +64739,9 @@
 /turf/open/floor/plating,
 /area/mine/laborcamp)
 "sPk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "sPy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -65508,7 +65470,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "sZQ" = (
-/obj/machinery/processor,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -66079,12 +66046,19 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "thg" = (
-/obj/machinery/smartfridge/drying_rack,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 6
+/obj/machinery/door/airlock{
+	name = "Gift Shop";
+	req_access_txt = "36"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/clerk)
 "thl" = (
 /turf/closed/wall,
 /area/maintenance/aft)
@@ -68526,19 +68500,13 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "tTQ" = (
-/obj/structure/table/wood,
-/obj/item/camera,
-/obj/item/camera_film,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Gift Shop";
-	dir = 4
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
-/turf/open/indestructible/carpet/black,
-/area/clerk)
+/area/crew_quarters/kitchen)
 "tTT" = (
 /obj/effect/turf_decal/trimline/green/warning/lower,
 /turf/open/floor/plasteel,
@@ -71132,12 +71100,13 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "uFH" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/indestructible/carpet/black,
-/area/clerk)
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "uFJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -74101,16 +74070,21 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/foyer)
 "vwc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/service";
+	dir = 1;
+	name = "Service Hall APC";
+	pixel_y = 23
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria{
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 5
 	},
-/area/crew_quarters/kitchen)
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "vwg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -76285,14 +76259,20 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "wbs" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/hallway/primary/central)
 "wbC" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -77868,21 +77848,20 @@
 /turf/open/floor/plasteel/dark,
 /area/mine/infirmary)
 "wxe" = (
-/obj/structure/table/glass,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop_ext"
 	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "wxw" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 4
@@ -81745,6 +81724,12 @@
 /obj/structure/bookcase/manuals/research_and_development,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"xyT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xzb" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -83444,12 +83429,14 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "xVd" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics)
+/obj/item/radio/intercom{
+	pixel_y = 21
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xVs" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -84342,6 +84329,15 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/solars/starboard/fore)
+"yho" = (
+/obj/effect/turf_decal/trimline/green/warning/lower{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "yhp" = (
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
@@ -113856,13 +113852,13 @@ jLJ
 cmS
 oWW
 rRb
-obf
-cKE
+olY
+fPk
 hiY
-tTQ
+qUs
 bVv
 tSd
-fPq
+ndS
 cnB
 bOW
 vfu
@@ -114119,7 +114115,7 @@ hiY
 xIS
 kCd
 hiY
-qGD
+cWR
 cnB
 oxp
 tHh
@@ -114369,14 +114365,14 @@ xqY
 iSn
 cmS
 pyr
-obf
-obf
-cKE
+olY
+olY
+fPk
 hiY
 pcc
 srT
 cxX
-dBp
+wxe
 aud
 mlF
 tHh
@@ -114626,14 +114622,14 @@ gax
 cUZ
 cmS
 lUJ
-obf
-obf
-cKE
+olY
+olY
+fPk
 hiY
-aZn
-uFH
+qQw
+jLL
 mrw
-fPq
+ndS
 cnB
 oxp
 weH
@@ -114884,7 +114880,7 @@ eIF
 rSI
 oWW
 oWW
-eEG
+thg
 oWW
 oWW
 bpB
@@ -115141,14 +115137,14 @@ iSn
 wEb
 auc
 oWW
-obf
-obf
+olY
+olY
 gDU
 rib
-obf
+olY
 aIK
 oWW
-dkk
+xVd
 oxp
 lbX
 aYY
@@ -115662,8 +115658,8 @@ xgE
 jXb
 xQt
 oWW
-njA
-oFF
+obf
+hOb
 cTp
 idf
 tMs
@@ -115920,7 +115916,7 @@ xeL
 oWW
 oWW
 uNg
-gkw
+wbs
 tHh
 uPN
 rbU
@@ -117203,7 +117199,7 @@ vdX
 vdX
 uer
 oxp
-olY
+xyT
 sJM
 sJM
 apG
@@ -117459,7 +117455,7 @@ rfi
 rfi
 oKl
 nSo
-mNG
+hRm
 abA
 uer
 sJM
@@ -118748,10 +118744,10 @@ fEM
 oKl
 xIU
 vKp
-wbs
-wbs
 sMm
-wbs
+sMm
+oFF
+sMm
 kXA
 tpY
 uvQ
@@ -119007,7 +119003,7 @@ vGl
 bNb
 fvz
 fvz
-xVd
+eTj
 fvz
 wIv
 rTH
@@ -119261,14 +119257,14 @@ aBh
 rvm
 oKl
 fZF
-hTj
-qIL
+rIb
+mNG
 oQc
-ogv
+jlF
 oQc
 vxy
 xPI
-jYL
+dBc
 rTH
 krH
 lXG
@@ -119511,13 +119507,13 @@ mDO
 gMX
 wrE
 uNy
-cWR
-sZQ
+eHU
+osp
 oKl
 ncZ
 lSi
 oKl
-iXN
+gkw
 bNb
 fvz
 fvz
@@ -119525,7 +119521,7 @@ fvz
 fvz
 tud
 mmO
-hOb
+cKE
 rTH
 wTo
 lXG
@@ -119768,21 +119764,21 @@ dFh
 ylz
 dbV
 gJr
-dBc
+fMy
 wAe
 oKl
 mDl
-osp
+dBp
 oKl
-wxe
-ikG
-qIL
+jrn
+irt
+mNG
 oQc
 oQc
 oQc
 mzb
 mmO
-ndS
+fPq
 rTH
 krH
 lXG
@@ -120025,13 +120021,13 @@ baV
 rGN
 sYB
 tmP
-vwc
-sPk
-qQw
+sZQ
+hTj
+aZn
 hCb
 oaz
 pqT
-eTj
+iXN
 xws
 fvz
 fvz
@@ -120279,18 +120275,18 @@ mAQ
 pkM
 vnv
 jXE
-hFR
+uFH
 khr
 ixM
 jIn
-jRa
-oNC
-cSj
+tTQ
+hFR
+yho
 rXT
 hyt
 qOL
-rIb
-mZy
+iMH
+qIL
 oQc
 oQc
 oQc
@@ -120536,14 +120532,14 @@ ptc
 mGA
 vnv
 iBm
-hFR
+uFH
 ekt
 qVL
-vwc
+sZQ
 gyG
 vGx
 qqo
-eHU
+sPk
 pkX
 bJb
 bNb
@@ -120793,20 +120789,20 @@ ptc
 mGA
 vnv
 mXZ
-iMH
+oNC
 epx
 sGy
 eKv
 gyG
 oKl
-fMy
-thg
+vwc
+jYL
 oKl
 vkD
-irt
+ikG
 iAd
 mqg
-qIL
+mNG
 gKt
 ydy
 xJH
@@ -121309,7 +121305,7 @@ lxH
 pOP
 xEE
 xlJ
-fPk
+eEG
 pOP
 uYU
 vhz

--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -222,6 +222,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "adt" = (
@@ -1222,13 +1225,13 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
 "aud" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -3431,21 +3434,12 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "aZn" = (
-/obj/machinery/door/airlock{
-	name = "Kitchen";
-	req_access_txt = "28"
+/obj/structure/table,
+/obj/machinery/plantgenes{
+	pixel_y = 6
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/hallway/secondary/service)
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "aZs" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
@@ -6095,6 +6089,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bOX" = (
@@ -8295,7 +8292,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
 /turf/open/indestructible/carpet/black,
 /area/clerk)
@@ -9151,12 +9148,20 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cKE" = (
-/obj/structure/table,
-/obj/machinery/smartfridge/disks{
-	pixel_y = 2
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics)
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop_ext"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "cKH" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/machinery/camera{
@@ -9604,6 +9609,17 @@
 /mob/living/simple_animal/sloth/citrus,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"cSj" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/obj/structure/sign/map/left{
+	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
+	icon_state = "map-left-MS";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cSm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -9684,13 +9700,10 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cTp" = (
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 4;
-	sortType = 22
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cTy" = (
@@ -9934,19 +9947,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cWR" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/structure/table,
+/obj/machinery/smartfridge/disks{
+	pixel_y = 2
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop_ext"
-	},
-/obj/machinery/door/airlock/glass_large{
-	doorOpen = 'sound/machines/defib_success.ogg';
-	name = "Gift Shop"
-	},
-/turf/open/indestructible/carpet/black,
-/area/clerk)
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "cWW" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -10744,6 +10750,20 @@
 	luminosity = 2
 	},
 /area/security/nuke_storage)
+"dkk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "dkz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11968,12 +11988,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "dBc" = (
-/obj/structure/table,
-/obj/machinery/plantgenes{
-	pixel_y = 6
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics)
+/area/crew_quarters/kitchen)
 "dBf" = (
 /turf/closed/wall,
 /area/science/robotics/lab)
@@ -11993,13 +12012,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"dBp" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "dBs" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/bot,
@@ -15391,12 +15403,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"eEG" = (
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "eEK" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -15587,15 +15593,12 @@
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "eHU" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "eIe" = (
 /obj/item/candle,
 /obj/machinery/light_switch{
@@ -16222,13 +16225,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"eTj" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics)
 "eTn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer2{
 	dir = 4
@@ -18567,6 +18563,7 @@
 "fEM" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/siding/wood,
+/obj/item/storage/box/donkpockets,
 /turf/open/floor/carpet,
 /area/hallway/secondary/service)
 "fFl" = (
@@ -19140,18 +19137,6 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
-"fMy" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "fML" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19174,9 +19159,6 @@
 "fNb" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
 /turf/open/floor/plasteel/dark,
 /area/clerk)
 "fNg" = (
@@ -19372,9 +19354,21 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "fPq" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics)
+/obj/machinery/door/airlock{
+	name = "Kitchen";
+	req_access_txt = "28"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/hallway/secondary/service)
 "fPt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -19729,9 +19723,6 @@
 	pixel_y = -30
 	},
 /obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
@@ -20941,19 +20932,16 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "gkw" = (
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/hydroponicsplants{
-	pixel_x = -3
-	},
-/obj/item/book/manual/wiki/hydroponicsguide{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 1
 	},
+/obj/structure/sign/map/right{
+	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
+	icon_state = "map-right-MS";
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/hallway/primary/central)
 "gkB" = (
 /turf/closed/wall,
 /area/hallway/primary/central)
@@ -22197,16 +22185,17 @@
 /turf/open/floor/plasteel/freezer,
 /area/mine/laborcamp)
 "gDH" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 8
 	},
-/obj/structure/sign/map/left{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-left-MS";
-	pixel_y = 32
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hydroponics)
 "gDI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -24186,9 +24175,15 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "hdB" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
-/turf/closed/wall,
-/area/maintenance/central)
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "hdE" = (
 /obj/effect/landmark/start/cyborg,
 /obj/machinery/light/small{
@@ -26001,19 +25996,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "hFR" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/window/eastleft{
-	dir = 1;
-	name = "Kitchen Window";
-	req_access_txt = "28"
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "hGA" = (
 /obj/structure/table,
@@ -26597,20 +26581,14 @@
 /turf/closed/wall,
 /area/science/xenobiology)
 "hOb" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hydroponics)
 "hOd" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -26856,21 +26834,23 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "hRm" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 4
+/obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/service";
+	dir = 1;
+	name = "Service Hall APC";
+	pixel_y = 23
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 5
+	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
+/obj/item/stack/packageWrap,
+/obj/item/kitchen/rollingpin,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/secondary/service)
 "hRr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 4;
@@ -26987,19 +26967,21 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hTj" = (
+/obj/structure/table/glass,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 1
+	},
 /obj/structure/disposalpipe/segment{
-	dir = 10
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "hTm" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/light/small{
@@ -27822,23 +27804,14 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "ikG" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "ikQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -28294,21 +28267,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "irt" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/hallway/primary/central)
 "irv" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -29907,19 +29870,13 @@
 /turf/closed/wall,
 /area/security/courtroom)
 "iMH" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "iMQ" = (
 /obj/structure/destructible/cult/tome,
 /obj/machinery/newscaster{
@@ -30633,17 +30590,19 @@
 /turf/open/floor/wood,
 /area/library)
 "iXN" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 4
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop_ext"
 	},
-/obj/structure/disposalpipe/sorting/mail{
-	sortType = 21
+/obj/machinery/door/airlock/glass_large{
+	doorOpen = 'sound/machines/defib_success.ogg';
+	name = "Gift Shop"
 	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "iXO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -31641,17 +31600,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "jlF" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 8
+/obj/machinery/power/apc{
+	areastring = "/area/clerk";
+	dir = 4;
+	name = "Gift Shop APC";
+	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "jlJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -32064,21 +32023,11 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "jrn" = (
-/obj/structure/table/glass,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 1
+/obj/machinery/processor,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/area/crew_quarters/kitchen)
 "jrJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -33548,12 +33497,13 @@
 	},
 /area/maintenance/starboard/secondary)
 "jLg" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
-/turf/open/floor/plasteel/dark,
-/area/clerk)
+/area/crew_quarters/kitchen)
 "jLj" = (
 /obj/machinery/light_switch{
 	pixel_x = 28
@@ -33578,12 +33528,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "jLL" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
-	},
-/turf/open/indestructible/carpet/black,
-/area/clerk)
+/obj/structure/table,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "jLP" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -33931,6 +33878,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"jRa" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jRd" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/structure/cable{
@@ -34262,13 +34227,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"jXb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/clerk)
 "jXc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -34383,12 +34341,16 @@
 /turf/closed/wall/r_wall,
 /area/aisat)
 "jYL" = (
-/obj/machinery/smartfridge/drying_rack,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 6
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/obj/structure/rack,
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "jYO" = (
 /obj/structure/table/wood,
 /obj/item/deskbell/preset/library{
@@ -36297,11 +36259,23 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "kCd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
-/turf/open/indestructible/carpet/black,
-/area/clerk)
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "kCn" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chemistry_shutters";
@@ -37887,9 +37861,6 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
 "lbX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
@@ -39728,10 +39699,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "lEU" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "lEY" = (
@@ -40842,6 +40811,9 @@
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -42183,6 +42155,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mlH" = (
@@ -42546,15 +42521,7 @@
 /turf/open/floor/plating,
 /area/mine/storage)
 "mrw" = (
-/obj/machinery/power/apc{
-	areastring = "/area/clerk";
-	dir = 4;
-	name = "Gift Shop APC";
-	pixel_x = 24
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
+/obj/structure/rack,
 /turf/open/indestructible/carpet/black,
 /area/clerk)
 "mrX" = (
@@ -44049,11 +44016,16 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "mNG" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 4
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/hydroponicsplants{
+	pixel_x = -3
+	},
+/obj/item/book/manual/wiki/hydroponicsguide{
+	pixel_x = 3;
+	pixel_y = 2
 	},
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -45072,6 +45044,19 @@
 /obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"mZy" = (
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "mZK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -45386,12 +45371,12 @@
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
 "ndS" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop_ext"
+/obj/machinery/smartfridge/drying_rack,
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 6
 	},
-/turf/open/floor/plating,
-/area/clerk)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "neg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48542,16 +48527,17 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "obf" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
 	},
-/obj/structure/sign/map/right{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-right-MS";
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "obl" = (
 /obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
 	dir = 8
@@ -49001,6 +48987,13 @@
 /obj/item/gun/ballistic/shotgun/automatic/breaching,
 /turf/open/floor/plasteel,
 /area/security/warden)
+"ogv" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/clerk)
 "ogK" = (
 /obj/machinery/light{
 	dir = 8
@@ -49332,9 +49325,21 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "olY" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/clerk)
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "omn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -49739,11 +49744,20 @@
 	},
 /area/security/prison)
 "osp" = (
-/obj/machinery/processor,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/area/crew_quarters/kitchen)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "osy" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -50567,18 +50581,24 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "oFF" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4;
+	sortType = 22
+	},
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/hallway/primary/central)
 "oFH" = (
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway - Fore";
@@ -50951,20 +50971,20 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "oNC" = (
-/obj/effect/landmark/start/cook,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+/obj/machinery/door/window/eastleft{
+	dir = 1;
+	name = "Kitchen Window";
+	req_access_txt = "28"
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
-/area/crew_quarters/kitchen)
+/area/hallway/secondary/service)
 "oND" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -51821,6 +51841,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "paJ" = (
@@ -51896,6 +51919,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/indestructible/carpet/black,
 /area/clerk)
@@ -53477,10 +53503,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "pzO" = (
@@ -58027,14 +58051,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "qQw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/effect/turf_decal/trimline/green/warning/lower{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/indestructible/carpet/black,
-/area/clerk)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "qQQ" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -58269,19 +58293,20 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "qUs" = (
-/obj/structure/table/wood,
-/obj/item/camera,
-/obj/item/camera_film,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/machinery/camera{
-	c_tag = "Gift Shop";
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/indestructible/carpet/black,
-/area/clerk)
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qUC" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -59073,11 +59098,11 @@
 /area/science/explab)
 "rib" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/clerk)
@@ -60620,21 +60645,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "rIb" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 8
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop_ext"
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/turf/open/floor/plating,
+/area/clerk)
 "rIx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -61352,7 +61368,7 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "rSP" = (
@@ -62988,8 +63004,11 @@
 /area/teleporter)
 "srT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
+	dir = 8
 	},
 /turf/open/indestructible/carpet/black,
 /area/clerk)
@@ -63630,9 +63649,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "syR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -64739,9 +64755,21 @@
 /turf/open/floor/plating,
 /area/mine/laborcamp)
 "sPk" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/area/hallway/secondary/command)
 "sPy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -65470,16 +65498,19 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "sZQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/door/airlock{
+	name = "Gift Shop";
+	req_access_txt = "36"
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/clerk)
 "sZY" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
@@ -66046,16 +66077,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "thg" = (
-/obj/machinery/door/airlock{
-	name = "Gift Shop";
-	req_access_txt = "36"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/plasteel/dark,
 /area/clerk)
@@ -67731,12 +67752,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
-"tHh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "tHq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -68500,13 +68515,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "tTQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
+/obj/item/radio/intercom{
+	pixel_y = 21
 	},
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "tTT" = (
 /obj/effect/turf_decal/trimline/green/warning/lower,
 /turf/open/floor/plasteel,
@@ -69765,9 +69781,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "umj" = (
@@ -71100,8 +71114,15 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "uFH" = (
+/obj/effect/landmark/start/cook,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -73019,14 +73040,12 @@
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
 "vfu" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/secondary/service)
 "vfx" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -74070,21 +74089,16 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/foyer)
 "vwc" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/service";
-	dir = 1;
-	name = "Service Hall APC";
-	pixel_y = 23
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/area/crew_quarters/kitchen)
 "vwg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -76260,19 +76274,10 @@
 /area/maintenance/fore)
 "wbs" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "wbC" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -76459,12 +76464,19 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "weH" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/table/wood,
+/obj/item/camera,
+/obj/item/camera_film,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/camera{
+	c_tag = "Gift Shop";
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "weJ" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
@@ -77848,20 +77860,19 @@
 /turf/open/floor/plasteel/dark,
 /area/mine/infirmary)
 "wxe" = (
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop_ext"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/indestructible/carpet/black,
-/area/clerk)
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "wxw" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 4
@@ -81725,11 +81736,21 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "xyT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hydroponics)
 "xzb" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -83429,11 +83450,18 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "xVd" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_y = 21
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -84330,14 +84358,17 @@
 	},
 /area/maintenance/solars/starboard/fore)
 "yho" = (
-/obj/effect/turf_decal/trimline/green/warning/lower{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	sortType = 21
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/area/hydroponics)
 "yhp" = (
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
@@ -113849,19 +113880,19 @@ urr
 uep
 kgs
 jLJ
-cmS
+xZW
 oWW
 rRb
-olY
+thg
 fPk
 hiY
-qUs
+weH
 bVv
 tSd
-ndS
+rIb
 cnB
 bOW
-vfu
+cTp
 uQD
 iUm
 vCR
@@ -114106,19 +114137,19 @@ crH
 xqY
 xto
 iSn
-cmS
+xZW
 oWW
 slM
 hEb
 lIL
 hiY
 xIS
-kCd
 hiY
-cWR
-cnB
-oxp
-tHh
+hiY
+iXN
+vNK
+osp
+sJM
 haI
 iXP
 rvN
@@ -114363,19 +114394,19 @@ oUm
 jDx
 xqY
 iSn
-cmS
+xZW
 pyr
-olY
-olY
+thg
+thg
 fPk
-hiY
+wbs
 pcc
 srT
 cxX
-wxe
+cKE
 aud
 mlF
-tHh
+sJM
 wVT
 dIY
 cNe
@@ -114620,19 +114651,19 @@ oUm
 kBU
 gax
 cUZ
-cmS
+sPk
 lUJ
-olY
-olY
+thg
+thg
 fPk
-hiY
-qQw
-jLL
+jlF
+ikG
+jYL
 mrw
-ndS
+rIb
 cnB
-oxp
-weH
+osp
+rVn
 cpP
 iXP
 mJY
@@ -114880,7 +114911,7 @@ eIF
 rSI
 oWW
 oWW
-thg
+sZQ
 oWW
 oWW
 bpB
@@ -115137,15 +115168,15 @@ iSn
 wEb
 auc
 oWW
-olY
-olY
+thg
+thg
 gDU
 rib
-olY
+ogv
 aIK
 oWW
-xVd
-oxp
+tTQ
+osp
 lbX
 aYY
 rbU
@@ -115398,12 +115429,12 @@ frf
 mQr
 xgX
 fNb
-jLg
+thg
 czk
 oWW
-gDH
-oxp
-tHh
+cSj
+osp
+sJM
 bKt
 rbU
 ils
@@ -115655,11 +115686,11 @@ cnf
 sAy
 wDy
 xgE
-jXb
+thg
 xQt
 oWW
-obf
-hOb
+gkw
+oFF
 cTp
 idf
 tMs
@@ -115916,8 +115947,8 @@ xeL
 oWW
 oWW
 uNg
-wbs
-tHh
+jRa
+sJM
 uPN
 rbU
 msv
@@ -116173,8 +116204,8 @@ boW
 fey
 nry
 lZF
-oxp
-tHh
+osp
+sJM
 nbE
 rbU
 ebw
@@ -116427,10 +116458,10 @@ byf
 byf
 byf
 byf
-hdB
-hdB
+byf
+byf
 sIM
-oxp
+qUs
 lEU
 cXt
 rbU
@@ -117199,7 +117230,7 @@ vdX
 vdX
 uer
 oxp
-xyT
+irt
 sJM
 sJM
 apG
@@ -117455,7 +117486,7 @@ rfi
 rfi
 oKl
 nSo
-hRm
+xVd
 abA
 uer
 sJM
@@ -118746,7 +118777,7 @@ xIU
 vKp
 sMm
 sMm
-oFF
+mZy
 sMm
 kXA
 tpY
@@ -119003,7 +119034,7 @@ vGl
 bNb
 fvz
 fvz
-eTj
+eHU
 fvz
 wIv
 rTH
@@ -119257,14 +119288,14 @@ aBh
 rvm
 oKl
 fZF
-rIb
-mNG
+olY
+hOb
 oQc
-jlF
+gDH
 oQc
 vxy
 xPI
-dBc
+aZn
 rTH
 krH
 lXG
@@ -119507,13 +119538,13 @@ mDO
 gMX
 wrE
 uNy
-eHU
-osp
+hdB
+jrn
 oKl
 ncZ
 lSi
 oKl
-gkw
+mNG
 bNb
 fvz
 fvz
@@ -119521,7 +119552,7 @@ fvz
 fvz
 tud
 mmO
-cKE
+cWR
 rTH
 wTo
 lXG
@@ -119764,21 +119795,21 @@ dFh
 ylz
 dbV
 gJr
-fMy
+obf
 wAe
 oKl
 mDl
-dBp
+vfu
 oKl
-jrn
-irt
-mNG
+hTj
+xyT
+hOb
 oQc
 oQc
 oQc
 mzb
 mmO
-fPq
+jLL
 rTH
 krH
 lXG
@@ -120021,13 +120052,13 @@ baV
 rGN
 sYB
 tmP
-sZQ
-hTj
-aZn
+vwc
+dkk
+fPq
 hCb
 oaz
 pqT
-iXN
+yho
 xws
 fvz
 fvz
@@ -120275,17 +120306,17 @@ mAQ
 pkM
 vnv
 jXE
-uFH
+jLg
 khr
 ixM
 jIn
-tTQ
-hFR
-yho
+iMH
+oNC
+qQw
 rXT
 hyt
 qOL
-iMH
+wxe
 qIL
 oQc
 oQc
@@ -120532,14 +120563,14 @@ ptc
 mGA
 vnv
 iBm
-uFH
+jLg
 ekt
 qVL
-sZQ
+vwc
 gyG
 vGx
 qqo
-sPk
+hFR
 pkX
 bJb
 bNb
@@ -120789,20 +120820,20 @@ ptc
 mGA
 vnv
 mXZ
-oNC
+uFH
 epx
 sGy
 eKv
 gyG
 oKl
-vwc
-jYL
+hRm
+ndS
 oKl
 vkD
-ikG
+kCd
 iAd
 mqg
-mNG
+hOb
 gKt
 ydy
 xJH
@@ -121305,7 +121336,7 @@ lxH
 pOP
 xEE
 xlJ
-eEG
+dBc
 pOP
 uYU
 vhz

--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -319,12 +319,8 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "afa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -1226,13 +1222,13 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
 "aud" = (
-/obj/structure/sign/map/right{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-right-MS";
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -1764,22 +1760,25 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "aBh" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/service";
-	dir = 1;
-	name = "Service Hall APC";
-	pixel_y = 23
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet,
 /area/hallway/secondary/service)
 "aBp" = (
 /obj/structure/cable/yellow{
@@ -2256,7 +2255,7 @@
 	pixel_y = 1
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "aIL" = (
 /obj/structure/disposalpipe/segment,
@@ -3432,20 +3431,21 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "aZn" = (
-/obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/hallway/primary/central";
-	dir = 1;
-	name = "Central Primary Hallway APC";
-	pixel_y = 23
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hydroponics)
 "aZs" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
@@ -5675,7 +5675,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bJa" = (
@@ -5980,9 +5980,15 @@
 /turf/open/floor/carpet,
 /area/medical/psych)
 "bNb" = (
-/obj/machinery/smartfridge/drying_rack,
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
+/obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -6082,9 +6088,6 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -6496,12 +6499,12 @@
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
 "bVv" = (
-/obj/machinery/button/door{
-	id = "giftshop";
-	name = "Gift Shop Button";
-	pixel_x = -24
+/obj/structure/table/wood,
+/obj/item/a_gift,
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/indestructible/carpet/black,
 /area/clerk)
 "bVw" = (
 /obj/machinery/light/small{
@@ -7716,7 +7719,7 @@
 "cnf" = (
 /obj/machinery/vending/autodrobe,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "cnn" = (
 /obj/structure/closet/secure_closet/medical1,
@@ -8289,9 +8292,12 @@
 	},
 /area/maintenance/port)
 "cxX" = (
-/obj/machinery/light,
-/obj/machinery/vending/gifts,
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/indestructible/carpet/black,
 /area/clerk)
 "cyh" = (
 /obj/machinery/light/small{
@@ -8380,12 +8386,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "czk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel,
+/obj/machinery/vending/gifts,
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "czm" = (
 /turf/open/floor/plating,
@@ -8518,10 +8522,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "cBu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "cBw" = (
@@ -9147,14 +9151,18 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cKE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/clerk)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "cKH" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/machinery/camera{
@@ -9603,11 +9611,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "cSj" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/plantgenes{
+	pixel_y = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "cSm" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -9939,11 +9947,19 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cWR" = (
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/hydroponicsplants{
+	pixel_x = -3
+	},
+/obj/item/book/manual/wiki/hydroponicsguide{
+	pixel_x = 3;
+	pixel_y = 2
+	},
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hydroponics)
 "cWW" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -10282,15 +10298,12 @@
 /turf/closed/wall,
 /area/maintenance/starboard/secondary)
 "dbV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+/obj/structure/disposalpipe/sorting/mail{
+	sortType = 21
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "dcc" = (
 /obj/effect/turf_decal/trimline/engiyellow/warning/lower{
@@ -10745,18 +10758,9 @@
 	},
 /area/security/nuke_storage)
 "dkk" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/airlock{
-	name = "Service Hall";
-	req_one_access_txt = "25;26;35;28;46;37;38"
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
@@ -10776,20 +10780,22 @@
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
 "dkL" = (
-/obj/machinery/camera{
-	c_tag = "Service Hall";
-	dir = 6
-	},
-/obj/machinery/firealarm{
-	pixel_y = 26
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet,
 /area/hallway/secondary/service)
 "dkS" = (
 /obj/structure/sign/plaques/kiddie/badger{
@@ -11981,18 +11987,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"dBc" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/obj/structure/sign/poster/random{
-	pixel_x = 32
-	},
-/obj/machinery/light,
-/obj/machinery/newscaster{
-	pixel_y = -29
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "dBf" = (
 /turf/closed/wall,
 /area/science/robotics/lab)
@@ -12013,10 +12007,21 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "dBp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/wood,
-/area/clerk)
+/obj/structure/table/glass,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "dBs" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/bot,
@@ -12198,8 +12203,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/obj/structure/mirror{
+	pixel_x = -28
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
@@ -14451,14 +14456,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "epx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -15414,12 +15414,18 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "eEG" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "Serving Hatch"
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
 /area/hallway/secondary/service)
 "eEK" = (
 /obj/machinery/door/airlock/external{
@@ -15611,15 +15617,21 @@
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "eHU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/clerk)
+/area/hydroponics)
 "eIe" = (
 /obj/item/candle,
 /obj/machinery/light_switch{
@@ -15781,16 +15793,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "eKv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
 /turf/open/floor/plasteel/cafeteria{
@@ -16249,16 +16259,15 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "eTj" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/structure/disposalpipe/sorting/mail{
+	sortType = 21
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "eTn" = (
@@ -17767,7 +17776,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "frh" = (
 /obj/structure/cable/yellow{
@@ -18597,15 +18606,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "fEM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/plasteel,
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/carpet,
 /area/hallway/secondary/service)
 "fFl" = (
 /obj/structure/cable/yellow{
@@ -19178,10 +19181,6 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
-"fMy" = (
-/obj/structure/kitchenspike,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
 "fML" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19204,7 +19203,10 @@
 "fNb" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "fNg" = (
 /obj/machinery/light{
@@ -19365,12 +19367,16 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "fPk" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
 	},
-/turf/open/floor/wood,
-/area/clerk)
+/obj/structure/sign/map/left{
+	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
+	icon_state = "map-left-MS";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "fPo" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser{
@@ -19394,18 +19400,16 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "fPq" = (
-/obj/structure/table/wood,
-/obj/item/camera,
-/obj/item/camera_film,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
+/obj/structure/table/wood/fancy/black,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Gift Shop";
-	dir = 4
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters{
+	id = "giftshop"
 	},
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "fPt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -20973,17 +20977,20 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "gkw" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop_ext"
+	},
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "gkB" = (
 /turf/closed/wall,
 /area/hallway/primary/central)
@@ -22227,15 +22234,20 @@
 /turf/open/floor/plasteel/freezer,
 /area/mine/laborcamp)
 "gDH" = (
-/obj/machinery/power/apc{
-	areastring = "/area/clerk";
-	dir = 4;
-	name = "Gift Shop APC";
-	pixel_x = 24
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/structure/cable/yellow,
-/turf/open/floor/wood,
-/area/clerk)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gDI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -22255,10 +22267,9 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "gDU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "gEe" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -22759,7 +22770,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "gKt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 26
@@ -24577,9 +24587,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "hiY" = (
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
+/turf/open/indestructible/carpet/black,
 /area/clerk)
 "hiZ" = (
 /obj/structure/lattice,
@@ -25329,11 +25337,20 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "hvx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/service)
@@ -25525,11 +25542,20 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "hyt" = (
-/obj/effect/turf_decal/trimline/green/warning/lower{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/eastleft{
+	dir = 1;
+	name = "Kitchen Window";
+	req_access_txt = "28"
+	},
+/obj/item/paper,
+/obj/machinery/door/window/eastleft{
+	dir = 2;
+	name = "Kitchen Window";
+	req_access_txt = "35"
 	},
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/hallway/secondary/service)
 "hyF" = (
 /obj/item/storage/box/beakers{
 	pixel_x = -7;
@@ -25758,8 +25784,17 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "hCb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 1
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	sortType = 21
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -25767,10 +25802,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "hCh" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/storage/box/lights/mixed,
@@ -25895,10 +25928,12 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "hEb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
+/obj/structure/chair/wood{
+	dir = 1
 	},
-/turf/open/floor/wood,
+/obj/effect/landmark/start/yogs/clerk,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "hEd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -25930,10 +25965,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "hEx" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -26015,23 +26046,6 @@
 /obj/item/cigbutt,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"hFR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "hGA" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -26614,18 +26628,10 @@
 /turf/closed/wall,
 /area/science/xenobiology)
 "hOb" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/landmark/start/botanist,
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26852,8 +26858,20 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "hRi" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/service)
@@ -26862,16 +26880,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/storage)
-"hRm" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "hRr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 4;
@@ -26988,16 +26996,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hTj" = (
-/obj/structure/sign/map/left{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-left-MS";
-	pixel_y = 32
+/obj/structure/table/wood,
+/obj/item/camera,
+/obj/item/camera_film,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
 	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Gift Shop";
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "hTm" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/light/small{
@@ -27820,16 +27831,15 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "ikG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
 	},
-/obj/machinery/smartfridge/drying_rack,
-/obj/structure/sign/poster/random{
-	pixel_y = -32
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/area/crew_quarters/kitchen)
 "ikQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -28285,18 +28295,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "irt" = (
-/obj/machinery/door/airlock{
-	name = "Gift Shop";
-	req_access_txt = "36"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/wood,
-/area/clerk)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "irv" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -29075,21 +29084,15 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "iAd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 8
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "iAk" = (
@@ -29901,23 +29904,14 @@
 /turf/closed/wall,
 /area/security/courtroom)
 "iMH" = (
-/obj/machinery/door/airlock/medical/glass{
-	name = "Service Door";
-	req_one_access_txt = "35;28"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 8
+/obj/item/radio/intercom{
+	pixel_y = 21
 	},
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/hallway/primary/central)
 "iMQ" = (
 /obj/structure/destructible/cult/tome,
 /obj/machinery/newscaster{
@@ -30631,10 +30625,11 @@
 /turf/open/floor/wood,
 /area/library)
 "iXN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics)
+/obj/machinery/processor,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "iXO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -30820,10 +30815,13 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -31629,14 +31627,21 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "jlF" = (
-/obj/item/radio/intercom{
-	pixel_y = 21
+/obj/machinery/door/airlock{
+	name = "Kitchen";
+	req_access_txt = "28"
 	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/hallway/secondary/service)
 "jlJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -32049,16 +32054,21 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "jrn" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "jrJ" = (
@@ -33251,11 +33261,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -33533,14 +33540,11 @@
 	},
 /area/maintenance/starboard/secondary)
 "jLg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "jLj" = (
 /obj/machinery/light_switch{
@@ -33566,12 +33570,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "jLL" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/wood,
-/area/clerk)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jLP" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -33919,10 +33931,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"jRa" = (
-/obj/machinery/autolathe,
-/turf/open/floor/carpet,
-/area/hallway/secondary/service)
 "jRd" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/structure/cable{
@@ -34259,7 +34267,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "jXc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -34375,21 +34383,9 @@
 /turf/closed/wall/r_wall,
 /area/aisat)
 "jYL" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "barshutters";
-	name = "bar shutters"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
+/obj/structure/table,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "jYO" = (
 /obj/structure/table/wood,
 /obj/item/deskbell/preset/library{
@@ -35781,15 +35777,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "ktN" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
@@ -36307,11 +36294,10 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "kCd" = (
-/obj/structure/chair/wood{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
 	},
-/obj/effect/landmark/start/yogs/clerk,
-/turf/open/floor/wood,
+/turf/open/indestructible/carpet/black,
 /area/clerk)
 "kCn" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -36618,19 +36604,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"kGj" = (
-/obj/structure/table/glass,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "kGl" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plating{
@@ -37216,6 +37189,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
+/obj/structure/reagent_dispensers/cooking_oil,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "kOM" = (
@@ -37674,16 +37648,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "kXB" = (
@@ -39381,9 +39354,6 @@
 /area/medical/medbay/aft)
 "lxH" = (
 /obj/item/kirbyplants/random,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_y = -32
-	},
 /obj/machinery/camera{
 	c_tag = "Kitchen Hatch";
 	dir = 1
@@ -40046,10 +40016,19 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "lIL" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
+/obj/structure/table/wood/fancy/black,
+/obj/machinery/paystand/register{
+	dir = 1
 	},
-/turf/open/floor/wood,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters{
+	id = "giftshop"
+	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "lIO" = (
 /obj/machinery/computer/crew{
@@ -40704,19 +40683,11 @@
 /turf/closed/wall/r_wall,
 /area/mine/maintenance)
 "lSi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/light{
+/obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/carpet,
 /area/hallway/secondary/service)
 "lSo" = (
 /obj/structure/window/reinforced{
@@ -40960,14 +40931,20 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "lUJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
+/obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/machinery/door/airlock{
+	name = "Gift Shop";
+	req_access_txt = "36"
+	},
+/turf/open/floor/plasteel,
 /area/clerk)
 "lUS" = (
 /obj/structure/cable/yellow{
@@ -42188,12 +42165,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -42462,16 +42438,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "mqb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Hydroponics South";
-	dir = 1
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
@@ -42479,24 +42445,27 @@
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "mqg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -42565,8 +42534,16 @@
 /turf/open/floor/plating,
 /area/mine/storage)
 "mrw" = (
-/obj/machinery/vending/games,
-/turf/open/floor/wood,
+/obj/machinery/power/apc{
+	areastring = "/area/clerk";
+	dir = 4;
+	name = "Gift Shop APC";
+	pixel_x = 24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/indestructible/carpet/black,
 /area/clerk)
 "mrX" = (
 /obj/machinery/door/airlock/security/glass{
@@ -43303,29 +43280,23 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "mDl" = (
-/obj/machinery/door/airlock{
-	name = "Kitchen";
-	req_access_txt = "28"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 9
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "mDu" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -44066,15 +44037,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "mNG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "mNN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -44312,7 +44280,7 @@
 "mQr" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "mQu" = (
 /obj/structure/lattice,
@@ -45090,13 +45058,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mZy" = (
-/obj/structure/table,
-/obj/machinery/microwave,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
 "mZK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -45322,20 +45283,29 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ncZ" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Service Hall";
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet,
 /area/hallway/secondary/service)
 "ndc" = (
 /obj/machinery/conveyor{
@@ -45402,15 +45372,14 @@
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
 "ndS" = (
-/obj/structure/table,
-/obj/machinery/smartfridge/disks{
-	pixel_y = 2
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "neg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45713,12 +45682,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "njA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 1
 	},
-/obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics)
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "njU" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -47945,21 +47916,8 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "nSo" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 4
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -48518,9 +48476,13 @@
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hor)
 "oaz" = (
-/obj/machinery/smartfridge,
-/turf/closed/wall,
-/area/crew_quarters/kitchen)
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "oaE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -48577,10 +48539,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "obf" = (
-/obj/structure/table/wood,
-/obj/item/a_gift,
-/turf/open/floor/wood,
-/area/clerk)
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "obl" = (
 /obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
 	dir = 8
@@ -49031,15 +48994,13 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "ogv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel,
-/area/clerk)
+/area/crew_quarters/kitchen)
 "ogK" = (
 /obj/machinery/light{
 	dir = 8
@@ -49371,14 +49332,21 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "olY" = (
-/obj/structure/table/wood,
-/obj/item/bikehorn/rubberducky,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/clerk)
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "omn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -49783,15 +49751,19 @@
 	},
 /area/security/prison)
 "osp" = (
-/obj/item/radio/intercom{
-	dir = 8;
-	pixel_x = -28
+/obj/machinery/door/airlock{
+	name = "Gift Shop";
+	req_access_txt = "36"
 	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/clerk)
 "osy" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -50615,12 +50587,19 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "oFF" = (
-/obj/structure/table,
-/obj/item/reagent_containers/glass/bucket,
-/obj/item/kitchen/rollingpin,
-/obj/effect/turf_decal/trimline/green/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "oFH" = (
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway - Fore";
@@ -50994,6 +50973,15 @@
 /area/maintenance/port/aft)
 "oNC" = (
 /obj/effect/landmark/start/cook,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -51848,10 +51836,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -51923,18 +51912,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "pcc" = (
-/obj/structure/table/wood/fancy/black,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop";
-	name = "gift shop shutters"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
+/turf/open/indestructible/carpet/black,
 /area/clerk)
 "pcg" = (
 /obj/machinery/light/small{
@@ -52511,18 +52495,9 @@
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "pkX" = (
-/obj/structure/table,
-/obj/machinery/plantgenes{
-	pixel_y = 6
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/obj/machinery/smartfridge,
+/turf/closed/wall,
+/area/hallway/secondary/service)
 "plu" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "chapel_shutters_space";
@@ -52903,10 +52878,22 @@
 /area/hallway/secondary/exit/departure_lounge)
 "pqT" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 9
+	dir = 8
+	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Service Door";
+	req_one_access_txt = "35;28"
+	},
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/hallway/secondary/service)
 "prh" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -53424,13 +53411,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "pyr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	id = "giftshop"
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/wood,
+/turf/open/floor/plating,
 /area/clerk)
 "pyy" = (
 /obj/structure/cable/yellow{
@@ -55759,8 +55744,33 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "qkW" = (
-/obj/machinery/rnd/production/techfab/department/service,
-/turf/open/floor/carpet,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
+/obj/machinery/door/airlock{
+	name = "Service Hall";
+	req_one_access_txt = "25;26;35;28;46;37;38"
+	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "qkX" = (
 /obj/structure/disposalpipe/segment{
@@ -56178,14 +56188,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
 "qqo" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 1
 	},
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "qqy" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -57339,11 +57349,11 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "qGD" = (
-/obj/machinery/smartfridge/drinks{
-	icon_state = "boozeomat"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
-/turf/closed/wall,
-/area/crew_quarters/bar)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qGE" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
@@ -57574,22 +57584,6 @@
 	},
 /turf/open/floor/wood,
 /area/vacant_room/office)
-"qIL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "qIN" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -57941,10 +57935,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"qOL" = (
-/obj/effect/landmark/start/botanist,
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "qOW" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -58045,9 +58035,12 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "qQw" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/hydroponics)
+/obj/machinery/smartfridge/drying_rack,
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "qQQ" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -58281,12 +58274,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"qUs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "qUC" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -59077,11 +59064,14 @@
 /turf/open/floor/plasteel,
 /area/science/explab)
 "rib" = (
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "ril" = (
 /obj/effect/turf_decal/stripes/line{
@@ -59872,16 +59862,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "rvm" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair/sofa/left{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet,
 /area/hallway/secondary/service)
 "rvy" = (
 /obj/effect/landmark/event_spawn,
@@ -60250,17 +60238,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "rBr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/light_switch{
-	pixel_y = 22
-	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -60520,10 +60502,10 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "rGN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
 /obj/effect/landmark/start/cook,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -60630,11 +60612,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "rIb" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/wood,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "rIx" = (
 /obj/structure/disposalpipe/segment{
@@ -61177,19 +61156,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "rQk" = (
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	sortType = 19
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+/obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/carpet,
 /area/hallway/secondary/service)
 "rQw" = (
 /obj/structure/ladder,
@@ -61248,13 +61226,26 @@
 /turf/closed/wall,
 /area/engine/engineering)
 "rRb" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/obj/structure/table/wood,
+/obj/item/a_gift,
+/obj/item/key,
+/obj/machinery/button/door{
+	id = "giftshop";
+	name = "Gift Shop Internal Shutters";
+	pixel_x = 26;
+	pixel_y = 24
 	},
+/obj/machinery/button/door{
+	id = "giftshop_ext";
+	name = "Gift Shop External Shutters";
+	pixel_x = 40;
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/wood,
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "rRv" = (
 /obj/effect/turf_decal/stripes/line{
@@ -61767,20 +61758,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "rXT" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/eastleft{
-	dir = 1;
-	name = "Kitchen Window";
-	req_access_txt = "28"
-	},
-/obj/item/paper,
-/obj/machinery/door/window/eastleft{
-	dir = 2;
-	name = "Kitchen Window";
-	req_access_txt = "35"
-	},
+/obj/effect/turf_decal/trimline/green/warning/lower,
 /turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
+/area/hallway/secondary/service)
 "rXX" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -62582,7 +62562,11 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "slM" = (
-/turf/open/floor/wood,
+/obj/structure/table/wood,
+/obj/item/instrument/accordion,
+/obj/item/instrument/guitar,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "sma" = (
 /obj/structure/cable/yellow{
@@ -62983,10 +62967,11 @@
 /turf/open/floor/plating,
 /area/teleporter)
 "srT" = (
-/obj/structure/chair/wood{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
 	},
-/turf/open/floor/wood,
+/turf/open/indestructible/carpet/black,
 /area/clerk)
 "srU" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
@@ -63728,8 +63713,11 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "sAy" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "sAM" = (
 /turf/open/floor/plasteel/freezer,
@@ -64329,17 +64317,11 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "sJO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/hydroponicsplants{
-	pixel_x = -3
-	},
-/obj/item/book/manual/wiki/hydroponicsguide{
-	pixel_x = 3;
-	pixel_y = 2
-	},
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
+	},
+/obj/machinery/light_switch{
+	pixel_y = 22
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -64446,11 +64428,12 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "sMm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "sMo" = (
@@ -64735,21 +64718,6 @@
 	},
 /turf/open/floor/plating,
 /area/mine/laborcamp)
-"sPk" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
 "sPy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -65478,22 +65446,16 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "sZQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/structure/sign/map/right{
+	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
+	icon_state = "map-right-MS";
+	pixel_y = 32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sZY" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
@@ -66060,12 +66022,21 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "thg" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/clerk)
+/area/hydroponics)
 "thl" = (
 /turf/closed/wall,
 /area/maintenance/aft)
@@ -66605,6 +66576,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
@@ -68307,10 +68280,12 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "tSd" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
 /obj/structure/table/wood,
-/obj/item/a_gift,
-/obj/item/key,
-/turf/open/floor/wood,
+/obj/item/bikehorn/rubberducky,
+/turf/open/indestructible/carpet/black,
 /area/clerk)
 "tSf" = (
 /obj/structure/cable/yellow{
@@ -68503,14 +68478,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "tTQ" = (
-/obj/structure/table,
-/obj/item/key/janitor,
-/obj/structure/sign/poster/random{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 6
-	},
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "tTT" = (
@@ -69179,25 +69147,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "udL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
+/obj/machinery/autolathe,
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/carpet,
 /area/hallway/secondary/service)
 "ueb" = (
@@ -71119,13 +71074,19 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "uFH" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/area/crew_quarters/kitchen)
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop_ext"
+	},
+/obj/machinery/door/airlock/glass_large{
+	doorOpen = 'sound/machines/defib_success.ogg';
+	name = "Gift Shop"
+	},
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "uFJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -71716,6 +71677,15 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
 	dir = 1
 	},
+/obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/hallway/primary/central";
+	dir = 1;
+	name = "Central Primary Hallway APC";
+	pixel_y = 23
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uNw" = (
@@ -71733,7 +71703,16 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/machinery/processor,
+/obj/structure/table,
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -71766,14 +71745,18 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "uNH" = (
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
 /obj/structure/cable/yellow{
-	icon_state = "2-4"
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+	dir = 9
 	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/service)
@@ -74067,14 +74050,11 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/foyer)
 "vwc" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -75044,14 +75024,15 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "vKp" = (
-/obj/structure/disposalpipe/sorting/mail{
-	sortType = 21
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -76253,18 +76234,21 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "wbs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+/obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/service";
+	dir = 1;
+	name = "Service Hall APC";
+	pixel_y = 23
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 5
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/hallway/secondary/service)
 "wbC" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -77477,17 +77461,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "wrE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12;
-	pixel_y = 2
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -77497,6 +77470,10 @@
 /obj/machinery/light_switch{
 	pixel_x = -21;
 	pixel_y = 10
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -77587,18 +77564,19 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "wtz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
 /obj/machinery/requests_console{
 	department = "Hydroponics";
 	departmentType = 2;
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/green/filled/line/lower,
+/obj/machinery/camera{
+	c_tag = "Hydroponics South";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "wtA" = (
@@ -77845,12 +77823,6 @@
 "wwU" = (
 /turf/open/floor/plasteel/dark,
 /area/mine/infirmary)
-"wxe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/closed/wall,
-/area/crew_quarters/kitchen)
 "wxw" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 4
@@ -78029,6 +78001,15 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -26
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -78238,7 +78219,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "wDD" = (
 /obj/machinery/hydroponics/constructable,
@@ -79374,16 +79355,14 @@
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "wTD" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+/obj/effect/turf_decal/siding/wood,
+/obj/structure/chair/sofa/right{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/carpet,
 /area/hallway/secondary/service)
 "wUj" = (
 /obj/structure/cable/yellow{
@@ -80265,7 +80244,8 @@
 /obj/item/reagent_containers/food/drinks/bottle/cognac,
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel,
+/obj/item/a_gift,
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "xgF" = (
 /obj/item/flashlight/lantern{
@@ -80276,7 +80256,7 @@
 "xgX" = (
 /mob/living/simple_animal/spiffles,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "xhg" = (
 /obj/structure/cable{
@@ -80792,7 +80772,15 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "xoO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
@@ -81221,6 +81209,10 @@
 	},
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 6
+	},
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -81687,11 +81679,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "xyT" = (
-/obj/structure/table/wood,
-/obj/item/instrument/accordion,
-/obj/item/instrument/guitar,
-/turf/open/floor/wood,
-/area/clerk)
+/obj/structure/table,
+/obj/machinery/smartfridge/disks{
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "xzb" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -82161,16 +82154,21 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "xEE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
 /obj/machinery/button/door{
 	id = "kitchen";
 	name = "Kitchen Shutters Control";
 	pixel_x = -8;
 	pixel_y = 23;
 	req_access_txt = "28"
-	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -82443,20 +82441,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "xIv" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/rnd/production/techfab/department/service,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/carpet,
 /area/hallway/secondary/service)
 "xIJ" = (
 /obj/structure/tank_dispenser{
@@ -82482,21 +82469,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
 "xIS" = (
-/obj/structure/table/wood/fancy/black,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop";
-	name = "gift shop shutters"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
 	},
-/obj/machinery/paystand/register{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
+/turf/open/indestructible/carpet/black,
 /area/clerk)
 "xIU" = (
 /obj/structure/window/reinforced{
@@ -82987,14 +82963,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "xOD" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/carpet,
 /area/hallway/secondary/service)
 "xOM" = (
 /obj/structure/cable/yellow{
@@ -83172,9 +83153,9 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "xQt" = (
-/obj/item/kirbyplants/random,
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel,
+/obj/machinery/vending/games,
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "xQE" = (
 /obj/structure/table/reinforced,
@@ -83403,18 +83384,12 @@
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "xVd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop_ext"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -26
-	},
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plating,
+/area/clerk)
 "xVs" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -83655,8 +83630,17 @@
 	name = "Kitchen APC";
 	pixel_y = 23
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -84023,9 +84007,6 @@
 /turf/open/floor/plasteel/dark,
 /area/mine/vacant)
 "ydy" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -84302,15 +84283,8 @@
 	},
 /area/maintenance/solars/starboard/fore)
 "yho" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	sortType = 20
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -84624,8 +84598,14 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "ylz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -113822,16 +113802,16 @@ uep
 kgs
 jLJ
 cmS
-jLL
+oWW
 rRb
-obf
+rIb
 fPq
 hiY
-pcc
+hTj
 bVv
 tSd
-oWW
-aZn
+xVd
+cnB
 bOW
 vfu
 uQD
@@ -114079,16 +114059,16 @@ xqY
 xto
 iSn
 cmS
-jLL
+oWW
 slM
 hEb
 lIL
 hiY
 xIS
 kCd
-xyT
-oWW
-hTj
+hiY
+uFH
+cnB
 oxp
 tHh
 haI
@@ -114335,16 +114315,16 @@ oUm
 jDx
 xqY
 iSn
-gkw
+cmS
 pyr
-dBp
 rIb
-fPk
+rIb
+fPq
 hiY
-pcc
+ndS
 srT
 cxX
-oWW
+gkw
 aud
 mlF
 tHh
@@ -114592,17 +114572,17 @@ oUm
 kBU
 gax
 cUZ
-sPk
+cmS
 lUJ
-gDH
-olY
-cKE
+rIb
+rIb
+fPq
 hiY
 pcc
-slM
+mNG
 mrw
-oWW
-jlF
+xVd
+cnB
 oxp
 weH
 cpP
@@ -114852,11 +114832,11 @@ eIF
 rSI
 oWW
 oWW
+osp
+oWW
 oWW
 bpB
 oWW
-oWW
-irt
 oWW
 oWW
 arA
@@ -115109,14 +115089,14 @@ iSn
 wEb
 auc
 oWW
-thg
-eHU
+rIb
+rIb
 gDU
 rib
-ogv
+rIb
 aIK
 oWW
-cnB
+iMH
 oxp
 lbX
 aYY
@@ -115373,7 +115353,7 @@ fNb
 jLg
 czk
 oWW
-cnB
+fPk
 oxp
 tHh
 bKt
@@ -115630,8 +115610,8 @@ xgE
 jXb
 xQt
 oWW
-cnB
-oxp
+sZQ
+jLL
 cTp
 idf
 tMs
@@ -115888,7 +115868,7 @@ xeL
 oWW
 oWW
 uNg
-oxp
+gDH
 tHh
 uPN
 rbU
@@ -116653,11 +116633,11 @@ xBa
 sci
 mwj
 hLf
-osp
+xBa
 wUA
 nUr
-xVd
-xBa
+hof
+sci
 vNK
 adi
 fTM
@@ -116914,7 +116894,7 @@ sLI
 sLI
 sLI
 iZR
-sLI
+jNP
 sLI
 paI
 pzL
@@ -117169,11 +117149,11 @@ rGk
 vdX
 vdX
 vdX
-vdX
-ixk
-abA
 uer
-adi
+oxp
+qGD
+sJM
+sJM
 apG
 rTH
 rTH
@@ -117426,11 +117406,11 @@ yiy
 rfi
 rfi
 oKl
-oKl
-oKl
-oKl
-cWR
-adi
+nSo
+olY
+abA
+uer
+sJM
 mZu
 noJ
 wNO
@@ -117683,16 +117663,16 @@ rfi
 jVO
 rNO
 oKl
-jRa
+oKl
 qkW
 oKl
 sCO
-adi
+sJM
 tTT
 ukq
 glV
 gmA
-qUs
+gmA
 fsq
 rTH
 gSU
@@ -117942,7 +117922,7 @@ bpM
 oKl
 hRi
 uNH
-dkk
+oKl
 nSo
 ktN
 wkk
@@ -118205,7 +118185,7 @@ bIP
 noJ
 rTH
 sJO
-tbG
+gmA
 wtz
 rTH
 rTH
@@ -118456,12 +118436,12 @@ bud
 oKl
 xOD
 xIv
-hRm
-rTH
+oKl
+vFv
 rBr
-cSj
+sXG
 hEx
-kGj
+xws
 gmA
 mqb
 rTH
@@ -118702,7 +118682,7 @@ xaD
 tqs
 jiQ
 sgE
-jYL
+dZb
 dyZ
 cLu
 fmy
@@ -118713,10 +118693,10 @@ sJA
 nRB
 rQk
 fEM
-eEG
-iMH
+oKl
+xIU
 vKp
-wbs
+sMm
 sMm
 sMm
 sMm
@@ -118970,10 +118950,10 @@ lPs
 oKl
 dkL
 wTD
-ikG
-rTH
-vFv
-eTj
+oKl
+vGl
+bNb
+fvz
 fvz
 fvz
 fvz
@@ -119215,9 +119195,9 @@ sAN
 nQU
 fJk
 fcc
-wgu
-dZb
-qGD
+huJ
+rfi
+rfi
 rfi
 llh
 rfi
@@ -119227,16 +119207,16 @@ rfi
 oKl
 aBh
 rvm
-oFF
-rTH
-xIU
+oKl
+fZF
+aZn
 hOb
 oQc
 oQc
 oQc
 vxy
 xPI
-fvz
+cSj
 rTH
 krH
 lXG
@@ -119476,24 +119456,24 @@ pIe
 uhL
 hMC
 mDO
-sGy
+gMX
 wrE
 uNy
-gyG
-gyG
-vGx
+ikG
+iXN
+oKl
 ncZ
 lSi
-tTQ
-rTH
-vGl
-eTj
+oKl
+cWR
+bNb
+fvz
 fvz
 fvz
 fvz
 tud
 mmO
-fvz
+xyT
 rTH
 wTo
 lXG
@@ -119735,22 +119715,22 @@ vnv
 dFh
 ylz
 dbV
-sGy
-gMX
+gJr
+irt
 wAe
-pOP
+oKl
 mDl
-pOP
-qQw
-rTH
-fZF
-qIL
+dkk
+oKl
+dBp
+thg
+hOb
 oQc
 oQc
 oQc
 mzb
 mmO
-fvz
+jYL
 rTH
 krH
 lXG
@@ -119991,19 +119971,19 @@ mGA
 vnv
 baV
 rGN
-qVL
+sYB
 tmP
 vwc
-gJr
-gJr
+oFF
+jlF
 hCb
 oaz
 pqT
-sXG
-xws
-jrn
-iXN
-njA
+eTj
+cKE
+fvz
+fvz
+fvz
 fvz
 eKa
 rfP
@@ -120247,18 +120227,18 @@ mAQ
 pkM
 vnv
 jXE
-xlJ
+ogv
 khr
-sYB
+ixM
 jIn
-xlJ
-oNC
-xlJ
+yho
+eEG
+njA
 rXT
 hyt
-qOL
-gmA
-qIL
+bJb
+eHU
+hOb
 oQc
 oQc
 oQc
@@ -120504,18 +120484,18 @@ ptc
 mGA
 vnv
 iBm
-xlJ
+ogv
 ekt
-ixM
-sZQ
-mZy
-maT
+qVL
+vwc
+gyG
+vGx
 qqo
-pOP
+tTQ
 pkX
-ndS
+bJb
 bNb
-eTj
+fvz
 fvz
 fvz
 fvz
@@ -120763,18 +120743,18 @@ vnv
 mXZ
 oNC
 epx
-uFH
+sGy
 eKv
-dBc
-pOP
-pOP
-pOP
-pOP
-rTH
+gyG
+oKl
+wbs
+qQw
+oKl
 vkD
+jrn
 iAd
 mqg
-mNG
+hOb
 gKt
 ydy
 xJH
@@ -121020,12 +121000,12 @@ vnv
 tEC
 xoO
 afa
-xlJ
+maT
 pOP
 pOP
 pOP
-fMy
-fMy
+pOP
+pOP
 pOP
 rTH
 rTH
@@ -121276,8 +121256,8 @@ wCo
 lxH
 pOP
 xEE
-yho
 xlJ
+obf
 pOP
 uYU
 vhz
@@ -121533,7 +121513,7 @@ eVZ
 wDv
 pOP
 xXM
-hFR
+pqv
 pqv
 tVU
 laU
@@ -122567,7 +122547,7 @@ uYz
 uha
 pOP
 onE
-wxe
+pOP
 ebn
 pOP
 kal

--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -3431,21 +3431,14 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "aZn" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "aZs" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
@@ -9610,19 +9603,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "cSj" = (
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/hydroponicsplants{
-	pixel_x = -3
-	},
-/obj/item/book/manual/wiki/hydroponicsguide{
-	pixel_x = 3;
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/hallway/secondary/service)
 "cSm" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -10763,10 +10751,8 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 1
 	},
-/obj/structure/sign/map/right{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-right-MS";
-	pixel_y = 32
+/obj/item/radio/intercom{
+	pixel_y = 21
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -11994,14 +11980,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "dBc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -12027,14 +12011,20 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "dBp" = (
-/obj/effect/turf_decal/trimline/green/warning/lower{
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop_ext"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "dBs" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/bot,
@@ -15426,6 +15416,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"eEG" = (
+/obj/machinery/door/airlock{
+	name = "Gift Shop";
+	req_access_txt = "36"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/clerk)
 "eEK" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -15616,11 +15620,9 @@
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "eHU" = (
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "eIe" = (
 /obj/item/candle,
 /obj/machinery/light_switch{
@@ -16247,6 +16249,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"eTj" = (
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	sortType = 21
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "eTn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer2{
 	dir = 4
@@ -19159,23 +19173,21 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "fMy" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 8
+/obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/service";
+	dir = 1;
+	name = "Service Hall APC";
+	pixel_y = 23
 	},
+/obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 4
+	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/hallway/secondary/service)
 "fML" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19362,12 +19374,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "fPk" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 10
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/area/crew_quarters/kitchen)
 "fPo" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser{
@@ -19391,20 +19402,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "fPq" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop_ext"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plating,
+/area/clerk)
 "fPt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -20971,14 +20974,20 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "gkw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/indestructible/carpet/black,
-/area/clerk)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gkB" = (
 /turf/closed/wall,
 /area/hallway/primary/central)
@@ -22222,18 +22231,13 @@
 /turf/open/floor/plasteel/freezer,
 /area/mine/laborcamp)
 "gDH" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/structure/sign/map/left{
+	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
+	icon_state = "map-left-MS";
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -24576,21 +24580,8 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "hiY" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "hiZ" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input{
@@ -26049,12 +26040,13 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "hFR" = (
-/obj/machinery/smartfridge/drying_rack,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 6
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "hGA" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -26637,13 +26629,11 @@
 /turf/closed/wall,
 /area/science/xenobiology)
 "hOb" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 4
+/obj/structure/table,
+/obj/machinery/smartfridge/disks{
+	pixel_y = 2
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "hOd" = (
 /obj/structure/cable/yellow{
@@ -26889,22 +26879,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/storage)
-"hRm" = (
-/obj/machinery/door/airlock{
-	name = "Kitchen";
-	req_access_txt = "28"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/hallway/secondary/service)
 "hRr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 4;
@@ -27021,11 +26995,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hTj" = (
-/obj/structure/table,
-/obj/machinery/plantgenes{
-	pixel_y = 6
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "hTm" = (
 /obj/machinery/portable_atmospherics/pump,
@@ -27849,20 +27832,21 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "ikG" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop_ext"
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/turf/open/indestructible/carpet/black,
-/area/clerk)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "ikQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -28318,17 +28302,23 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "irt" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/area/crew_quarters/kitchen)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "irv" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -29927,18 +29917,20 @@
 /turf/closed/wall,
 /area/security/courtroom)
 "iMH" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower,
+/obj/effect/landmark/start/cook,
 /obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+	dir = 6
 	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "iMQ" = (
 /obj/structure/destructible/cult/tome,
 /obj/machinery/newscaster{
@@ -30652,21 +30644,19 @@
 /turf/open/floor/wood,
 /area/library)
 "iXN" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/service";
-	dir = 1;
-	name = "Service Hall APC";
-	pixel_y = 23
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/hydroponicsplants{
+	pixel_x = -3
 	},
-/obj/structure/table/reinforced,
+/obj/item/book/manual/wiki/hydroponicsguide{
+	pixel_x = 3;
+	pixel_y = 2
+	},
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 5
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/area/hydroponics)
 "iXO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -31663,20 +31653,6 @@
 "jlE" = (
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"jlF" = (
-/obj/structure/table/wood,
-/obj/item/camera,
-/obj/item/camera_film,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/camera{
-	c_tag = "Gift Shop";
-	dir = 4
-	},
-/turf/open/indestructible/carpet/black,
-/area/clerk)
 "jlJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -34393,20 +34369,11 @@
 /turf/closed/wall/r_wall,
 /area/aisat)
 "jYL" = (
-/obj/structure/table/glass,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 1
+/obj/structure/table,
+/obj/machinery/plantgenes{
+	pixel_y = 6
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "jYO" = (
 /obj/structure/table/wood,
@@ -36627,18 +36594,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "kGj" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 8
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -44074,6 +44034,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"mNG" = (
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mNN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -45089,6 +45065,18 @@
 /obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"mZy" = (
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "mZK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -45402,6 +45390,10 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
+"ndS" = (
+/obj/structure/table,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "neg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45703,6 +45695,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"njA" = (
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/obj/structure/sign/map/right{
+	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
+	icon_state = "map-right-MS";
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "njU" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -48552,18 +48555,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "obf" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop_ext"
-	},
-/obj/machinery/door/airlock/glass_large{
-	doorOpen = 'sound/machines/defib_success.ogg';
-	name = "Gift Shop"
-	},
-/turf/open/indestructible/carpet/black,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "obl" = (
 /obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
@@ -49015,9 +49008,17 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "ogv" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/clerk)
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "ogK" = (
 /obj/machinery/light{
 	dir = 8
@@ -49349,13 +49350,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "olY" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
-	},
-/obj/structure/sign/map/left{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-left-MS";
-	pixel_y = 32
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -49763,11 +49759,12 @@
 	},
 /area/security/prison)
 "osp" = (
-/obj/machinery/processor,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 10
 	},
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "osy" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -50601,7 +50598,7 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -57353,11 +57350,18 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "qGD" = (
-/obj/effect/spawner/structure/window,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "giftshop_ext"
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/glass_large{
+	doorOpen = 'sound/machines/defib_success.ogg';
+	name = "Gift Shop"
+	},
+/turf/open/indestructible/carpet/black,
 /area/clerk)
 "qGE" = (
 /obj/effect/landmark/event_spawn,
@@ -57590,20 +57594,14 @@
 /turf/open/floor/wood,
 /area/vacant_room/office)
 "qIL" = (
-/obj/effect/landmark/start/cook,
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "qIN" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -57956,11 +57954,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "qOL" = (
-/obj/structure/table,
-/obj/machinery/smartfridge/disks{
-	pixel_y = 2
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "qOW" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -58062,13 +58060,21 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "qQw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/airlock{
+	name = "Kitchen";
+	req_access_txt = "28"
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
-/area/crew_quarters/kitchen)
+/area/hallway/secondary/service)
 "qQQ" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -58302,13 +58308,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"qUs" = (
-/obj/structure/table/wood,
-/obj/item/instrument/accordion,
-/obj/item/instrument/guitar,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/clerk)
 "qUC" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -60646,6 +60645,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"rIb" = (
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "rIx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -62593,11 +62606,11 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "slM" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
-	},
-/turf/open/indestructible/carpet/black,
+/obj/structure/table/wood,
+/obj/item/instrument/accordion,
+/obj/item/instrument/guitar,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "sma" = (
 /obj/structure/cable/yellow{
@@ -64459,14 +64472,18 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "sMm" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 4
 	},
-/obj/item/radio/intercom{
-	pixel_y = 21
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hydroponics)
 "sMo" = (
 /obj/machinery/newscaster{
 	pixel_x = -32
@@ -64750,11 +64767,19 @@
 /turf/open/floor/plating,
 /area/mine/laborcamp)
 "sPk" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "sPy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -65482,6 +65507,12 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"sZQ" = (
+/obj/machinery/processor,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "sZY" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
@@ -66048,19 +66079,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "thg" = (
-/obj/machinery/door/airlock{
-	name = "Gift Shop";
-	req_access_txt = "36"
+/obj/machinery/smartfridge/drying_rack,
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 6
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/clerk)
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "thl" = (
 /turf/closed/wall,
 /area/maintenance/aft)
@@ -68501,6 +68525,20 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
+"tTQ" = (
+/obj/structure/table/wood,
+/obj/item/camera,
+/obj/item/camera_film,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/camera{
+	c_tag = "Gift Shop";
+	dir = 4
+	},
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "tTT" = (
 /obj/effect/turf_decal/trimline/green/warning/lower,
 /turf/open/floor/plasteel,
@@ -71094,9 +71132,12 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "uFH" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "uFJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -77827,14 +77868,18 @@
 /turf/open/floor/plasteel/dark,
 /area/mine/infirmary)
 "wxe" = (
+/obj/structure/table/glass,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	sortType = 21
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -81420,8 +81465,15 @@
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
 /area/engine/atmos/distro)
 "xws" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 1
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -81693,9 +81745,6 @@
 /obj/structure/bookcase/manuals/research_and_development,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"xyT" = (
-/turf/open/indestructible/carpet/black,
-/area/clerk)
 "xzb" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -83394,6 +83443,13 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
+"xVd" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "xVs" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -84286,10 +84342,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/solars/starboard/fore)
-"yho" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics)
 "yhp" = (
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
@@ -113804,13 +113856,13 @@ jLJ
 cmS
 oWW
 rRb
-ogv
+obf
 cKE
-xyT
-jlF
+hiY
+tTQ
 bVv
 tSd
-qGD
+fPq
 cnB
 bOW
 vfu
@@ -114060,14 +114112,14 @@ xto
 iSn
 cmS
 oWW
-qUs
+slM
 hEb
 lIL
-xyT
+hiY
 xIS
 kCd
-xyT
-obf
+hiY
+qGD
 cnB
 oxp
 tHh
@@ -114317,14 +114369,14 @@ xqY
 iSn
 cmS
 pyr
-ogv
-ogv
+obf
+obf
 cKE
-xyT
+hiY
 pcc
 srT
 cxX
-ikG
+dBp
 aud
 mlF
 tHh
@@ -114574,14 +114626,14 @@ gax
 cUZ
 cmS
 lUJ
-ogv
-ogv
+obf
+obf
 cKE
-xyT
-gkw
-slM
+hiY
+aZn
+uFH
 mrw
-qGD
+fPq
 cnB
 oxp
 weH
@@ -114832,7 +114884,7 @@ eIF
 rSI
 oWW
 oWW
-thg
+eEG
 oWW
 oWW
 bpB
@@ -115089,14 +115141,14 @@ iSn
 wEb
 auc
 oWW
-ogv
-ogv
+obf
+obf
 gDU
 rib
-ogv
+obf
 aIK
 oWW
-sMm
+dkk
 oxp
 lbX
 aYY
@@ -115353,7 +115405,7 @@ fNb
 jLg
 czk
 oWW
-olY
+gDH
 oxp
 tHh
 bKt
@@ -115610,8 +115662,8 @@ xgE
 jXb
 xQt
 oWW
-dkk
-fPq
+njA
+oFF
 cTp
 idf
 tMs
@@ -115868,7 +115920,7 @@ xeL
 oWW
 oWW
 uNg
-oFF
+gkw
 tHh
 uPN
 rbU
@@ -117151,7 +117203,7 @@ vdX
 vdX
 uer
 oxp
-sPk
+olY
 sJM
 sJM
 apG
@@ -117407,7 +117459,7 @@ rfi
 rfi
 oKl
 nSo
-gDH
+mNG
 abA
 uer
 sJM
@@ -118441,7 +118493,7 @@ vFv
 rBr
 sXG
 hEx
-xws
+kGj
 gmA
 mqb
 rTH
@@ -118698,7 +118750,7 @@ xIU
 vKp
 wbs
 wbs
-wbs
+sMm
 wbs
 kXA
 tpY
@@ -118955,7 +119007,7 @@ vGl
 bNb
 fvz
 fvz
-fvz
+xVd
 fvz
 wIv
 rTH
@@ -119209,14 +119261,14 @@ aBh
 rvm
 oKl
 fZF
-aZn
-hOb
+hTj
+qIL
 oQc
-oQc
+ogv
 oQc
 vxy
 xPI
-hTj
+jYL
 rTH
 krH
 lXG
@@ -119460,12 +119512,12 @@ gMX
 wrE
 uNy
 cWR
-osp
+sZQ
 oKl
 ncZ
 lSi
 oKl
-cSj
+iXN
 bNb
 fvz
 fvz
@@ -119473,7 +119525,7 @@ fvz
 fvz
 tud
 mmO
-qOL
+hOb
 rTH
 wTo
 lXG
@@ -119716,21 +119768,21 @@ dFh
 ylz
 dbV
 gJr
-irt
+dBc
 wAe
 oKl
 mDl
-fPk
+osp
 oKl
-jYL
-hiY
-hOb
+wxe
+ikG
+qIL
 oQc
 oQc
 oQc
 mzb
 mmO
-yho
+ndS
 rTH
 krH
 lXG
@@ -119974,13 +120026,13 @@ rGN
 sYB
 tmP
 vwc
-dBc
-hRm
+sPk
+qQw
 hCb
 oaz
 pqT
-wxe
-iMH
+eTj
+xws
 fvz
 fvz
 fvz
@@ -120227,18 +120279,18 @@ mAQ
 pkM
 vnv
 jXE
-qQw
+hFR
 khr
 ixM
 jIn
 jRa
 oNC
-dBp
+cSj
 rXT
 hyt
-bJb
-kGj
-hOb
+qOL
+rIb
+mZy
 oQc
 oQc
 oQc
@@ -120484,14 +120536,14 @@ ptc
 mGA
 vnv
 iBm
-qQw
+hFR
 ekt
 qVL
 vwc
 gyG
 vGx
 qqo
-uFH
+eHU
 pkX
 bJb
 bNb
@@ -120741,20 +120793,20 @@ ptc
 mGA
 vnv
 mXZ
-qIL
+iMH
 epx
 sGy
 eKv
 gyG
 oKl
-iXN
-hFR
+fMy
+thg
 oKl
 vkD
-fMy
+irt
 iAd
 mqg
-hOb
+qIL
 gKt
 ydy
 xJH
@@ -121257,7 +121309,7 @@ lxH
 pOP
 xEE
 xlJ
-eHU
+fPk
 pOP
 uYU
 vhz

--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -9151,18 +9151,17 @@
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cKE" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/structure/table/wood/fancy/black,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters{
+	id = "giftshop"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/clerk)
 "cKH" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/machinery/camera{
@@ -9611,11 +9610,18 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "cSj" = (
-/obj/structure/table,
-/obj/machinery/plantgenes{
-	pixel_y = 6
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/hydroponicsplants{
+	pixel_x = -3
 	},
-/turf/open/floor/plasteel/dark,
+/obj/item/book/manual/wiki/hydroponicsguide{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "cSm" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -9947,19 +9953,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cWR" = (
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/hydroponicsplants{
-	pixel_x = -3
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
 	},
-/obj/item/book/manual/wiki/hydroponicsguide{
-	pixel_x = 3;
-	pixel_y = 2
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/area/crew_quarters/kitchen)
 "cWW" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -10758,12 +10760,16 @@
 	},
 /area/security/nuke_storage)
 "dkk" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 10
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
+	},
+/obj/structure/sign/map/right{
+	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
+	icon_state = "map-right-MS";
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/area/hallway/primary/central)
 "dkz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11987,6 +11993,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"dBc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "dBf" = (
 /turf/closed/wall,
 /area/science/robotics/lab)
@@ -12007,21 +12027,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "dBp" = (
-/obj/structure/table/glass,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+/obj/effect/turf_decal/trimline/green/warning/lower{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/hallway/secondary/service)
 "dBs" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/bot,
@@ -15413,20 +15426,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"eEG" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "Serving Hatch"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/hallway/secondary/service)
 "eEK" = (
 /obj/machinery/door/airlock/external{
 	glass = 1;
@@ -15617,21 +15616,11 @@
 /turf/open/floor/plasteel,
 /area/mine/eva)
 "eHU" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 8
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/area/crew_quarters/kitchen)
 "eIe" = (
 /obj/item/candle,
 /obj/machinery/light_switch{
@@ -16258,18 +16247,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"eTj" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	sortType = 21
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "eTn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer2{
 	dir = 4
@@ -19181,6 +19158,24 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"fMy" = (
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "fML" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19367,16 +19362,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "fPk" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
-	},
-/obj/structure/sign/map/left{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-left-MS";
-	pixel_y = 32
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hallway/secondary/service)
 "fPo" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser{
@@ -19400,17 +19391,20 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "fPq" = (
-/obj/structure/table/wood/fancy/black,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters{
-	id = "giftshop"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/clerk)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "fPt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -20977,17 +20971,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "gkw" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop_ext"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/indestructible/carpet/black,
 /area/clerk)
@@ -22234,6 +22222,10 @@
 /turf/open/floor/plasteel/freezer,
 /area/mine/laborcamp)
 "gDH" = (
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -22242,9 +22234,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -24587,8 +24576,21 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "hiY" = (
-/turf/open/indestructible/carpet/black,
-/area/clerk)
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "hiZ" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input{
@@ -26046,6 +26048,13 @@
 /obj/item/cigbutt,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"hFR" = (
+/obj/machinery/smartfridge/drying_rack,
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "hGA" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -26880,6 +26889,22 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/storage)
+"hRm" = (
+/obj/machinery/door/airlock{
+	name = "Kitchen";
+	req_access_txt = "28"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/hallway/secondary/service)
 "hRr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 4;
@@ -26996,19 +27021,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hTj" = (
-/obj/structure/table/wood,
-/obj/item/camera,
-/obj/item/camera_film,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
+/obj/structure/table,
+/obj/machinery/plantgenes{
+	pixel_y = 6
 	},
-/obj/machinery/camera{
-	c_tag = "Gift Shop";
-	dir = 4
-	},
-/turf/open/indestructible/carpet/black,
-/area/clerk)
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "hTm" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/machinery/light/small{
@@ -27831,15 +27849,20 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "ikG" = (
-/obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop_ext"
 	},
-/area/crew_quarters/kitchen)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "ikQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -29904,14 +29927,18 @@
 /turf/closed/wall,
 /area/security/courtroom)
 "iMH" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/item/radio/intercom{
-	pixel_y = 21
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/hydroponics)
 "iMQ" = (
 /obj/structure/destructible/cult/tome,
 /obj/machinery/newscaster{
@@ -30625,11 +30652,21 @@
 /turf/open/floor/wood,
 /area/library)
 "iXN" = (
-/obj/machinery/processor,
-/turf/open/floor/plasteel/cafeteria{
+/obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/service";
+	dir = 1;
+	name = "Service Hall APC";
+	pixel_y = 23
+	},
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 5
 	},
-/area/crew_quarters/kitchen)
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "iXO" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -31627,21 +31664,19 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "jlF" = (
-/obj/machinery/door/airlock{
-	name = "Kitchen";
-	req_access_txt = "28"
+/obj/structure/table/wood,
+/obj/item/camera,
+/obj/item/camera_film,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Gift Shop";
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/hallway/secondary/service)
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "jlJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -32053,24 +32088,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"jrn" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "jrJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -33569,21 +33586,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"jLL" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "jLP" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -33931,6 +33933,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"jRa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "jRd" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/structure/cable{
@@ -34383,8 +34393,20 @@
 /turf/closed/wall/r_wall,
 /area/aisat)
 "jYL" = (
-/obj/structure/table,
-/turf/open/floor/plasteel/dark,
+/obj/structure/table/glass,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "jYO" = (
 /obj/structure/table/wood,
@@ -36604,6 +36626,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"kGj" = (
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "kGl" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plating{
@@ -40944,7 +40982,7 @@
 	name = "Gift Shop";
 	req_access_txt = "36"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/clerk)
 "lUS" = (
 /obj/structure/cable/yellow{
@@ -44036,13 +44074,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"mNG" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
-	},
-/turf/open/indestructible/carpet/black,
-/area/clerk)
 "mNN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -45371,15 +45402,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
-"ndS" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/indestructible/carpet/black,
-/area/clerk)
 "neg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -45681,15 +45703,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"njA" = (
-/obj/effect/turf_decal/trimline/green/warning/lower{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "njU" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -48539,11 +48552,19 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "obf" = (
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/area/crew_quarters/kitchen)
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop_ext"
+	},
+/obj/machinery/door/airlock/glass_large{
+	doorOpen = 'sound/machines/defib_success.ogg';
+	name = "Gift Shop"
+	},
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "obl" = (
 /obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
 	dir = 8
@@ -48994,13 +49015,9 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "ogv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/clerk)
 "ogK" = (
 /obj/machinery/light{
 	dir = 8
@@ -49332,18 +49349,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "olY" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/structure/sign/map/left{
+	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
+	icon_state = "map-left-MS";
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -49751,19 +49763,11 @@
 	},
 /area/security/prison)
 "osp" = (
-/obj/machinery/door/airlock{
-	name = "Gift Shop";
-	req_access_txt = "36"
+/obj/machinery/processor,
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/clerk)
+/area/crew_quarters/kitchen)
 "osy" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -50587,19 +50591,20 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "oFF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
+	dir = 4
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "oFH" = (
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway - Fore";
@@ -50972,20 +50977,19 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "oNC" = (
-/obj/effect/landmark/start/cook,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "Serving Hatch"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
 	},
-/area/crew_quarters/kitchen)
+/area/hallway/secondary/service)
 "oND" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -51912,11 +51916,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "pcc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
+	dir = 6
 	},
 /turf/open/indestructible/carpet/black,
 /area/clerk)
@@ -57349,11 +57353,12 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "qGD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop_ext"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plating,
+/area/clerk)
 "qGE" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
@@ -57584,6 +57589,21 @@
 	},
 /turf/open/floor/wood,
 /area/vacant_room/office)
+"qIL" = (
+/obj/effect/landmark/start/cook,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "qIN" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -57935,6 +57955,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"qOL" = (
+/obj/structure/table,
+/obj/machinery/smartfridge/disks{
+	pixel_y = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "qOW" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -58035,12 +58062,13 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "qQw" = (
-/obj/machinery/smartfridge/drying_rack,
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 6
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/turf/open/floor/plasteel/cafeteria{
+	dir = 5
+	},
+/area/crew_quarters/kitchen)
 "qQQ" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -58274,6 +58302,13 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"qUs" = (
+/obj/structure/table/wood,
+/obj/item/instrument/accordion,
+/obj/item/instrument/guitar,
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/clerk)
 "qUC" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -60611,10 +60646,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"rIb" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel/dark,
-/area/clerk)
 "rIx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -62562,11 +62593,11 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "slM" = (
-/obj/structure/table/wood,
-/obj/item/instrument/accordion,
-/obj/item/instrument/guitar,
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/indestructible/carpet/black,
 /area/clerk)
 "sma" = (
 /obj/structure/cable/yellow{
@@ -64428,14 +64459,14 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "sMm" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 4
+/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/item/radio/intercom{
+	pixel_y = 21
+	},
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/hallway/primary/central)
 "sMo" = (
 /obj/machinery/newscaster{
 	pixel_x = -32
@@ -64718,6 +64749,12 @@
 	},
 /turf/open/floor/plating,
 /area/mine/laborcamp)
+"sPk" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sPy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -65445,17 +65482,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"sZQ" = (
-/obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
-	dir = 1
-	},
-/obj/structure/sign/map/right{
-	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
-	icon_state = "map-right-MS";
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "sZY" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
@@ -66022,21 +66048,19 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "thg" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 8
+/obj/machinery/door/airlock{
+	name = "Gift Shop";
+	req_access_txt = "36"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/turf/open/floor/plasteel/dark,
+/area/clerk)
 "thl" = (
 /turf/closed/wall,
 /area/maintenance/aft)
@@ -68477,10 +68501,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
-"tTQ" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
 "tTT" = (
 /obj/effect/turf_decal/trimline/green/warning/lower,
 /turf/open/floor/plasteel,
@@ -71074,19 +71094,9 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "uFH" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop_ext"
-	},
-/obj/machinery/door/airlock/glass_large{
-	doorOpen = 'sound/machines/defib_success.ogg';
-	name = "Gift Shop"
-	},
-/turf/open/indestructible/carpet/black,
-/area/clerk)
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
 "uFJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -76234,21 +76244,14 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "wbs" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/service";
-	dir = 1;
-	name = "Service Hall APC";
-	pixel_y = 23
-	},
-/obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 5
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/service)
+/area/hydroponics)
 "wbC" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -77823,6 +77826,18 @@
 "wwU" = (
 /turf/open/floor/plasteel/dark,
 /area/mine/infirmary)
+"wxe" = (
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	sortType = 21
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "wxw" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 4
@@ -81679,12 +81694,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "xyT" = (
-/obj/structure/table,
-/obj/machinery/smartfridge/disks{
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics)
+/turf/open/indestructible/carpet/black,
+/area/clerk)
 "xzb" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -83383,13 +83394,6 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
-"xVd" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop_ext"
-	},
-/turf/open/floor/plating,
-/area/clerk)
 "xVs" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -84283,13 +84287,9 @@
 	},
 /area/maintenance/solars/starboard/fore)
 "yho" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 5
-	},
-/area/crew_quarters/kitchen)
+/obj/structure/table,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "yhp" = (
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
@@ -113804,13 +113804,13 @@ jLJ
 cmS
 oWW
 rRb
-rIb
-fPq
-hiY
-hTj
+ogv
+cKE
+xyT
+jlF
 bVv
 tSd
-xVd
+qGD
 cnB
 bOW
 vfu
@@ -114060,14 +114060,14 @@ xto
 iSn
 cmS
 oWW
-slM
+qUs
 hEb
 lIL
-hiY
+xyT
 xIS
 kCd
-hiY
-uFH
+xyT
+obf
 cnB
 oxp
 tHh
@@ -114317,14 +114317,14 @@ xqY
 iSn
 cmS
 pyr
-rIb
-rIb
-fPq
-hiY
-ndS
+ogv
+ogv
+cKE
+xyT
+pcc
 srT
 cxX
-gkw
+ikG
 aud
 mlF
 tHh
@@ -114574,14 +114574,14 @@ gax
 cUZ
 cmS
 lUJ
-rIb
-rIb
-fPq
-hiY
-pcc
-mNG
+ogv
+ogv
+cKE
+xyT
+gkw
+slM
 mrw
-xVd
+qGD
 cnB
 oxp
 weH
@@ -114832,7 +114832,7 @@ eIF
 rSI
 oWW
 oWW
-osp
+thg
 oWW
 oWW
 bpB
@@ -115089,14 +115089,14 @@ iSn
 wEb
 auc
 oWW
-rIb
-rIb
+ogv
+ogv
 gDU
 rib
-rIb
+ogv
 aIK
 oWW
-iMH
+sMm
 oxp
 lbX
 aYY
@@ -115353,7 +115353,7 @@ fNb
 jLg
 czk
 oWW
-fPk
+olY
 oxp
 tHh
 bKt
@@ -115610,8 +115610,8 @@ xgE
 jXb
 xQt
 oWW
-sZQ
-jLL
+dkk
+fPq
 cTp
 idf
 tMs
@@ -115868,7 +115868,7 @@ xeL
 oWW
 oWW
 uNg
-gDH
+oFF
 tHh
 uPN
 rbU
@@ -117151,7 +117151,7 @@ vdX
 vdX
 uer
 oxp
-qGD
+sPk
 sJM
 sJM
 apG
@@ -117407,7 +117407,7 @@ rfi
 rfi
 oKl
 nSo
-olY
+gDH
 abA
 uer
 sJM
@@ -118696,10 +118696,10 @@ fEM
 oKl
 xIU
 vKp
-sMm
-sMm
-sMm
-sMm
+wbs
+wbs
+wbs
+wbs
 kXA
 tpY
 uvQ
@@ -119216,7 +119216,7 @@ oQc
 oQc
 vxy
 xPI
-cSj
+hTj
 rTH
 krH
 lXG
@@ -119459,13 +119459,13 @@ mDO
 gMX
 wrE
 uNy
-ikG
-iXN
+cWR
+osp
 oKl
 ncZ
 lSi
 oKl
-cWR
+cSj
 bNb
 fvz
 fvz
@@ -119473,7 +119473,7 @@ fvz
 fvz
 tud
 mmO
-xyT
+qOL
 rTH
 wTo
 lXG
@@ -119720,17 +119720,17 @@ irt
 wAe
 oKl
 mDl
-dkk
+fPk
 oKl
-dBp
-thg
+jYL
+hiY
 hOb
 oQc
 oQc
 oQc
 mzb
 mmO
-jYL
+yho
 rTH
 krH
 lXG
@@ -119974,13 +119974,13 @@ rGN
 sYB
 tmP
 vwc
-oFF
-jlF
+dBc
+hRm
 hCb
 oaz
 pqT
-eTj
-cKE
+wxe
+iMH
 fvz
 fvz
 fvz
@@ -120227,17 +120227,17 @@ mAQ
 pkM
 vnv
 jXE
-ogv
+qQw
 khr
 ixM
 jIn
-yho
-eEG
-njA
+jRa
+oNC
+dBp
 rXT
 hyt
 bJb
-eHU
+kGj
 hOb
 oQc
 oQc
@@ -120484,14 +120484,14 @@ ptc
 mGA
 vnv
 iBm
-ogv
+qQw
 ekt
 qVL
 vwc
 gyG
 vGx
 qqo
-tTQ
+uFH
 pkX
 bJb
 bNb
@@ -120741,17 +120741,17 @@ ptc
 mGA
 vnv
 mXZ
-oNC
+qIL
 epx
 sGy
 eKv
 gyG
 oKl
-wbs
-qQw
+iXN
+hFR
 oKl
 vkD
-jrn
+fMy
 iAd
 mqg
 hOb
@@ -121257,7 +121257,7 @@ lxH
 pOP
 xEE
 xlJ
-obf
+eHU
 pOP
 uYU
 vhz


### PR DESCRIPTION
# Document the changes in your pull request
Mainly touches kitchen, parts of bar, botany, service hall and clerk's shop.

Main differences:
Clerks Shop is flipped, now it no longer faces the Least Used Corridor Ever
![image](https://github.com/yogstation13/Yogstation/assets/42524344/76af8971-7900-4920-824e-e2d92fc46832)

Kitchens design completely altered, now it no longer is a complete mess.
![image](https://github.com/yogstation13/Yogstation/assets/42524344/07ae712d-427e-4d20-bcb8-21f98bd92d17)

Service hallway moved slightly, extended and beautifed:
![image](https://github.com/yogstation13/Yogstation/assets/42524344/7c69352c-3e6a-4d13-bf4e-e0f8c386928d)

Botany has a slightly different layout, makes it more uniform:
![image](https://github.com/yogstation13/Yogstation/assets/42524344/707fbcd4-bcbc-4d0e-a554-a55725c1dac0)


# Why is this good for the game?
Before, clerks would serve directly onto one of the least used corridors on the station, meaning theyre completely out of the way and able to serve no one, The vacant office has more foot-traffic, now thats reduced.
All of kitchen was a complete nightmare of a layout, completely incomprehensible, should be easier now.
Service hallway is now nice to be in and not a weird mess.

# Changelog
:cl:  
mapping: Clerk's shop on IceMeta has been flipped
mapping: Kitchen on IceMeta has a new layout
mapping: Service Hallway on IceMeta is longer
/:cl:
