### PR TITLE
It's Greenshift Wardens why you lethalling?

### DIFF
--- a/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
@@ -20,7 +20,7 @@
 
 /obj/item/ammo_box/magazine/internal/shot/com/compact
 	name = "compact combat shotgun internal magazine"
-	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
+	ammo_type = /obj/item/ammo_casing/shotgun/rubbershot
 	max_ammo = 4
 
 /obj/item/ammo_box/magazine/internal/shot/dual


### PR DESCRIPTION
# Document the changes in your pull request

Yes, I know. Another Warden Nerf, someone needed to take up the anti-sec mantle and I know we aren't the server that deserves anti-sec coder but needs it. 

Ever since we made it that we start off on green alert roundstart, it's baffled me why wardens have a full-lethal weapon in their locker that they're allowed to carry about. SOP aside, it makes less sense for wardens to carry roundstart lethals now, when they are just meant to protect the brig and this can be done easily with non-lethals, krav, airlock braces, portable flashers and the smoke machine. This makes it so Wardens don't get to ignore the alert level. They can still change their ammo type out but this should encourage them to do it at the appropriate alert level or when they spot an antag that can't be safely contained. 

# Why is this good for the game?

Stops giving Warden's a reason to lethal anyone that does anything they don't like by making them abide to the proper Alert procedures better.

# Testing

Each shotgun has an internal magazine they start off with, this only affects the compact combat shotgun which afaik only warden's have this.

# Changelog

:cl:  

tweak: Warden's roundstart compact shotgun has now been pacified (starts with Rubber Bullets not Buckshot)

/:cl:
