### PR TITLE
Removes unneeded smile translation

### DIFF
--- a/code/datums/mutations/acid_spit.dm
+++ b/code/datums/mutations/acid_spit.dm
@@ -1,6 +1,6 @@
 /datum/mutation/human/acidspit // polysmorph inert mutation
 	name = "Acid Spit"
-	desc = "An ancient mutation from xenomorphs that changes the salivary glands to produce acid"
+	desc = "An ancient mutation from xenomorphs that changes the salivary glands to produce acid."
 	instability = 50
 	difficulty = 12
 	locked = TRUE

--- a/code/datums/mutations/radiantburst.dm
+++ b/code/datums/mutations/radiantburst.dm
@@ -1,6 +1,6 @@
 /datum/mutation/human/radiantburst
 	name = "Radiant Burst"
-	desc = "An mutation hidden deep within ethereal genetic code that."
+	desc = "A mutation hidden deep within ethereal genetic code that allows you to blind people nearby."
 	quality = POSITIVE
 	difficulty = 12
 	locked = TRUE
@@ -28,7 +28,7 @@
 
 /datum/action/cooldown/spell/aoe/radiantburst
 	name = "Radiant Burst"
-	desc = "You release all the light that is within you"
+	desc = "You release all the light that is within you."
 	button_icon = 'icons/mob/actions/actions_clockcult.dmi'
 	button_icon_state = "Kindle"
 	active_icon_state = "Kindle"
@@ -40,7 +40,7 @@
 	cooldown_time = 15 SECONDS
 	sound = 'sound/magic/blind.ogg'
 	var/safe = FALSE
-	
+
 
 /datum/action/cooldown/spell/aoe/radiantburst/get_things_to_cast_on(atom/center)
 	var/list/things = list()

--- a/code/datums/mutations/sapblood.dm
+++ b/code/datums/mutations/sapblood.dm
@@ -4,7 +4,7 @@
 	quality = POSITIVE
 	difficulty = 16
 	locked = TRUE
-	text_gain_indication = span_notice("Your feel your arteries cloying!")
+	text_gain_indication = span_notice("You feel your arteries cloying!")
 	instability = 20
 	/// The bloodiest wound that the patient has will have its blood_flow reduced by this much each tick
 	var/clot_rate = 0.2

--- a/code/datums/mutations/speech.dm
+++ b/code/datums/mutations/speech.dm
@@ -54,8 +54,8 @@
 	name = "Smile"
 	desc = "Causes the user to be in constant mania."
 	quality = MINOR_NEGATIVE
-	text_gain_indication = span_notice("You feel so happy. Nothing can be wrong with anything. :)")
-	text_lose_indication = span_notice("Everything is terrible again. :(")
+	text_gain_indication = span_notice("You feel so happy. Nothing can be wrong with anything.")
+	text_lose_indication = span_notice("Everything is terrible again.")
 
 /datum/mutation/human/smile/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
@@ -104,7 +104,6 @@
 		message = replacetext(message," drink "," water ")
 		message = replacetext(message," feminist "," empowered woman ")
 		message = replacetext(message," i hate you "," you're mean ")
-		message = replacetext(message," black "," african american ") //YOGS - Bigotry rule
 		message = replacetext(message," jew "," jewish ")
 		message = replacetext(message," shit "," shiz ")
 		message = replacetext(message," crap "," poo ")

--- a/code/game/objects/items/dna_injector.dm
+++ b/code/game/objects/items/dna_injector.dm
@@ -112,7 +112,7 @@
 
 /obj/item/dnainjector/antispit
 	name ="\improper DNA injector (Anti-Acid Spit)"
-	desc = "Cures your corrosive saliva"
+	desc = "Cures your corrosive saliva."
 	remove_mutations = list(ACIDSPIT)
 
 /obj/item/dnainjector/xraymut


### PR DESCRIPTION
A while back (years) people went around replacing all the naughty words and this one was changed but it makes more sense to just remove it. 
Removes black translating to african american when you have the smile gene.
Fixes some punctuation and completes a sentence from the more recent mutation prs.
Removes netspeak in smile gene.

# Why is this good for the game?
so we can stop saying african american crayon idk pick some other examples

# Testing
no

:cl:  ktlwjec
spellcheck: Removes netspeak and unneeded translation in smile gene. Fixes punctuation issues in some mutations.
/:cl:
