### PR TITLE
The final shitcode is destroyed from a bad port (You can get Mushroom Powder now)

### DIFF
--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -149,6 +149,7 @@
 //SNACKS
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora
+	seed = /obj/item/seeds/lavaland/polypore
 	name = "mushroom shavings"
 	desc = "Some shavings from a tall mushroom. With enough, might serve as a bowl."
 	icon = 'icons/obj/lavaland/ash_flora.dmi'
@@ -157,7 +158,6 @@
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
 	max_integrity = 100
-	seed = /obj/item/seeds/lavaland/polypore
 	distill_reagent = /datum/reagent/consumable/ethanol/polyporepop
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/Initialize(mapload)
@@ -168,26 +168,26 @@
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/shavings //So we can't craft bowls from everything.
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_leaf
+	seed = /obj/item/seeds/lavaland/porcini
 	name = "mushroom leaf"
 	desc = "A leaf, from a mushroom."
 	icon_state = "mushroom_leaf"
-	seed = /obj/item/seeds/lavaland/porcini
 	distill_reagent = /datum/reagent/consumable/ethanol/porcinisap
 	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_cap
+	seed = /obj/item/seeds/lavaland/inocybe
 	name = "mushroom cap"
 	desc = "The cap of a large mushroom."
 	icon_state = "mushroom_cap"
-	seed = /obj/item/seeds/lavaland/inocybe
 	distill_reagent = /datum/reagent/consumable/ethanol/inocybeshine
 	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_stem
+	seed = /obj/item/seeds/lavaland/ember
 	name = "mushroom stem"
 	desc = "A long mushroom stem. It's slightly glowing."
 	icon_state = "mushroom_stem"
-	seed = /obj/item/seeds/lavaland/ember
 	distill_reagent = /datum/reagent/consumable/ethanol/embershroomcream
 	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
 

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -153,7 +153,7 @@
 	desc = "Some shavings from a tall mushroom. With enough, might serve as a bowl."
 	icon = 'icons/obj/lavaland/ash_flora.dmi'
 	icon_state = "mushroom_shavings"
-	grind_results = list(/datum/reagent/toxin/mushroom_powder = 5)
+	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
 	max_integrity = 100
@@ -173,6 +173,7 @@
 	icon_state = "mushroom_leaf"
 	seed = /obj/item/seeds/lavaland/porcini
 	distill_reagent = /datum/reagent/consumable/ethanol/porcinisap
+	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_cap
 	name = "mushroom cap"
@@ -180,6 +181,7 @@
 	icon_state = "mushroom_cap"
 	seed = /obj/item/seeds/lavaland/inocybe
 	distill_reagent = /datum/reagent/consumable/ethanol/inocybeshine
+	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_stem
 	name = "mushroom stem"
@@ -187,6 +189,7 @@
 	icon_state = "mushroom_stem"
 	seed = /obj/item/seeds/lavaland/ember
 	distill_reagent = /datum/reagent/consumable/ethanol/embershroomcream
+	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/cactus_fruit
 	name = "cactus fruit"
@@ -221,7 +224,7 @@
 	genes = list(/datum/plant_gene/trait/fire_resistance)
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
 	growthstages = 2
-	reagents_add = list(/datum/reagent/consumable/nutriment = 0.02, /datum/reagent/consumable/vitfro = 0.08, /datum/reagent/consumable/ashresin = 0.02)
+	reagents_add = list(/datum/reagent/consumable/nutriment = 0.02, /datum/reagent/consumable/vitfro = 0.08, /datum/reagent/consumable/ashresin = 0.02,	/datum/reagent/consumable/nutriment = 0.1)
 
 /obj/item/seeds/lavaland/polypore
 	name = "pack of polypore mycelium"
@@ -232,7 +235,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/ash_flora/shavings
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/fire_resistance)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
-	reagents_add = list(/datum/reagent/consumable/sugar = 0.06, /datum/reagent/consumable/ethanol = 0.04, /datum/reagent/stabilizing_agent = 0.06, /datum/reagent/consumable/mintextract = 0.02, /datum/reagent/consumable/ashresin = 0.08)
+	reagents_add = list(/datum/reagent/consumable/sugar = 0.06, /datum/reagent/consumable/ethanol = 0.04, /datum/reagent/stabilizing_agent = 0.06, /datum/reagent/consumable/mintextract = 0.02, /datum/reagent/consumable/ashresin = 0.08,	/datum/reagent/consumable/nutriment = 0.1)
 
 /obj/item/seeds/lavaland/porcini
 	name = "pack of porcini mycelium"
@@ -243,7 +246,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_leaf
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/fire_resistance)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
-	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.02, /datum/reagent/consumable/vitfro = 0.04, /datum/reagent/drug/nicotine = 0.04, /datum/reagent/consumable/ashresin = 0.02)
+	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.02, /datum/reagent/consumable/vitfro = 0.04, /datum/reagent/drug/nicotine = 0.04, /datum/reagent/consumable/ashresin = 0.02, /datum/reagent/consumable/nutriment = 0.1)
 
 /obj/item/seeds/lavaland/inocybe
 	name = "pack of inocybe mycelium"
@@ -254,7 +257,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_cap
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/fire_resistance)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
-	reagents_add = list(/datum/reagent/toxin/mindbreaker = 0.04, /datum/reagent/consumable/entpoly = 0.08, /datum/reagent/drug/mushroomhallucinogen = 0.04, /datum/reagent/consumable/ashresin = 0.02)
+	reagents_add = list(/datum/reagent/toxin/mindbreaker = 0.04, /datum/reagent/consumable/entpoly = 0.08, /datum/reagent/drug/mushroomhallucinogen = 0.04, /datum/reagent/consumable/ashresin = 0.02, /datum/reagent/consumable/nutriment = 0.1)
 
 /obj/item/seeds/lavaland/ember
 	name = "pack of embershroom mycelium"
@@ -265,7 +268,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_stem
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/glow, /datum/plant_gene/trait/fire_resistance)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
-	reagents_add = list(/datum/reagent/consumable/tinlux = 0.04, /datum/reagent/consumable/nutriment = 0.02, /datum/reagent/drug/space_drugs = 0.02, /datum/reagent/consumable/ashresin = 0.02)
+	reagents_add = list(/datum/reagent/consumable/tinlux = 0.04, /datum/reagent/consumable/nutriment = 0.02, /datum/reagent/drug/space_drugs = 0.02, /datum/reagent/consumable/ashresin = 0.02, /datum/reagent/consumable/nutriment = 0.1)
 
 //CRAFTING
 /datum/crafting_recipe/mushroomwood

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -153,7 +153,6 @@
 	desc = "Some shavings from a tall mushroom. With enough, might serve as a bowl."
 	icon = 'icons/obj/lavaland/ash_flora.dmi'
 	icon_state = "mushroom_shavings"
-	grind_results = list(/datum/reagent/toxin/mushroom_powder = 5)
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
 	max_integrity = 100
@@ -233,6 +232,7 @@
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/fire_resistance)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	reagents_add = list(/datum/reagent/consumable/sugar = 0.06, /datum/reagent/consumable/ethanol = 0.04, /datum/reagent/stabilizing_agent = 0.06, /datum/reagent/consumable/mintextract = 0.02, /datum/reagent/consumable/ashresin = 0.08)
+	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
 
 /obj/item/seeds/lavaland/porcini
 	name = "pack of porcini mycelium"
@@ -244,6 +244,7 @@
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/fire_resistance)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.02, /datum/reagent/consumable/vitfro = 0.04, /datum/reagent/drug/nicotine = 0.04, /datum/reagent/consumable/ashresin = 0.02)
+	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
 
 /obj/item/seeds/lavaland/inocybe
 	name = "pack of inocybe mycelium"
@@ -255,6 +256,7 @@
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/fire_resistance)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	reagents_add = list(/datum/reagent/toxin/mindbreaker = 0.04, /datum/reagent/consumable/entpoly = 0.08, /datum/reagent/drug/mushroomhallucinogen = 0.04, /datum/reagent/consumable/ashresin = 0.02)
+	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
 
 /obj/item/seeds/lavaland/ember
 	name = "pack of embershroom mycelium"
@@ -266,6 +268,7 @@
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/glow, /datum/plant_gene/trait/fire_resistance)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	reagents_add = list(/datum/reagent/consumable/tinlux = 0.04, /datum/reagent/consumable/nutriment = 0.02, /datum/reagent/drug/space_drugs = 0.02, /datum/reagent/consumable/ashresin = 0.02)
+	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
 
 //CRAFTING
 /datum/crafting_recipe/mushroomwood

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -149,15 +149,15 @@
 //SNACKS
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora
-	seed = /obj/item/seeds/lavaland/polypore
 	name = "mushroom shavings"
 	desc = "Some shavings from a tall mushroom. With enough, might serve as a bowl."
 	icon = 'icons/obj/lavaland/ash_flora.dmi'
 	icon_state = "mushroom_shavings"
-	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
+	grind_results = list(/datum/reagent/toxin/mushroom_powder = 5)
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
 	max_integrity = 100
+	seed = /obj/item/seeds/lavaland/polypore
 	distill_reagent = /datum/reagent/consumable/ethanol/polyporepop
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/Initialize(mapload)
@@ -168,28 +168,25 @@
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/shavings //So we can't craft bowls from everything.
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_leaf
-	seed = /obj/item/seeds/lavaland/porcini
 	name = "mushroom leaf"
 	desc = "A leaf, from a mushroom."
 	icon_state = "mushroom_leaf"
+	seed = /obj/item/seeds/lavaland/porcini
 	distill_reagent = /datum/reagent/consumable/ethanol/porcinisap
-	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_cap
-	seed = /obj/item/seeds/lavaland/inocybe
 	name = "mushroom cap"
 	desc = "The cap of a large mushroom."
 	icon_state = "mushroom_cap"
+	seed = /obj/item/seeds/lavaland/inocybe
 	distill_reagent = /datum/reagent/consumable/ethanol/inocybeshine
-	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_stem
-	seed = /obj/item/seeds/lavaland/ember
 	name = "mushroom stem"
 	desc = "A long mushroom stem. It's slightly glowing."
 	icon_state = "mushroom_stem"
+	seed = /obj/item/seeds/lavaland/ember
 	distill_reagent = /datum/reagent/consumable/ethanol/embershroomcream
-	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/cactus_fruit
 	name = "cactus fruit"

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -224,7 +224,7 @@
 	genes = list(/datum/plant_gene/trait/fire_resistance)
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
 	growthstages = 2
-	reagents_add = list(/datum/reagent/consumable/nutriment = 0.02, /datum/reagent/consumable/vitfro = 0.08, /datum/reagent/consumable/ashresin = 0.02,	/datum/reagent/consumable/nutriment = 0.1)
+	reagents_add = list(/datum/reagent/consumable/nutriment = 0.02, /datum/reagent/consumable/vitfro = 0.08, /datum/reagent/consumable/ashresin = 0.02)
 
 /obj/item/seeds/lavaland/polypore
 	name = "pack of polypore mycelium"

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -153,6 +153,7 @@
 	desc = "Some shavings from a tall mushroom. With enough, might serve as a bowl."
 	icon = 'icons/obj/lavaland/ash_flora.dmi'
 	icon_state = "mushroom_shavings"
+	grind_results = list(/datum/reagent/toxin/mushroom_powder = 5)
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
 	max_integrity = 100
@@ -232,7 +233,6 @@
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/fire_resistance)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	reagents_add = list(/datum/reagent/consumable/sugar = 0.06, /datum/reagent/consumable/ethanol = 0.04, /datum/reagent/stabilizing_agent = 0.06, /datum/reagent/consumable/mintextract = 0.02, /datum/reagent/consumable/ashresin = 0.08)
-	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
 
 /obj/item/seeds/lavaland/porcini
 	name = "pack of porcini mycelium"
@@ -244,7 +244,6 @@
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/fire_resistance)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	reagents_add = list(/datum/reagent/consumable/nutriment/vitamin = 0.02, /datum/reagent/consumable/vitfro = 0.04, /datum/reagent/drug/nicotine = 0.04, /datum/reagent/consumable/ashresin = 0.02)
-	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
 
 /obj/item/seeds/lavaland/inocybe
 	name = "pack of inocybe mycelium"
@@ -256,7 +255,6 @@
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/fire_resistance)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	reagents_add = list(/datum/reagent/toxin/mindbreaker = 0.04, /datum/reagent/consumable/entpoly = 0.08, /datum/reagent/drug/mushroomhallucinogen = 0.04, /datum/reagent/consumable/ashresin = 0.02)
-	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
 
 /obj/item/seeds/lavaland/ember
 	name = "pack of embershroom mycelium"
@@ -268,7 +266,6 @@
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/glow, /datum/plant_gene/trait/fire_resistance)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	reagents_add = list(/datum/reagent/consumable/tinlux = 0.04, /datum/reagent/consumable/nutriment = 0.02, /datum/reagent/drug/space_drugs = 0.02, /datum/reagent/consumable/ashresin = 0.02)
-	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
 
 //CRAFTING
 /datum/crafting_recipe/mushroomwood

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -153,7 +153,7 @@
 	desc = "Some shavings from a tall mushroom. With enough, might serve as a bowl."
 	icon = 'icons/obj/lavaland/ash_flora.dmi'
 	icon_state = "mushroom_shavings"
-	grind_results = list(/datum/reagent/toxin/mushroom_powder = 5)
+	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
 	w_class = WEIGHT_CLASS_TINY
 	resistance_flags = FLAMMABLE
 	max_integrity = 100
@@ -173,6 +173,7 @@
 	icon_state = "mushroom_leaf"
 	seed = /obj/item/seeds/lavaland/porcini
 	distill_reagent = /datum/reagent/consumable/ethanol/porcinisap
+	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_cap
 	name = "mushroom cap"
@@ -180,6 +181,7 @@
 	icon_state = "mushroom_cap"
 	seed = /obj/item/seeds/lavaland/inocybe
 	distill_reagent = /datum/reagent/consumable/ethanol/inocybeshine
+	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_stem
 	name = "mushroom stem"
@@ -187,6 +189,7 @@
 	icon_state = "mushroom_stem"
 	seed = /obj/item/seeds/lavaland/ember
 	distill_reagent = /datum/reagent/consumable/ethanol/embershroomcream
+	grind_results = list(/datum/reagent/toxin/mushroom_powder = 0)
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/cactus_fruit
 	name = "cactus fruit"


### PR DESCRIPTION
# Document the changes in your pull request

Thanks to @Chubbygummibear for telling me that plants need nutriments to give grind results. The final part of the very badly ported shitcode Bood ported over from TG is now fixed. You can actually get mushroom powder from grinding Mushroom cap, stem, leaf, shavings & Ash flora (literally just mushroom shaving) since now the seeds (Polypore, Porcini, inocybe & ember) have a nutriment value to allow this.

# Why is this good for the game?

It actually works as intended now instead of straight up lying to you how to get it, this also allows Barkeeps to actually make the drinks that require this like Mushroom Tea which is a requirement for Mushi Kombucha too. So this lets the species drinks to actually be made.

# Testing

Added nutriments, ground up the mushroom parts from Ash flora and got the actual results.

# Wiki Documentation

In the Guide to Chemistry part, Mushroom powder needs to include shavings & stem in the "found in" part.

# Changelog

:cl:  
rscadd: Added nutriments to Polypore, Porcini, inocybe & ember so grind results will work
tweak: Ash flora, mushroom shavings, stem, cap & leaves now give mushroom powder when you grind them

/:cl:
