### PR TITLE
I can't spell (Fixes typo for screwdriver syndicate)

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -938,4 +938,4 @@
 	id = /datum/reagent/consumable/ethanol/syndicate_screwdriver
 	results = list(/datum/reagent/consumable/ethanol/syndicate_screwdriver = 1)
 	required_reagents = list (/datum/reagent/consumable/ethanol/screwdrivercocktail = 5, /datum/reagent/consumable/ethanol/syndicatebomb = 5)
-	mix_message = "The mixture sparkles with a meancing red aura"
+	mix_message = "The mixture sparkles with a menacing red aura"


### PR DESCRIPTION
# Document the changes in your pull request

I can't spell, we can't spellcheck either and I know no one cares but me. Fixes typo in screwdriver syndicate thanks to someone reporting it. This is the report  #20435 

# Why is this good for the game?

Because it means I can actually make sure no typos are in the game


# Changelog

:cl:  

spellcheck: Fixed the typo for when you make syndicate screwdriver (flavour text)

/:cl:
