### PR TITLE
Makes luminescent jellypeople not able to use slime core activations while incapacitated

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -597,7 +597,7 @@
 
 /datum/action/innate/use_extract/Activate()
 	var/mob/living/carbon/human/H = owner
-	if(!is_species(H, /datum/species/jelly/luminescent) || !species)
+	if(!is_species(H, /datum/species/jelly/luminescent) || !species || H.incapacitated())
 		return
 	CHECK_DNA_AND_SPECIES(H)
 


### PR DESCRIPTION
# Document the changes in your pull request

# Why is this good for the game?
It's annoying, and makes no sense to have someone teleport/explode/spawn hostile mobs while they are incapacitated.

# Testing
no testing needed, it's a simple additional check

# Changelog
:cl:  
tweak: cannot activate luminescent slime core effects while incapacitated
/:cl:
