### PR TITLE
Quick use ladders with ctrl and alt click

### DIFF
--- a/code/game/objects/structures/ladders.dm
+++ b/code/game/objects/structures/ladders.dm
@@ -85,15 +85,16 @@
 	if(AM)
 		user.start_pulling(AM)
 
-/obj/structure/ladder/proc/use(mob/user, is_ghost=FALSE)
+/obj/structure/ladder/proc/use(mob/user, is_ghost=FALSE, direction)
 	if (!is_ghost && !in_range(src, user))
 		return
 
 	if (up && down)
-		var/result = tgui_alert(user, "Go up or down [src]?", "Ladder", list("Up", "Down", "Cancel"))
+		if(!direction)
+			direction = tgui_alert(user, "Go up or down [src]?", "Ladder", list("Up", "Down", "Cancel"))
 		if (!is_ghost && !in_range(src, user))
 			return  // nice try
-		switch(result)
+		switch(direction)
 			if("Up")
 				travel(TRUE, user, is_ghost, up)
 			if("Down")
@@ -109,6 +110,24 @@
 
 	if(!is_ghost)
 		add_fingerprint(user)
+
+/obj/structure/ladder/CtrlClick(mob/user)
+	. = ..()
+	if(.)
+		return
+	if(down)
+		use(user, FALSE, "Down")
+	else
+		to_chat(user, span_warning("[src] doesn't seem to lead anywhere!"))
+
+/obj/structure/ladder/AltClick(mob/user)
+	. = ..()
+	if(.)
+		return
+	if(up)
+		use(user, FALSE, "Up")
+	else
+		to_chat(user, span_warning("[src] doesn't seem to lead anywhere!"))
 
 /obj/structure/ladder/attack_hand(mob/user)
 	. = ..()


### PR DESCRIPTION
# Why is this good for the game?
When multi-z gets added, we're gonna be dealing with ladders a lot more, adding a keyboard combo to quick use ladders just seems like QoL

:cl:  
rscadd: Use ctrl or alt click to go down or up a ladder
/:cl:
