### PR TITLE
Eldritch Horror's got eye surgery???!? 

### DIFF
--- a/code/modules/antagonists/horror/horror.dm
+++ b/code/modules/antagonists/horror/horror.dm
@@ -10,6 +10,7 @@
 	melee_damage_lower = 10
 	melee_damage_upper = 10
 	see_in_dark = 8
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	stop_automated_movement = TRUE
 	attacktext = "bites"
 	speak_emote = list("gurgles")


### PR DESCRIPTION
# Document the changes in your pull request

They are from the abyss, its dark in abyss so why can they no see in dark? I've never understood why they can't see in the dark. It makes no sense game wise, lore wise or sense wise.

# Why is this good for the game?

It means horrors don't have to click around in the dark trying to find the vent quickly before sec gamers them.

# Changelog

:cl:  

rscadd: Horror's got that very needed eye surgery to give them vision in the dark

/:cl:
