### PR TITLE
Makes icemoon surface less bright

### DIFF
--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -637,8 +637,6 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 //Solars
 
 /area/solar
-	requires_power = FALSE
-	dynamic_lighting = DYNAMIC_LIGHTING_IFSTARLIGHT
 	valid_territory = FALSE
 	blob_allowed = FALSE
 	flags_1 = NONE

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -176,6 +176,7 @@
 
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer
 	light_range = 2
+	light_power = 0.1
 
 /turf/open/lava/plasma/ice_moon
 	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
@@ -213,6 +214,7 @@
 
 /turf/open/floor/plating/asteroid/snow/ice/icemoon/top_layer
 	light_range = 2
+	light_power = 0.1
 
 /turf/open/floor/plating/asteroid/snow/ice/burn_tile()
 	return FALSE

--- a/code/game/turfs/simulated/floor/plating/misc_plating.dm
+++ b/code/game/turfs/simulated/floor/plating/misc_plating.dm
@@ -217,6 +217,7 @@
 
 /turf/open/floor/plating/ice/icemoon/top_layer
 	light_range = 2
+	light_power = 0.1
 
 /turf/open/floor/plating/snowed
 	name = "snowed-over plating"

--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -220,6 +220,7 @@
 
 /turf/closed/mineral/random/high_chance/snow/top_layer
 	light_range = 2
+	light_power = 0.1
 	mineralSpawnChanceList = list(
 		/turf/closed/mineral/uranium/ice/icemoon/top_layer = 35, /turf/closed/mineral/diamond/ice/icemoon/top_layer = 25, /turf/closed/mineral/gold/ice/icemoon/top_layer = 40, /turf/closed/mineral/titanium/ice/icemoon/top_layer = 45,
 		/turf/closed/mineral/silver/ice/icemoon/top_layer = 50, /turf/closed/mineral/plasma/ice/icemoon/top_layer = 50, /turf/closed/mineral/bscrystal/ice/icemoon/top_layer = 15, /turf/closed/mineral/dilithium/ice/icemoon/top_layer = 15)
@@ -306,6 +307,7 @@
 
 /turf/closed/mineral/random/snow/top_layer
 	light_range = 2
+	light_power = 0.1
 	mineralSpawnChanceList = list(
 		/turf/closed/mineral/uranium/ice/icemoon/top_layer = 5, /turf/closed/mineral/diamond/ice/icemoon/top_layer = 1, /turf/closed/mineral/gold/ice/icemoon/top_layer = 10, /turf/closed/mineral/titanium/ice/icemoon/top_layer = 10,
 		/turf/closed/mineral/silver/ice/icemoon/top_layer = 12, /turf/closed/mineral/plasma/ice/icemoon/top_layer = 19, /turf/closed/mineral/iron/ice/icemoon/top_layer = 40,
@@ -377,6 +379,7 @@
 
 /turf/closed/mineral/iron/ice/icemoon/top_layer
 	light_range = 2
+	light_power = 0.1
 
 /turf/closed/mineral/uranium
 	mineralType = /obj/item/stack/ore/uranium
@@ -417,6 +420,7 @@
 
 /turf/closed/mineral/uranium/ice/icemoon/top_layer
 	light_range = 2
+	light_power = 0.1
 
 /turf/closed/mineral/diamond
 	mineralType = /obj/item/stack/ore/diamond
@@ -457,6 +461,7 @@
 
 /turf/closed/mineral/diamond/ice/icemoon/top_layer
 	light_range = 2
+	light_power = 0.1
 
 /turf/closed/mineral/gold
 	mineralType = /obj/item/stack/ore/gold
@@ -497,6 +502,7 @@
 
 /turf/closed/mineral/gold/ice/icemoon/top_layer
 	light_range = 2
+	light_power = 0.1
 
 /turf/closed/mineral/silver
 	mineralType = /obj/item/stack/ore/silver
@@ -537,6 +543,7 @@
 
 /turf/closed/mineral/silver/ice/icemoon/top_layer
 	light_range = 2
+	light_power = 0.1
 
 /turf/closed/mineral/titanium
 	mineralType = /obj/item/stack/ore/titanium
@@ -577,6 +584,7 @@
 
 /turf/closed/mineral/titanium/ice/icemoon/top_layer
 	light_range = 2
+	light_power = 0.1
 
 
 /turf/closed/mineral/plasma
@@ -618,6 +626,7 @@
 
 /turf/closed/mineral/plasma/ice/icemoon/top_layer
 	light_range = 2
+	light_power = 0.1
 
 /turf/closed/mineral/bananium
 	mineralType = /obj/item/stack/ore/bananium
@@ -697,6 +706,7 @@
 
 /turf/closed/mineral/bscrystal/ice/icemoon/top_layer
 	light_range = 2
+	light_power = 0.1
 
 /turf/closed/mineral/volcanic
 	environment_type = "basalt"
@@ -906,6 +916,7 @@
 
 /turf/closed/mineral/gibtonite/ice/icemoon/top_layer
 	light_range = 2
+	light_power = 0.1
 
 /turf/closed/mineral/magmite
 	mineralType = /obj/item/magmite

--- a/yogstation/code/game/turfs/simulated/minerals.dm
+++ b/yogstation/code/game/turfs/simulated/minerals.dm
@@ -37,3 +37,4 @@
 
 /turf/closed/mineral/dilithium/ice/icemoon/top_layer
 	light_range = 2
+	light_power = 0.1


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Makes the icemeta surface much less bright (still being bright enough to hurt darkspawn/nightmares/etc) because I think it looks a lot cooler and bright lights hurt my eyes

# Why is this good for the game?
<!-- Describe why you think this change is good for the game. This section is not required for bugfixes. -->
Looks a lot cooler and hurts my eyes less

# Testing
<!-- Describe what testing you did with this PR. Try to be thorough, especially if this is a larger project. -->
![image](https://github.com/yogstation13/Yogstation/assets/93578146/414065ba-f622-4496-a45d-c56570d31a93)

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: icemoon surface is less bright
/:cl:
