### PR TITLE
Explosions create turf fires instead of hotspots

### DIFF
--- a/code/controllers/subsystem/explosions.dm
+++ b/code/controllers/subsystem/explosions.dm
@@ -521,7 +521,7 @@ SUBSYSTEM_DEF(explosions)
 		for(var/thing in flame_turf)
 			if(thing)
 				var/turf/T = thing
-				new /obj/effect/hotspot(T) //Mostly for ambience!
+				T.IgniteTurf(rand(4, 24)) //Mostly for ambience!
 		cost_flameturf = MC_AVERAGE(cost_flameturf, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 
 		if (low_turf.len || med_turf.len || high_turf.len)


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Explosions will now create turf fires instead of hotspots.

# Why is this good for the game?
<!-- Describe why you think this change is good for the game. This section is not required for bugfixes. -->
Turf fires are way cooler than hotspots, and explosions that were supposed to set things on fire like welding tank explosions and firebombs can actually start fires now.

# Testing
<!-- Describe what testing you did with this PR. Try to be thorough, especially if this is a larger project. -->
Aftermath of a welding tank explosion on icemeta:
![image](https://github.com/yogstation13/Yogstation/assets/93578146/01e96880-8a1e-48bf-961c-7d24b916a066)

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: explosions cause turf fires instead of hotspots
/:cl:
