### PR TITLE
[s]Sanguirite creation exploit fix

### DIFF
--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -671,7 +671,7 @@
 	time = 2 SECONDS
 	reqs = list(/obj/item/reagent_containers/autoinjector/medipen = 1,
 				/datum/reagent/medicine/epinephrine = 10,
-				/datum/reagent/medicine/Sanguirite = 2)
+				/datum/reagent/medicine/coagulant = 2)
 
 	category = CAT_MEDICAL
 

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -670,8 +670,7 @@
 	result = /obj/item/reagent_containers/autoinjector/medipen
 	time = 2 SECONDS
 	reqs = list(/obj/item/reagent_containers/autoinjector/medipen = 1,
-				/datum/reagent/medicine/epinephrine = 10,
-				/datum/reagent/medicine/coagulant = 2)
+				/datum/reagent/medicine/epinephrine = 10)
 
 	category = CAT_MEDICAL
 

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -670,7 +670,9 @@
 	result = /obj/item/reagent_containers/autoinjector/medipen
 	time = 2 SECONDS
 	reqs = list(/obj/item/reagent_containers/autoinjector/medipen = 1,
-				/datum/reagent/medicine/epinephrine = 10)
+				/datum/reagent/medicine/epinephrine = 10,
+				/datum/reagent/medicine/Sanguirite = 2)
+
 	category = CAT_MEDICAL
 
 /datum/crafting_recipe/refill_atropine_medipen

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -671,7 +671,6 @@
 	time = 2 SECONDS
 	reqs = list(/obj/item/reagent_containers/autoinjector/medipen = 1,
 				/datum/reagent/medicine/epinephrine = 10)
-
 	category = CAT_MEDICAL
 
 /datum/crafting_recipe/refill_atropine_medipen

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -109,7 +109,6 @@
 	amount_per_transfer_from_this = 12
 	volume = 12
 	ignore_flags = 1 //so you can medipen through hardsuits
-	reagent_flags = DRAWABLE
 	flags_1 = null
 	list_reagents = list(/datum/reagent/medicine/epinephrine = 10, /datum/reagent/medicine/coagulant = 2)
 	custom_price = 40

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -109,6 +109,7 @@
 	amount_per_transfer_from_this = 12
 	volume = 12
 	ignore_flags = 1 //so you can medipen through hardsuits
+	reagent_flags = NONE
 	flags_1 = null
 	list_reagents = list(/datum/reagent/medicine/epinephrine = 10, /datum/reagent/medicine/coagulant = 2)
 	custom_price = 40


### PR DESCRIPTION
# Document the changes in your pull request

It's no longer possible to draw reagents out of an epipen, making it more difficult to generate infinite sanguirite while still allowing proper use of an epipen.

# Why is this good for the game?

Patches an exploit that allowed a character to generate infinate sanguirite effortlessly.

# Testing

Tested on a local server to confirm it's no longer possible to draw free sanguirite out of the epipen.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: It's no longer possible to draw infinite sanguirite from an epipen.
/:cl:
