### PR TITLE
slight reduction to dumb ultrakill reference weapn attack speed

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -434,7 +434,7 @@
 	item_state = "fulldual"
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_HUGE
-	force = 12
+	force = 10
 	block_chance = 10
 	wound_bonus = -20
 	attack_verb = list("thwacked")

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -539,7 +539,7 @@
 		return
 	user.swap_hand()
 	secondsword.attack(M, user, TRUE)
-	user.changeNext_move(CLICK_CD_MELEE*1.4)
+	user.changeNext_move(CLICK_CD_MELEE * 1.4)
 
 /obj/item/nullrod/handedsword/dropped(mob/user, silent = TRUE)
 	. = ..()

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -434,7 +434,7 @@
 	item_state = "fulldual"
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_HUGE
-	force = 10
+	force = 12
 	block_chance = 10
 	wound_bonus = -20
 	attack_verb = list("thwacked")
@@ -539,7 +539,7 @@
 		return
 	user.swap_hand()
 	secondsword.attack(M, user, TRUE)
-	user.changeNext_move(CLICK_CD_MELEE)
+	user.changeNext_move(CLICK_CD_MELEE*1.4)
 
 /obj/item/nullrod/handedsword/dropped(mob/user, silent = TRUE)
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

apostate blade attack cooldown increased by 40%, putting its damage in line with a default nullrod




# Why is this good for the game?
near armblade level damage plus ~20 blockchance is probably worth a bit more than just using a twohanded weapon

# Testing
small number change, unrequired

# Wiki Documentation

poastate blade attack cooldown increased by 40% (~.3 seconds)
# Changelog


:cl:  
tweak: apostate blade attack cooldown increased by 40%, putting its damage in line with other nullrods
/:cl:
