### PR TITLE
Welding fuel tank explosion tweaks

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -65,7 +65,7 @@
 	reagent_id = /datum/reagent/fuel
 
 /obj/structure/reagent_dispensers/fueltank/boom()
-	explosion(get_turf(src), 0, 1, 5, flame_range = 5)
+	explosion(get_turf(src), 0, 0, 8, flame_range = 8)
 	qdel(src)
 
 /obj/structure/reagent_dispensers/fueltank/blob_act(obj/structure/blob/B)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -65,7 +65,11 @@
 	reagent_id = /datum/reagent/fuel
 
 /obj/structure/reagent_dispensers/fueltank/boom()
-	explosion(get_turf(src), 0, 0, 7, flame_range = 8)
+	explosion(get_turf(src), 0, 0, 7, flame_range = 9)
+	var/turf/center = get_turf(src)
+	center.IgniteTurf(50)
+	for(var/turf/open/T in center.GetAtmosAdjacentTurfs())
+		T.IgniteTurf(30)
 	qdel(src)
 
 /obj/structure/reagent_dispensers/fueltank/blob_act(obj/structure/blob/B)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -63,12 +63,13 @@
 	desc = "A tank full of industrial welding fuel. Do not consume."
 	icon_state = "fuel"
 	reagent_id = /datum/reagent/fuel
+	var/fire_range = 5 //for busing
 
 /obj/structure/reagent_dispensers/fueltank/boom()
 	explosion(get_turf(src), 0, 0, 7, flame_range = 9)
 	var/turf/center = get_turf(src)
 	center.IgniteTurf(50)
-	for(var/turf/open/T in range(9, src))
+	for(var/turf/open/T in range(fire_range, src))
 		T.IgniteTurf(30)
 	qdel(src)
 

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -68,7 +68,7 @@
 	explosion(get_turf(src), 0, 0, 7, flame_range = 9)
 	var/turf/center = get_turf(src)
 	center.IgniteTurf(50)
-	for(var/turf/open/T in center.GetAtmosAdjacentTurfs())
+	for(var/turf/open/T in range(9, src))
 		T.IgniteTurf(30)
 	qdel(src)
 

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -65,7 +65,7 @@
 	reagent_id = /datum/reagent/fuel
 
 /obj/structure/reagent_dispensers/fueltank/boom()
-	explosion(get_turf(src), 0, 0, 8, flame_range = 8)
+	explosion(get_turf(src), 0, 0, 7, flame_range = 8)
 	qdel(src)
 
 /obj/structure/reagent_dispensers/fueltank/blob_act(obj/structure/blob/B)


### PR DESCRIPTION


![image](https://github.com/yogstation13/Yogstation/assets/89688125/58f4568d-6e00-4975-8eff-b347b316284a)

# Document the changes in your pull request
welding fuel tank no longer cause a turf hull breach instead it will have more light explosion and flame radius, plus additional turf fires

# Why is this good for the game?
The random spacing of maintenance areas caused by fuel tank explosion due to shootouts, anomalies, or intentional actions by individuals is frustrating. Moreover, people being ignited and immediately get extinguished after the flame due to the spaced environment, this minimizes the impact of welding fuel tank explosion.
# Testing
looks fine to me


# Wiki Documentation
welding fuel tank explosion tweaks

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: welding fuel tank no longer cause a turf hull breach instead it will have more light explosion and flame radius, plus additional turf fires
/:cl:
