### PR TITLE
mobs spawned by holodeck now respect hologram checks

### DIFF
--- a/code/modules/holodeck/holo_effect.dm
+++ b/code/modules/holodeck/holo_effect.dm
@@ -78,6 +78,7 @@
 	// these vars are not really standardized but all would theoretically create stuff on death
 	for(var/v in list("butcher_results","corpse","weapon1","weapon2","blood_volume") & mob.vars)
 		mob.vars[v] = null
+	mob.flags_1 |= HOLOGRAM_1
 	return mob
 
 /obj/effect/holodeck_effect/mobspawner/deactivate(obj/machinery/computer/holodeck/HC)


### PR DESCRIPTION
# Document the changes in your pull request

Main difference: you can no longer pet everything at the holodeck for +200 mood. They should also become immune to certain sentience effects that would otherwise result in less "enjoyable gameplay" for the person now stuck playing as a holographic butterfly

# Why is this good for the game?
intended game design

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/24857008/0108dea8-eef1-4462-b239-a16ff3b0ff53)

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: holodeck animals no longer provide a mood buff
/:cl:
