### PR TITLE
Fixes overlays w/ devices and tanks

### DIFF
--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -86,9 +86,8 @@
 		qdel(air_contents)
 
 	if(tank_assembly)
-		qdel(tank_assembly)
 		tank_assembly.master = null
-		tank_assembly = null
+		QDEL_NULL(tank_assembly)
 
 	STOP_PROCESSING(SSobj, src)
 	. = ..()
@@ -317,7 +316,7 @@
 	. = ..()
 	if(tank_assembly)
 		. += tank_assembly.icon_state
-		copy_overlays(tank_assembly)
+		. += tank_assembly.overlays
 		. += "bomb_assembly"
 
 /obj/item/tank/wrench_act(mob/living/user, obj/item/I)


### PR DESCRIPTION
# Document the changes in your pull request

Fixes the sprites of tanks with an assembly on them, not properly removing them on removal.

# Why is this good for the game?

Closes https://github.com/yogstation13/Yogstation/issues/20388

# Testing

https://github.com/yogstation13/Yogstation/assets/53777086/2aa37afa-de3d-495b-bfa2-1cd3c76d8398

# Spriting

# Wiki Documentation

# Changelog

:cl:  
bugfix: Tanks with devices attached to it now properly remove their appearance when the devices are removed.
/:cl:
