### PR TITLE
All megafauna leave items when dusting a miner + always drop gib

### DIFF
--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -1,12 +1,11 @@
 GLOBAL_VAR_INIT(permadeath, FALSE)
 
-/mob/living/proc/gib(no_brain, no_organs, no_bodyparts, drop_items)
+/mob/living/proc/gib(no_brain, no_organs, no_bodyparts)
 	var/prev_lying = lying
 	if(stat != DEAD)
 		death(TRUE)
 
-	if(drop_items)
-		unequip_everything()
+	unequip_everything()
 
 	if(!prev_lying)
 		gib_animation()

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -17,7 +17,7 @@ GLOBAL_VAR_INIT(permadeath, FALSE)
 		spread_bodyparts(no_brain, no_organs)
 
 	spawn_gibs(no_bodyparts)
-	SEND_SIGNAL(src, COMSIG_LIVING_GIBBED, no_brain, no_organs, no_bodyparts, drop_items)
+	SEND_SIGNAL(src, COMSIG_LIVING_GIBBED, no_brain, no_organs, no_bodyparts)
 	qdel(src)
 
 /mob/living/proc/gib_animation()

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -1,9 +1,12 @@
 GLOBAL_VAR_INIT(permadeath, FALSE)
 
-/mob/living/proc/gib(no_brain, no_organs, no_bodyparts)
+/mob/living/proc/gib(no_brain, no_organs, no_bodyparts, drop_items)
 	var/prev_lying = lying
 	if(stat != DEAD)
 		death(TRUE)
+
+	if(drop_items)
+		unequip_everything()
 
 	if(!prev_lying)
 		gib_animation()

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -17,7 +17,7 @@ GLOBAL_VAR_INIT(permadeath, FALSE)
 		spread_bodyparts(no_brain, no_organs)
 
 	spawn_gibs(no_bodyparts)
-	SEND_SIGNAL(src, COMSIG_LIVING_GIBBED, no_brain, no_organs, no_bodyparts)
+	SEND_SIGNAL(src, COMSIG_LIVING_GIBBED, no_brain, no_organs, no_bodyparts, drop_items)
 	qdel(src)
 
 /mob/living/proc/gib_animation()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -226,7 +226,7 @@ Difficulty: Very Hard
 
 /mob/living/simple_animal/hostile/megafauna/colossus/devour(mob/living/L)
 	visible_message(span_colossus("[src] disintegrates [L]!"))
-	L.dust()
+	L.dust(drop_items = TRUE)
 
 /obj/effect/temp_visual/at_shield
 	name = "anti-toolbox field"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -418,13 +418,10 @@ Difficulty: Hard
 	. = ..()
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/devour(mob/living/L)
-	for(var/obj/item/W in L)
-		if(!L.dropItemToGround(W))
-			qdel(W)
 	visible_message("[span_hierophant_warning("\"[pick(kill_phrases)]\"")]")
 	visible_message("[span_hierophant_warning("[src] annihilates [L]!")]",span_userdanger("You annihilate [L], restoring your health!"))
 	adjustHealth(-L.maxHealth*0.5)
-	L.dust()
+	L.dust(drop_items = TRUE)
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/CanAttack(atom/the_target)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -119,7 +119,7 @@
 		span_userdanger("You feast on [L], restoring your health!"))
 	if(!is_station_level(z) || client) //NPC monsters won't heal while on station
 		adjustBruteLoss(-L.maxHealth/2)
-	L.gib()
+	L.gib(drop_items = TRUE)
 	return TRUE
 
 /mob/living/simple_animal/hostile/megafauna/ex_act(severity, target)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -119,7 +119,7 @@
 		span_userdanger("You feast on [L], restoring your health!"))
 	if(!is_station_level(z) || client) //NPC monsters won't heal while on station
 		adjustBruteLoss(-L.maxHealth/2)
-	L.gib(drop_items = TRUE)
+	L.gib()
 	return TRUE
 
 /mob/living/simple_animal/hostile/megafauna/ex_act(severity, target)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/stalwart.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/stalwart.dm
@@ -397,4 +397,4 @@
 
 /mob/living/simple_animal/hostile/megafauna/stalwart/devour(mob/living/L)
 	visible_message(span_danger("[src] atomizes [L]!"))
-	L.dust()
+	L.dust(drop_items = TRUE)


### PR DESCRIPTION
# Why is this good for the game?
Because it's both funny to see a pile of loot on the ground, and also annoying having no clue what happened to a miner that just suddenly disappeared from sensors

Some megafauna already worth this way, not all though

:cl:  
tweak: All megafauna leave items when dusting a miner
tweak: gibbing always leaves the victim's items
/:cl:
