### PR TITLE
Removes crew manifest from late join players

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -57,7 +57,7 @@
 			if(PLAYER_READY_TO_OBSERVE)
 				output += "<p>\[ [LINKIFY_READY("Ready", PLAYER_READY_TO_PLAY)] | [LINKIFY_READY("Not Ready", PLAYER_NOT_READY)] | <b> Observe </b> \]</p>"
 	else
-		output += "<p><a href='byond://?src=[REF(src)];manifest=1'>View the Crew Manifest</a></p>"
+		output += "<p><a href='byond://?src=[REF(src)];late_join=1'>Join Game!</a></p>"
 		output += "<p>[LINKIFY_READY("Observe", PLAYER_READY_TO_OBSERVE)]</p>"
 
 	if(!IsGuestKey(src.key))

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -58,7 +58,6 @@
 				output += "<p>\[ [LINKIFY_READY("Ready", PLAYER_READY_TO_PLAY)] | [LINKIFY_READY("Not Ready", PLAYER_NOT_READY)] | <b> Observe </b> \]</p>"
 	else
 		output += "<p><a href='byond://?src=[REF(src)];manifest=1'>View the Crew Manifest</a></p>"
-		output += "<p><a href='byond://?src=[REF(src)];late_join=1'>Join Game!</a></p>"
 		output += "<p>[LINKIFY_READY("Observe", PLAYER_READY_TO_OBSERVE)]</p>"
 
 	if(!IsGuestKey(src.key))
@@ -173,9 +172,6 @@
 			return
 
 		GLOB.latejoin_menu.ui_interact(usr)
-
-	if(href_list["manifest"])
-		ViewManifest()
 
 	else if(!href_list["late_join"])
 		new_player_panel()


### PR DESCRIPTION
# Document the changes in your pull request

Crew manifest can convey a significant amount of IC information, so lets keep it IC

# Why is this good for the game?
IC in OOC bad

# Testing
I saw the button was gone when I tried to late join my test server

![image](https://github.com/yogstation13/Yogstation/assets/4607006/f6296ee1-f1c6-4692-aa82-a5f0d3ab1634)


# Changelog

:cl:   
rscdel: Removed crew manifest from latejoin menu
/:cl:
