### PR TITLE
Cogging an APC removes access requirement to locking

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -261,6 +261,9 @@
 	else if(isarea(A) && src.areastring == null)
 		src.area = A
 
+	if(prob(20))
+		locked = FALSE
+
 	make_terminal()
 
 	addtimer(CALLBACK(src, PROC_REF(update)), 5)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -261,7 +261,7 @@
 	else if(isarea(A) && src.areastring == null)
 		src.area = A
 
-	if(prob(20))
+	if(prob(15))
 		locked = FALSE
 
 	make_terminal()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -831,7 +831,7 @@
 	else if(stat & (BROKEN|MAINT))
 		to_chat(user, span_warning("Nothing happens!"))
 	else
-		if(allowed(usr) && !wires.is_cut(WIRE_IDSCAN) && !malfhack && !integration_cog)
+		if((allowed(usr) && !wires.is_cut(WIRE_IDSCAN) && !malfhack) || integration_cog)
 			locked = !locked
 			to_chat(user, span_notice("You [ locked ? "lock" : "unlock"] the APC interface."))
 			update_appearance(UPDATE_ICON)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -261,6 +261,9 @@
 	else if(isarea(A) && src.areastring == null)
 		src.area = A
 
+	if(prob(10))
+		locked = FALSE
+
 	make_terminal()
 
 	addtimer(CALLBACK(src, PROC_REF(update)), 5)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -261,9 +261,6 @@
 	else if(isarea(A) && src.areastring == null)
 		src.area = A
 
-	if(prob(15))
-		locked = FALSE
-
 	make_terminal()
 
 	addtimer(CALLBACK(src, PROC_REF(update)), 5)
@@ -831,7 +828,7 @@
 	else if(stat & (BROKEN|MAINT))
 		to_chat(user, span_warning("Nothing happens!"))
 	else
-		if(allowed(usr) && !wires.is_cut(WIRE_IDSCAN) && !malfhack)
+		if(allowed(usr) && !wires.is_cut(WIRE_IDSCAN) && !malfhack && !integration_cog)
 			locked = !locked
 			to_chat(user, span_notice("You [ locked ? "lock" : "unlock"] the APC interface."))
 			update_appearance(UPDATE_ICON)


### PR DESCRIPTION
# Why is this good for the game?
Helps to curb clock cult metagaming as they'll be able to lock it right after

:cl:  
tweak: Cogging an APC removes access requirement to locking
tweak: Random chance for APCs to be unlocked round start
/:cl:
