### PR TITLE
You can now re-description your guns because that's FUN

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -8,7 +8,7 @@
 	icon_state = "detective"
 	item_state = "gun"
 	flags_1 =  CONDUCT_1
-	obj_flags = UNIQUE_RENAME
+	obj_flags = UNIQUE_RENAME | UNIQUE_REDESC
 	slot_flags = ITEM_SLOT_BELT
 	materials = list(/datum/material/iron=2000)
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/modules/projectiles/guns/ballistic/toy.dm
+++ b/code/modules/projectiles/guns/ballistic/toy.dm
@@ -11,6 +11,7 @@
 	can_suppress = TRUE
 	clumsy_check = 0
 	item_flags = NONE
+	obj_flags = UNIQUE_RENAME
 	casing_ejector = FALSE
 
 /obj/item/gun/ballistic/automatic/toy/update_overlays()
@@ -53,6 +54,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/toy
 	clumsy_check = FALSE
 	item_flags = NONE
+	obj_flags = UNIQUE_RENAME
 	casing_ejector = FALSE
 	can_suppress = FALSE
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -15,6 +15,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/practice)
 	clumsy_check = 0
 	item_flags = NONE
+	obj_flags = UNIQUE_RENAME
 
 /obj/item/gun/energy/laser/retro
 	name ="retro laser gun"


### PR DESCRIPTION
# Document the changes in your pull request

Added the UNIQUIE_REDESC back to guns because it's fun to do it and makes me feel good when I can customize my Ratvar. Toy guns and the practice laser gun can't be re-descriptioned because that was apparently the issue originally and instead of just fixing that all guns had this capability removed because SOMEONE hates fun.


# Why is this good for the game?
Funny guns are cooler than boring guns

# Testing

If the variable doesn't work it's ynot's fault not mine.


# Wiki Documentation

Guns can be redescribed though i dunno if thats actually on the wiki.

# Changelog

:cl:  
rscadd: You can give your guns new descriptions again! Hooray!
tweak: Toy guns and the practice laser gun still are rename-only.
/:cl:
