### PR TITLE
Janitors can now get mail delivered again

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -249,7 +249,7 @@ GLOBAL_LIST_INIT(TAGGERLOCATIONS_DEPARTMENTAL, list(
 	"Engineering" = list("Engineering", "Atmospherics", "CE Office"),
 	"Cargo" = list("Disposals", "Cargo Bay", "QM Office"),
 	"Service" = list("Bar", "Kitchen", "Hydroponics", "Janitor Closet", "HoP Office"),
-	"Civillian" = list("Dormitories", "Theatre", "Chapel", "Law Office", "Library")
+	"Civilian" = list("Dormitories", "Theatre", "Chapel", "Law Office", "Library")
 ))
 
 GLOBAL_LIST_INIT(station_prefixes, world.file2list("strings/station_prefixes.txt") + "")

--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -247,9 +247,9 @@ GLOBAL_LIST_INIT(TAGGERLOCATIONS_DEPARTMENTAL, list(
 	"Medical" = list("Medbay", "Chemistry", "Genetics", "Virology", "CMO Office"),
 	"Science" = list("Research", "Robotics", "Xenobiology", "Toxins", "Testing Range", "RD Office"),
 	"Engineering" = list("Engineering", "Atmospherics", "CE Office"),
-	"Civilian" = list("Disposals", "Cargo Bay", "QM Office"),
-	"Service" = list("Bar", "Kitchen", "Hydroponics", "HoP Office"),
-	"Miscellaneous" = list("Dormitories", "Theatre", "Chapel", "Law Office", "Library")
+	"Cargo" = list("Disposals", "Cargo Bay", "QM Office"),
+	"Service" = list("Bar", "Kitchen", "Hydroponics", "Janitor Closet", "HoP Office"),
+	"Civillian" = list("Dormitories", "Theatre", "Chapel", "Law Office", "Library")
 ))
 
 GLOBAL_LIST_INIT(station_prefixes, world.file2list("strings/station_prefixes.txt") + "")


### PR DESCRIPTION
# Document the changes in your pull request

Adds Janitor Closet back to the destination tagger menu, where it was missing.
Also renamed some of the groupings to be more accurate.

Eventually a full disposals redo is probably needed as I don't think it's working QUITE right but that's not the scope of this PR.

# Why is this good for the game?

It was there, then it wasn't, now it's back. Fixed.

# Testing

Tested item, all items appear as desired.

# Changelog

:cl:  
bugfix: Added Janitor Closet back to destination tagger menu
tweak: Changed a couple of the group names to be more accurate
/:cl:
