### PR TITLE
Shifts around some Vampire ability unlocks + bat buff

### DIFF
--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -32,7 +32,7 @@
 		return TRUE
 
 	while(do_after(user, 1 SECONDS, timed_action_flags = IGNORE_USER_LOC_CHANGE))
-		if(!reagents.total_volume)
+		if(reagents.total_volume <= 0)
 			user.balloon_alert(user, "empty!")
 			return ..()
 
@@ -42,7 +42,7 @@
 		)
 		if(is_vampire(user))
 			var/datum/antagonist/vampire/V = user.mind.has_antag_datum(/datum/antagonist/vampire)
-			V.usable_blood += 5
+			V.usable_blood += BLOODBAG_GULP_SIZE / 4 //they should really be drinking from people, yknow, be antagonistic?
 
 		reagents.reaction(user, INGEST, fraction)
 		reagents.trans_to(user, BLOODBAG_GULP_SIZE, transfered_by = user)

--- a/code/modules/reagents/reagent_containers/blood_pack.dm
+++ b/code/modules/reagents/reagent_containers/blood_pack.dm
@@ -31,8 +31,8 @@
 		playsound(user.loc, 'sound/items/drink.ogg', rand(10, 50), TRUE)
 		return TRUE
 
-	while(do_after(user, 1 SECONDS, timed_action_flags = IGNORE_USER_LOC_CHANGE))
-		if(reagents.total_volume <= 0)
+	while(do_after(user, 1 SECONDS, src, timed_action_flags = IGNORE_USER_LOC_CHANGE))
+		if(!reagents.total_volume)
 			user.balloon_alert(user, "empty!")
 			return ..()
 

--- a/yogstation/code/datums/antagonists/vampire.dm
+++ b/yogstation/code/datums/antagonists/vampire.dm
@@ -30,18 +30,18 @@
 		/datum/action/cooldown/spell/pointed/hypno = 0,
 		/datum/vampire_passive/vision = 75,
 		/datum/action/cooldown/spell/appearanceshift = 75,
-		/datum/vampire_passive/nostealth = 100,
 		/datum/action/cooldown/spell/cloak = 100,
 		/datum/action/cooldown/spell/revive = 100,
-		/datum/action/cooldown/spell/pointed/disease = 200,
-		/datum/action/cooldown/spell/shapeshift/vampire = 200,
-		/datum/action/cooldown/spell/aoe/screech = 215,
+		/datum/vampire_passive/nostealth = 150, //only lose the ability to stealth once you get a proper way to escape
+		/datum/action/cooldown/spell/shapeshift/vampire = 150,
+		/datum/action/cooldown/spell/aoe/screech = 200,
+		/datum/action/cooldown/spell/pointed/disease = 225,
 		/datum/action/cooldown/spell/bats = 250,
-		/datum/vampire_passive/regen = 255,
+		/datum/vampire_passive/regen = 250,
 		/datum/action/cooldown/spell/jaunt/ethereal_jaunt/mistform = 300,
-		/datum/vampire_passive/full = 420,
-		/datum/action/cooldown/spell/summon_coat = 420,
-		/datum/action/cooldown/spell/pointed/vampirize = 450)
+		/datum/vampire_passive/full = 400,
+		/datum/action/cooldown/spell/summon_coat = 400,
+		/datum/action/cooldown/spell/pointed/vampirize = 500)
 
 /datum/antagonist/vampire/new_blood
 	full_vampire = FALSE

--- a/yogstation/code/datums/antagonists/vampire.dm
+++ b/yogstation/code/datums/antagonists/vampire.dm
@@ -41,7 +41,7 @@
 		/datum/action/cooldown/spell/jaunt/ethereal_jaunt/mistform = 300,
 		/datum/vampire_passive/full = 400,
 		/datum/action/cooldown/spell/summon_coat = 400,
-		/datum/action/cooldown/spell/pointed/vampirize = 500)
+		/datum/action/cooldown/spell/pointed/vampirize = 450)
 
 /datum/antagonist/vampire/new_blood
 	full_vampire = FALSE

--- a/yogstation/code/game/gamemodes/vampire/vampire_bat.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_bat.dm
@@ -12,7 +12,9 @@
 	speak_chance = 0
 	maxHealth = 20
 	health = 20
+	speed = 0
 	see_in_dark = 10
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	harm_intent_damage = 7
 	melee_damage_lower = 5
 	melee_damage_upper = 7
@@ -27,9 +29,6 @@
 	mob_size = MOB_SIZE_TINY
 	movement_type = FLYING
 	speak_emote = list("squeaks")
-	var/max_co2 = 0 //to be removed once metastation map no longer use those for Sgt Araneus
-	var/min_oxy = 0
-	var/max_tox = 0
 
 	var/mob/living/controller
 

--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -590,11 +590,10 @@
 	convert_damage_type = STAMINA
 	blood_used = 15
 	vamp_req = TRUE
+	check_flags = AB_CHECK_CONSCIOUS | AB_CHECK_INCAPACITATED
 	possible_shapes = list(/mob/living/simple_animal/hostile/vampire_bat)
 
 /datum/action/cooldown/spell/shapeshift/vampire/can_cast_spell()
-	if(owner.incapacitated(TRUE, TRUE))
-		return FALSE
 	if(ishuman(owner))
 		blood_used = 15
 	else

--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -593,6 +593,8 @@
 	possible_shapes = list(/mob/living/simple_animal/hostile/vampire_bat)
 
 /datum/action/cooldown/spell/shapeshift/vampire/can_cast_spell()
+	if(owner.incapacitated(TRUE, TRUE))
+		return FALSE
 	if(ishuman(owner))
 		blood_used = 15
 	else


### PR DESCRIPTION
Changes
Loss of stealthy drinking moved from 100 to 150
Vampire bat transformation moved from 200 to 150
Screech moved from 215 to 200
Disease touch moved from 200 to 225
Passive regen moved from 255 to 250
Full vampire power and cloak moved from 420 to 400

# Why is this good for the game?
Should give vampires both more reason to go after people to succ them
as well as allowing them to be more risky once they're forced to be loud, by giving them a proper escape tool
and arguably, their bat form is far more interesting than jaunt, so this seeks to make it more enticing to use

# Wiki Documentation
Will need to update the numbers for when abilities are unlocked

:cl:  
bugfix: Can no longer infinitely drink bloodpacks that are empty
tweak: Shifted around some vampire blood thresholds to unlocking certain ability
tweak: Vampire bat is slightly faster and can see in the dark
tweak: Can no longer transform into a bat if incapacitated
tweak: Vampires get 1/2 the previous amount of usable blood from drinking blood packs
/:cl:
