### PR TITLE
Atheist's Fedora can no longer embed (+ one extra attack verb for shits and giggles)

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -655,7 +655,7 @@
 	throwforce = 30
 	sharpness = SHARP_EDGED
 	embedding = list("embed_chance" = 0)
-	attack_verb = list("enlightened", "redpilled")
+	attack_verb = list("enlightened", "redpilled", "m'lady'ed")
 	menutab = MENU_CLOTHING
 	additional_desc = "This gaudy hat has surprisingly good weight distribution, you could probably throw it very effectively."
 

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -654,6 +654,7 @@
 	throw_range = 7
 	throwforce = 30
 	sharpness = SHARP_EDGED
+	embedding = list("embed_chance" = 0)
 	attack_verb = list("enlightened", "redpilled")
 	menutab = MENU_CLOTHING
 	additional_desc = "This gaudy hat has surprisingly good weight distribution, you could probably throw it very effectively."


### PR DESCRIPTION
# Document the changes in your pull request

Makes the Atheist's Fedora null rod unable to embed itself into people, as well as adding a new "m'lady'ed" attack verb.

# Why is this good for the game?

Buffs the fedora to be slightly more usable, even without the possibility of your weapon embedding into your opponent and becoming unusable, it's still very impractical and prone to being caught/picked up, so why not make it easier to use.

# Testing

EDIT 2: Now actually tested, it workies

# Spriting

N/A

# Wiki Documentation

If the chaplain wiki page mentions the Fedora can embed itself into people, get rid of that.

# Changelog
:cl:
tweak: Dials back Atheist's Fedora users red pill prescription, allowing them to throw their fedora without it embedding into people.
/:cl:
