### PR TITLE
warden's shotgun starts loaded with rubbershot

### DIFF
--- a/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
@@ -20,7 +20,7 @@
 
 /obj/item/ammo_box/magazine/internal/shot/com/compact
 	name = "compact combat shotgun internal magazine"
-	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
+	ammo_type = /obj/item/ammo_casing/shotgun/rubbershot
 	max_ammo = 4
 
 /obj/item/ammo_box/magazine/internal/shot/dual


### PR DESCRIPTION


# Document the changes in your pull request

Changes warden's buckshot in his shotgun to rubber shot

# Why is this good for the game?
for a person meant to protect the armory there sure is a lot of time when they actually aren't. there have been times when i get mag dumped by a warden when I disarmed them of their disabler, critted on green alert doing tasks.  if they actually are aiding/are officers of the field and it isn't ling or a martial user. take them without violence unless stam damage isn't doing anything.

if anyone on council is reading this then I ask for a ruling on wardens changing their rounds when in and out of the brig. i think it's fine for them to change to lethals while in the brig. but for anything else unless it is against a violent antag or another alert outside brig they run around with rubbershot and beanbags.


# Changelog

:cl:  
tweak: changes wardens shotgun shells
/:cl:
