### PR TITLE
Prevents non-cultists from using the blood cult mirror shield.

### DIFF
--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -1035,3 +1035,23 @@ GLOBAL_VAR_INIT(curselimit, 0)
 					throw_at(D.thrower, 7, 1, null)
 	else
 		..()
+
+/obj/item/shield/mirror/pickup(mob/living/user)
+	. = ..()
+	if(!iscultist(user))
+		if(!is_servant_of_ratvar(user))
+			to_chat(user, span_cultlarge("\"Foolish.\""))
+			to_chat(user, span_userdanger("A horrible force yanks at your arm!"))
+			user.emote("scream")
+			user.apply_damage(30, BRUTE, pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
+			user.dropItemToGround(src, TRUE)
+			user.Paralyze(50)
+			return
+		else
+			to_chat(user, span_cultlarge("\"One of Ratvar's toys is trying to play with things [user.p_they()] shouldn't. Cute.\""))
+			to_chat(user, span_userdanger("A horrible force yanks at your arm!"))
+			user.emote("scream")
+			user.apply_damage(30, BRUTE, pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
+			user.dropItemToGround(src, TRUE)
+			user.Paralyze(50)
+			return

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -1043,7 +1043,7 @@ GLOBAL_VAR_INIT(curselimit, 0)
 			to_chat(user, span_cultlarge("\"Foolish.\""))
 			to_chat(user, span_userdanger("A horrible force yanks at your arm!"))
 			user.emote("scream")
-			user.apply_damage(30, BRUTE, pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
+			user.apply_damage(15, BRUTE, pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM))
 			user.dropItemToGround(src, TRUE)
 			user.Paralyze(50)
 			return


### PR DESCRIPTION
# Document the changes in your pull request

In response to #20370

Picking up a blood cult mirror shield as a non-cultist will now cause you to take significant arm damage and be temporarily paralyzed.

# Why is this good for the game?

Being able to use the mirror shield as a normal member of the crew is both confusing and significantly advantageous. Most other cult items disallow the crew from taking advantage of them, while the shield was perfectly harmless to pick up and entirely safe to use. 

# Testing
Spawned in a mirror shield on a local server, picked it up as a non-cultist and had my arm battered and dislocated. Works as intended.

# Changelog
:cl:  
tweak: Picking up a blood cult mirror shield as a non-cultist will cause significant arm damage and short term paralysis.
/:cl:
