### PR TITLE
Fixes a null loc bug with lings' Last Stand spell

### DIFF
--- a/code/modules/antagonists/changeling/powers/headcrab.dm
+++ b/code/modules/antagonists/changeling/powers/headcrab.dm
@@ -11,10 +11,12 @@
 
 /datum/action/changeling/headcrab/sting_action(mob/living/user)
 	set waitfor = FALSE
+	if(tgui_alert(user,"Are we sure we wish to kill ourself and create a headslug?",,list("Yes", "No")) != "Yes")
+		return
+	if(QDELETED(user)) // Yogs: Implies maybe that the user was already gibbed or something. Prevents a null mob loc later on
+		return
 	if(ismob(user.pulledby) && is_changeling(user.pulledby) && user.pulledby.grab_state >= GRAB_NECK)
 		to_chat(user, span_warning("Our abilities are being dampened! We cannot use [src]!"))
-		return
-	if(tgui_alert(usr,"Are we sure we wish to kill ourself and create a headslug?",,list("Yes", "No")) != "Yes")
 		return
 	..()
 	var/datum/mind/M = user.mind


### PR DESCRIPTION
![image](https://github.com/yogstation13/Yogstation/assets/29939414/4d29d475-45f6-4505-b11b-346850292c6e)
Fixes #19916 :)
Hi guys! I return like a roaming cowboy.
Doing a small bug fix while I get used to working on this codebase again. A classic "the state of the game changes between the function being called and `alert()` finally returning something from the user" sort of scenario.

### Changelog
:cl: Altoids
bugfix: Fixed being able to use Last Stand as Changeling to get a null loc. No rubies for you!
/:cl:
