### PR TITLE
Fixes changeling mutation being storable on DNA console

### DIFF
--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -5,6 +5,8 @@
 /datum/mutation/human
 	name = "mutation"
 	var/desc = "A mutation."
+	///Whether the mutation is locked, and therefore will not show up in
+	///people's genes randomly.
 	var/locked
 	var/quality
 	var/get_chance = 100
@@ -29,7 +31,11 @@
 	var/scrambled = FALSE //Wheter we can read it if it's active. To avoid cheesing with mutagen
 	var/class           //Decides player accesibility, sorta
 	var/list/conflicts //any mutations that might conflict. put mutation typepath defines in here. make sure to enter it both ways (so that A conflicts with B, and B with A)
-	var/allow_transfer  //Do we transfer upon cloning?
+	
+	///Boolean on whether the mutation can be transferred through cloning
+	var/allow_transfer = FALSE
+	///Boolean on whether the mutation can be downloaded onto a DNA console and cloned.
+	var/allow_cloning = TRUE
 	//MUT_NORMAL - A mutation that can be activated and deactived by completing a sequence
 	//MUT_EXTRA - A mutation that is in the mutations tab, and can be given and taken away through though the DNA console. Has a 0 before it's name in the mutation section of the dna console
 	//MUT_OTHER Cannot be interacted with by players through normal means. I.E. wizards mutate

--- a/code/datums/mutations/chameleon.dm
+++ b/code/datums/mutations/chameleon.dm
@@ -40,6 +40,7 @@
 /datum/mutation/human/chameleon/super // Changeling chameleon
 	conflicts = list(/datum/mutation/human/chameleon)
 	allow_transfer = FALSE
+	allow_cloning = FALSE
 	mutadone_proof = TRUE
 	locked = TRUE
 	efficiency = 50

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -665,11 +665,14 @@
 			// GUARD CHECK - This should not be possible. Unexpected result
 			if(!HM)
 				return
+			if(HM.allow_cloning)
+				say("ERROR: This mutation is anomalous, and cannot be saved.")
+				return
 
 			var/datum/mutation/human/A = new HM.type()
 			A.copy_mutation(HM)
 			stored_mutations += A
-			to_chat(usr,span_notice("Mutation successfully stored."))
+			to_chat(usr, span_notice("Mutation successfully stored."))
 			return
 
 		// Save a mutation to the diskette's storage buffer.

--- a/code/game/machinery/computer/dna_console.dm
+++ b/code/game/machinery/computer/dna_console.dm
@@ -665,7 +665,7 @@
 			// GUARD CHECK - This should not be possible. Unexpected result
 			if(!HM)
 				return
-			if(HM.allow_cloning)
+			if(!HM.allow_cloning)
 				say("ERROR: This mutation is anomalous, and cannot be saved.")
 				return
 


### PR DESCRIPTION
# Document the changes in your pull request

DNA console can no longer save changeling's special mutation and also adds some autodoc comments because i was confused at first (especially with dumb var names like ``locked``).

# Why is this good for the game?

No storing super chameleon

# Testing

![image](https://github.com/yogstation13/Yogstation/assets/53777086/f52a5304-f20f-4440-9209-058818848c2f)

# Spriting

# Wiki Documentation

# Changelog

:cl:  
bugfix: Super Chameleon (Changeling chameleon) can no longer be downloaded from a DNA console.
/:cl:
