### PR TITLE
Adds a new gene as Ethereal's inert mutation, Radiant Burst

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -59,6 +59,7 @@
 #define CEREBRAL	/datum/mutation/human/cerebral
 #define THICKSKIN	/datum/mutation/human/thickskin
 #define DENSEBONES	/datum/mutation/human/densebones
+#define RADIANTBURST	/datum/mutation/human/radiantburst
 
 
 #define UI_CHANGED "ui changed"

--- a/code/datums/mutations/body.dm
+++ b/code/datums/mutations/body.dm
@@ -201,7 +201,7 @@
 	var/glow_color
 	var/current_nullify_timer // For veil yogstation\code\modules\antagonists\shadowling\shadowling_abilities.dm
 	power_coeff = 1
-	conflicts = list(/datum/mutation/human/glow/anti)
+	conflicts = list(/datum/mutation/human/glow/anti, /datum/mutation/human/radiantburst)
 
 /datum/mutation/human/glow/on_acquiring(mob/living/carbon/human/owner)
 	. = ..()
@@ -229,7 +229,7 @@
 	desc = "Your skin seems to attract and absorb nearby light creating 'darkness' around you."
 	text_gain_indication = span_notice("Your light around you seems to disappear.")
 	glow = -3.5
-	conflicts = list(/datum/mutation/human/glow)
+	conflicts = list(/datum/mutation/human/glow, /datum/mutation/human/radiantburst)
 	locked = TRUE
 
 /datum/mutation/human/thickskin

--- a/code/datums/mutations/radiantburst.dm
+++ b/code/datums/mutations/radiantburst.dm
@@ -1,0 +1,61 @@
+/datum/mutation/human/radiantburst
+	name = "Radiant Burst"
+	desc = "An mutation hidden deep within ethereal genetic code that."
+	quality = POSITIVE
+	difficulty = 12
+	locked = TRUE
+	text_gain_indication = span_notice("There is no darkness, even when you close your eyes!")
+	text_lose_indication = span_notice("The blinding light fades.")
+	power_path = /datum/action/cooldown/spell/aoe/radiantburst
+	instability = 30
+	power_coeff = 1 //increases aoe
+	synchronizer_coeff = 1 //prevents blinding
+	energy_coeff = 1 //reduces cooldown
+	conflicts = list(/datum/mutation/human/glow, /datum/mutation/human/glow/anti)
+
+/datum/mutation/human/radiantburst/modify()
+	. = ..()
+	var/datum/action/cooldown/spell/aoe/radiantburst/to_modify = .
+	if(!istype(to_modify)) // null or invalid
+		return
+
+	if(GET_MUTATION_SYNCHRONIZER(src) > 1)
+		to_modify.safe = TRUE //don't blind yourself
+	if(GET_MUTATION_ENERGY(src) > 1)
+		to_modify.cooldown_time -= 5 SECONDS //blind more often
+	if(GET_MUTATION_POWER(src) > 1)
+		to_modify.aoe_radius += 2 //bigger blind
+
+/datum/action/cooldown/spell/aoe/radiantburst
+	name = "Radiant Burst"
+	desc = "You release all the light that is within you"
+	button_icon = 'icons/mob/actions/actions_clockcult.dmi'
+	button_icon_state = "Kindle"
+	active_icon_state = "Kindle"
+	base_icon_state = "Kindle"
+	aoe_radius = 3
+	antimagic_flags = NONE
+	spell_requirements = NONE
+	school = SCHOOL_EVOCATION
+	cooldown_time = 15 SECONDS
+	sound = 'sound/magic/blind.ogg'
+	var/safe = FALSE
+	
+
+/datum/action/cooldown/spell/aoe/radiantburst/get_things_to_cast_on(atom/center)
+	var/list/things = list()
+	for(var/mob/living/nearby_mob in view(aoe_radius, center))
+		if(nearby_mob == owner && safe)
+			continue
+		things += nearby_mob
+
+	return things
+
+/datum/action/cooldown/spell/aoe/radiantburst/cast(atom/cast_on)
+	. = ..()
+	owner.visible_message(span_warning("[owner] releases a blinding light from within themselves."), span_notice("You release all the light within you."))
+
+/datum/action/cooldown/spell/aoe/radiantburst/cast_on_thing_in_aoe(atom/victim, atom/caster)
+	if(ishuman(victim))
+		var/mob/living/carbon/human/hurt = victim
+		hurt.flash_act()//only strength of 1, so sunglasses protect from it

--- a/code/datums/mutations/radiantburst.dm
+++ b/code/datums/mutations/radiantburst.dm
@@ -54,6 +54,7 @@
 /datum/action/cooldown/spell/aoe/radiantburst/cast(atom/cast_on)
 	. = ..()
 	owner.visible_message(span_warning("[owner] releases a blinding light from within themselves."), span_notice("You release all the light within you."))
+	flash_color(owner, flash_color = LIGHT_COLOR_HOLY_MAGIC, flash_time = 0.5 SECONDS)
 
 /datum/action/cooldown/spell/aoe/radiantburst/cast_on_thing_in_aoe(atom/victim, atom/caster)
 	if(ishuman(victim))

--- a/code/game/objects/items/dna_injector.dm
+++ b/code/game/objects/items/dna_injector.dm
@@ -196,6 +196,16 @@
 	desc = "Gives you space adaptation."
 	add_mutations = list(SPACEMUT)
 
+/obj/item/dnainjector/antiradiant
+	name = "\improper DNA injector (Anti-Radiant Burst)"
+	desc = "Cures radiant burst."
+	remove_mutations = list(RADIANTBURST)
+
+/obj/item/dnainjector/radiantburst
+	name = "\improper DNA injector (Radiant Burst)"
+	desc = "Gives you radiant burst."
+	add_mutations = list(RADIANTBURST)
+
 /obj/item/dnainjector/antiheat
 	name = "\improper DNA injector (Anti-Heat Adaptation)"
 	desc = "Cures heat adaptation."

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -31,7 +31,7 @@
 	screamsound = list('sound/voice/ethereal/ethereal_scream_1.ogg', 'sound/voice/ethereal/ethereal_scream_2.ogg', 'sound/voice/ethereal/ethereal_scream_3.ogg')
 	sexes = FALSE //no fetish content allowed
 	toxic_food = NONE
-	inert_mutation = SHOCKTOUCH
+	inert_mutation = RADIANTBURST
 	hair_color = "fixedmutcolor"
 	hair_alpha = 140
 	swimming_component = /datum/component/swimming/ethereal

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -714,6 +714,7 @@
 #include "code\datums\mutations\heat_adaptation.dm"
 #include "code\datums\mutations\hulk.dm"
 #include "code\datums\mutations\olfaction.dm"
+#include "code\datums\mutations\radiantburst.dm"
 #include "code\datums\mutations\radioactive.dm"
 #include "code\datums\mutations\radproof.dm"
 #include "code\datums\mutations\sight.dm"


### PR DESCRIPTION
# Why is this good for the game?
Adds genetic interactions for more species
Also, ethereal's current inert gene is shock touch which is craftable using other genes, sidestepping ethereals

all it does is blind in an aoe, no knockdown, no cc, just a blind, doesn't affect borgs

i'd add a cool light based visual effect if i knew of one that already exists in game

:cl:  
rscadd: Adds a new gene called radiant burst that blinds people nearby upon use
tweak: Ethereal inert gene is now radiant burst instead of shock touch 
/:cl:
