### PR TITLE
You can no longer use heretic movement abillities while stunned

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -8,7 +8,7 @@
 	sound = null
 
 	school = SCHOOL_FORBIDDEN
-	cooldown_time = 20 SECONDS
+	cooldown_time = 15 SECONDS
 
 	spell_requirements = SPELL_CASTABLE_WITHOUT_INVOCATION
 
@@ -18,13 +18,13 @@
 	jaunt_out_time = 0.6 SECONDS
 	jaunt_in_type = /obj/effect/temp_visual/dir_setting/ash_shift
 	jaunt_out_type = /obj/effect/temp_visual/dir_setting/ash_shift/out
-
-/datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash/before_cast(atom/cast_on) //removes all stuns before jaunting
+	
+/datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash/can_cast_spell(feedback)
 	. = ..()
-	var/mob/living/jaunter = owner
-	jaunter.SetAllImmobility(0)
-	jaunter.setStaminaLoss(0)
-	jaunter.clear_stamina_regen()	
+	var/mob/living/carbon/caster = owner
+	if(caster.incapacitated())
+		to_chat(caster, span_warning("You are incapacitated!"))
+		return FALSE
 
 /datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash/do_steam_effects()
 	return
@@ -1002,6 +1002,13 @@
 	deactive_msg = span_notice("You relax your mind.")
 	spell_requirements = SPELL_CASTABLE_WITHOUT_INVOCATION
 
+/datum/action/cooldown/spell/pointed/phase_jump/can_cast_spell(feedback)
+	. = ..()
+	var/mob/living/carbon/caster = owner
+	if(caster.incapacitated())
+		to_chat(caster, span_warning("You are incapacitated!"))
+		return FALSE
+
 /datum/action/cooldown/spell/pointed/projectile/assault
 	name = "Amygdala Assault"
 	desc = "Blast a single ray of concentrated mental energy at a target, dealing high brute damage if they are caught in it"
@@ -1043,6 +1050,13 @@
 	var/min_cast_range = 3
 	/// The radius of damage around the void bubble
 	var/damage_radius = 1
+
+/datum/action/cooldown/spell/pointed/void_phase/can_cast_spell(feedback)
+	. = ..()
+	var/mob/living/carbon/caster = owner
+	if(caster.incapacitated())
+		to_chat(caster, span_warning("You are incapacitated!"))
+		return FALSE
 
 /datum/action/cooldown/spell/pointed/void_phase/before_cast(atom/cast_on)
 	. = ..()

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -8,7 +8,7 @@
 	sound = null
 
 	school = SCHOOL_FORBIDDEN
-	cooldown_time = 15 SECONDS
+	cooldown_time = 20 SECONDS
 
 	spell_requirements = SPELL_CASTABLE_WITHOUT_INVOCATION
 
@@ -18,7 +18,13 @@
 	jaunt_out_time = 0.6 SECONDS
 	jaunt_in_type = /obj/effect/temp_visual/dir_setting/ash_shift
 	jaunt_out_type = /obj/effect/temp_visual/dir_setting/ash_shift/out
-	
+
+/datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash/before_cast(atom/cast_on) //removes all stuns before jaunting
+	. = ..()
+	var/mob/living/jaunter = owner
+	jaunter.SetAllImmobility(0)
+	jaunter.setStaminaLoss(0)
+	jaunter.clear_stamina_regen()	
 
 /datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash/do_steam_effects()
 	return


### PR DESCRIPTION

# Document the changes in your pull request

you can no longer use ash jaunt, mental obfuscation or void phase while incapacitated

# Why is this good for the game?
"get out of jail free" cards are bad
if ash jaunt can't do it then none should be able to

# Testing

https://github.com/yogstation13/Yogstation/assets/140007537/ffb8015d-71e6-48e6-8b68-4b6ef6f7af1d


# Wiki Documentation
none

# Changelog

:cl:  
tweak: You can no longer use heretic movement abillities while incapacitated
/:cl:
