### PR TITLE
Reverts adding alien tools to the bluespace harvester

### DIFF
--- a/code/modules/goals/station_goals/bluespace_tap.dm
+++ b/code/modules/goals/station_goals/bluespace_tap.dm
@@ -112,18 +112,6 @@
 		/obj/item/clothing/gloves/combat,
 	)
 
-/obj/effect/spawner/lootdrop/bluespace_tap/alien_objects
-	name = "alien objects"
-	loot = list(
-		/obj/item/weldingtool/abductor,
-		/obj/item/screwdriver/abductor,
-		/obj/item/multitool/abductor,
-		/obj/item/wirecutters/abductor,
-		/obj/item/crowbar/abductor,
-		/obj/item/wrench/abductor,
-		/obj/item/stack/sheet/mineral/abductor,
-	)
-
 /obj/effect/spawner/lootdrop/bluespace_tap/organic
 	name = "organic objects"
 	loot = list(
@@ -227,7 +215,6 @@
 	new /datum/data/bluespace_tap_product("Unknown Cultural Artifact", /obj/effect/spawner/lootdrop/bluespace_tap/cultural, 15000),
 	new /datum/data/bluespace_tap_product("Unknown Biological Artifact", /obj/effect/spawner/lootdrop/bluespace_tap/organic, 20000),
 	new /datum/data/bluespace_tap_product("Unknown Materials", /obj/effect/spawner/lootdrop/bluespace_tap/mats, 30000),
-	new /datum/data/bluespace_tap_product("Unknown Alien Objects", /obj/effect/spawner/lootdrop/bluespace_tap/alien_objects, 250000),
 	)
 
 	/// The level the machine is currently mining at. 0 means off


### PR DESCRIPTION
# Why is this good for the game?
Alien tools should be random and rare in order to not just be a powergamer's main strategy
Them being so rare is also what makes them so special and nice
No matter how much it costs, it's just too deterministic to come from the bluespace harvester

# Wiki Documentation
update the bluespace harvester page i guess

:cl:  
rscdel: Bluespace harvester can no longer give alien tools
/:cl:
