### PR TITLE
V1 Module can no longer be bought on lowpop (>25 players)

### DIFF
--- a/yogstation/code/modules/uplink/uplink_item.dm
+++ b/yogstation/code/modules/uplink/uplink_item.dm
@@ -180,6 +180,7 @@
 			If you install this, it will make you incapable of pushing and pulling. \
 			There are no half-measures, either you succeed or you die."
 	cost = 20
+	player_minimum = 25 //maybe we SHOULDNT be giving this to lowpop traitors when theres no sec?
 	item = /obj/item/book/granter/martial/ultra_violence
 	restricted_species = list("ipc")
 	include_objectives = list(/datum/objective/hijack, /datum/objective/martyr, /datum/objective/nuclear) // designed around mass murder, no need to use this if you aren't allowed to do that


### PR DESCRIPTION
# Document the changes in your pull request
title

# Why is this good for the game?
lowpop murder sprees are bad, this makes it very easy and easy murder on lowpop when no sec exist = bad

# Wiki Documentation

needs mention on wiki that this cant be bought under 25 people

# Changelog

:cl:  cark
tweak: v1 can no longer be bought if there are under 25 players in the round
/:cl:
