### PR TITLE
Fixes the flesh heretic upgraded mansus grasp

### DIFF
--- a/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
+++ b/code/modules/antagonists/eldritch_cult/knowledge/flesh_lore.dm
@@ -109,7 +109,6 @@
 	SIGNAL_HANDLER
 
 	if(isliving(target))
-		. = TRUE
 		var/mob/living/living_target = target
 		living_target.apply_status_effect(/datum/status_effect/eldritch/flesh)
 


### PR DESCRIPTION
# Document the changes in your pull request

Removes a line that prevented the flesh heretic grasp from properly functioning once the tier 2 mark had been researched.

Before this fix once the mark had been obtained it'd replace the mansus grasps knockdown and stamina damage with a mark instead of adding the mark ontop of the effect.

# Testing
I murdered a felinid with my now functioning mansus grasp.

# Changelog

:cl:  
bugfix: The flesh heretic "Lover's Exsanguination" research no longer breaks their mansus grasp.
/:cl:
