### PR TITLE
cyborg and cyborg monitor program tweaks

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -539,7 +539,7 @@
 		else
 			to_chat(user, span_warning("Unable to locate a radio!"))
 
-	else if(W.GetID())			// trying to unlock the interface with an ID card
+	else if(W.GetID() && user.a_intent == INTENT_HELP)			// trying to unlock the interface with an ID card only on help intent.
 		togglelock(user)
 
 	else if(istype(W, /obj/item/borg/upgrade/))

--- a/code/modules/modular_computers/file_system/programs/medical/crew_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/medical/crew_monitor.dm
@@ -8,7 +8,7 @@
 	requires_ntnet = FALSE
 	transfer_access = ACCESS_MEDICAL
 	available_on_ntnet = TRUE
-	usage_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP | PROGRAM_TABLET | PROGRAM_PHONE | PROGRAM_TELESCREEN | PROGRAM_INTEGRATED | PROGRAM_PDA
+	usage_flags = PROGRAM_ALL
 	network_destination = "tracking program"
 	size = 5
 	tgui_id = "NtosCrewMonitor"

--- a/code/modules/modular_computers/file_system/programs/science/borg_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/science/borg_monitor.dm
@@ -6,7 +6,7 @@
 	program_icon_state = "generic"
 	extended_desc = "This program allows for remote monitoring of station cyborgs."
 	requires_ntnet = TRUE
-	usage_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP | PROGRAM_TABLET | PROGRAM_PHONE | PROGRAM_TELESCREEN | PROGRAM_PDA
+	usage_flags = PROGRAM_ALL
 	transfer_access = ACCESS_ROBO_CONTROL
 	network_destination = "cyborg remote monitoring"
 	size = 5

--- a/tgui/packages/tgui/interfaces/NtosCyborgRemoteMonitor.js
+++ b/tgui/packages/tgui/interfaces/NtosCyborgRemoteMonitor.js
@@ -162,7 +162,7 @@ export const NtosCyborgRemoteMonitorContent = (props, context) => {
               <>
                 <Flex.Item>
                   <Section width={49}>
-                    Scan a cyborg to download stored logs.
+                    Hit a cyborg with the device to download stored logs.
                     <ProgressBar
                       value={DL_progress/100}>
                       {ProgressSwitch(DL_progress)}


### PR DESCRIPTION


# Document the changes in your pull request
- Give cyborg tablet access to the cyborg monitor program.
- Fix the issue of the log file not being downloaded in the cyborg monitor program when using an ID with cyborg access in the card slot. The problem occurs because the ID unlocks the cyborg cover instead of initiating the download. I changed it so that the help intent is now used for unlocking the cover. If you have an ID with cyborg access in the card slot, you need to use intents other than help to download the log file.

# Why is this good for the game?
Granting cyborgs access to the cyborg monitor program enables them to track cyborgs from any location as needed, instead of having to download a cyborg monitor program in a nearby computer

# Testing
Local tested, no runtimes, everything works as intended


# Wiki Documentation
program and cyborg document of changes?

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Give cyborg tablet access to the cyborg monitor program.
bugfix: Fix the issue of the log file not being downloaded in the cyborg monitor program.
/:cl:
