### PR TITLE
Nerf to preternis eating

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/power_suck.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/power_suck.dm
@@ -16,7 +16,7 @@
 
 	draining = TRUE
 
-	var/siemens_coefficient = H.dna.species.siemens_coeff //makes power drain speed scale with preternis stats
+	var/siemens_coefficient = 1 //makes power drain speed scale with preternis stats
 
 	if(H.reagents.has_reagent("teslium"))
 		siemens_coefficient *= 1.5
@@ -78,7 +78,7 @@
 				playsound(A.loc, "sparks", 50, 1)
 				if(prob(75))
 					spark_system.start()
-				var/drained = A.consume_power_from(drain)
+				var/drained = A.consume_power_from(drain) / 2 //they consume more power than they actually get
 				if(drained < drain)
 					to_chat(H, span_info("[A]'s power has been depleted, CONSUME protocol halted."))
 					done = TRUE


### PR DESCRIPTION
# Why is this good for the game?
They get to sidestep the chef for electricity, but they don't actually have any real power-drain as far as the station is concerned
It also lets them use a single battery as a snack for the entire shift with no worry of ever running out
This should make them actually care about the station's power status

:cl:  
tweak: Preterni consume more power and take slightly longer to fully charge
/:cl:
