### PR TITLE
Fixes a single letter (life changing)

### DIFF
--- a/code/modules/projectiles/guns/ballistic/rifle.dm
+++ b/code/modules/projectiles/guns/ballistic/rifle.dm
@@ -158,7 +158,7 @@ obj/item/gun/ballistic/rifle/attackby(obj/item/A, mob/user, params)
 //////////////////
 
 /obj/item/gun/ballistic/rifle/sniper_rifle
-	name = "\improper anti-materiel sniper rifle"
+	name = "\improper anti-material sniper rifle"
 	desc = "A long ranged weapon that does significant damage. No, you can't quickscope."
 	icon_state = "sniper"
 	item_state = "sniper"


### PR DESCRIPTION
# Document the changes in your pull request
Fixes a microscopic typo from "anti-materiel sniper rifle" to "anti-material sniper rifle".
I was told to start small for my first PR, I don't think I can go smaller than this.

# Changelog
:cl: 
spellcheck: anti-materiel -> anti-material.
/:cl:
