### PR TITLE
stops waiting for webhook proc

### DIFF
--- a/yogstation/code/modules/webhook/webhook.dm
+++ b/yogstation/code/modules/webhook/webhook.dm
@@ -1,4 +1,5 @@
 /proc/webhook_send(method, data)
+	set waitfor = FALSE
 	if(!CONFIG_GET(string/webhook_address) || !CONFIG_GET(string/webhook_key))
 		return
 


### PR DESCRIPTION
# Document the changes in your pull request

since the memory leak was fixed it made all OOC messages and all interaction with tickets wait a tick, this maybe fixes it

# Changelog

:cl:  
bugfix: some webhook actions won't wait a tick to finish anymore
/:cl:
