### PR TITLE
Lets nukies and clownops buy species restricted items

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2250,7 +2250,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 //Race-specific items
 /datum/uplink_item/race_restricted
 	category = "Species-Restricted"
-	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 	surplus = 0
 
 /datum/uplink_item/race_restricted/syndilamp


### PR DESCRIPTION
# Why is this good for the game?
If an admin wants to bus nukies as a specific species, this will allow those species to buy their special items
It won't otherwise affect nukies

:cl:  
tweak: Lets nukies and clownops buy species restricted items if species swapped by an admin
/:cl:
