### PR TITLE
redspace teleport now requires 5 units of redspace dust per teleport

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1113,19 +1113,18 @@
 
 //Teleport like normal telecrystals
 /datum/reagent/redspace/on_mob_metabolize(mob/living/L)
-	if(volume < REDSPACE_TELEPORT_MINIMUM)
-		return
-	var/turf/destination = get_teleport_loc(L.loc, L, rand(3,6))
-	if(!istype(destination))
-		return
-	new /obj/effect/particle_effect/sparks(L.loc)
-	playsound(L.loc, "sparks", 50, 1)
-	if(!do_teleport(L, destination, asoundin = 'sound/effects/phaseinred.ogg', channel = TELEPORT_CHANNEL_BLUESPACE))
-		return
-	L.throw_at(get_edge_target_turf(L, L.dir), 1, 3, spin = FALSE, diagonals_first = TRUE)
-	if(iscarbon(L))
-		var/mob/living/carbon/C = L
-		C.adjust_disgust(15)
+	if(volume >= REDSPACE_TELEPORT_MINIMUM)
+		var/turf/destination = get_teleport_loc(L.loc, L, rand(3,6))
+		if(!istype(destination))
+			return
+		new /obj/effect/particle_effect/sparks(L.loc)
+		playsound(L.loc, "sparks", 50, 1)
+		if(!do_teleport(L, destination, asoundin = 'sound/effects/phaseinred.ogg', channel = TELEPORT_CHANNEL_BLUESPACE))
+			return
+		L.throw_at(get_edge_target_turf(L, L.dir), 1, 3, spin = FALSE, diagonals_first = TRUE)
+		if(iscarbon(L))
+			var/mob/living/carbon/C = L
+			C.adjust_disgust(15)
 	remove_reagent(type, volume)
 
 #undef REDSPACE_TELEPORT_MINIMUM

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1126,7 +1126,7 @@
 		if(iscarbon(L))
 			var/mob/living/carbon/C = L
 			C.adjust_disgust(15)
-	L.remove_reagent(type, volume)
+	L.reagents.remove_reagent(type, volume)
 
 #undef REDSPACE_TELEPORT_MINIMUM
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1126,7 +1126,7 @@
 		if(iscarbon(L))
 			var/mob/living/carbon/C = L
 			C.adjust_disgust(15)
-	remove_reagent(type, volume)
+	L.remove_reagent(type, volume)
 
 #undef REDSPACE_TELEPORT_MINIMUM
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1099,7 +1099,7 @@
 
 /mob/living/proc/bluespace_shuffle()
 	do_teleport(src, get_turf(src), 5, asoundin = 'sound/effects/phasein.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)
-
+#define REDSPACE_TELEPORT_MINIMUM 5
 //Gateway to traitor chemistry, want a drug to be traitor only? use this
 /datum/reagent/redspace
 	name = "Redspace Dust"
@@ -1113,6 +1113,8 @@
 
 //Teleport like normal telecrystals
 /datum/reagent/redspace/on_mob_metabolize(mob/living/L)
+	if(volume < REDSPACE_TELEPORT_MINIMUM)
+		return
 	var/turf/destination = get_teleport_loc(L.loc, L, rand(3,6))
 	if(!istype(destination))
 		return
@@ -1124,6 +1126,9 @@
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
 		C.adjust_disgust(15)
+	remove_reagent(type, volume)
+
+#undef REDSPACE_TELEPORT_MINIMUM
 
 /datum/reagent/aluminium
 	name = "Aluminium"

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1099,6 +1099,7 @@
 
 /mob/living/proc/bluespace_shuffle()
 	do_teleport(src, get_turf(src), 5, asoundin = 'sound/effects/phasein.ogg', channel = TELEPORT_CHANNEL_BLUESPACE)
+
 #define REDSPACE_TELEPORT_MINIMUM 5
 //Gateway to traitor chemistry, want a drug to be traitor only? use this
 /datum/reagent/redspace


### PR DESCRIPTION
# Document the changes in your pull request

Reduces the number of teleports you can get with redspace from "however diluted you can get it without failing to metabolize" to "4 per TC"

# Why is this good for the game?
less infinite directed teleports for cheap

# Testing
tested via setting a dropper to 1 unit, injecting, then setting the dropper to 5 units and injecting. 1 unit results in 0 teleports, 5 units results in a teleport


# Wiki Documentation

Redspace dust now only teleports if injected in a 5 unit dose

# Changelog


:cl:  
tweak: Redspace dust now only teleports if injected in a 5 unit dose
/:cl:
