### PR TITLE
Reduce syndicate turret range but increase fire rate and health

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -643,7 +643,8 @@
 	always_up = 1
 	use_power = NO_POWER_USE
 	has_cover = 0
-	scan_range = 9
+	max_integrity = 320 //double default
+	shot_delay = 1 SECONDS //33% faster than regular one
 	req_access = list(ACCESS_SYNDICATE)
 	mode = TURRET_LETHAL
 	stun_projectile = /obj/item/projectile/bullet

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -643,8 +643,8 @@
 	always_up = 1
 	use_power = NO_POWER_USE
 	has_cover = 0
+	scan_range = 9
 	max_integrity = 320 //double default health
-	shot_delay = 8 //almost half the delay
 	req_access = list(ACCESS_SYNDICATE)
 	mode = TURRET_LETHAL
 	stun_projectile = /obj/item/projectile/bullet
@@ -698,7 +698,6 @@
 	lethal_projectile = /obj/item/projectile/bullet/syndicate_turret
 
 /obj/machinery/porta_turret/syndicate/shuttle
-	shot_delay = 2
 	stun_projectile = /obj/item/projectile/bullet/p50/penetrator/shuttle
 	lethal_projectile = /obj/item/projectile/bullet/p50/penetrator/shuttle
 	lethal_projectile_sound = 'sound/weapons/gunshot_smg.ogg'

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -643,8 +643,8 @@
 	always_up = 1
 	use_power = NO_POWER_USE
 	has_cover = 0
-	max_integrity = 320 //double default
-	shot_delay = 1 SECONDS //33% faster than regular one
+	max_integrity = 320 //double default health
+	shot_delay = 8 //almost half the delay
 	req_access = list(ACCESS_SYNDICATE)
 	mode = TURRET_LETHAL
 	stun_projectile = /obj/item/projectile/bullet
@@ -698,8 +698,7 @@
 	lethal_projectile = /obj/item/projectile/bullet/syndicate_turret
 
 /obj/machinery/porta_turret/syndicate/shuttle
-	scan_range = 9
-	shot_delay = 3
+	shot_delay = 2
 	stun_projectile = /obj/item/projectile/bullet/p50/penetrator/shuttle
 	lethal_projectile = /obj/item/projectile/bullet/p50/penetrator/shuttle
 	lethal_projectile_sound = 'sound/weapons/gunshot_smg.ogg'


### PR DESCRIPTION
# Why is this good for the game?
Currently they have so much range that they're often used to cheese specific station locations rather than actually be used for defending the ship
they also have so much range that you can't even see them before they're shooting you

If only the range was reduced, it'd make it too easy to cheese them using regular firearms by ducking into and out of range
so i've doubled the health (more than doubled effective health since they fail to work below 60)
i've also increased the fire rate, so they're more likely to hit someone that's coming into their range

:cl:  
tweak: Reduce syndicate turret range but increase fire rate and health
/:cl:
