### PR TITLE
adds new speedy mutation to genetics

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -57,6 +57,7 @@
 #define GELADIKINESIS		/datum/mutation/human/geladikinesis
 #define CRYOKINESIS /datum/mutation/human/cryokinesis
 #define CEREBRAL	/datum/mutation/human/cerebral
+#define SPEEDY		/datum/mutation/human/speedy
 #define THICKSKIN	/datum/mutation/human/thickskin
 #define DENSEBONES	/datum/mutation/human/densebones
 

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -253,6 +253,24 @@
 		owner.physiology.brute_mod /= 0.8
 		owner.physiology.burn_mod /= 0.9
 
+/datum/mutation/human/speedy //only obtainable through polysmorphs
+	name = "Speedy"
+	desc = "The user's leg muscles dispose of their lactic acid more efficiently and faster, allowing for faster running."
+	text_gain_indication = span_notice("You feel like you can run faster!")
+	text_gain_indication = span_notice("You feel slow again.")
+	quality = POSITIVE
+	difficulty = 18
+	instability = 40
+
+/datum/mutation/human/speedy/on_acquiring(mob/living/carbon/human/owner)
+	. = ..()
+	if(!ispolysmorph(owner)) //polysmorphs "already have the gene" so they can't go even faster
+		owner.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=-0.1, blacklisted_movetypes=(FLYING|FLOATING))
+
+/datum/mutation/human/speedy/on_losing(mob/living/carbon/human/owner)
+	. = ..()
+	owner.remove_movespeed_modifier(type)
+
 //Makes strong actually useful. Somewhat.
 /datum/mutation/human/strong
 	name = "Strength"

--- a/code/game/objects/items/dna_injector.dm
+++ b/code/game/objects/items/dna_injector.dm
@@ -105,6 +105,11 @@
 	desc = "Restores the dragon ancestry."
 	add_mutations = list(FIREBREATH)
 
+/obj/item/dnainjector/speedy
+	name = "\improper DNA injector (Speedy)"
+	desc = "This will make you run faster"
+	add_mutations = list(SPEEDY)
+
 /obj/item/dnainjector/xraymut
 	name = "\improper DNA injector (X-ray)"
 	desc = "Finally you can see what the Captain does."

--- a/code/modules/mob/living/carbon/human/species_types/polysmorphs.dm
+++ b/code/modules/mob/living/carbon/human/species_types/polysmorphs.dm
@@ -18,6 +18,7 @@
 	acidmod = 0.2 //Their blood is literally acid
 	action_speed_coefficient = 1.1 //claws aren't dextrous like hands
 	speedmod = -0.1 //apex predator humanoid hybrid
+	inert_mutation = SPEEDY
 	punchdamagehigh = 11 //slightly better high end of damage
 	punchstunthreshold = 11 //technically slightly worse stunchance
 	payday_modifier = 0.3 //Some are quite literally slaves + they HAVE to work for NT


### PR DESCRIPTION

# Document the changes in your pull request

adds a new mutation only obtainable through polysmorphs, similarly to fire breath.
makes you go 10% faster, like polysmorphs.
has 40 instability.

# Why is this good for the game?
more species specific genes are good.
the speed bonus is only 10% so it won't be a meta pick.

# Testing
tested on local, was able to find the gene from a polysmorph, make a mutator and run slightly faster

# Wiki Documentation

add this to guide to genetics:

mutation name: Speedy
description: "The user's leg muscles dispose of their lactic acid more efficiently and faster, allowing for faster running."
message: "You feel like you can run faster!"
how to obtain: Polysmorph species
incompatible with: none
instability: 40
compatible chromosomes: Reinforcement, Stabilizer

# Changelog

:cl:  
rscadd: Added new Speedy mutation, obtainable through Polysmorphs.
/:cl:
