### PR TITLE
Gives heretics a packet of poppy seeds to grow

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -229,6 +229,7 @@
 		return
 	. += ecult_give_item(/obj/item/forbidden_book, H)
 	. += ecult_give_item(/obj/item/living_heart, H)
+	. += ecult_give_item(/obj/item/seeds/poppy, H)
 
 /datum/antagonist/heretic/proc/ecult_give_item(obj/item/item_path, mob/living/carbon/human/H)
 	var/list/slots = list(


### PR DESCRIPTION
# Document the changes in your pull request

Roundstart heretics + heretics who get equipped (by admins) will now have a packet of poppy seeds to grow if they so choose

# Why is this good for the game?

This should do two things- firstly, heretics have a few recipes that require poppies now, and their reluctance to ask botany to "just grow them" and the lack thereof for the random spawn of them hampers their overall gameplay. Do I think every heretic is going to use this? Probably not, although for those who take advantage of it and not just throw the packet in the trash, may be able to identify other heretics early on- to make plans as allies or to have a future target in mind.

# Testing

Tested it on my private server, works like a charm.

# Changelog

:cl:  

tweak: Heretics now spawn w/ a packet of poppy seeds roundstart

/:cl:
