### PR TITLE
Anomalous Crystal: We hate clowns

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -474,21 +474,6 @@ Difficulty: Very Hard
 /obj/machinery/anomalous_crystal/ex_act()
 	ActivationReaction(null, ACTIVATE_BOMB)
 
-/obj/machinery/anomalous_crystal/honk //Strips and equips you as a clown. I apologize for nothing
-	observer_desc = "This crystal strips and equips its targets as clowns."
-	possible_methods = list(ACTIVATE_MOB_BUMP, ACTIVATE_SPEECH)
-	activation_sound = 'sound/items/bikehorn.ogg'
-
-/obj/machinery/anomalous_crystal/honk/ActivationReaction(mob/user)
-	if(..() && ishuman(user) && !(user in affected_targets))
-		var/mob/living/carbon/human/H = user
-		for(var/obj/item/W in H)
-			H.dropItemToGround(W)
-		var/datum/job/clown/C = new /datum/job/clown()
-		C.equip(H)
-		qdel(C)
-		affected_targets.Add(H)
-
 /obj/machinery/anomalous_crystal/theme_warp //Warps the area you're in to look like a new one
 	observer_desc = "This crystal warps the area around it to a theme."
 	activation_method = ACTIVATE_TOUCH


### PR DESCRIPTION
# Document the changes in your pull request

We hate clowns, clowns are dumb, clumsy and goofy and we as a NRP server, we hate them. Fighting a colossus and potentially being rewarded a forced job change whilst it makes you drop all your items isn't fun at all. I am leaving this up to the community and personally don't care what happens. 

# Why is this good for the game?

Stops people from being clowned because they beat a boss that is apparently very hard, kinda lame to be rewarded with a slap in the face and a "job" change whilst dropping all your shit.

Also forgot to mention, stops miners or griefers from abusing said crystal effect to ruin people's rounds.

# Wiki Documentation

The HONK and anything clown related needs to be removed from the wiki and redacted so no one knows what we did.

# Changelog

:cl:  

rscdel: Removed the potential to spawn the clown effect for the anomalous crystal after you beat the colossus megafauna

/:cl:
