### PR TITLE
Makes cautery tool do burn damage + adv drill sharp

### DIFF
--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -99,7 +99,6 @@
 	materials = list(/datum/material/iron=2500, /datum/material/glass=750)
 	w_class = WEIGHT_CLASS_TINY
 	toolspeed = 0.5
-	attack_verb = list("burnt")
 
 
 /obj/item/cautery/bone

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -83,7 +83,7 @@
 	item_flags = SURGICAL_TOOL
 	tool_behaviour = TOOL_CAUTERY
 	w_class = WEIGHT_CLASS_TINY
-	force = 2
+	force = 3
 	damtype = BURN
 	attack_verb = list("burnt")
 

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -83,6 +83,8 @@
 	item_flags = SURGICAL_TOOL
 	tool_behaviour = TOOL_CAUTERY
 	w_class = WEIGHT_CLASS_TINY
+	force = 2
+	damtype = BURN
 	attack_verb = list("burnt")
 
 /obj/item/cautery/attack(mob/living/M, mob/user)
@@ -459,11 +461,15 @@
 		playsound(get_turf(user),'sound/items/welderdeactivate.ogg',50,1)
 		to_chat(user, span_notice("You focus the lensess, it is now set to drilling mode."))
 		tool_behaviour = TOOL_DRILL
+		sharpness = SHARP_POINTY
+		force += 1 //we don't want to ruin sharpened stuff
 		icon_state = "surgicaldrill_a"
 	else
 		playsound(get_turf(user),'sound/weapons/tap.ogg',50,1)
 		to_chat(user, span_notice("You dilate the lenses, setting it to mending mode."))
 		tool_behaviour = TOOL_CAUTERY
+		sharpness = SHARP_NONE
+		force -= 1
 		icon_state = "cautery_a"
 
 /obj/item/cautery/advanced/examine()

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -462,7 +462,7 @@
 		to_chat(user, span_notice("You focus the lensess, it is now set to drilling mode."))
 		tool_behaviour = TOOL_DRILL
 		sharpness = SHARP_POINTY
-		force += 1 //we don't want to ruin sharpened stuff
+		force += 1
 		icon_state = "surgicaldrill_a"
 	else
 		playsound(get_turf(user),'sound/weapons/tap.ogg',50,1)


### PR DESCRIPTION
# Why is this good for the game?
The nerf to welding tools will weaken being able to fight space vines
Since vines take 4x damage to burn, and 4x damage to sharp (16x if both)
this will give another weapon to fight vines for those that feel like running into maints after the vines without giving another civilian weapon

Also this just sorta makes sense, it's hot, it's gonna burn

:cl:  
tweak: Cautery tools have 3 force and do burn damage
tweak: Advanced Catuery tools in drill mode are sharp and have 4 force
/:cl:
