### PR TITLE
Lets preterni recharge off other robotic species

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/power_suck.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/power_suck.dm
@@ -110,14 +110,14 @@
 
 //IPC lol, lmao
 /mob/living/carbon/human/can_consume_power_from()
-	return isipc(src)
+	return isipc(src) || ispreternis(src)
 
 /mob/living/carbon/human/consume_power_from(amount)
 	if((nutrition - amount) < NUTRITION_LEVEL_HUNGRY)
 		amount = max(charge - NUTRITION_LEVEL_HUNGRY, 0)
 	adjust_nutrition(-amount)
 	return amount
-	
+
 //CELL//
 /obj/item/stock_parts/cell/can_consume_power_from()
 	if(charge < MIN_DRAINABLE_POWER)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/power_suck.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/power_suck.dm
@@ -108,6 +108,16 @@
 
 #define MIN_DRAINABLE_POWER 10
 
+//IPC lol, lmao
+/mob/living/carbon/human/can_consume_power_from()
+	return isipc(src)
+
+/mob/living/carbon/human/consume_power_from(amount)
+	if((nutrition - amount) < NUTRITION_LEVEL_HUNGRY)
+		amount = max(charge - NUTRITION_LEVEL_HUNGRY, 0)
+	adjust_nutrition(-amount)
+	return amount
+	
 //CELL//
 /obj/item/stock_parts/cell/can_consume_power_from()
 	if(charge < MIN_DRAINABLE_POWER)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/power_suck.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/power_suck.dm
@@ -114,7 +114,7 @@
 
 /mob/living/carbon/human/consume_power_from(amount)
 	if((nutrition - amount) < NUTRITION_LEVEL_HUNGRY)
-		amount = max(charge - NUTRITION_LEVEL_HUNGRY, 0)
+		amount = max(nutrition - NUTRITION_LEVEL_HUNGRY, 0)
 	adjust_nutrition(-amount)
 	return amount
 

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/power_suck.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/power_suck.dm
@@ -110,7 +110,7 @@
 
 //IPC lol, lmao
 /mob/living/carbon/human/can_consume_power_from()
-	return isipc(src) || ispreternis(src)
+	return HAS_TRAIT(src, TRAIT_POWERHUNGRY)
 
 /mob/living/carbon/human/consume_power_from(amount)
 	if((nutrition - amount) < NUTRITION_LEVEL_HUNGRY)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/power_suck.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/power_suck.dm
@@ -113,8 +113,8 @@
 	return HAS_TRAIT(src, TRAIT_POWERHUNGRY)
 
 /mob/living/carbon/human/consume_power_from(amount)
-	if((nutrition - amount) < NUTRITION_LEVEL_HUNGRY)
-		amount = max(nutrition - NUTRITION_LEVEL_HUNGRY, 0)
+	if((nutrition - amount) < NUTRITION_LEVEL_STARVING)
+		amount = max(nutrition - NUTRITION_LEVEL_STARVING, 0)
 	adjust_nutrition(-amount)
 	return amount
 


### PR DESCRIPTION
# Why is this good for the game?
They can steal power from mechs, borgs, you name it, what's one more robot

:cl:  
rscadd: Preterni can recharge using other electricity using species
/:cl:
