### PR TITLE
Heretic ash jaunt now clears stuns

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -8,7 +8,7 @@
 	sound = null
 
 	school = SCHOOL_FORBIDDEN
-	cooldown_time = 15 SECONDS
+	cooldown_time = 20 SECONDS
 
 	spell_requirements = SPELL_CASTABLE_WITHOUT_INVOCATION
 
@@ -18,7 +18,13 @@
 	jaunt_out_time = 0.6 SECONDS
 	jaunt_in_type = /obj/effect/temp_visual/dir_setting/ash_shift
 	jaunt_out_type = /obj/effect/temp_visual/dir_setting/ash_shift/out
-	
+
+/datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash/before_cast(atom/cast_on) //removes all stuns before jaunting
+	. = ..()
+	var/mob/living/jaunter = owner
+	jaunter.SetAllImmobility(0)
+	jaunter.setStaminaLoss(0)
+	jaunter.clear_stamina_regen()	
 
 /datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash/do_steam_effects()
 	return


### PR DESCRIPTION

# Document the changes in your pull request

ash jaunt now removes any stuns and stamina damage
cooldown increased to 20 seconds

# Why is this good for the game?
every other heretic escape abillity can be used while stunned and can teleport you a screen away
jaunt can only move you 4 tiles at most and you stay in place if you get stunned and use it
makes the cooldown more on par with the other escape abillities aswell for consistency and to make it less spammable
I'm litteraly turning into DUST let me move!!!

# Testing

https://github.com/yogstation13/Yogstation/assets/140007537/f229cd30-492d-44c6-8986-5c5f762e43da

# Changelog

:cl:   
tweak: Heretic ash jaunt now clear stuns
tweak: Heretic ash jaunt cooldown increased to 20 seconds
/:cl:
