### PR TITLE
Fixes IPCs taking 3x more damage in crit than intended

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -265,7 +265,7 @@
 		if(H.mind?.has_martialart(MARTIALART_ULTRAVIOLENCE))
 			H.death() // YOU'RE GETTING RUSTY, MACHINE!!
 			return .
-		H.adjustFireLoss(6) // After bodypart_robotic resistance this is ~2/second
+		H.adjustFireLoss(2) // someone forgor IPCs don't have damage reduction
 		if(prob(5))
 			to_chat(H, "<span class='warning'>Alert: Internal temperature regulation systems offline; thermal damage sustained. Shutdown imminent.</span>")
 			H.visible_message("[H]'s cooling system fans stutter and stall. There is a faint, yet rapid beeping coming from inside their chassis.")


### PR DESCRIPTION
# Document the changes in your pull request

IPCs were meant to take 2 burn damage per tick when in crit but whoever added them thought they had the 4 burn damage reduction cyborg limbs have and made it 6 damage instead to counteract it, so they just take 3x as much damage for no reason because of an oversight.

![image](https://github.com/yogstation13/Yogstation/assets/93578146/075f73f0-7eb3-4545-a657-889b1407207f)

This fixes that.

# Why is this good for the game?

IPC crit damage being this high is unintentional and kinda wack (6 damage/tick, holy hell)

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: fixed IPCs taking 3x more damage in crit than intended
/:cl:
