### PR TITLE
Wooden barrel tweak and bugfixes

### DIFF
--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -50,8 +50,14 @@
 		to_chat(user, span_notice("You place [I] into [src] to start the fermentation process."))
 		addtimer(CALLBACK(src, PROC_REF(makeWine), fruit), rand(80, 120) * speed_multiplier)
 		return TRUE
+	if(istype(I, /obj/item/reagent_containers))
+		return TRUE
 	else
 		return ..()
+
+/obj/structure/fermenting_barrel/deconstruct(disassembled = TRUE)
+	new /obj/item/stack/sheet/mineral/wood (loc, 30)
+	qdel(src)
 
 /obj/structure/fermenting_barrel/attack_hand(mob/user)
 	open = !open
@@ -75,6 +81,6 @@
 /datum/crafting_recipe/fermenting_barrel
 	name = "Wooden Barrel"
 	result = /obj/structure/fermenting_barrel
-	reqs = list(/obj/item/stack/sheet/mineral/wood = 30)
+	reqs = list(/obj/item/stack/sheet/mineral/wood = 10)
 	time = 5 SECONDS
 	category = CAT_STRUCTURES

--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -50,8 +50,8 @@
 		to_chat(user, span_notice("You place [I] into [src] to start the fermentation process."))
 		addtimer(CALLBACK(src, PROC_REF(makeWine), fruit), rand(80, 120) * speed_multiplier)
 		return TRUE
-	if(istype(I, /obj/item/reagent_containers))
-		return TRUE
+	if(I.is_refillable())
+		return FALSE
 	else
 		return ..()
 

--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -56,7 +56,7 @@
 		return ..()
 
 /obj/structure/fermenting_barrel/deconstruct(disassembled = TRUE)
-	new /obj/item/stack/sheet/mineral/wood (loc, 30)
+	new /obj/item/stack/sheet/mineral/wood (loc, 10)
 	qdel(src)
 
 /obj/structure/fermenting_barrel/attack_hand(mob/user)


### PR DESCRIPTION

![image](https://github.com/yogstation13/Yogstation/assets/89688125/7e9ad304-1b09-4dad-93c7-60fa803ae1ff)

# Document the changes in your pull request
Wooden barrel build cost lowered from 30-10 woods
Wooden barrel now properly drops materials upon deconstruction
Wooden barrel wont be damaged by containers anymore

# Why is this good for the game?
30 woods for a barrel is a bit too much, i think 10 is more reasonable.

# Testing
local tested

# Changelog


:cl:  
tweak: Wooden barrel build cost lowered from 30-10 woods
bugfix: Wooden barrel now properly drops materials upon deconstruction
bugfix: Wooden barrel wont be damaged by containers anymore
/:cl:
