### PR TITLE
Medical doctors and paramedic spawn with medical belts

### DIFF
--- a/code/modules/clothing/outfits/plasmaman.dm
+++ b/code/modules/clothing/outfits/plasmaman.dm
@@ -254,6 +254,8 @@
 	ears = /obj/item/radio/headset/headset_med
 	suit =  /obj/item/clothing/suit/toggle/labcoat/md
 	l_hand = /obj/item/storage/firstaid/medical
+	glasses = /obj/item/clothing/glasses/hud/health
+	belt = /obj/item/storage/belt/medical
 	suit_store = /obj/item/flashlight/pen
 	backpack = /obj/item/storage/backpack/medic
 	satchel = /obj/item/storage/backpack/satchel/med
@@ -512,6 +514,8 @@
 	l_pocket = /obj/item/flashlight
 	r_pocket = /obj/item/gps
 	backpack = /obj/item/storage/backpack/medic
+	glasses = /obj/item/clothing/glasses/hud/health
+	belt = /obj/item/storage/belt/medical
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
 	gloves = /obj/item/clothing/gloves/color/latex/nitrile

--- a/code/modules/clothing/outfits/plasmaman.dm
+++ b/code/modules/clothing/outfits/plasmaman.dm
@@ -254,7 +254,6 @@
 	ears = /obj/item/radio/headset/headset_med
 	suit =  /obj/item/clothing/suit/toggle/labcoat/md
 	l_hand = /obj/item/storage/firstaid/medical
-	glasses = /obj/item/clothing/glasses/hud/health
 	belt = /obj/item/storage/belt/medical
 	suit_store = /obj/item/flashlight/pen
 	backpack = /obj/item/storage/backpack/medic
@@ -514,7 +513,6 @@
 	l_pocket = /obj/item/flashlight
 	r_pocket = /obj/item/gps
 	backpack = /obj/item/storage/backpack/medic
-	glasses = /obj/item/clothing/glasses/hud/health
 	belt = /obj/item/storage/belt/medical
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -40,7 +40,6 @@
 /datum/outfit/job/doctor
 	name = "Medical Doctor"
 	jobtype = /datum/job/doctor
-	glasses = /obj/item/clothing/glasses/hud/health
 	belt = /obj/item/storage/belt/medical
 	ears = /obj/item/radio/headset/headset_med
 	pda_type = /obj/item/modular_computer/tablet/pda/preset/medical

--- a/code/modules/jobs/job_types/medical_doctor.dm
+++ b/code/modules/jobs/job_types/medical_doctor.dm
@@ -40,6 +40,8 @@
 /datum/outfit/job/doctor
 	name = "Medical Doctor"
 	jobtype = /datum/job/doctor
+	glasses = /obj/item/clothing/glasses/hud/health
+	belt = /obj/item/storage/belt/medical
 	ears = /obj/item/radio/headset/headset_med
 	pda_type = /obj/item/modular_computer/tablet/pda/preset/medical
 	uniform = /obj/item/clothing/under/rank/medical
@@ -53,6 +55,7 @@
 	satchel = /obj/item/storage/backpack/satchel/med
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
 	chameleon_extras = /obj/item/gun/syringe
+
 /datum/outfit/job/doctor/dead
 	name = "Medical Doctor"
 	jobtype = /datum/job/doctor

--- a/yogstation/code/modules/jobs/job_types/paramedic.dm
+++ b/yogstation/code/modules/jobs/job_types/paramedic.dm
@@ -41,6 +41,8 @@
 
 	backpack_contents = list(/obj/item/storage/firstaid/regular)
 	ears = /obj/item/radio/headset/headset_med
+	glasses = /obj/item/clothing/glasses/hud/health
+	belt = /obj/item/storage/belt/medical
 	uniform = /obj/item/clothing/under/rank/medical
 	suit = /obj/item/clothing/suit/toggle/labcoat/emt
 	shoes = /obj/item/clothing/shoes/sneakers/white

--- a/yogstation/code/modules/jobs/job_types/paramedic.dm
+++ b/yogstation/code/modules/jobs/job_types/paramedic.dm
@@ -41,7 +41,6 @@
 
 	backpack_contents = list(/obj/item/storage/firstaid/regular)
 	ears = /obj/item/radio/headset/headset_med
-	glasses = /obj/item/clothing/glasses/hud/health
 	belt = /obj/item/storage/belt/medical
 	uniform = /obj/item/clothing/under/rank/medical
 	suit = /obj/item/clothing/suit/toggle/labcoat/emt


### PR DESCRIPTION
# Why is this good for the game?
Late joining and finding that everything's already been gobbled up is annoying as hell considering how much space everything takes

Other medical jobs spawn with empty medical belts too
engineers and roboticists spawn with full tool belts

huds can be printed, so they still don't get those

:cl:  
tweak: Medical doctor and paramedic spawn with medical belts
/:cl:
