### PR TITLE
Colorblind people can't see wire colors

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -280,6 +280,8 @@
 #define TRAIT_BALD "bald"
 /// Reduces severity of EMPs by one level, heavy becomes light and light is ignored
 #define TRAIT_FARADAYCAGE "faraday_cage"
+/// You can't see color!
+#define TRAIT_COLORBLIND "color_blind"
 
 /// This person is crying
 #define TRAIT_CRYING "crying"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -823,7 +823,8 @@
 	name = "Monochromacy"
 	desc = "You suffer from full colorblindness, and perceive nearly the entire world in blacks and whites."
 	icon = "palette"
-	value = -2
+	value = -4
+	mob_trait = TRAIT_COLORBLIND
 	medical_record_text = "Patient is afflicted with almost complete color blindness."
 
 /datum/quirk/monochromatic/add()

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -259,16 +259,18 @@
 			if(P.picture.has_blueprints)	//if the blueprints are in frame
 				reveal_wires = TRUE
 
+	var/colorblind = HAS_TRAIT(user, TRAIT_COLORBLIND)
 	for(var/color in colors)
 		payload.Add(list(list(
 			"color" = color,
-			"wire" = ((reveal_wires && !is_dud_color(color)) ? get_wire(color) : null),
+			"wire" = ((reveal_wires && !is_dud_color(color) && !colorblind) ? get_wire(color) : null),
 			"cut" = is_color_cut(color),
 			"attached" = is_attached(color)
 		)))
 	data["wires"] = payload
 	data["status"] = get_status()
 	data["proper_name"] = (proper_name != "Unknown") ? proper_name : null
+	data["colorblind"] = colorblind
 	return data
 
 /datum/wires/ui_act(action, params)

--- a/tgui/packages/tgui/interfaces/Wires.js
+++ b/tgui/packages/tgui/interfaces/Wires.js
@@ -6,6 +6,7 @@ export const Wires = (props, context) => {
   const { act, data } = useBackend(context);
   const wires = data.wires || [];
   const statuses = data.status || [];
+  const colorblind = data.colorblind;
   return (
     <Window
       width={350}
@@ -17,9 +18,9 @@ export const Wires = (props, context) => {
               <LabeledList.Item
                 key={wire.color}
                 className="candystripe"
-                label={wire.color}
-                labelColor={wire.color}
-                color={wire.color}
+                label={colorblind ? "grey" : wire.color}
+                labelColor={colorblind ? "grey" : wire.color}
+                color={colorblind ? "grey" : wire.color}
                 buttons={(
                   <>
                     <Button


### PR DESCRIPTION
# Document the changes in your pull request

When hacking, all of the wires will show up as grey if you're colorblind. Also increases monochromacy's value from -2 to -4 to compensate.

# Why is this good for the game?
I thought it was kinda weird that with monochromacy you can just tell what the colors of all the wires are, and this idea was just too funny to ignore.

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/93578146/b35c1a65-cd1c-4fe6-abd3-5d8625f6e540)

# Wiki Documentation

On the quirks wiki page, add to the gameplay effects of monochromacy that you can't tell the colors of wires when hacking.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: colorblind people can't tell the color of wires
tweak: colorblind quirk is -4 instead of -2
/:cl:
