### PR TITLE
Brings back nightmare

### DIFF
--- a/code/modules/events/nightmare.dm
+++ b/code/modules/events/nightmare.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/ghost_role/nightmare
 	max_occurrences = 1
 	min_players = 30
-	weight = 0 // Disabled in favor of darkspawn
+	weight = 5
 	earliest_start = 45 MINUTES
 	dynamic_should_hijack = TRUE
 

--- a/code/modules/events/nightmare.dm
+++ b/code/modules/events/nightmare.dm
@@ -3,7 +3,6 @@
 	typepath = /datum/round_event/ghost_role/nightmare
 	max_occurrences = 1
 	min_players = 30
-	weight = 5
 	earliest_start = 45 MINUTES
 	dynamic_should_hijack = TRUE
 


### PR DESCRIPTION
# Why is this good for the game?
It was removed because darkspawn was made a midround
darkspawn stopped being a midround, so i'm bringing it back

:cl:  
rscadd: Reenables nightmares
/:cl:
