### PR TITLE
Prevents the removal of objects from yourself while disabled.

### DIFF
--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -248,7 +248,10 @@ If you're feeling frisky, examine yourself and click the underlined item to pull
 /atom/movable/screen/alert/embeddedobject/Click()
 	if(iscarbon(usr))
 		var/mob/living/carbon/C = usr
-		return C.try_remove_embedded_object(C)
+		if (C.IsSleeping() || C.IsParalyzed())
+			to_chat(C, span_warning("You can't do that while disabled!"))
+		else
+			return C.try_remove_embedded_object(C)
 
 /atom/movable/screen/alert/weightless
 	name = "Weightless"

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -248,7 +248,7 @@ If you're feeling frisky, examine yourself and click the underlined item to pull
 /atom/movable/screen/alert/embeddedobject/Click()
 	if(iscarbon(usr))
 		var/mob/living/carbon/C = usr
-		if (C.IsSleeping() || C.IsParalyzed())
+		if (C.incapacitated())
 			to_chat(C, span_warning("You can't do that while disabled!"))
 		else
 			return C.try_remove_embedded_object(C)


### PR DESCRIPTION
# Document the changes in your pull request

In relation to #19807, it's no longer possible to remove your own embedded objects while unconcious or paralyzed. 

# Testing
Embedded a syringe into my chest while unconcious, attempted to remove it. Was greeted with the appropriate error message.

# Changelog
:cl:  
bugfix: It's no longer possible to remove embedded objects from yourself while unconcious or paralyzed.
/:cl:
