### PR TITLE
Nerfs wizard taser (mjolnir)

### DIFF
--- a/code/game/objects/items/singularityhammer.dm
+++ b/code/game/objects/items/singularityhammer.dm
@@ -139,4 +139,4 @@
 			new /obj/structure/mjollnir(loc)
 			qdel(src)
 		else
-			shock(hit_atom, 0)
+			shock(hit_atom, 0 SECONDS)

--- a/code/game/objects/items/singularityhammer.dm
+++ b/code/game/objects/items/singularityhammer.dm
@@ -107,24 +107,8 @@
 	. = ..()
 	icon_state = "[base_icon_state]0"
 
-//normal hit
-
-/obj/item/mjolnir/proc/shock(mob/living/target)
-	target.Stun(20)
-	target.Knockdown(50)
-	var/datum/effect_system/lightning_spread/s = new /datum/effect_system/lightning_spread
-	s.set_up(5, 1, target.loc)
-	s.start()
-	target.visible_message(span_danger("[target.name] was shocked by [src]!"), \
-		span_userdanger("You feel a powerful shock course through your body sending you flying!"), \
-		span_italics("You hear a heavy electrical crack!"))
-	var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
-	target.throw_at(throw_target, 200, 4)
-	return
-
-//throw hit
-
-/obj/item/mjolnir/proc/throwshock(mob/living/target)
+/obj/item/mjolnir/proc/shock(mob/living/target, StunDuration)
+	target.Stun(StunDuration)
 	target.Knockdown(50)
 	var/datum/effect_system/lightning_spread/s = new /datum/effect_system/lightning_spread
 	s.set_up(5, 1, target.loc)
@@ -140,7 +124,7 @@
 	..()
 	if(HAS_TRAIT(src, TRAIT_WIELDED))
 		playsound(loc, "sparks", 50, 1)
-		shock(M)
+		shock(M, 20)
 
 /obj/item/mjolnir/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()
@@ -155,4 +139,4 @@
 			new /obj/structure/mjollnir(loc)
 			qdel(src)
 		else
-			throwshock(hit_atom)
+			shock(hit_atom, 0)

--- a/code/game/objects/items/singularityhammer.dm
+++ b/code/game/objects/items/singularityhammer.dm
@@ -124,7 +124,7 @@
 	..()
 	if(HAS_TRAIT(src, TRAIT_WIELDED))
 		playsound(loc, "sparks", 50, 1)
-		shock(M, 20)
+		shock(M, 2 SECONDS)
 
 /obj/item/mjolnir/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	. = ..()

--- a/code/game/objects/items/singularityhammer.dm
+++ b/code/game/objects/items/singularityhammer.dm
@@ -109,7 +109,7 @@
 
 /obj/item/mjolnir/proc/shock(mob/living/target, StunDuration)
 	target.Stun(StunDuration)
-	target.Knockdown(50)
+	target.Knockdown(5 SECONDS)
 	var/datum/effect_system/lightning_spread/s = new /datum/effect_system/lightning_spread
 	s.set_up(5, 1, target.loc)
 	s.start()

--- a/code/game/objects/items/singularityhammer.dm
+++ b/code/game/objects/items/singularityhammer.dm
@@ -107,8 +107,25 @@
 	. = ..()
 	icon_state = "[base_icon_state]0"
 
+//normal hit
+
 /obj/item/mjolnir/proc/shock(mob/living/target)
-	target.Stun(60)
+	target.Stun(20)
+	target.Knockdown(50)
+	var/datum/effect_system/lightning_spread/s = new /datum/effect_system/lightning_spread
+	s.set_up(5, 1, target.loc)
+	s.start()
+	target.visible_message(span_danger("[target.name] was shocked by [src]!"), \
+		span_userdanger("You feel a powerful shock course through your body sending you flying!"), \
+		span_italics("You hear a heavy electrical crack!"))
+	var/atom/throw_target = get_edge_target_turf(target, get_dir(src, get_step_away(target, src)))
+	target.throw_at(throw_target, 200, 4)
+	return
+
+//throw hit
+
+/obj/item/mjolnir/proc/throwshock(mob/living/target)
+	target.Knockdown(50)
 	var/datum/effect_system/lightning_spread/s = new /datum/effect_system/lightning_spread
 	s.set_up(5, 1, target.loc)
 	s.start()
@@ -138,4 +155,4 @@
 			new /obj/structure/mjollnir(loc)
 			qdel(src)
 		else
-			shock(hit_atom)
+			throwshock(hit_atom)


### PR DESCRIPTION
# Document the changes in your pull request
mjolnir now only stuns for 2 seconds and has a 5 second knockdown
mjolnir now only applies a 5 second knockdown on throw hits


# Why is this good for the game?
its straight up a taser for 2 points. this thing is way too strong and unfun to play against. now you need to get in close to deal your stunlocks and has more leeway for the person receiving punishment

# Testing

worked fine on my testing

# Wiki Documentation

wiki doesn't state stun times on the hammer

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Mjolnir now applies a 2 second stun and 5 second knockdown on normal hits
tweak: Mjolnir no longer stuns on throw hits, only applies a 5 second knockdown
/:cl:
