### PR TITLE
Increases alien tools from bluespace tap from 60,000 to 250,000

### DIFF
--- a/code/modules/goals/station_goals/bluespace_tap.dm
+++ b/code/modules/goals/station_goals/bluespace_tap.dm
@@ -213,7 +213,7 @@
 	new /datum/data/bluespace_tap_product("Unknown Snack", /obj/effect/spawner/lootdrop/bluespace_tap/food, 6000),
 	new /datum/data/bluespace_tap_product("Unknown Cultural Artifact", /obj/effect/spawner/lootdrop/bluespace_tap/cultural, 15000),
 	new /datum/data/bluespace_tap_product("Unknown Biological Artifact", /obj/effect/spawner/lootdrop/bluespace_tap/organic, 20000),
-	new /datum/data/bluespace_tap_product("Unknown Alien Objects", /obj/effect/spawner/lootdrop/bluespace_tap/alien_objects, 3000000),
+	new /datum/data/bluespace_tap_product("Unknown Alien Objects", /obj/effect/spawner/lootdrop/bluespace_tap/alien_objects, 250000),
 	)
 
 	/// The level the machine is currently mining at. 0 means off

--- a/code/modules/goals/station_goals/bluespace_tap.dm
+++ b/code/modules/goals/station_goals/bluespace_tap.dm
@@ -213,7 +213,7 @@
 	new /datum/data/bluespace_tap_product("Unknown Snack", /obj/effect/spawner/lootdrop/bluespace_tap/food, 6000),
 	new /datum/data/bluespace_tap_product("Unknown Cultural Artifact", /obj/effect/spawner/lootdrop/bluespace_tap/cultural, 15000),
 	new /datum/data/bluespace_tap_product("Unknown Biological Artifact", /obj/effect/spawner/lootdrop/bluespace_tap/organic, 20000),
-	new /datum/data/bluespace_tap_product("Unknown Alien Objects", /obj/effect/spawner/lootdrop/bluespace_tap/alien_objects, 60000),
+	new /datum/data/bluespace_tap_product("Unknown Alien Objects", /obj/effect/spawner/lootdrop/bluespace_tap/alien_objects, 3000000),
 	)
 
 	/// The level the machine is currently mining at. 0 means off


### PR DESCRIPTION
# Document the changes in your pull request

step 1. fusion TEG
step 2. there's no step 2 you just have alien tools at 14 minutes

# Why is this good for the game?
makes the loop actually last longer so you dont get end game tools by 14 minutes in

# Wiki Documentation

not even on the wiki

# Changelog


:cl:  
tweak: increases alien tool's bluespace tap cost from 60,000 to 250,000
/:cl:
