### PR TITLE
You need arms to clutch your chest to show you are having a heart attack

### DIFF
--- a/code/datums/diseases/heart_failure.dm
+++ b/code/datums/diseases/heart_failure.dm
@@ -62,7 +62,7 @@
 					if(H.get_num_arms(FALSE) >= 1)
 						H.visible_message(span_userdanger("[H] clutches at [H.p_their()] chest as if [H.p_their()] heart is stopping!"))
 					else
-						H.visible_message(span_userdanger("[H] clenches [H.p_their()] jaw[H.getorganslot(ORGAN_SLOT_EYES) ? "and stares off into space." : "."]"))
+						H.visible_message(span_userdanger("[H] clenches [H.p_their()] jaw[H.getorganslot(ORGAN_SLOT_EYES) ? " and stares off into space." : "."]"))
 				H.adjustStaminaLoss(60)
 				H.set_heartattack(TRUE)
 				H.reagents.add_reagent(/datum/reagent/medicine/corazone, 3) // To give the victim a final chance to shock their heart before losing consciousness

--- a/code/datums/diseases/heart_failure.dm
+++ b/code/datums/diseases/heart_failure.dm
@@ -59,7 +59,10 @@
 				H.stop_sound_channel(CHANNEL_HEARTBEAT)
 				H.playsound_local(H, 'sound/effects/singlebeat.ogg', 100, 0)
 				if(H.stat == CONSCIOUS)
-					H.visible_message(span_userdanger("[H] clutches at [H.p_their()] chest as if [H.p_their()] heart is stopping!"))
+					if(H.get_num_arms(FALSE) >= 1)
+						H.visible_message(span_userdanger("[H] clutches at [H.p_their()] chest as if [H.p_their()] heart is stopping!"))
+					else
+						H.visible_message(span_userdanger("[H] clenches [H.p_their()] jaw[H.getorganslot(ORGAN_SLOT_EYES) ? "and stares off into space." : "."]"))
 				H.adjustStaminaLoss(60)
 				H.set_heartattack(TRUE)
 				H.reagents.add_reagent(/datum/reagent/medicine/corazone, 3) // To give the victim a final chance to shock their heart before losing consciousness

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -96,14 +96,14 @@
 					if(owner.get_num_arms(FALSE) >= 1) //gotta have an arm to clutch your chest
 						owner.visible_message(span_userdanger("[owner] clutches at [owner.p_their()] chest as if [owner.p_their()] heart is stopping!"))
 					else
-						owner.visible_message(span_userdanger("[owner] clenches [owner.p_their()] jaw[owner.getorganslot(ORGAN_SLOT_EYES) ? "and stares off into space." : "."]")) //ok you also need eyes
+						owner.visible_message(span_userdanger("[owner] clenches [owner.p_their()] jaw[owner.getorganslot(ORGAN_SLOT_EYES) ? " and stares off into space." : "."]")) //ok you also need eyes
 				owner.set_heartattack(TRUE) //yogs end
 	if(organ_flags & ORGAN_FAILING)	//heart broke, stopped beating, death imminent
 		if(owner.stat == CONSCIOUS)
 			if(owner.get_num_arms(FALSE) >= 1)
 				owner.visible_message(span_userdanger("[owner] clutches at [owner.p_their()] chest as if [owner.p_their()] heart is stopping!"))
 			else
-				owner.visible_message(span_userdanger("[owner] clenches [owner.p_their()] jaw[owner.getorganslot(ORGAN_SLOT_EYES) ? "and stares off into space." : "."]"))
+				owner.visible_message(span_userdanger("[owner] clenches [owner.p_their()] jaw[owner.getorganslot(ORGAN_SLOT_EYES) ? " and stares off into space." : "."]"))
 		owner.set_heartattack(TRUE)
 		failed = TRUE
 

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -93,11 +93,17 @@
 		if(damage >= 80 && beating)
 			if(prob(1))
 				if(owner.stat == CONSCIOUS)
-					owner.visible_message(span_userdanger("[owner] clutches at [owner.p_their()] chest as if [owner.p_their()] heart is stopping!"))
+					if(owner.get_num_arms(FALSE) >= 1) //gotta have an arm to clutch your chest
+						owner.visible_message(span_userdanger("[owner] clutches at [owner.p_their()] chest as if [owner.p_their()] heart is stopping!"))
+					else
+						owner.visible_message(span_userdanger("[owner] clenches [owner.p_their()] jaw[owner.getorganslot(ORGAN_SLOT_EYES) ? "and stares off into space." : "."]")) //ok you also need eyes
 				owner.set_heartattack(TRUE) //yogs end
 	if(organ_flags & ORGAN_FAILING)	//heart broke, stopped beating, death imminent
 		if(owner.stat == CONSCIOUS)
-			owner.visible_message(span_userdanger("[owner] clutches at [owner.p_their()] chest as if [owner.p_their()] heart is stopping!"))
+			if(owner.get_num_arms(FALSE) >= 1)
+				owner.visible_message(span_userdanger("[owner] clutches at [owner.p_their()] chest as if [owner.p_their()] heart is stopping!"))
+			else
+				owner.visible_message(span_userdanger("[owner] clenches [owner.p_their()] jaw[owner.getorganslot(ORGAN_SLOT_EYES) ? "and stares off into space." : "."]"))
 		owner.set_heartattack(TRUE)
 		failed = TRUE
 


### PR DESCRIPTION
# Document the changes in your pull request

resolves https://github.com/yogstation13/Yogstation/issues/20300

you will now clench your jaw and stare into the distance if you don't have enough arms to clutch your chest with.
if you don't have eyes you don't stare into the distance, just your jaw


# Why is this good for the game?
The message lies. I like confusing medical personnel. 

# Testing

2 arms:
![image](https://github.com/yogstation13/Yogstation/assets/5091394/281f93a1-486c-4b89-bbaa-acd19f594374)

1 arm:
![image](https://github.com/yogstation13/Yogstation/assets/5091394/cd10fdf6-6849-4236-89b5-bb4c89dcb5f3)

0 arms:
![image](https://github.com/yogstation13/Yogstation/assets/5091394/9963d0f5-e6ae-4f09-aafb-48e3aa265f30)


# Wiki Documentation

Should be added to guide to medical

# Changelog

:cl:  
tweak: you won't clutch your chest while having a heart attack if you have no arms.
/:cl:
