### PR TITLE
Go back to school Wardens

### DIFF
--- a/code/modules/jobs/job_types/warden.dm
+++ b/code/modules/jobs/job_types/warden.dm
@@ -12,7 +12,7 @@
 	supervisors = "the head of security"
 	selection_color = "#ffeeee"
 	minimal_player_age = 7
-	exp_requirements = 300
+	exp_requirements = 600
 	exp_type = EXP_TYPE_CREW
 	exp_type_department = EXP_TYPE_SECURITY
 


### PR DESCRIPTION
# Document the changes in your pull request

This should of been done a while ago, but better late than never. 5 hours is a really short req time for someone to unlock warden considering it is a fairly important role. They have to make sure prisoners are processed right, make sure brig is safe, know when to open armoury depending on alerts and to ensure Sec don't get too out of control for their hunger for stun-battoning. Which requires a lot more time than roughly five rounds, this also makes sure that a warden at least has better knowledge of space law too before jumping straight into that role.

# Why is this good for the game?

The increased time Req means that Sec players will have a better understanding of Space Law, how the brig works and how armoury is ran which is very needed. The only next step to make Warden a better role is to add a gibbing effect if they leave the brig but I will get bonked for that so for now. Have this.

# Changelog

:cl:  

tweak: Increased Req to unlock Warden job role from 5hrs to 10hrs

/:cl:
