### PR TITLE
Clockwork teleport sound is now quieter

### DIFF
--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -387,8 +387,8 @@
 	button_icon_state = "warp_down"
 	owner.update_action_buttons()
 	teleport_turf.visible_message(span_warning("[user] warps in!"))
-	playsound(user, 'sound/magic/magic_missile.ogg', 5, TRUE)
-	playsound(teleport_turf, 'sound/magic/magic_missile.ogg', 5, TRUE)
+	playsound(user, 'sound/magic/magic_missile.ogg', 15, TRUE)
+	playsound(teleport_turf, 'sound/magic/magic_missile.ogg', 15, TRUE)
 	user.forceMove(get_turf(teleport_turf))
 	user.setDir(SOUTH)
 	flash_color(user, flash_color = "#AF0AAF", flash_time = 5)

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -387,8 +387,8 @@
 	button_icon_state = "warp_down"
 	owner.update_action_buttons()
 	teleport_turf.visible_message(span_warning("[user] warps in!"))
-	playsound(user, 'sound/magic/magic_missile.ogg', 50, TRUE)
-	playsound(teleport_turf, 'sound/magic/magic_missile.ogg', 50, TRUE)
+	playsound(user, 'sound/magic/magic_missile.ogg', 5, TRUE)
+	playsound(teleport_turf, 'sound/magic/magic_missile.ogg', 5, TRUE)
 	user.forceMove(get_turf(teleport_turf))
 	user.setDir(SOUTH)
 	flash_color(user, flash_color = "#AF0AAF", flash_time = 5)


### PR DESCRIPTION

# Document the changes in your pull request

the warp sound that plays when you teleport onto station as clockie is now set to 15% volume instead of 50

# Why is this good for the game?

lets clockies be able to actually stealth. anybody that has played for 5 hours recognizes the sound and immediately knows somebody teleported nearby.

# Testing

sounds quiet

# Wiki Documentation

probably not

# Changelog

:cl:  
tweak: Clockwork cult teleport sound is quieter
/:cl:
