### PR TITLE
NT IRN app tweaks, bugfixes and code refactor

### DIFF
--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -90,7 +90,8 @@
 			"cost" = SO.pack.get_cost(),
 			"id" = SO.id,
 			"orderer" = SO.orderer,
-			"paid" = !isnull(SO.paying_account) //paid by requester
+			"paid" = !isnull(SO.paying_account), //paid by requester
+			"budget" = SO.budget
 		))
 
 	data["requests"] = list()
@@ -100,7 +101,8 @@
 			"cost" = SO.pack.get_cost(),
 			"orderer" = SO.orderer,
 			"reason" = SO.reason,
-			"id" = SO.id
+			"id" = SO.id,
+			"budget" = SO.budget
 		))
 
 	return data

--- a/code/modules/cargo/order.dm
+++ b/code/modules/cargo/order.dm
@@ -27,10 +27,11 @@
 	var/orderer_rank
 	var/orderer_ckey
 	var/reason
+	var/budget
 	var/datum/supply_pack/pack
 	var/datum/bank_account/paying_account
 
-/datum/supply_order/New(datum/supply_pack/pack, orderer, orderer_rank, orderer_ckey, reason, paying_account)
+/datum/supply_order/New(datum/supply_pack/pack, orderer, orderer_rank, orderer_ckey, reason, paying_account, budget)
 	id = SSshuttle.ordernum++
 	src.pack = pack
 	src.orderer = orderer
@@ -38,6 +39,7 @@
 	src.orderer_ckey = orderer_ckey
 	src.reason = reason
 	src.paying_account = paying_account
+	src.budget = budget
 
 /datum/supply_order/proc/generateRequisition(turf/T)
 	var/obj/item/paper/P = new(T)
@@ -51,6 +53,7 @@
 	P.info += "Requested by: [orderer]<br/>"
 	if(paying_account)
 		P.info += "Paid by: [paying_account.account_holder]<br/>"
+	P.info += "Crate Type: [budget? "[paying_account.account_holder] Crate":"Normal Crate"]<br/>"
 	P.info += "Rank: [orderer_rank]<br/>"
 	P.info += "Comment: [reason]<br/>"
 
@@ -70,6 +73,7 @@
 		P.name += " - Purchased by [owner]"
 	P.info += "Order[packname?"":"s"]: [id]<br/>"
 	P.info += "Destination: [station_name]<br/>"
+	P.info += "Crate Type: [budget? "[paying_account.account_holder] Crate":"Normal Crate"]<br/>"
 	if(packname)
 		P.info += "Item: [packname]<br/>"
 	P.info += "Contents: <br/>"

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -30,8 +30,11 @@
 	if(id)
 		return id.registered_name
 	var/obj/item/pda/pda = wear_id
+	var/obj/item/modular_computer/tablet/tablet = wear_id
 	if(istype(pda))
 		return pda.owner
+	if(istype(tablet))
+		return tablet.name
 	return if_no_id
 
 //repurposed proc. Now it combines get_id_name() and get_face_name() to determine a mob's name variable. Made into a separate proc as it'll be useful elsewhere

--- a/code/modules/modular_computers/file_system/programs/supply/budgetordering.dm
+++ b/code/modules/modular_computers/file_system/programs/supply/budgetordering.dm
@@ -77,6 +77,7 @@
 	var/obj/item/computer_hardware/card_slot/card_slot = computer.all_components[MC_CARD]
 	var/obj/item/card/id/id_card = card_slot?.GetID()
 	if(id_card?.registered_account)
+		unlock_budget = TRUE
 		if(id_card?.registered_account?.account_job?.paycheck_department == ACCOUNT_CAR)
 			unlock_budget = FALSE //cargo tech is already using the same budget.
 		if(id_card?.registered_account?.account_job?.paycheck_department && budget_order)
@@ -89,7 +90,6 @@
 			requestonly = TRUE
 			can_approve_requests = FALSE
 			can_send = FALSE
-		unlock_budget = TRUE
 	else
 		requestonly = TRUE
 		unlock_budget = FALSE //none registered account shouldnt be using budget order
@@ -267,9 +267,6 @@
 			var/id = text2num(params["id"])
 			for(var/datum/supply_order/SO in SSshuttle.requestlist)
 				if(SO.id == id)
-					var/obj/item/card/id/id_card = card_slot?.GetID()
-					if(id_card && id_card?.registered_account)
-						SO.paying_account = SSeconomy.get_dep_account(id_card?.registered_account?.account_job.paycheck_department)
 					SSshuttle.requestlist -= SO
 					SSshuttle.shoppinglist += SO
 					. = TRUE

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -60,7 +60,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		for(var/trf in shuttle_area)
 			var/turf/T = trf
 			for(var/a in T.get_all_contents())
-				var/obj/structure/closet/crate/secure/owned/crate = a
+				var/obj/structure/closet/crate/secure/owned/crate = locate() in a
 				if(is_type_in_typecache(a, GLOB.blacklisted_cargo_types) || crate.locked)
 					return FALSE
 	return TRUE

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -26,7 +26,6 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/structure/extraction_point,
 		/obj/machinery/syndicatebomb,
 		/obj/item/hilbertshotel,
-		/obj/structure/closet/crate/secure/owned,
 		/obj/structure/closet/bluespace // yogs - nope nice try
 	)))
 
@@ -61,7 +60,8 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		for(var/trf in shuttle_area)
 			var/turf/T = trf
 			for(var/a in T.get_all_contents())
-				if(is_type_in_typecache(a, GLOB.blacklisted_cargo_types))
+				var/obj/structure/closet/crate/secure/owned/crate = a
+				if(is_type_in_typecache(a, GLOB.blacklisted_cargo_types) || crate.locked)
 					return FALSE
 	return TRUE
 

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -60,8 +60,10 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		for(var/trf in shuttle_area)
 			var/turf/T = trf
 			for(var/a in T.get_all_contents())
-				var/obj/structure/closet/crate/secure/owned/crate = locate() in a
-				if(is_type_in_typecache(a, GLOB.blacklisted_cargo_types) || crate.locked)
+				for(var/obj/structure/closet/crate/secure/owned/crate in a)
+					if(crate.locked)
+						return FALSE
+				if(is_type_in_typecache(a, GLOB.blacklisted_cargo_types))
 					return FALSE
 	return TRUE
 

--- a/tgui/packages/tgui/interfaces/Cargo.js
+++ b/tgui/packages/tgui/interfaces/Cargo.js
@@ -151,7 +151,7 @@ export const CargoCatalog = (props, context) => {
             onClick={() => act('toggleprivate')} />}
           {!self_paid && !!unlock_budget && <Button.Checkbox
             ml={2}
-            content="Budget Ordering"
+            content="Departmental Purchasing"
             checked={budget_order}
             onClick={() => act('togglebudget')} />}
         </>

--- a/tgui/packages/tgui/interfaces/Cargo.js
+++ b/tgui/packages/tgui/interfaces/Cargo.js
@@ -128,7 +128,7 @@ export const CargoCatalog = (props, context) => {
   const { express } = props;
   const { act, data } = useBackend(context);
 
-  const { self_paid, app_cost } = data;
+  const { self_paid, app_cost, budget_order, unlock_budget } = data;
 
   const supplies = Object.values(data.supplies);
   const [
@@ -144,11 +144,16 @@ export const CargoCatalog = (props, context) => {
       buttons={!express && (
         <>
           <CargoCartButtons />
-          <Button.Checkbox
+          {!budget_order && <Button.Checkbox
             ml={2}
             content="Buy Privately"
             checked={self_paid}
-            onClick={() => act('toggleprivate')} />
+            onClick={() => act('toggleprivate')} />}
+          {!self_paid && !!unlock_budget && <Button.Checkbox
+            ml={2}
+            content="Budget Ordering"
+            checked={budget_order}
+            onClick={() => act('togglebudget')} />}
         </>
       )}>
       <Flex>
@@ -347,6 +352,9 @@ const CargoCart = (props, context) => {
                 {entry.object}
               </Table.Cell>
               <Table.Cell collapsing>
+                {!!entry.budget && (
+                  <b>[{entry.budget}]</b>
+                )}
                 {!!entry.paid && (
                   <b>[Paid Privately]</b>
                 )}


### PR DESCRIPTION
# Document the changes in your pull request
Add an option to toggle between using departmental budget or cargo budget when requesting a package
Using department budget to order now actually show the departmental name to avoid confusion
Fixes issue when departmental budget amount not appearing on the app
Fixes NT IRN app not printing requisition paper
Fixes modular computer's NT IRN app showing buyer as unknown because it doesnt recognize the pda
Refactored code a bit
private crate can now be sent back to CC if unlocked

# Why is this good for the game?
Having it as a toggle allows you to conveniently order things without affecting the departmental budget or cargo budget. Currently, switching budgets requires removing the ID, which is inconvenient.

# Testing
tested on local, results:
![buget](https://github.com/yogstation13/Yogstation/assets/89688125/1180a1dc-449c-4798-93e5-0a5630ba0bef)

![budget2](https://github.com/yogstation13/Yogstation/assets/89688125/485402d5-9c06-4264-913f-db4d9099adce)




# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Add an option to toggle between using departmental budget or cargo budget when requesting a package
tweak: Using department budget to order now actually show the departmental name to avoid confusion
bugfix: Fixes issue when departmental budget amount not appearing on the app
bugfix: Fixes NT IRN app not printing requisition paper
bugfix: Fixes modular computer's NT IRN app showing buyer as unknown because it doesnt recognize the pda
tweak: Refactored code a bit
tweak: private crate can now be sent back to CC if unlocked
/:cl:
