### PR TITLE
Buffs toolbox damage like god intended (nerfs welder)

### DIFF
--- a/code/game/objects/items/his_grace.dm
+++ b/code/game/objects/items/his_grace.dm
@@ -13,7 +13,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/toolbox_righthand.dmi'
 	icon = 'icons/obj/storage.dmi'
 	w_class = WEIGHT_CLASS_GIGANTIC
-	force = 12
+	force = 15
 	attack_verb = list("robusted")
 	hitsound = 'sound/weapons/smash.ogg'
 	var/awakened = FALSE

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -111,8 +111,8 @@
 	var/power = 0
 	for (var/obj/item/stack/telecrystal/TC in get_all_contents())
 		power += TC.amount
-	force = 22 + power
-	throwforce = 25 + power
+	force = initial(force) + power
+	throwforce = initial(throwforce) + power
 
 /obj/item/storage/toolbox/mechanical/old/clean/attack(mob/target, mob/living/user)
 	calc_damage()

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -6,8 +6,8 @@
 	lefthand_file = 'icons/mob/inhands/equipment/toolbox_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/toolbox_righthand.dmi'
 	flags_1 = CONDUCT_1
-	force = 12
-	throwforce = 12
+	force = 15
+	throwforce = 15
 	throw_speed = 2
 	throw_range = 7
 	w_class = WEIGHT_CLASS_BULKY
@@ -92,7 +92,7 @@
 /obj/item/storage/toolbox/mechanical/old/heirloom
 	name = "toolbox" //this will be named "X family toolbox"
 	desc = "It's seen better days."
-	force = 5
+	force = 8
 	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/storage/toolbox/mechanical/old/heirloom/PopulateContents()
@@ -104,15 +104,15 @@
 	icon_state = "oldtoolboxclean"
 	item_state = "toolbox_blue"
 	has_latches = FALSE
-	force = 19
-	throwforce = 22
+	force = 22
+	throwforce = 25
 
 /obj/item/storage/toolbox/mechanical/old/clean/proc/calc_damage()
 	var/power = 0
 	for (var/obj/item/stack/telecrystal/TC in get_all_contents())
 		power += TC.amount
-	force = 19 + power
-	throwforce = 22 + power
+	force = 22 + power
+	throwforce = 25 + power
 
 /obj/item/storage/toolbox/mechanical/old/clean/attack(mob/target, mob/living/user)
 	calc_damage()
@@ -154,8 +154,8 @@
 	name = "suspicious looking toolbox"
 	icon_state = "syndicate"
 	item_state = "toolbox_syndi"
-	force = 15
-	throwforce = 18
+	force = 18
+	throwforce = 21
 	w_class = WEIGHT_CLASS_NORMAL
 	material_flags = MATERIAL_NO_COLOR
 

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -77,7 +77,7 @@
 			return
 	//Welders left on now use up fuel, but lets not have them run out quite that fast
 		if(1)
-			force = 15
+			force = 12
 			damtype = BURN
 			burned_fuel_for += delta_time
 			if(burned_fuel_for >= WELDER_FUEL_BURN_INTERVAL)
@@ -223,7 +223,7 @@
 		if(get_fuel() >= 1)
 			to_chat(user, span_notice("You switch [src] on."))
 			playsound(loc, acti_sound, 50, 1)
-			force = 15
+			force = 12
 			damtype = BURN
 			hitsound = 'sound/items/welder.ogg'
 			update_appearance(UPDATE_ICON)


### PR DESCRIPTION
# Document the changes in your pull request

All toolboxes have received a +3 damage/throw damage buff, all welders have received a -3 damage nerf while turned on

# Why is this good for the game?

If this gets merged I'll come back

Welding tools are small sized and are slightly more plentiful than toolboxes, so they should not be more powerful in terms of combat. Toolboxes are meant to be robust, which is reflected in their bulky size.

The main complaint I got when attempting a welding tool nerf was that crew need *some* kind of weapon, so I decided it should be toolboxes instead of welding tools, which are bulky instead of small sized.

The toolbox will also help fill the small amount of high damage blunt force in the game currently, which will lead to healthier rebalances of blunt force wounds if it is deemed necessary.

# Testing
Numbers change

# Wiki Documentation
Most toolboxes now deal 15 damage instead of 12.

Heirloom toolbox is now 8 damage instead of 5

The base damage of the ancient toolbox is now 22 instead of 19, meaning you now require 12+2TC instead of 15+2TC to reach the 34 damage threshold.

His Grace now starts at 15 damage instead of 12, which does not affect the amount of kills needed.

# Changelog

:cl:  
tweak: Toolboxes now universally do 3 more damage
tweak: Welding tool flames now do 3 less damage
/:cl:
