### PR TITLE
Buffs all of Detective's clothing so that they have the armor values they should

### DIFF
--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -52,7 +52,7 @@
 	item_state = "det_suit"
 	blood_overlay_type = "coat"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(MELEE = 25, BULLET = 10, LASER = 25, ENERGY = 10, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 45)
+	armor = list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 10, BOMB = 25, BIO = 0, RAD = 0, FIRE = 50, ACID = 50, WOUND = 15)
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	heat_protection = CHEST|GROIN|LEGS|ARMS
 	mutantrace_variation = MUTANTRACE_VARIATION

--- a/yogstation/code/modules/clothing/suits/miscellaneous.dm
+++ b/yogstation/code/modules/clothing/suits/miscellaneous.dm
@@ -248,7 +248,7 @@
 	desc = "A detective jacket, in gold!"
 	icon_state = "gold_detective"
 	item_state = "gold_item"
-	armor = list(MELEE = 25, BULLET = 10, LASER = 25, ENERGY = 10, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 45)
+	armor = list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 10, BOMB = 25, BIO = 0, RAD = 0, FIRE = 50, ACID = 50, WOUND = 15)
 
 /obj/item/clothing/suit/yogs/golddetective/Initialize(mapload)
 	. = ..()
@@ -277,7 +277,7 @@
 	desc = "For those detectives that value fashion over function."
 	icon_state = "detective_coat"
 	item_state = "detective_item"
-	armor = list(MELEE = 25, BULLET = 10, LASER = 25, ENERGY = 10, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 45)
+	armor = list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 10, BOMB = 25, BIO = 0, RAD = 0, FIRE = 50, ACID = 50, WOUND = 15)
 
 /obj/item/clothing/suit/yogs/detectivecoat/Initialize(mapload)
 	. = ..()
@@ -307,7 +307,7 @@
 	desc = "A detective jacket that is blue!"
 	icon_state = "blue_detective"
 	item_state = "blue_item"
-	armor = list(MELEE = 25, BULLET = 10, LASER = 25, ENERGY = 10, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 45)
+	armor = list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 10, BOMB = 25, BIO = 0, RAD = 0, FIRE = 50, ACID = 50, WOUND = 15)
 
 /obj/item/clothing/suit/yogs/bluedetective/Initialize(mapload)
 	. = ..()

--- a/yogstation/code/modules/clothing/under/miscellaneous.dm
+++ b/yogstation/code/modules/clothing/under/miscellaneous.dm
@@ -225,6 +225,7 @@
 	desc = "A suit often worn by those detective types. Now in blue!"
 	icon_state = "blue_detective"
 	item_state = "blue_detective"
+	armor = list(MELEE = 10, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 30, ACID = 30, WOUND = 10)
 	can_adjust = FALSE
 
 /obj/item/clothing/under/yogs/golddetective
@@ -232,12 +233,14 @@
 	desc = "A suit often worn by those detective types. Now in gold!"
 	icon_state = "gold_detective"
 	item_state = "gold_detective"
+	armor = list(MELEE = 10, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 30, ACID = 30, WOUND = 10)
 
 /obj/item/clothing/under/yogs/greydetective
 	name = "grey detective suit"
 	desc = "A suit often worn by those detective types. Now in boring old grey!"
 	icon_state = "grey_detective"
 	item_state = "grey_detective"
+	armor = list(MELEE = 10, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 30, ACID = 30, WOUND = 10)
 	can_adjust = FALSE
 
 /obj/item/clothing/under/yogs/blackdetective
@@ -245,6 +248,7 @@
 	desc = "A suit often worn by those detective types. Now in black!"
 	icon_state = "black_detective"
 	item_state = "black_detective"
+	armor = list(MELEE = 10, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 30, ACID = 30, WOUND = 10)
 	can_adjust = FALSE
 
 /obj/item/clothing/under/yogs/whitetuxedo


### PR DESCRIPTION
# Document the changes in your pull request

Buffs all the detective's under items to have the same armor as the hard-worn suit (generic det suit, same armor as sec clothes) because they didn't.

Buffs all of det's coats to have the same armor as his vest so he need not choose function over fasion

# Why is this good for the game?
being able to customize your look without having to worry about being less armored good

# Changelog

:cl:  cark
tweak: buffed detective's armor to be the values it rightfully should be
/:cl:
