### PR TITLE
dragnet tweaks

### DIFF
--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -49,10 +49,15 @@
 
 /obj/item/ammo_casing/energy/net
 	projectile_type = /obj/item/projectile/energy/net
-	select_name = "netting"
+	select_name = "netting (single)"
+	e_cost = 50
+	harmful = FALSE
+
+/obj/item/ammo_casing/energy/net/scatter
+	projectile_type = /obj/item/projectile/energy/net/scatter
+	select_name = "netting (scatter)"
 	pellets = 6
 	variance = 26
-	harmful = FALSE
 
 /obj/item/ammo_casing/energy/net/ready_proj(atom/target, mob/living/user, quiet, zone_override = "")
 	..()

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -118,11 +118,11 @@
 	. = ..()
 	teleport_mode = !teleport_mode
 	to_chat(user, span_notice("You turn [teleport_mode? "on":"off"] the teleport mode."))
-	for(var/obj/item/ammo_casing/energy/net/EN in ammo_type)
-		EN.teleport_mode = teleport_mode
+	modify_projectile()
 
 /obj/item/gun/energy/e_gun/dragnet/proc/modify_projectile(obj/item/projectile/energy/net/N)
 	N.teletarget = teletarget
+	N.teleport_mode = teleport_mode
 
 /obj/item/gun/energy/e_gun/dragnet/snare
 	name = "Energy Snare Launcher"

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -70,11 +70,12 @@
 	item_state = "dragnet"
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
-	ammo_type = list(/obj/item/ammo_casing/energy/net, /obj/item/ammo_casing/energy/trap)
+	ammo_type = list(/obj/item/ammo_casing/energy/net, /obj/item/ammo_casing/energy/net/scatter, /obj/item/ammo_casing/energy/trap)
 	can_flashlight = FALSE
 	ammo_x_offset = 1
 	weapon_weight = WEAPON_MEDIUM
 	var/obj/item/beacon/teletarget = null
+	var/teleport_mode = FALSE
 
 /obj/item/gun/energy/e_gun/dragnet/AltClick(mob/living/user) //stolen from hand teleporter code
 	var/turf/current_location = get_turf(user)//What turf is the user on?
@@ -113,8 +114,14 @@
 		teletarget = T
 		user.show_message(span_notice("Locked In."), MSG_AUDIBLE)
 
+/obj/item/gun/energy/e_gun/dragnet/CtrlClick(mob/user)
+	. = ..()
+	teleport_mode = !teleport_mode
+	to_chat(user, span_notice("You turn [teleport_mode? "on":"off"] the teleport mode."))
+
 /obj/item/gun/energy/e_gun/dragnet/proc/modify_projectile(obj/item/projectile/energy/net/N)
 	N.teletarget = teletarget
+	N.teleport_mode = teleport_mode
 
 /obj/item/gun/energy/e_gun/dragnet/snare
 	name = "Energy Snare Launcher"

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -118,10 +118,11 @@
 	. = ..()
 	teleport_mode = !teleport_mode
 	to_chat(user, span_notice("You turn [teleport_mode? "on":"off"] the teleport mode."))
+	for(var/obj/item/ammo_casing/energy/net/EN in ammo_type)
+		EN.teleport_mode = teleport_mode
 
 /obj/item/gun/energy/e_gun/dragnet/proc/modify_projectile(obj/item/projectile/energy/net/N)
 	N.teletarget = teletarget
-	N.teleport_mode = teleport_mode
 
 /obj/item/gun/energy/e_gun/dragnet/snare
 	name = "Energy Snare Launcher"

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -121,7 +121,7 @@
 
 /obj/item/gun/energy/e_gun/dragnet/proc/modify_projectile(obj/item/projectile/energy/net/N)
 	N.teletarget = teletarget
-	N.teleport_mode = teleport
+	N.teleport_mode = teleport_mode
 
 /obj/item/gun/energy/e_gun/dragnet/snare
 	name = "Energy Snare Launcher"

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -122,6 +122,7 @@
 /obj/item/gun/energy/e_gun/dragnet/proc/modify_projectile(obj/item/projectile/energy/net/N)
 	N.teletarget = teletarget
 	N.teleport_mode = teleport
+
 /obj/item/gun/energy/e_gun/dragnet/snare
 	name = "Energy Snare Launcher"
 	desc = "Fires an energy snare that slows the target down."

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -65,7 +65,7 @@
 
 /obj/item/gun/energy/e_gun/dragnet
 	name = "\improper DRAGnet"
-	desc = "The \"Dynamic Rapid-Apprehension of the Guilty\" net is a revolution in law enforcement technology. Alt+click it to set a destination for the netting mode if a teleporter is set up."
+	desc = "The \"Dynamic Rapid-Apprehension of the Guilty\" net is a revolution in law enforcement technology. Alt+click it to set a destination for the netting mode if a teleporter is set up. Ctrl+click to toggle on/off teleport mode "
 	icon_state = "dragnet"
 	item_state = "dragnet"
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -118,12 +118,10 @@
 	. = ..()
 	teleport_mode = !teleport_mode
 	to_chat(user, span_notice("You turn [teleport_mode? "on":"off"] the teleport mode."))
-	modify_projectile()
 
 /obj/item/gun/energy/e_gun/dragnet/proc/modify_projectile(obj/item/projectile/energy/net/N)
 	N.teletarget = teletarget
-	N.teleport_mode = teleport_mode
-
+	N.teleport_mode = teleport
 /obj/item/gun/energy/e_gun/dragnet/snare
 	name = "Energy Snare Launcher"
 	desc = "Fires an energy snare that slows the target down."

--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -1,11 +1,15 @@
 /obj/item/projectile/energy/net
 	name = "energy netting"
 	icon_state = "e_netting"
-	damage = 10
+	damage = 40
 	damage_type = STAMINA
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 10
 	var/obj/item/beacon/teletarget = null
+	var/teleport_mode = FALSE
+
+/obj/item/projectile/energy/net/scatter
+	damage = 10
 
 /obj/item/projectile/energy/net/Initialize(mapload)
 	. = ..()
@@ -14,7 +18,7 @@
 /obj/item/projectile/energy/net/on_hit(atom/target, blocked = FALSE)
 	if(isliving(target))
 		var/turf/Tloc = get_turf(target)
-		if(!locate(/obj/effect/nettingportal) in Tloc)
+		if(!locate(/obj/effect/nettingportal) in Tloc && teleport_mode)
 			new /obj/effect/nettingportal(Tloc, destination = teletarget)
 	..()
 

--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -18,7 +18,7 @@
 /obj/item/projectile/energy/net/on_hit(atom/target, blocked = FALSE)
 	if(isliving(target))
 		var/turf/Tloc = get_turf(target)
-		if(!locate(/obj/effect/nettingportal) in Tloc && teleport_mode)
+		if((!locate(/obj/effect/nettingportal) in Tloc) && teleport_mode)
 			new /obj/effect/nettingportal(Tloc, destination = teletarget)
 	..()
 


### PR DESCRIPTION


# Document the changes in your pull request
- splits netting mode into two seperated modes: 
1. single mode: does less stamina damage than 6 pellets combined with single shot and consume less energy
2. scatter: still the same and still cost high energy
- dragnet now has an option to toggle teleportation on or off



# Why is this good for the game?
single shot is cool, let you focus on further target.

teleportation toggle is also very connvenient. Sometimes you do not want your target to be teleported or whatsoever

# Testing
tested on local



# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: splits netting mode into two seperated modes: single and scatter
tweak: dragnet now has an option to toggle teleportation on or off
/:cl:
