### PR TITLE
You can no longer duplicate nanite resurrection serum

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1878,6 +1878,7 @@
 	name = "Resurrector Nanite Serum"
 	description = "A serum of nanites capable of restoring corpses to living people in a timely manner."
 	taste_description = "a bunch of tiny robots"
+	can_synth = FALSE
 
 /datum/reagent/medicine/resurrector_nanites/reaction_mob(mob/living/carbon/M)
 	..()


### PR DESCRIPTION
# Document the changes in your pull request

Just changes can_synth to false. something like this really shouldnt be easily duplicated

# Why is this good for the game?
Strong item, shouldnt be easily duped.

# Testing
Doesn't need, one line change.

# Changelog
:cl:  
tweak: you can no longer duplicate resurrection serum
/:cl:
