### PR TITLE
lemoline is no longer makeable

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -153,12 +153,6 @@
 	required_reagents = list(/datum/reagent/ammonia = 2, /datum/reagent/nitrogen = 1, /datum/reagent/oxygen = 2)
 	required_temp = 525
 
-/datum/chemical_reaction/lemolime
-	name = "Lemoline"
-	id = /datum/reagent/lemoline
-	required_reagents = list(/datum/reagent/consumable/lemonjuice = 1, /datum/reagent/consumable/limejuice = 1, /datum/reagent/consumable/ethanol = 2)
-	results = list(/datum/reagent/lemoline = 2)
-
 //Technically a mutation toxin
 /datum/chemical_reaction/mulligan
 	name = "Mulligan"


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Lemoline is no longer craftable, this is technically a revert.

# Why is this good for the game?
Lemoline was originally added as a means to try to encourage medical to go to cargo to obtain higher tier medicines, and for whatever reason that was changed. Now a chemist or anyone with chem access can go to the bar and get the ingredients (as none of them are ID locked) without even having to interact with someone. This is good for the game as we should encourage players to go to cargo to receive higher tier chemicals, as it generates interaction and gives cargo slightly more to do when security isn't blowing half the budget on mindshields or weapons. If this gets through I'll add a new recipe that uses lemoline to help compensate.

# Testing
Tested it on a local hosted server, the recipe in fact does not work anymore.

# Wiki Documentation

Remove the chemistry recipe for lemoline from guide to chem, only can get it from strange seeds and cargo now.
# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:

rscdel: Deletes the lemoline recipe  

/:cl:
