### PR TITLE
drunk eyeblur no longer lasts 10x as long as it should

### DIFF
--- a/code/datums/status_effects/debuffs/drunk.dm
+++ b/code/datums/status_effects/debuffs/drunk.dm
@@ -171,7 +171,7 @@
 
 	// Over 71, we will constantly have blurry eyes
 	if(drunk_value >= 71)
-		owner.blur_eyes(drunk_value * 2 SECONDS - 140 SECONDS)
+		owner.blur_eyes(drunk_value * 2 - 140)
 
 	// Over 81, we will gain constant toxloss
 	if(drunk_value >= 81)


### PR DESCRIPTION
# Document the changes in your pull request

eyeblur is reduced significantly slower than most other status effects

# Why is this good for the game?
HELLO permanently blurred vision

# Changelog
:cl:  
bugfix: blurred vision from alcohol shouldn't last 2 trillion years
/:cl:
