### PR TITLE
Fix unnable to give rnd console access

### DIFF
--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -239,7 +239,7 @@
 		if(ACCESS_RND)
 			return "R&D Lab and Console"
 		if(ACCESS_TOX)
-			return "Toxin Lab"
+			return "Toxins Lab"
 		if(ACCESS_TOX_STORAGE)
 			return "Toxins Lab Storage"
 		if(ACCESS_CHEMISTRY)

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -236,10 +236,12 @@
 			return "Genetics Lab"
 		if(ACCESS_MORGUE)
 			return "Morgue"
+		if(ACCESS_RND)
+			return "R&D Lab and Console"
 		if(ACCESS_TOX)
-			return "R&D Lab"
+			return "Toxin Lab"
 		if(ACCESS_TOX_STORAGE)
-			return "Toxins Lab"
+			return "Toxins Lab Storage"
 		if(ACCESS_CHEMISTRY)
 			return "Chemistry Lab"
 		if(ACCESS_RD)


### PR DESCRIPTION
you can still give rnd console access but you will have to grant research region access and not doing so manually, also the R&D desc on id mod is wrong, it gives you toxin access but not the rnd console access due to the recent change #20222 

# Document the changes in your pull request
Fix unnable to give rnd console access to ID
Changed the "R&D Access" desc on id mod to "Toxin Access" desc so it wont confuse people

# Testing
tested, id console now shows and gives the access properly
![image](https://github.com/yogstation13/Yogstation/assets/89688125/2206f743-6608-456e-a7a1-46e6c001a4b8)
![image](https://github.com/yogstation13/Yogstation/assets/89688125/d521f661-c6f6-4696-a5f0-23f6b935e65c)






# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: Fix unnable to give rnd console access to ID
spellcheck: Changed the "R&D Access" desc on id mod to "Toxins Access" desc so it wont confuse people
/:cl:
