### PR TITLE
Buffs all of Detective's clothing so that they have the armor values they should

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -757,13 +757,13 @@
 	new /obj/item/clothing/head/fedora/det_hat/grey(src)
 	new /obj/item/clothing/shoes/laceup(src)
 	new /obj/item/clothing/under/yogs/forensictech(src)
-	new /obj/item/clothing/under/yogs/bluedetective(src)
-	new /obj/item/clothing/under/yogs/golddetective(src)
-	new /obj/item/clothing/under/yogs/greydetective(src)
-	new /obj/item/clothing/under/yogs/blackdetective(src)
-	new /obj/item/clothing/suit/yogs/golddetective(src)
-	new /obj/item/clothing/suit/yogs/detectivecoat(src)
-	new /obj/item/clothing/suit/yogs/bluedetective(src)
+	new /obj/item/clothing/under/rank/det/bluedetective(src)
+	new /obj/item/clothing/under/rank/det/golddetective(src)
+	new /obj/item/clothing/under/rank/det/greydetective(src)
+	new /obj/item/clothing/under/rank/det/blackdetective(src)
+	new /obj/item/clothing/suit/det_suit/golddetective(src)
+	new /obj/item/clothing/suit/det_suit/detectivecoat(src)
+	new /obj/item/clothing/suit/det_suit/bluedetective(src)
 
 /obj/item/storage/backpack/duffelbag/clothing/sec/warden
 	name = "Warden's clothing duffelbag"

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -756,7 +756,7 @@
 	new /obj/item/clothing/suit/det_suit/tan(src)
 	new /obj/item/clothing/head/fedora/det_hat/grey(src)
 	new /obj/item/clothing/shoes/laceup(src)
-	new /obj/item/clothing/under/yogs/forensictech(src)
+	new /obj/item/clothing/under/rank/det/forensictech(src)
 	new /obj/item/clothing/under/rank/det/bluedetective(src)
 	new /obj/item/clothing/under/rank/det/golddetective(src)
 	new /obj/item/clothing/under/rank/det/greydetective(src)

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -52,7 +52,7 @@
 	item_state = "det_suit"
 	blood_overlay_type = "coat"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(MELEE = 25, BULLET = 10, LASER = 25, ENERGY = 10, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 45)
+	armor = list(MELEE = 30, BULLET = 30, LASER = 30, ENERGY = 10, BOMB = 25, BIO = 0, RAD = 0, FIRE = 50, ACID = 50, WOUND = 15)
 	cold_protection = CHEST|GROIN|LEGS|ARMS
 	heat_protection = CHEST|GROIN|LEGS|ARMS
 	mutantrace_variation = MUTANTRACE_VARIATION

--- a/yogstation/code/modules/clothing/suits/miscellaneous.dm
+++ b/yogstation/code/modules/clothing/suits/miscellaneous.dm
@@ -243,17 +243,24 @@
     icon_state = "caretakerhood"
     flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEFACIALHAIR|HIDEHAIR
 
-/obj/item/clothing/suit/yogs/golddetective
+/obj/item/clothing/suit/det_suit/golddetective
 	name = "gold detective jacket"
 	desc = "A detective jacket, in gold!"
 	icon_state = "gold_detective"
 	item_state = "gold_item"
-	armor = list(MELEE = 25, BULLET = 10, LASER = 25, ENERGY = 10, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 45)
 
-/obj/item/clothing/suit/yogs/golddetective/Initialize(mapload)
-	. = ..()
-	allowed = GLOB.detective_vest_allowed
+/obj/item/clothing/suit/det_suit/detectivecoat
+	name = "detective long coat"
+	desc = "For those detectives that value fashion over function."
+	icon_state = "detective_coat"
+	item_state = "detective_item"
 
+/obj/item/clothing/suit/det_suit/bluedetective
+	name = "blue detective jacket"
+	desc = "A detective jacket that is blue!"
+	icon_state = "blue_detective"
+	item_state = "blue_item"
+	
 /obj/item/clothing/suit/yogs/leathercoat
 	name = "black leather coat"
 	desc = "So you too can be the one."
@@ -272,16 +279,6 @@
 	icon_state = "janitor_coat"
 	item_state = "janitor_item"
 
-/obj/item/clothing/suit/yogs/detectivecoat
-	name = "detective long coat"
-	desc = "For those detectives that value fashion over function."
-	icon_state = "detective_coat"
-	item_state = "detective_item"
-	armor = list(MELEE = 25, BULLET = 10, LASER = 25, ENERGY = 10, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 45)
-
-/obj/item/clothing/suit/yogs/detectivecoat/Initialize(mapload)
-	. = ..()
-	allowed = GLOB.detective_vest_allowed
 
 /obj/item/clothing/suit/yogs/blacktrenchcoat
 	name = "black trenchcoat"
@@ -301,17 +298,6 @@
 	desc = "To help achieve inner peace."
 	icon_state = "monkrobes"
 	item_state = "monkrobes"
-
-/obj/item/clothing/suit/yogs/bluedetective
-	name = "blue detective jacket"
-	desc = "A detective jacket that is blue!"
-	icon_state = "blue_detective"
-	item_state = "blue_item"
-	armor = list(MELEE = 25, BULLET = 10, LASER = 25, ENERGY = 10, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 45)
-
-/obj/item/clothing/suit/yogs/bluedetective/Initialize(mapload)
-	. = ..()
-	allowed = GLOB.detective_vest_allowed
 
 /obj/item/clothing/suit/hooded/spesshoodie
     mob_overlay_icon = 'yogstation/icons/mob/clothing/suit/suit.dmi'

--- a/yogstation/code/modules/clothing/under/miscellaneous.dm
+++ b/yogstation/code/modules/clothing/under/miscellaneous.dm
@@ -220,27 +220,27 @@
 	item_state = "cowboy"
 	can_adjust = FALSE
 
-/obj/item/clothing/under/yogs/bluedetective
+/obj/item/clothing/under/rank/det/bluedetective
 	name = "blue detective suit"
 	desc = "A suit often worn by those detective types. Now in blue!"
 	icon_state = "blue_detective"
 	item_state = "blue_detective"
 	can_adjust = FALSE
 
-/obj/item/clothing/under/yogs/golddetective
+/obj/item/clothing/under/rank/det/golddetective
 	name = "gold detective suit"
 	desc = "A suit often worn by those detective types. Now in gold!"
 	icon_state = "gold_detective"
 	item_state = "gold_detective"
 
-/obj/item/clothing/under/yogs/greydetective
+/obj/item/clothing/under/rank/det/greydetective
 	name = "grey detective suit"
 	desc = "A suit often worn by those detective types. Now in boring old grey!"
 	icon_state = "grey_detective"
 	item_state = "grey_detective"
 	can_adjust = FALSE
 
-/obj/item/clothing/under/yogs/blackdetective
+/obj/item/clothing/under/rank/det/blackdetective
 	name = "black detective suit"
 	desc = "A suit often worn by those detective types. Now in black!"
 	icon_state = "black_detective"
@@ -392,7 +392,7 @@
 	item_state = "hop_suit"
 	can_adjust = FALSE
 
-/obj/item/clothing/under/yogs/forensictech
+/obj/item/clothing/under/rank/det/forensictech
 	name = "forensic technician suit"
 	desc = "Hmm, this bloody toolbox has insulated fibers on it..."
 	icon_state = "forensic_tech"


### PR DESCRIPTION
# Document the changes in your pull request

Buffs all the detective's under items to have the same armor as the hard-worn suit (generic det suit, same armor as sec clothes) because they didn't.

Buffs all of det's coats to have the same armor as his vest so he need not choose function over fasion

# Why is this good for the game?
being able to customize your look without having to worry about being less armored good

# Changelog

:cl:  @neeshacark 
tweak: buffed detective's armor to be the values it rightfully should be
/:cl:
