### PR TITLE
Demons of Sin have been purified(removed)

### DIFF
--- a/code/modules/events/sinfuldemon.dm
+++ b/code/modules/events/sinfuldemon.dm
@@ -2,7 +2,7 @@
 	name = "Create Demon of Sin"
 	typepath = /datum/round_event/ghost_role/sinfuldemon
 	max_occurrences = 2 //misery loves company
-	weight = 5 //50% less likely to happen compared to most events
+	weight = 0 //50% less likely to happen compared to most events
 	min_players = 15
 	earliest_start = 20 MINUTES
 


### PR DESCRIPTION
# Document the changes in your pull request

Demons of Sin have finally been purged from touching the holy grail that is the Station, some invisible barrier prevents them from entering it. In seriousness though, due to the recent vote, demons of sin are now just noob-bait and with them now being PTE. They are just a pointless mid-round roll. Regardless of being "stealthy" or not, they will get executed on sight due to their demon form and the fact that all of them don't have any actual kill objectives (Even wrath says not to quickly murder) makes it even more shitty for them to play.

Demon of Sin players will end up either doing nothing all round or doing one thing and dying. So, until then. We shouldn't have them playable.

# Why is this good for the game?
Stops new players and anyone from getting speedran into dying within the first 5 minutes which is good because it means players won't leave because they got instant-killed by the hungry sec needing that sweet release of serotonin when they redtext an antag. 

# Changelog
:cl:  

tweak: Demons of Sin rolling weight is 0 now because they got purified.

/:cl:
