### PR TITLE
The Incredible Hulk 4: Into the Hulkerverse

### DIFF
--- a/code/datums/mutations/hulk.dm
+++ b/code/datums/mutations/hulk.dm
@@ -27,11 +27,6 @@
 	if(proximity) //no telekinetic hulk attack
 		return target.attack_hulk(owner)
 
-/datum/mutation/human/hulk/on_life()
-	if(owner.health < 0)
-		on_losing(owner)
-		to_chat(owner, span_danger("You suddenly feel very weak."))
-
 /datum/mutation/human/hulk/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2304,7 +2304,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/race_restricted/hulk
 	name = "Hulk Mutator"
 	desc = "Stolen research from a SIC scientist who went postal led to the development of this revolutionary mutator. Causes extreme muscle growth, enough to punch through walls, and practically limitless stamina, at the cost of reduced cognitive ability, and green skin pigmentation."
-	cost = 15
+	cost = 12
 	manufacturer = /datum/corporation/traitor/vahlen
 	item = /obj/item/dnainjector/hulkmut
 	restricted_species = list("human")


### PR DESCRIPTION
# Document the changes in your pull request

Buffs the hulk mutator by making it cost 12 tc instead of 15 and removing the 'lose on crit' stuff.

# Why is this good for the game?
Cost reduction was based on the feedback of players, removing the losing on crit stuff is because I think it's dumb, and it can still be removed via dna scanner anyways

# Testing
works (on my machine)
what doesnt seem to work is the goated punching strength that hulk is supposed to give you but that could be due to me beating the shit out of myself, sooo *shrug

# Spriting
no

# Wiki Documentation
change cost on syndicate items (you cant believe how happy i was to see it already on the syndicate items page btw)

# Changelog

:cl:   
tweak: HULK COST DECREASED TO 12 TEE SEE FROM 15!!!
rscdel: HULK IS NO LONGER LOST ON CRIT!!!
/:cl:
