### PR TITLE
Preterni get cooked less by trying to not starve

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/power_suck.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/power_suck.dm
@@ -81,7 +81,7 @@
 					to_chat(H, span_info("[A]'s power has been depleted, CONSUME protocol halted."))
 					done = TRUE
 
-				H.adjust_bodytemperature(drained * (1 - ELECTRICITY_TO_NUTRIMENT_FACTOR)) //the extra electricity becomes heat, they aren't suited to charging from non-vxtrin power sources
+				H.adjust_bodytemperature(drained * (1 - ELECTRICITY_TO_NUTRIMENT_FACTOR) /2) //the extra electricity becomes heat, they aren't suited to charging from non-vxtrin power sources
 				drained *= ELECTRICITY_TO_NUTRIMENT_FACTOR //loss of efficiency
 
 				if(H.nutrition + drained > NUTRITION_LEVEL_FAT)


### PR DESCRIPTION
# Why is this good for the game?
i guess it's probably bad for them to take damage from doing normal amounts of eating

:cl:  
tweak: Preterni only get 1/2 the heat from charging
/:cl:
