### PR TITLE
Makes ethereal light power and range scale both with health and hunger + saturation reduction

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -66,17 +66,7 @@
 		return
 
 	var/mob/living/carbon/human/ethereal = C
-	default_color = ethereal.dna.features["mcolor"]
-	r1 = GETREDPART(default_color)
-	g1 = GETGREENPART(default_color)
-	b1 = GETBLUEPART(default_color)
-
-	var/list/hsl = rgb2hsl(r1, g1, b1)
-	hsl[2] *= 0.5
-	var/list/rgb = hsl2rgb(hsl[1], hsl[2], hsl[3]) //terrible way to do it, but it works
-	r1 = rgb[1]
-	g1 = rgb[2]
-	b1 = rgb[3]
+	setup_color(ethereal)
 
 	ethereal_light = ethereal.mob_light()
 	spec_updatehealth(ethereal)
@@ -94,21 +84,24 @@
 
 	return randname
 
+/datum/species/ethereal/proc/setup_color(mob/living/carbon/human/ethereal)
+	default_color = ethereal.dna.features["mcolor"]
+	r1 = GETREDPART(default_color)
+	g1 = GETGREENPART(default_color)
+	b1 = GETBLUEPART(default_color)
+	var/list/hsl = rgb2hsl(r1, g1, b1)
+	hsl[2] *= 0.6
+	var/list/rgb = hsl2rgb(hsl[1], hsl[2], hsl[3]) //terrible way to do it, but it works
+	r1 = rgb[1]
+	g1 = rgb[2]
+	b1 = rgb[3]
+
 /datum/species/ethereal/spec_updatehealth(mob/living/carbon/human/ethereal)
 	. = ..()
 	if(!ethereal_light)
 		return
 	if(default_color != ethereal.dna.features["mcolor"])
-		default_color = ethereal.dna.features["mcolor"]
-		r1 = GETREDPART(new_color)
-		g1 = GETGREENPART(new_color)
-		b1 = GETBLUEPART(new_color)
-		var/list/hsl = rgb2hsl(r1, g1, b1)
-		hsl[2] *= 0.5
-		var/list/rgb = hsl2rgb(hsl[1], hsl[2], hsl[3])
-		r1 = rgb[1]
-		g1 = rgb[2]
-		b1 = rgb[3]
+		setup_color(ethereal)
 
 	if(ethereal.stat != DEAD && !EMPeffect)
 		var/healthpercent = max(ethereal.health, 0) / ethereal.maxHealth//scale with the lower of health and hunger
@@ -132,11 +125,7 @@
 	EMPeffect = TRUE
 	spec_updatehealth(H)
 	to_chat(H, span_notice("You feel the light of your body leave you."))
-	switch(severity)
-		if(EMP_LIGHT)
-			addtimer(CALLBACK(src, PROC_REF(stop_emp), H), 100, TIMER_UNIQUE|TIMER_OVERRIDE) //We're out for 10 seconds
-		if(EMP_HEAVY)
-			addtimer(CALLBACK(src, PROC_REF(stop_emp), H), 200, TIMER_UNIQUE|TIMER_OVERRIDE) //We're out for 20 seconds
+	addtimer(CALLBACK(src, PROC_REF(stop_emp), H), 200 / severity, TIMER_UNIQUE|TIMER_OVERRIDE) //We're out for 10 to 20 seconds depending on severity
 
 /datum/species/ethereal/spec_emag_act(mob/living/carbon/human/H, mob/user, obj/item/card/emag/emag_card)
 	if(emageffect)

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -37,7 +37,7 @@
 	swimming_component = /datum/component/swimming/ethereal
 
 	var/max_range = 5
-	var/max_power = 0.5
+	var/max_power = 2
 	var/current_color
 	var/EMPeffect = FALSE
 	var/emageffect = FALSE
@@ -70,6 +70,14 @@
 	r1 = GETREDPART(default_color)
 	g1 = GETGREENPART(default_color)
 	b1 = GETBLUEPART(default_color)
+
+	var/list/hsl = rgb2hsl(r1, g1, b1)
+	hsl[2] *= 0.5
+	var/list/rgb = hsl2rgb(hsl[1], hsl[2], hsl[3]) //terrible way to do it, but it works
+	r1 = rgb[1]
+	g1 = rgb[2]
+	b1 = rgb[3]
+
 	ethereal_light = ethereal.mob_light()
 	spec_updatehealth(ethereal)
 
@@ -91,10 +99,17 @@
 	if(!ethereal_light)
 		return
 	if(default_color != ethereal.dna.features["mcolor"])
-		var/new_color = ethereal.dna.features["mcolor"]
+		default_color = ethereal.dna.features["mcolor"]
 		r1 = GETREDPART(new_color)
 		g1 = GETGREENPART(new_color)
 		b1 = GETBLUEPART(new_color)
+		var/list/hsl = rgb2hsl(r1, g1, b1)
+		hsl[2] *= 0.5
+		var/list/rgb = hsl2rgb(hsl[1], hsl[2], hsl[3])
+		r1 = rgb[1]
+		g1 = rgb[2]
+		b1 = rgb[3]
+
 	if(ethereal.stat != DEAD && !EMPeffect)
 		var/healthpercent = max(ethereal.health, 0) / ethereal.maxHealth//scale with the lower of health and hunger
 		var/hungerpercent = min((ethereal.nutrition / NUTRITION_LEVEL_FED), 1)//scale only when below a certain hunger threshold

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -37,7 +37,7 @@
 	swimming_component = /datum/component/swimming/ethereal
 
 	var/max_range = 5
-	var/max_power = 1
+	var/max_power = 1.5
 	var/current_color
 	var/EMPeffect = FALSE
 	var/emageffect = FALSE

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -96,9 +96,10 @@
 		g1 = GETGREENPART(new_color)
 		b1 = GETBLUEPART(new_color)
 	if(ethereal.stat != DEAD && !EMPeffect)
-		var/healthpercent = min((max(ethereal.health, 0) / ethereal.maxHealth), min((ethereal.nutrition / NUTRITION_LEVEL_FULL), 1))//scale with the lower of health and hunger
-		var/light_range = max_range * healthpercent
-		var/light_power = max_range * healthpercent
+		var/healthpercent = max(ethereal.health, 0) / ethereal.maxHealth//scale with the lower of health and hunger
+		var/hungerpercent = min((ethereal.nutrition / NUTRITION_LEVEL_FULL), 1)
+		var/light_range = max_range * min(healthpercent, hungerpercent)//only power and range scale with hunger, not colour
+		var/light_power = max_range * min(healthpercent, hungerpercent)
 		if(!emageffect)
 			current_color = rgb(r2 + ((r1-r2)*healthpercent), g2 + ((g1-g2)*healthpercent), b2 + ((b1-b2)*healthpercent))
 		ethereal.set_light(light_range + 1, 0.1, current_color)//this just controls actual view range, not the overlay

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -36,6 +36,8 @@
 	hair_alpha = 140
 	swimming_component = /datum/component/swimming/ethereal
 
+	var/max_range = 5
+	var/max_power = 1
 	var/current_color
 	var/EMPeffect = FALSE
 	var/emageffect = FALSE
@@ -94,9 +96,9 @@
 		g1 = GETGREENPART(new_color)
 		b1 = GETBLUEPART(new_color)
 	if(ethereal.stat != DEAD && !EMPeffect)
-		var/healthpercent = max(ethereal.health, 0) / 100
-		var/light_range = 1 + (4 * healthpercent)
-		var/light_power = 1 + healthpercent
+		var/healthpercent = min((max(ethereal.health, 0) / ethereal.maxHealth), min((ethereal.nutrition / NUTRITION_LEVEL_FULL), 1))//scale with the lower of health and hunger
+		var/light_range = max_range * healthpercent
+		var/light_power = max_range * healthpercent
 		if(!emageffect)
 			current_color = rgb(r2 + ((r1-r2)*healthpercent), g2 + ((g1-g2)*healthpercent), b2 + ((b1-b2)*healthpercent))
 		ethereal.set_light(light_range + 1, 0.1, current_color)//this just controls actual view range, not the overlay

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -37,7 +37,7 @@
 	swimming_component = /datum/component/swimming/ethereal
 
 	var/max_range = 5
-	var/max_power = 1
+	var/max_power = 0.5
 	var/current_color
 	var/EMPeffect = FALSE
 	var/emageffect = FALSE
@@ -97,9 +97,9 @@
 		b1 = GETBLUEPART(new_color)
 	if(ethereal.stat != DEAD && !EMPeffect)
 		var/healthpercent = max(ethereal.health, 0) / ethereal.maxHealth//scale with the lower of health and hunger
-		var/hungerpercent = min((ethereal.nutrition / NUTRITION_LEVEL_FULL), 1)
-		var/light_range = max_range * min(healthpercent, hungerpercent)//only power and range scale with hunger, not colour
-		var/light_power = max_range * min(healthpercent, hungerpercent)
+		var/hungerpercent = min((ethereal.nutrition / NUTRITION_LEVEL_WELL_FED), 1)
+		var/light_range = max_range * min(healthpercent, hungerpercent)
+		var/light_power = max_power * min(healthpercent, hungerpercent)
 		if(!emageffect)
 			current_color = rgb(r2 + ((r1-r2)*healthpercent), g2 + ((g1-g2)*healthpercent), b2 + ((b1-b2)*healthpercent))
 		ethereal.set_light(light_range + 1, 0.1, current_color)//this just controls actual view range, not the overlay

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -122,9 +122,10 @@
 
 /datum/species/ethereal/spec_emp_act(mob/living/carbon/human/H, severity)
 	.=..()
+	if(!EMPeffect)
+		to_chat(H, span_notice("You feel the light of your body leave you."))
 	EMPeffect = TRUE
 	spec_updatehealth(H)
-	to_chat(H, span_notice("You feel the light of your body leave you."))
 	addtimer(CALLBACK(src, PROC_REF(stop_emp), H), 200 / severity, TIMER_UNIQUE|TIMER_OVERRIDE) //We're out for 10 to 20 seconds depending on severity
 
 /datum/species/ethereal/spec_emag_act(mob/living/carbon/human/H, mob/user, obj/item/card/emag/emag_card)

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -37,7 +37,7 @@
 	swimming_component = /datum/component/swimming/ethereal
 
 	var/max_range = 5
-	var/max_power = 1.5
+	var/max_power = 1
 	var/current_color
 	var/EMPeffect = FALSE
 	var/emageffect = FALSE

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -97,7 +97,7 @@
 		b1 = GETBLUEPART(new_color)
 	if(ethereal.stat != DEAD && !EMPeffect)
 		var/healthpercent = max(ethereal.health, 0) / ethereal.maxHealth//scale with the lower of health and hunger
-		var/hungerpercent = min((ethereal.nutrition / NUTRITION_LEVEL_WELL_FED), 1)
+		var/hungerpercent = min((ethereal.nutrition / NUTRITION_LEVEL_FED), 1)//scale only when below a certain hunger threshold
 		var/light_range = max_range * min(healthpercent, hungerpercent)
 		var/light_power = max_power * min(healthpercent, hungerpercent)
 		if(!emageffect)


### PR DESCRIPTION
# Why is this good for the game?
So you can tell when your ethereal friend is hungy

doesn't touch max power, instead just reduces the saturation of any selected colour so it blinds less

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/130985bf-4f30-4711-a801-42b7961e91ab)



:cl:  
tweak: Ethereal brightness and range now scales with hunger in addition to health
tweak: Ethereal lights are slightly less overpowering
/:cl:
