### PR TITLE
Adds a delay to leaving ventcrawling

### DIFF
--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -35,7 +35,8 @@
 	goal = goal_number
 	bar_loc = target
 	bar = image('icons/effects/progessbar.dmi', bar_loc, "prog_bar_0")
-	bar.plane = ABOVE_HUD_PLANE //SET_PLANE_EXPLICIT(bar, ABOVE_HUD_PLANE, User) //comment in when we port TG planes
+	bar.plane = ABOVE_HUD_PLANE + 1 //yogs change, increased so it draws ontop of ventcrawling overlays
+	//SET_PLANE_EXPLICIT(bar, ABOVE_HUD_PLANE, User) //comment in when we port TG planes
 	bar.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
 	user = User
 

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -327,6 +327,8 @@ GLOBAL_LIST_EMPTY(pipeimages)
 	if(target_move)
 		if(target_move.can_crawl_through())
 			if(is_type_in_typecache(target_move, GLOB.ventcrawl_machinery))
+				if(!do_after(user, 2 SECONDS, get_turf(target_move)))
+					return
 				user.forceMove(target_move.loc) //handle entering and so on.
 				user.visible_message(span_notice("You hear something squeezing through the ducts..."), "<span class='notice'>You climb out the ventilation system.")
 			else


### PR DESCRIPTION
# Why is this good for the game?
A slime or horror accidentally leaving a vent at the wrong time can instantly kill them
adds a slight delay so they have a chance to cancel it if they weren't wanting to leave

:cl:  
tweak: Adds a 2 second delay to leaving ventcrawling
/:cl:
