### PR TITLE
Make geranium seed useful and tweaks

### DIFF
--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -269,7 +269,7 @@
 	growing_icon = 'icons/obj/hydroponics/growing_flowers.dmi'
 	icon_grow = "bee_balm-grow"
 	icon_dead = "bee_balm-dead"
-	mutatelist = list(/obj/item/seeds/bee_balm/honey) //Lower odds of becoming honey
+	mutatelist = list(/obj/item/seeds/bee_balm/honey)
 	reagents_add = list(/datum/reagent/medicine/spaceacillin = 0.1, /datum/reagent/space_cleaner/sterilizine = 0.05)
 	rarity = 20
 

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -87,7 +87,7 @@
 	species = "geranium"
 	plantname = "Geranium Plants"
 	product = /obj/item/reagent_containers/food/snacks/grown/poppy/geranium
-	mutatelist = list()
+	mutatelist = list(/obj/item/seeds/bee_balm)
 	rarity = 10
 
 /obj/item/reagent_containers/food/snacks/grown/poppy/geranium
@@ -269,7 +269,7 @@
 	growing_icon = 'icons/obj/hydroponics/growing_flowers.dmi'
 	icon_grow = "bee_balm-grow"
 	icon_dead = "bee_balm-dead"
-	mutatelist = list(/obj/item/seeds/poppy/geranium, /obj/item/seeds/bee_balm/honey) //Lower odds of becoming honey
+	mutatelist = list(/obj/item/seeds/bee_balm/honey) //Lower odds of becoming honey
 	reagents_add = list(/datum/reagent/medicine/spaceacillin = 0.1, /datum/reagent/space_cleaner/sterilizine = 0.05)
 	rarity = 20
 


### PR DESCRIPTION
# Document the changes in your pull request
Geranium seed can now be mutated into Bee balm
Bee balm can no longer be mutated into Geranium



# Why is this good for the game?
Currently geranium seed is very useless in botany because it has nothing, no trait, no chem, no mutation. And the fact that bee balm can be mutated back to geranium can be frustrating for botanist so this should make it less suffering





# Wiki Documentation
Guide to plants document changes

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Geranium seed can now be mutated into Bee balm
tweak: Bee balm can no longer be mutated into Geranium
/:cl:
