### PR TITLE
You can now hack buttons

### DIFF
--- a/code/__DEFINES/wires.dm
+++ b/code/__DEFINES/wires.dm
@@ -49,3 +49,4 @@
 #define WIRE_ZAP1 "High Voltage Circuit 1"
 #define WIRE_ZAP2 "High Voltage Circuit 2"
 #define WIRE_AGELIMIT "Age Limit"
+#define WIRE_MAINTENANCE "Maintenance Access"

--- a/code/datums/wires/button.dm
+++ b/code/datums/wires/button.dm
@@ -1,0 +1,30 @@
+/datum/wires/button
+	holder_type = /obj/machinery/button
+	proper_name = "Button"
+	randomize = TRUE
+
+/datum/wires/button/New(atom/holder)
+	wires = list(
+		WIRE_ACTIVATE,
+		WIRE_IDSCAN,
+		WIRE_MAINTENANCE,
+		WIRE_POWER1
+	)
+	..()
+
+/datum/wires/button/interactable(mob/user)
+	var/obj/machinery/button/M = holder
+	if(M.panel_open && !M.hatch)
+		return TRUE
+
+/datum/wires/button/on_pulse(wire, mob/user)
+	var/obj/machinery/button/button_holder = holder
+	switch(wire)
+		if(WIRE_ACTIVATE)
+			button_holder.attack_hand(hacked = TRUE)
+		if(WIRE_IDSCAN)
+			holder.visible_message(span_notice("[icon2html(button_holder, viewers(holder))] The access light flickers."))
+		if(WIRE_MAINTENANCE)
+			holder.visible_message(span_notice("[icon2html(button_holder, viewers(holder))] The maintenance hatch wobbles."))
+		else
+			holder.visible_message(span_notice("[icon2html(button_holder, viewers(holder))] The lights shut off briefly."))

--- a/code/datums/wires/button.dm
+++ b/code/datums/wires/button.dm
@@ -21,6 +21,7 @@
 	var/obj/machinery/button/button_holder = holder
 	switch(wire)
 		if(WIRE_ACTIVATE)
+			holder.visible_message(span_notice("[icon2html(button_holder, viewers(holder))] The button clanks."))
 			button_holder.attack_hand(hacked = TRUE)
 		if(WIRE_IDSCAN)
 			holder.visible_message(span_notice("[icon2html(button_holder, viewers(holder))] The access light flickers."))

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -763,6 +763,7 @@
 #include "code\datums\wires\airlock_cycle.dm"
 #include "code\datums\wires\apc.dm"
 #include "code\datums\wires\autolathe.dm"
+#include "code\datums\wires\button.dm"
 #include "code\datums\wires\emitter.dm"
 #include "code\datums\wires\explosive.dm"
 #include "code\datums\wires\igniter.dm"


### PR DESCRIPTION
# Document the changes in your pull request

Buttons such as blast door buttons are now able to be hacked, featuring 4 wires.
WIRE_ACTIVATE - Activates the device when pulsed, if IDSCAN is also cut
WIRE_IDSCAN - Allows you to activate the button without an ID when cut.
WIRE_MAINTENANCE - Allows you to open the maintenence hatch, allowing you to access its internals
WIRE_POWER1 - When cut the button will be unpowered.

# Why is this good for the game?
More consistency, no real reason a button should be more secure than a door, allows you to have some emergent gameplay with it.

# Testing
Tested, currently a few issues which is why its a draft

# Wiki Documentation
Will need to add the hacking information to the wiki.

	switch(wire)
		if(WIRE_ACTIVATE)
			holder.visible_message(span_notice("[icon2html(button_holder, viewers(holder))] The button clanks."))
			button_holder.attack_hand(hacked = TRUE)
		if(WIRE_IDSCAN)
			holder.visible_message(span_notice("[icon2html(button_holder, viewers(holder))] The access light flickers."))
		if(WIRE_MAINTENANCE)
			holder.visible_message(span_notice("[icon2html(button_holder, viewers(holder))] The maintenance hatch wobbles."))
		else
			holder.visible_message(span_notice("[icon2html(button_holder, viewers(holder))] The lights shut off briefly."))

# Changelog
:cl:  
rscadd: Buttons can now be hacked 
/:cl:
