### PR TITLE
Medhud examine of implants now splits them into individual lines

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -451,7 +451,7 @@
 					var/cyberimp_detect
 					for(var/obj/item/organ/cyberimp/CI in internal_organs)
 						if(CI.status == ORGAN_ROBOTIC && !CI.syndicate_implant)
-							cyberimp_detect += "[name] is modified with a [CI.name]."
+							cyberimp_detect += "[name] is modified with a [CI.name].\n"
 					if(cyberimp_detect)
 						. += "Detected cybernetic modifications:"
 						. += cyberimp_detect


### PR DESCRIPTION
# Why is this good for the game?
Hard to read a giant blob of text compared to orderly lines

:cl:  
tweak: Medhud examine of implants now splits them into individual lines
/:cl:
