### PR TITLE
change stabilized plasma decal sprite to something that doesnt block you from clicking the tile

### DIFF
--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -215,8 +215,8 @@
 /obj/effect/decal/cleanable/plasma
 	name = "stabilized plasma"
 	desc = "A puddle of stabilized plasma."
-	icon_state = "flour"
-	icon = 'icons/effects/tomatodecal.dmi'
+	icon_state = "molten"
+	icon = 'icons/effects/effects.dmi'
 	color = "#C8A5DC"
 
 /obj/effect/decal/cleanable/insectguts


### PR DESCRIPTION
bad

# Document the changes in your pull request
change stabilized plasma decal sprite to something that doesnt block you from clicking the tile

# Why is this good for the game?
blocking tile is bad

# Testing
new sprite made the tile clickable

# Spriting
the new sprite which already exists
![image](https://github.com/yogstation13/Yogstation/assets/89688125/5b181fe1-9d90-40c3-9fb0-c13bf61e8e17)



# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

imageadd: change stabilized plasma decal sprite to something that doesnt block you from clicking the tile
/:cl:
