### PR TITLE
Bugfix for #20440, crusades are not an excuse for bad code

### DIFF
--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -181,7 +181,7 @@
 
 /obj/item/clothing/neck/petcollar/mob_can_equip(mob/M, mob/equipper, slot, disable_warning = 0)
 	var/mob/living/carbon/C = M
-	if(C && ishuman(C))
+	if(C)
 		return FALSE
 	return ..()
 


### PR DESCRIPTION
# Document the changes in your pull request

Original check disallowed pet collars to be worn on non-humans carbons (Monkies, true devil, aliens, etc) but allowed humans. #20440 switched this, only disallowing the wearing on humans, allowing it on other carbons, and I'm not sure this is intentional

# Changelog

:cl:  
bugfix: carbons being allowed to wear collars
/:cl:
