### PR TITLE
Significantly alters the length of RDS.

### DIFF
--- a/code/datums/brain_damage/mild.dm
+++ b/code/datums/brain_damage/mild.dm
@@ -38,7 +38,7 @@
 	if(owner.reagents.has_reagent(/datum/reagent/toxin/mindbreaker, needs_metabolizing = TRUE))
 		owner.remove_status_effect(/datum/status_effect/hallucination)
 	else if(prob(2))
-		owner.adjust_hallucinations(rand(10, 25))
+		owner.adjust_hallucinations(rand(30, 90))
 	..()
 
 /datum/brain_trauma/mild/reality_dissociation/on_lose()


### PR DESCRIPTION
# Document the changes in your pull request

I've increased the length of the hallucinations triggered by reality dissasociation syndrome from 5 to 25 ticks to 30 to 90 ticks. 

# Why is this good for the game?

Currently RDS is a very ineffective negative perk that very often doesn't really seem to work as intended. Currently there's a 2% chance per tick to trigger 10 to 25 ticks of hallucinations, the issue is that hallucinations have an internal timer to prevent spam of 5 to 30 ticks. In effect the length of any hallucination was never usually long enough for it to matter as the second set of hallucinations would likely never make it in before your hallucinations naturally ended.

With this change the RDS hallucinations will last for a lengthy period of time, but processing any mindbreaker during them will immediately put the hallucinations to an end. Given that the person with this negative quirk spawns with a large number of mindbreaker gummies they should be able to manage a full round.

# Testing
Just a number tweak, no testing seemed needed.

# Changelog

:cl:  
tweak: Hallucinations from RDS will now last significantly longer.
/:cl:
