### PR TITLE
removes a bunch of useless stuff from bluespace harvester

### DIFF
--- a/code/modules/goals/station_goals/bluespace_tap.dm
+++ b/code/modules/goals/station_goals/bluespace_tap.dm
@@ -104,13 +104,6 @@
 		/obj/item/coin/antagtoken,
 		/obj/item/clothing/suit/cardborg,
 		/obj/item/toy/prize/honk,
-		/obj/item/bedsheet/patriot,
-		/obj/item/bedsheet/rainbow,
-		/obj/item/bedsheet/captain,
-		/obj/item/bedsheet/centcom,
-		/obj/item/bedsheet/syndie,
-		/obj/item/bedsheet/cult,
-		/obj/item/bedsheet/wiz,
 		/obj/item/clothing/gloves/combat,
 	)
 
@@ -130,9 +123,6 @@
 	name = "organic objects"
 	loot = list(
 		/obj/item/seeds/random,
-		/obj/item/storage/pill_bottle/charcoal,
-		/obj/item/storage/pill_bottle/mannitol,
-		/obj/item/storage/pill_bottle/mutadone,
 		/obj/item/dnainjector/telemut,
 		/obj/item/dnainjector/chameleonmut,
 		/obj/item/dnainjector/dwarf,
@@ -142,12 +132,8 @@
 		/mob/living/simple_animal/pet/penguin,
 		/mob/living/simple_animal/parrot,
 		/obj/item/slimepotion/slime/sentience,
-		/obj/item/clothing/mask/cigarette/cigar/havana,
 		/obj/item/stack/sheet/mineral/bananium/five,	//bananas are organic, clearly.
 		/obj/item/storage/box/monkeycubes,
-		/obj/item/stack/tile/carpet/black/fifty,
-		/obj/item/stack/tile/carpet/blue/fifty,
-		/obj/item/stack/tile/carpet/cyan/fifty,
 		/obj/item/soap/deluxe,
 	)
 


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

removes the bedsheets, carpets, cigars and pills from the harvester

# Why is this good for the game?
this stuff is completely useless and just lowers the chances of actually getting cool stuff like the slip bombs

# Testing
it works probably

# Wiki Documentation

bs harvester isn't on the wiki

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:   
rscdel: Removed many useless items from the bluespace harvester loot pool
/:cl:
