### PR TITLE
Fix unnable to put screwdriver into deconstructive analyzer or autolathe

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -184,8 +184,10 @@
 	materials.retrieve_all()
 
 /obj/machinery/autolathe/attackby(obj/item/O, mob/user, params)
-	if(default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O))
-		return TRUE
+	if(istype(O, /obj/item/screwdriver))
+		var/choice = tgui_alert(user, "Do you want to open/close the maintenance hatch of the [src]?",,list("Proceed", "Abort"))
+		if(choice=="Proceed" && default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O))
+			return TRUE
 
 	if(default_deconstruction_crowbar(O))
 		return TRUE

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -184,10 +184,8 @@
 	materials.retrieve_all()
 
 /obj/machinery/autolathe/attackby(obj/item/O, mob/user, params)
-	if(istype(O, /obj/item/screwdriver))
-		var/choice = tgui_alert(user, "Do you want to open/close the maintenance hatch of the [src]?",,list("Proceed", "Abort"))
-		if(choice=="Proceed" && default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O))
-			return TRUE
+	if(user.a_intent == INTENT_DISARM && default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O))
+		return TRUE
 
 	if(default_deconstruction_crowbar(O))
 		return TRUE

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -184,7 +184,7 @@
 	materials.retrieve_all()
 
 /obj/machinery/autolathe/attackby(obj/item/O, mob/user, params)
-	if(user.a_intent == INTENT_DISARM && default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O))
+	if(default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O))
 		return TRUE
 
 	if(default_deconstruction_crowbar(O))
@@ -194,7 +194,7 @@
 		wires.interact(user)
 		return TRUE
 
-	if(user.a_intent == INTENT_HARM) //so we can hit the machine
+	if(user.a_intent == INTENT_HARM || user.a_intent == INTENT_DISARM) //so we can hit the machine or put item in it
 		return ..()
 
 	if(stat)

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -184,7 +184,7 @@
 	materials.retrieve_all()
 
 /obj/machinery/autolathe/attackby(obj/item/O, mob/user, params)
-	if(default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O))
+	if(user.a_intent == INTENT_DISARM && default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O))
 		return TRUE
 
 	if(default_deconstruction_crowbar(O))
@@ -193,9 +193,6 @@
 	if(panel_open && is_wire_tool(O))
 		wires.interact(user)
 		return TRUE
-
-	if(user.a_intent == INTENT_HARM || user.a_intent == INTENT_DISARM) //so we can hit the machine or put item in it
-		return ..()
 
 	if(stat)
 		return TRUE

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -31,6 +31,16 @@ Note: Must be placed within 3 tiles of the R&D Console
 	linked_console.linked_destroy = null
 	..()
 
+/obj/machinery/rnd/destructive_analyzer/screwdriver_act(mob/living/user, obj/item/I)
+	if(..())
+		return TRUE
+	var/choice = tgui_alert(user, "Do you want to open/close the maintenance hatch of the [src]?",,list("Proceed", "Abort"))
+	if(choice=="Proceed")
+		return FALSE
+	else
+		Insert_Item(I, user)
+	return TRUE
+
 /obj/machinery/rnd/destructive_analyzer/Insert_Item(obj/item/O, mob/user)
 	if(user.a_intent != INTENT_HARM)
 		. = 1

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -34,8 +34,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 /obj/machinery/rnd/destructive_analyzer/screwdriver_act(mob/living/user, obj/item/I)
 	if(..())
 		return TRUE
-	var/choice = tgui_alert(user, "Do you want to open/close the maintenance hatch of the [src]?",,list("Proceed", "Abort"))
-	if(choice=="Proceed")
+	if(user.a_intent == INTENT_DISARM)
 		return FALSE
 	else
 		Insert_Item(I, user)

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -34,7 +34,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 /obj/machinery/rnd/destructive_analyzer/screwdriver_act(mob/living/user, obj/item/I)
 	if(..())
 		return TRUE
-	if(user.a_intent == INTENT_DISARM)
+	if(user.a_intent != INTENT_DISARM)
 		return FALSE
 	else
 		Insert_Item(I, user)

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -34,7 +34,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 /obj/machinery/rnd/destructive_analyzer/screwdriver_act(mob/living/user, obj/item/I)
 	if(..())
 		return TRUE
-	if(user.a_intent != INTENT_DISARM)
+	if(user.a_intent == INTENT_DISARM)
 		return FALSE
 	else
 		Insert_Item(I, user)


### PR DESCRIPTION
# Document the changes in your pull request
Fix unnable to put screwdriver into deconstructive analyzer or autolathe, you will now have to use disarm intent to open/close panel and help intent to put the screw in.


# Testing

![screw](https://github.com/yogstation13/Yogstation/assets/89688125/b777ec4c-bb07-4153-a628-1bb4075e5dea)






# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

bugfix: Fix unnable to put screwdriver into deconstructive analyzer or autolathe, you will now have to use disarm intent to open/close panel and help intent to put the screw in.
/:cl:
