### PR TITLE
Research access restrictions can be hacked

### DIFF
--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -362,7 +362,7 @@
 		if(build_path == /obj/item/circuitboard/computer/rdconsole/production)
 			to_chat(user, span_danger("[src] sparks! That isn't right."))
 			var/datum/effect_system/spark_spread/p = new /datum/effect_system/spark_spread
-			p.set_up(12, 1, user)
+			p.set_up(6, 1, user)
 			p.start()
 		if(build_path == /obj/machinery/computer/rdconsole/core)
 			name = "R&D Console - Robotics (Computer Board)"
@@ -374,6 +374,12 @@
 			to_chat(user, span_notice("Defaulting access protocols."))
 
 /obj/item/circuitboard/computer/rdconsole/screwdriver_act(mob/living/user, obj/item/I)
+	if(build_path != /obj/item/circuitboard/computer/rdconsole/production)
+		to_chat(user, span_danger("[src] sparks! That isn't right."))
+		var/datum/effect_system/spark_spread/p = new /datum/effect_system/spark_spread
+		p.set_up(6, 1, user)
+		p.start()
+		return TRUE
 	if(unlocked)
 		to_chat(user, span_notice("It seems to have a deep groove cutting some traces. Maybe welding it will help?"))
 		return TRUE
@@ -382,7 +388,9 @@
 		to_chat(user, span_notice("You scrape a deep groove into some of the traces, severing them."))
 
 
-/obj/item/circuitboard/computer/rdconsole/welder_act(mob/living/user, obj/item/I)	
+/obj/item/circuitboard/computer/rdconsole/welder_act(mob/living/user, obj/item/I)
+	if(build_path != /obj/item/circuitboard/computer/rdconsole/production)
+		return
 	if(!unlocked)
 		return TRUE
 	if(!I.tool_start_check(user, amount=0))

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -344,6 +344,7 @@
 	name = "R&D Console (Computer Board)"
 	icon_state = "science"
 	build_path = /obj/machinery/computer/rdconsole/core
+	var/unlocked = FALSE
 
 /obj/item/circuitboard/computer/rdconsole/ruin
 	name = "Experimental R&D Console (Computer Board)"
@@ -353,12 +354,16 @@
 /obj/item/circuitboard/computer/rdconsole/production
 	name = "R&D Console Production Only (Computer Board)"
 	build_path = /obj/machinery/computer/rdconsole/production
-
-
-/obj/item/circuitboard/computer/rdconsole/attackby(obj/item/I, mob/user, params)
-	if(I.tool_behaviour == TOOL_SCREWDRIVER)
-		if(build_path == /obj/machinery/computer/rdconsole/production)
-			return
+	
+/obj/item/circuitboard/computer/rdconsole/multitool_act(mob/living/user, obj/item/I)
+	. = ..()
+	visible_message("[user] fiddles with [src].", "You fiddle with [src].")
+	if(I.use_tool(src, user, 2 SECONDS, volume = 75))
+		if(build_path == /obj/item/circuitboard/computer/rdconsole/production)
+			to_chat(user, span_danger("[src] sparks! That isn't right."))
+			var/datum/effect_system/spark_spread/p = new /datum/effect_system/spark_spread
+			p.set_up(12, 1, user)
+			p.start()
 		if(build_path == /obj/machinery/computer/rdconsole/core)
 			name = "R&D Console - Robotics (Computer Board)"
 			build_path = /obj/machinery/computer/rdconsole/robotics
@@ -367,8 +372,25 @@
 			name = "R&D Console (Computer Board)"
 			build_path = /obj/machinery/computer/rdconsole/core
 			to_chat(user, span_notice("Defaulting access protocols."))
-	else
-		return ..()
+
+/obj/item/circuitboard/computer/rdconsole/screwdriver_act(mob/living/user, obj/item/I)
+	if(unlocked)
+		to_chat(user, span_notice("It seems to have a deep groove cutting some traces. Maybe welding it will help?"))
+		return TRUE
+	if(I.use_tool(src, user, 2 SECONDS, volume = 75))
+		unlocked = TRUE
+		to_chat(user, span_notice("You scrape a deep groove into some of the traces, severing them."))
+
+
+/obj/item/circuitboard/computer/rdconsole/welder_act(mob/living/user, obj/item/I)	
+	if(!unlocked)
+		return TRUE
+	if(!I.tool_start_check(user, amount=0))
+		return TRUE
+	if(I.use_tool(src, user, 2 SECONDS, volume = 75))
+		unlocked = FALSE
+		to_chat(user, span_notice("You melt the solder back into place, restoring the connections in the traces."))	
+	
 
 /obj/item/circuitboard/computer/rdservercontrol
 	name = "R&D Server Control (Computer Board)"

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -357,7 +357,7 @@
 	
 /obj/item/circuitboard/computer/rdconsole/multitool_act(mob/living/user, obj/item/I)
 	. = ..()
-	visible_message("[user] fiddles with [src].", "You fiddle with [src].")
+	user.visible_message(span_notice("[user] fiddles with [src]."), span_notice( "You fiddle with [src]."))
 	if(I.use_tool(src, user, 2 SECONDS, volume = 75))
 		if(build_path == /obj/item/circuitboard/computer/rdconsole/production)
 			to_chat(user, span_danger("[src] sparks! That isn't right."))

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -33,7 +33,8 @@ Nothing else in the console has ID requirements.
 	//UI VARS
 	var/screen = RDSCREEN_MENU
 	var/back = RDSCREEN_MENU
-	var/locked = FALSE
+	var/locked = FALSE ///if the actual console is locked down, nobody can access it
+	var/anyone_can_research = FALSE
 	var/tdisk_uple = FALSE
 	var/ddisk_uple = FALSE
 	var/datum/selected_node_id
@@ -95,6 +96,8 @@ Nothing else in the console has ID requirements.
 	stored_research = SSresearch.science_tech
 	stored_research.consoles_accessing[src] = TRUE
 	matching_design_ids = list()
+	var/obj/item/circuitboard/computer/rdconsole/board = circuit
+	anyone_can_research = board.unlocked
 	SyncRDevices()
 
 /obj/machinery/computer/rdconsole/Destroy()
@@ -238,7 +241,7 @@ Nothing else in the console has ID requirements.
 	l += "[sheet.css_tag()][RDSCREEN_NOBREAK]"
 	l += "<div class='statusDisplay'><b>[stored_research.organization] Research and Development Network</b>"
 	l += "Available points: <BR>[techweb_point_display_rdconsole(stored_research.research_points, stored_research.last_bitcoins)]"
-	l += "Security protocols: [obj_flags & EMAGGED ? "<font color='red'>Disabled</font>" : "<font color='green'>Enabled</font>"]"
+	l += "Security protocols: [obj_flags & EMAGGED ? "<font color='red'>Disabled</font>" : (anyone_can_research ? "<font color='yellow'>Timed Out</font>" : "<font color='green'>Enabled</font>")]"
 	l += "<a href='?src=[REF(src)];switch_screen=[RDSCREEN_MENU]'>Main Menu</a> | <a href='?src=[REF(src)];switch_screen=[back]'>Back</a></div>[RDSCREEN_NOBREAK]"
 	l += "[ui_mode == 1? span_linkOn("Normal View") : "<a href='?src=[REF(src)];ui_mode=1'>Normal View</a>"] | [ui_mode == 2? span_linkOn("Expert View") : "<a href='?src=[REF(src)];ui_mode=2'>Expert View</a>"] | [ui_mode == 3? span_linkOn("List View") : "<a href='?src=[REF(src)];ui_mode=3'>List View</a>"]"
 	return l
@@ -706,7 +709,7 @@ Nothing else in the console has ID requirements.
 	return icon2html(initial(item.icon), usr, initial(item.icon_state), SOUTH)
 
 /obj/machinery/computer/rdconsole/proc/can_research(mob/user)
-	if(!locked && (allowed(user) || (obj_flags & EMAGGED)))
+	if(!locked && (allowed(user) || (obj_flags & EMAGGED) || anyone_can_research))
 		return TRUE
 	return FALSE
 
@@ -987,7 +990,7 @@ Nothing else in the console has ID requirements.
 		disk_slot_selected = text2num(ls["disk_slot"])
 	if(ls["research_node"])
 		if(!can_research(usr))
-			to_chat(usr, "ACCESS DENIED")
+			to_chat(usr, span_danger("Access Denied."))
 			return
 		if(!research_control)
 			return				//honestly should call them out for href exploiting :^)


### PR DESCRIPTION
# Document the changes in your pull request

A while we locked research access behind science access. this is good because we don't want HOS doing science's job and researching all their stuff. Later, we added an emagged option for traitors. This adds a third option for antags that aren't traitors.

You can deconstruct the machine and use a screwdriver on the board to jailbreak it (kinda like the contraband for cargo console). Welding it will restore the access. This adds another way for people to approach this besides an emag, and it's sufficiently shifty that it's technically sabotage. Also makes this a WORSE option than emagging, as you're still messing with it publicly but this takes 20+ seconds to do instead of the instant an emag takes.

**This is only for production type boards, so it's specifically the one in science, not the one in engineering (break into science)**

Type changes are now in the multitool act.

# Why is this good for the game?
Stopping research kneecaps lowpop/no-science rounds way harder than HOS being a bitch has. Fix both problems with one stone

# Testing
I gotta

# Wiki Documentation

Needs to be added the ways the access can change

# Changelog

:cl:  ToasterBiome, Someguymanperson
tweak: Research circuit boards in R&D can be "hacked" with a screwdriver to unlock access.
/:cl:
