### PR TITLE
Nerfs lichdom holoparasite combo

### DIFF
--- a/code/datums/components/phylactery.dm
+++ b/code/datums/components/phylactery.dm
@@ -215,5 +215,14 @@
 			body_turf.Beam(parent_turf, icon_state = "lichbeam", time = 1 SECONDS * (num_resurrections + 1))
 
 		corpse.dust(drop_items = TRUE)
+	
+	var/list/guardians = lich.hasparasites()
+	if(guardians)
+		for(var/mob/living/simple_animal/hostile/guardian/G in guardians)
+			if(istype(G))
+				var/datum/guardian_stats/stats = G.stats
+				stats.weaken(4)//-4 stats each death
+				stats.Unapply(G)
+				stats.Apply(G)
 
 	return TRUE

--- a/yogstation/code/modules/guardian/guardian.dm
+++ b/yogstation/code/modules/guardian/guardian.dm
@@ -197,12 +197,12 @@ GLOBAL_LIST_INIT(guardian_projectile_damage, list(
 				forceMove(summoner.current)
 				to_chat(src, span_userdanger("Your summoner has died!"))
 				visible_message(span_bolddanger("[src] dies along with its user!"))
-				summoner.current.visible_message(span_bolddanger("[summoner.current]'s body is completely consumed by the strain of sustaining [src]!"))
-				for (var/obj/item/W in summoner.current)
-					if (!summoner.current.dropItemToGround(W))
-						qdel(W)
 				death(TRUE)
-				summoner.current.dust()
+				if(!HAS_TRAIT_FROM(summoner.current, TRAIT_NO_SOUL, LICH_TRAIT))//body will be dusted upon revival anyways
+					summoner.current.visible_message(span_bolddanger("[summoner.current]'s body sudders as clashing forces fight for the soul!"))
+				else
+					summoner.current.visible_message(span_bolddanger("[summoner.current]'s body is completely consumed by the strain of sustaining [src]!"))
+					summoner.current.dust(drop_items = TRUE)
 	else
 		if (transforming)
 			GoBerserk()

--- a/yogstation/code/modules/guardian/guardianstats.dm
+++ b/yogstation/code/modules/guardian/guardianstats.dm
@@ -75,3 +75,33 @@
 		var/datum/guardian_ability/minor/minor_ability = A
 		stats_info += minor_ability.name
 	return stats_info.Join(", ")
+
+/datum/guardian_stats/proc/weaken(times = 1)//reduces a random stat x times
+	for(var/i = 0; i < times; i++)
+		var/list/reduction = list("damage", "defense", "speed", "potential", "range")
+			shuffle(reduction)
+		var/found = FALSE
+		for(var/option in reduction)
+			switch(option)
+				if("damage")
+					if(damage > 1)
+						damage --
+						found = TRUE
+				if("defense")
+					if(defense > 1)
+						defense --
+						found = TRUE
+				if("speed")
+					if(speed > 1)
+						speed --
+						found = TRUE
+				if("potential")
+					if(potential > 1)
+						potential --
+						found = TRUE
+				if("range")
+					if(range > 1)
+						range --
+						found = TRUE
+			if(found)
+				break

--- a/yogstation/code/modules/guardian/guardianstats.dm
+++ b/yogstation/code/modules/guardian/guardianstats.dm
@@ -79,7 +79,7 @@
 /datum/guardian_stats/proc/weaken(times = 1)//reduces a random stat x times
 	for(var/i = 0; i < times; i++)
 		var/list/reduction = list("damage", "defense", "speed", "potential", "range")
-			shuffle(reduction)
+		shuffle(reduction)
 		var/found = FALSE
 		for(var/option in reduction)
 			switch(option)


### PR DESCRIPTION
# Why is this good for the game?
Undying holoparasite that deletes the corpse of a dead lich
Makes it impossible to find the phylactery
Removes the downside of holoparasite

rather than removing the interesting combo, makes it less meta

:cl:  
tweak: Holoparasites no longer dust liches upon death
tweak: Holoparasites lose 4 random stats upon revival by a lich
/:cl:
