### PR TITLE
Blood tomato now has 20% bloody mary production trait

### DIFF
--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -36,7 +36,7 @@
 	plantname = "Blood-Tomato Plants"
 	product = /obj/item/reagent_containers/food/snacks/grown/tomato/blood
 	mutatelist = list()
-	reagents_add = list(/datum/reagent/blood = 0.2, /datum/reagent/consumable/nutriment = 0.1)
+	reagents_add = list(/datum/reagent/consumable/ethanol/bloody_mary = 0.2, /datum/reagent/blood = 0.2, /datum/reagent/consumable/nutriment = 0.1)
 	rarity = 20
 
 /obj/item/reagent_containers/food/snacks/grown/tomato/blood


### PR DESCRIPTION
# Document the changes in your pull request
Blood tomato now has 20% bloody mary production trait

# Why is this good for the game?
Good to have in bloody tomato, can be combined with other plant genes to make a good healing plant for some people.

# Testing
Ran a local test, worked even tho this doesnt have to be tested it but i did anyway



# Wiki Documentation
Update guide to plants document of changes

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: Blood tomato now has 20% bloody mary production trait
/:cl:
