### PR TITLE
Adds a single chem heater board to secure tech storage.

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -704,7 +704,8 @@
 				/obj/item/circuitboard/machine/smoke_machine,
 				/obj/item/circuitboard/machine/chem_master,
 				/obj/item/circuitboard/machine/clonescanner,
-				/obj/item/circuitboard/computer/pandemic
+				/obj/item/circuitboard/computer/pandemic,
+				/obj/item/circuitboard/machine/chem_heater
 				)
 
 /obj/effect/spawner/lootdrop/techstorage/AI


### PR DESCRIPTION
# Document the changes in your pull request

Adds a single chemical heater board to the secure tech storage medical board spawner. This should cause it to spawn on any maps that have a secure tech storage.

# Why is this good for the game?

If chemistry is destroyed, or if you want to steal a chemistry setup you can quite reasonably make or rebuild the chem master but the chemical heater doesn't have a provided board. This means you can be in an unfortunate position of only being able to rebuild some of the required machines for chemistry to function.

Adding one board to secure storage allows an engineer to rebuild chemistry once without needing to wait around on research, or it allows for an opportunistic antagonist to build a full chemistry setup provided they can get their hands onto the boards. 

Overall it's a small change that fills in a gap for board avaliability.

# Testing
Tested to see if the change to the loot pool would cause the additional board to spawn on yogstation within the secure tech storage. 

# Changelog

:cl:  
rscadd: Added a chemical heater board to secure storage 
/:cl:
