### PR TITLE
Adds maint lootdrops to bluespace harvester

### DIFF
--- a/code/modules/goals/station_goals/bluespace_tap.dm
+++ b/code/modules/goals/station_goals/bluespace_tap.dm
@@ -188,6 +188,19 @@
 		/obj/item/stack/ore/silver = 6
 	)
 
+/obj/effect/spawner/lootdrop/bluespace_tap/maintenance
+	name = "assorted trash"
+	loot = list(
+		/obj/effect/spawner/lootdrop/maintenance = 8,
+		/obj/effect/spawner/lootdrop/maintenance/two = 7,
+		/obj/effect/spawner/lootdrop/maintenance/three = 6,
+		/obj/effect/spawner/lootdrop/maintenance/four = 5,
+		/obj/effect/spawner/lootdrop/maintenance/five = 4,
+		/obj/effect/spawner/lootdrop/maintenance/six = 3,
+		/obj/effect/spawner/lootdrop/maintenance/seven = 2,
+		/obj/effect/spawner/lootdrop/maintenance/eight = 1
+	)
+
 #define kW *1000
 #define MW kW *1000
 #define GW MW *1000
@@ -224,6 +237,7 @@
 	var/static/product_list = list(
 	new /datum/data/bluespace_tap_product("Unknown Exotic Hat", /obj/effect/spawner/lootdrop/bluespace_tap/hat, 5000),
 	new /datum/data/bluespace_tap_product("Unknown Snack", /obj/effect/spawner/lootdrop/bluespace_tap/food, 6000),
+	new /datum/data/bluespace_tap_product("Unknown Biological Artifact", /obj/effect/spawner/lootdrop/bluespace_tap/maintenance, 10000),
 	new /datum/data/bluespace_tap_product("Unknown Cultural Artifact", /obj/effect/spawner/lootdrop/bluespace_tap/cultural, 15000),
 	new /datum/data/bluespace_tap_product("Unknown Biological Artifact", /obj/effect/spawner/lootdrop/bluespace_tap/organic, 20000),
 	new /datum/data/bluespace_tap_product("Unknown Materials", /obj/effect/spawner/lootdrop/bluespace_tap/mats, 30000),

--- a/code/modules/goals/station_goals/bluespace_tap.dm
+++ b/code/modules/goals/station_goals/bluespace_tap.dm
@@ -237,7 +237,7 @@
 	var/static/product_list = list(
 	new /datum/data/bluespace_tap_product("Unknown Exotic Hat", /obj/effect/spawner/lootdrop/bluespace_tap/hat, 5000),
 	new /datum/data/bluespace_tap_product("Unknown Snack", /obj/effect/spawner/lootdrop/bluespace_tap/food, 6000),
-	new /datum/data/bluespace_tap_product("Unknown Biological Artifact", /obj/effect/spawner/lootdrop/bluespace_tap/maintenance, 10000),
+	new /datum/data/bluespace_tap_product("Unknown Refuse", /obj/effect/spawner/lootdrop/bluespace_tap/maintenance, 10000),
 	new /datum/data/bluespace_tap_product("Unknown Cultural Artifact", /obj/effect/spawner/lootdrop/bluespace_tap/cultural, 15000),
 	new /datum/data/bluespace_tap_product("Unknown Biological Artifact", /obj/effect/spawner/lootdrop/bluespace_tap/organic, 20000),
 	new /datum/data/bluespace_tap_product("Unknown Materials", /obj/effect/spawner/lootdrop/bluespace_tap/mats, 30000),


### PR DESCRIPTION
# Why is this good for the game?
Adds something that's super gimmicky to the bluespace harvester so that maybe something interesting will happen, but probably not

:cl:  
rscadd: Adds maint lootdrops to bluespace harvester for 10,000
/:cl:
