### PR TITLE
Adds a maint ruin with the experimental tools

### DIFF
--- a/_maps/RandomRuins/StationRuins/maint/3x5/3x5_experimental.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x5/3x5_experimental.dmm
@@ -11,42 +11,29 @@
 /obj/item/wirecutters/caravan,
 /obj/item/wrench/caravan,
 /obj/item/screwdriver/caravan,
-/obj/structure/closet/crate/secure{
-	req_access_txt = "19"
+/obj/structure/safe{
+	number_of_tumblers = 6
 	},
-/turf/open/floor/plating,
-/area/template_noop)
-"Q" = (
-/obj/effect/spawner/lootdrop/maintenance/four,
-/obj/structure/closet/crate/secure{
-	req_access_txt = "19"
-	},
-/turf/open/floor/plating,
-/area/template_noop)
-"Y" = (
-/obj/effect/spawner/lootdrop/maintenance/eight,
-/obj/structure/closet/crate/secure{
-	req_access_txt = "19"
-	},
+/obj/machinery/light/floor,
 /turf/open/floor/plating,
 /area/template_noop)
 
 (1,1,1) = {"
-Y
+a
 a
 t
 a
-Q
+a
 "}
 (2,1,1) = {"
-a
+t
 a
 w
 a
 a
 "}
 (3,1,1) = {"
-Q
+a
 a
 a
 a

--- a/_maps/RandomRuins/StationRuins/maint/3x5/3x5_experimental.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x5/3x5_experimental.dmm
@@ -1,0 +1,54 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/open/floor/plating,
+/area/template_noop)
+"t" = (
+/obj/effect/decal/cleanable/shreds,
+/turf/open/floor/plating,
+/area/template_noop)
+"w" = (
+/obj/item/crowbar/red/caravan,
+/obj/item/wirecutters/caravan,
+/obj/item/wrench/caravan,
+/obj/item/screwdriver/caravan,
+/obj/structure/closet/crate/secure{
+	req_access_txt = "19"
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"Q" = (
+/obj/effect/spawner/lootdrop/maintenance/four,
+/obj/structure/closet/crate/secure{
+	req_access_txt = "19"
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"Y" = (
+/obj/effect/spawner/lootdrop/maintenance/eight,
+/obj/structure/closet/crate/secure{
+	req_access_txt = "19"
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+
+(1,1,1) = {"
+Y
+a
+t
+a
+Q
+"}
+(2,1,1) = {"
+a
+a
+w
+a
+a
+"}
+(3,1,1) = {"
+Q
+a
+a
+a
+t
+"}

--- a/yogstation/code/datums/ruins/station.dm
+++ b/yogstation/code/datums/ruins/station.dm
@@ -623,6 +623,11 @@
 	suffix = "3x5_checkpoint.dmm"
 	name = "Maint checkpoint"
 
+/datum/map_template/ruin/station/maint/threexfive/experimental
+	id = "experimental"
+	suffix = "3x5_experimental.dmm"
+	name = "Secure Loot"
+
 /datum/map_template/ruin/station/maint/threexfive/hank
 	id = "hank"
 	suffix = "3x5_hank.dmm"


### PR DESCRIPTION
# Document the changes in your pull request

They don't really show up anywhere; Somewhat powerful but wont really change any balance

Contains
 - Experimental tool set (in a 6 tumbler safe)

All locked in crates that require head access (wasn't sure what to put on them

# Why is this good for the game?
More maint variety 

# Testing
Place template make sure it looks correct

# Wiki Documentation

Shows up in caravan ambush; White Ship (Variation 2); and maintenance in this case

# Changelog

:cl:  
rscadd: Experimental tools can now be potentially found in maint
/:cl:
