### PR TITLE
Tweaks worldbreaker's pummel targeting

### DIFF
--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -57,7 +57,7 @@
 
 	if(isitem(target))//don't attack if we're clicking on our inventory
 		var/obj/item/thing = target
-		if(thing.item_flags & IN_INVENTORY || thing.loc == H)
+		if(thing in H.get_all_contents())
 			return
 
 	if(H.a_intent == INTENT_DISARM)


### PR DESCRIPTION
# Why is this good for the game?
Makes pummel feel better

:cl:  
tweak: No longer need to click adjacent tiles to attack using worldbreaker's pummel
bugfix: Can no longer use worldbreaker abilities on items in inventory
/:cl:
