### PR TITLE
Finishes off remaining anti_magic_check and uses the proper version

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -194,7 +194,8 @@
 #define TRAIT_TOXINLOVER		"toxinlover"
 #define TRAIT_TOXIMMUNE         "toxin_immune"
 #define TRAIT_NOBREATH			"no_breath"
-#define TRAIT_ANTIMAGIC			"anti_magic"
+/// This mob is antimagic, and immune to spells / cannot cast spells
+#define TRAIT_ANTIMAGIC "anti_magic"
 #define TRAIT_HOLY				"holy"
 #define TRAIT_DEPRESSION		"depression"
 #define TRAIT_JOLLY				"jolly"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -196,6 +196,8 @@
 #define TRAIT_NOBREATH			"no_breath"
 /// This mob is antimagic, and immune to spells / cannot cast spells
 #define TRAIT_ANTIMAGIC "anti_magic"
+/// This mob recently blocked magic with some form of antimagic
+#define TRAIT_RECENTLY_BLOCKED_MAGIC "recently_blocked_magic"
 #define TRAIT_HOLY				"holy"
 #define TRAIT_DEPRESSION		"depression"
 #define TRAIT_JOLLY				"jolly"

--- a/code/datums/components/anti_magic.dm
+++ b/code/datums/components/anti_magic.dm
@@ -1,49 +1,131 @@
+/// This provides different types of magic resistance on an object
 /datum/component/anti_magic
-	var/magic = FALSE
-	var/holy = FALSE
-	var/psychic = FALSE
-	var/allowed_slots = ~ITEM_SLOT_BACKPACK
-	var/charges = INFINITY
-	var/blocks_self = TRUE
-	var/datum/callback/reaction
-	var/datum/callback/expire
+	/// A bitflag with the types of magic resistance on the object
+	var/antimagic_flags
+	/// The amount of times the object can protect the user from magic
+	/// Set to INFINITY to have, well, infinite charges.
+	var/charges
+	/// The inventory slot the object must be located at in order to activate
+	var/inventory_flags
+	/// The callback invoked when we have been drained a antimagic charge
+	var/datum/callback/drain_antimagic
+	/// The callback invoked when twe have been depleted of all charges
+	var/datum/callback/expiration
+	/// Whether we should, on equipping, alert the caster that this item can block any of their spells
+	/// This changes between true and false on equip and drop, don't set it outright to something
+	var/alert_caster_on_equip = TRUE
 
-/datum/component/anti_magic/Initialize(_magic = FALSE, _holy = FALSE, _psychic = FALSE, _allowed_slots, _charges, _blocks_self = TRUE, datum/callback/_reaction, datum/callback/_expire)
+/**
+ * Adds magic resistances to an object
+ *
+ * Magic resistance will prevent magic from affecting the user if it has the correct resistance
+ * against the type of magic being used
+ *
+ * args:
+ * * antimagic_flags (optional) A bitflag with the types of magic resistance on the object
+ * * charges (optional) The amount of times the object can protect the user from magic
+ * * inventory_flags (optional) The inventory slot the object must be located at in order to activate
+ * * drain_antimagic (optional) The proc that is triggered when an object has been drained a antimagic charge
+ * * expiration (optional) The proc that is triggered when the object is depleted of charges
+ * *
+ * antimagic bitflags: (see code/__DEFINES/magic.dm)
+ * * MAGIC_RESISTANCE - Default magic resistance that blocks normal magic (wizard, spells, staffs)
+ * * MAGIC_RESISTANCE_MIND - Tinfoil hat magic resistance that blocks mental magic (telepathy, abductors, jelly people)
+ * * MAGIC_RESISTANCE_HOLY - Holy magic resistance that blocks unholy magic (revenant, cult, vampire, voice of god)
+**/
+/datum/component/anti_magic/Initialize(
+	antimagic_flags = MAGIC_RESISTANCE,
+	charges = INFINITY,
+	inventory_flags = ~ITEM_SLOT_BACKPACK, // items in a backpack won't activate, anywhere else is fine
+	datum/callback/drain_antimagic,
+	datum/callback/expiration,
+)
+
 	if(isitem(parent))
 		RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, PROC_REF(on_equip))
 		RegisterSignal(parent, COMSIG_ITEM_DROPPED, PROC_REF(on_drop))
 	else if(ismob(parent))
-		RegisterSignal(parent, COMSIG_MOB_RECEIVE_MAGIC, PROC_REF(protect))
+		register_antimagic_signals(parent)
 	else
 		return COMPONENT_INCOMPATIBLE
 
-	magic = _magic
-	holy = _holy
-	psychic = _psychic
-	if(_allowed_slots)
-		allowed_slots = _allowed_slots
-	if(!isnull(_charges))
-		charges = _charges
-	blocks_self = _blocks_self
-	reaction = _reaction
-	expire = _expire
+	src.antimagic_flags = antimagic_flags
+	src.charges = charges
+	src.inventory_flags = inventory_flags
+	src.drain_antimagic = drain_antimagic
+	src.expiration = expiration
 
-/datum/component/anti_magic/proc/on_equip(datum/source, mob/equipper, slot)
-	if(!CHECK_BITFIELD(allowed_slots, slot)) //Check that the slot is valid for antimagic
-		UnregisterSignal(equipper, COMSIG_MOB_RECEIVE_MAGIC)
+/datum/component/anti_magic/Destroy(force, silent)
+	drain_antimagic = null
+	expiration = null
+	return ..()
+
+/datum/component/anti_magic/proc/register_antimagic_signals(datum/on_what)
+	RegisterSignal(on_what, COMSIG_MOB_RECEIVE_MAGIC, PROC_REF(block_receiving_magic), override = TRUE)
+	RegisterSignal(on_what, COMSIG_MOB_RESTRICT_MAGIC, PROC_REF(restrict_casting_magic), override = TRUE)
+
+/datum/component/anti_magic/proc/unregister_antimagic_signals(datum/on_what)
+	UnregisterSignal(on_what, list(COMSIG_MOB_RECEIVE_MAGIC, COMSIG_MOB_RESTRICT_MAGIC))
+
+/datum/component/anti_magic/proc/on_equip(atom/movable/source, mob/equipper, slot)
+	SIGNAL_HANDLER
+
+	if(!(inventory_flags & slot)) //Check that the slot is valid for antimagic
+		unregister_antimagic_signals(equipper)
 		return
-	RegisterSignal(equipper, COMSIG_MOB_RECEIVE_MAGIC, PROC_REF(protect), TRUE)
 
-/datum/component/anti_magic/proc/on_drop(datum/source, mob/user)
-	UnregisterSignal(user, COMSIG_MOB_RECEIVE_MAGIC)
+	register_antimagic_signals(equipper)
+	if(!alert_caster_on_equip)
+		return
 
-/datum/component/anti_magic/proc/protect(datum/source, mob/user, _magic, _holy, _psychic, chargecost, self, list/protection_sources)
-	if(((_magic && magic) || (_holy && holy) || (_psychic && psychic)) && (!self || blocks_self))
-		protection_sources += parent
-		reaction?.Invoke(user, chargecost)
-		charges -= chargecost
+	// Check to see if we have any spells that are blocked due to antimagic
+	for(var/datum/action/cooldown/spell/magic_spell in equipper.actions)
+		if(!(magic_spell.spell_requirements & SPELL_REQUIRES_NO_ANTIMAGIC))
+			continue
+
+		if(!(antimagic_flags & magic_spell.antimagic_flags))
+			continue
+
+		to_chat(equipper, span_warning("[parent] is interfering with your ability to cast magic!"))
+		alert_caster_on_equip = FALSE
+		break
+
+/datum/component/anti_magic/proc/on_drop(atom/movable/source, mob/user)
+	SIGNAL_HANDLER
+
+	// Reset alert
+	if(source.loc != user)
+		alert_caster_on_equip = TRUE
+	unregister_antimagic_signals(user)
+
+/datum/component/anti_magic/proc/block_receiving_magic(mob/living/carbon/source, casted_magic_flags, charge_cost, list/antimagic_sources)
+	SIGNAL_HANDLER
+
+	// We do not block this type of magic, good day
+	if(!(casted_magic_flags & antimagic_flags))
+		return NONE
+
+	// We have already blocked this spell
+	if(parent in antimagic_sources)
+		return NONE
+
+	// Block success! Add this parent to the list of antimagic sources
+	antimagic_sources += parent
+
+	if((charges != INFINITY) && charge_cost > 0)
+		drain_antimagic?.Invoke(source, parent)
+		charges -= charge_cost
 		if(charges <= 0)
-			expire?.Invoke(user)
-			qdel(src)
+			expiration?.Invoke(source, parent)
+			qdel(src) // no more antimagic
+
+	return COMPONENT_MAGIC_BLOCKED
+
+/// cannot cast magic with the same type of antimagic present
+/datum/component/anti_magic/proc/restrict_casting_magic(mob/user, magic_flags)
+	SIGNAL_HANDLER
+
+	if(magic_flags & antimagic_flags)
 		return COMPONENT_MAGIC_BLOCKED
 
+	return NONE

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -378,7 +378,7 @@
 
 /datum/status_effect/belligerent/proc/do_movement_toggle(force_damage)
 	var/number_legs = owner.get_num_legs(FALSE)
-	if(iscarbon(owner) && !is_servant_of_ratvar(owner) && !owner.can_block_magic(chargecost = 0) && number_legs)
+	if(iscarbon(owner) && !is_servant_of_ratvar(owner) && !owner.can_block_magic(charge_cost = 0) && number_legs)
 		if(force_damage || owner.m_intent != MOVE_INTENT_WALK)
 			if(GLOB.ratvar_awakens)
 				owner.Paralyze(20)
@@ -467,7 +467,7 @@
 		owner.remove_status_effect(/datum/status_effect/drowsiness)
 		owner.remove_status_effect(/datum/status_effect/confusion)
 		severity = 0
-	else if(!owner.can_block_magic(chargecost = 0) && owner.stat != DEAD && severity)
+	else if(!owner.can_block_magic(charge_cost = 0) && owner.stat != DEAD && severity)
 		var/static/hum = get_sfx('sound/effects/screech.ogg') //same sound for every proc call
 		if(owner.getToxLoss() > MANIA_DAMAGE_TO_CONVERT)
 			if(is_eligible_servant(owner))

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -378,7 +378,7 @@
 
 /datum/status_effect/belligerent/proc/do_movement_toggle(force_damage)
 	var/number_legs = owner.get_num_legs(FALSE)
-	if(iscarbon(owner) && !is_servant_of_ratvar(owner) && !owner.anti_magic_check(chargecost = 0) && number_legs)
+	if(iscarbon(owner) && !is_servant_of_ratvar(owner) && !owner.can_block_magic(chargecost = 0) && number_legs)
 		if(force_damage || owner.m_intent != MOVE_INTENT_WALK)
 			if(GLOB.ratvar_awakens)
 				owner.Paralyze(20)
@@ -467,7 +467,7 @@
 		owner.remove_status_effect(/datum/status_effect/drowsiness)
 		owner.remove_status_effect(/datum/status_effect/confusion)
 		severity = 0
-	else if(!owner.anti_magic_check(chargecost = 0) && owner.stat != DEAD && severity)
+	else if(!owner.can_block_magic(chargecost = 0) && owner.stat != DEAD && severity)
 		var/static/hum = get_sfx('sound/effects/screech.ogg') //same sound for every proc call
 		if(owner.getToxLoss() > MANIA_DAMAGE_TO_CONVERT)
 			if(is_eligible_servant(owner))

--- a/code/game/objects/items/gems.dm
+++ b/code/game/objects/items/gems.dm
@@ -162,7 +162,7 @@
 
 /obj/item/gem/dark/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/anti_magic, TRUE, TRUE, FALSE, null, null, FALSE)
+	AddComponent(/datum/component/anti_magic, MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY)
 
 /obj/item/gem/random
 	name = "random gem"

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -33,7 +33,7 @@
 
 /obj/item/nullrod/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/anti_magic, TRUE, TRUE, FALSE, null, null, FALSE)
+	AddComponent(/datum/component/anti_magic, MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY)
 
 /obj/item/nullrod/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is killing [user.p_them()]self with [src]! It looks like [user.p_theyre()] trying to get closer to god!"))
@@ -1174,7 +1174,7 @@ it also swaps back if it gets thrown into the chaplain, but the chaplain catches
 
 /mob/living/simple_animal/nullrod/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/anti_magic, TRUE, TRUE, FALSE, null, null, FALSE)
+	AddComponent(/datum/component/anti_magic, MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY)
 	button = new(src)
 	button.Grant(src)
 

--- a/code/game/objects/items/singularityhammer.dm
+++ b/code/game/objects/items/singularityhammer.dm
@@ -129,7 +129,7 @@
 	. = ..()
 	if(isliving(hit_atom))
 		var/mob/M = hit_atom
-		var/atom/A = M.anti_magic_check()
+		var/atom/A = M.can_block_magic()
 		if(A)
 			if(isitem(A))
 				M.visible_message(span_warning("[M]'s [A] glows brightly as it disrupts the Mjolnir's power!"))

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -872,7 +872,7 @@
 	/// The time it takes for an arrow to return
 	var/return_time = 5 SECONDS
 	/// If the return is blocked by anti-magic
-	var/anti_magic_check = TRUE
+	var/check_for_antimagic = TRUE
 
 /obj/item/storage/belt/quiver/returning/Initialize(mapload)
 	. = ..()
@@ -888,7 +888,7 @@
 		return
 	if(ismob(arrow.loc))
 		var/mob/arrow_holder = arrow.loc
-		if(anti_magic_check && arrow_holder.anti_magic_check(TRUE, FALSE ,FALSE, 0))
+		if(check_for_antimagic && arrow_holder.can_block_magic(charge_cost = 0))
 			to_chat(arrow_holder, span_notice("You feel [arrow] tugging on you."))
 			return
 		var/mob/living/carbon/carbon = arrow.loc
@@ -935,7 +935,7 @@
 	icon_state = "quiver_holding"
 	item_state = "quiver_holding"
 	content_overlays = FALSE // The arrows are stored in the quiver, so none of it hangs out
-	anti_magic_check = FALSE
+	check_for_antimagic = FALSE
 
 /obj/item/storage/belt/quiver/returning/holding/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -43,6 +43,10 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "burning",
 	slot_flags = ITEM_SLOT_BELT
 	var/success_heal_chance = 60
 
+/obj/item/storage/book/bible/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/anti_magic, MAGIC_RESISTANCE_HOLY)
+
 /obj/item/storage/book/bible/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is offering [user.p_them()]self to [deity_name]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return (BRUTELOSS)

--- a/code/game/objects/structures/traps.dm
+++ b/code/game/objects/structures/traps.dm
@@ -66,7 +66,7 @@
 		var/mob/M = AM
 		if(M.mind in immune_minds)
 			return
-		if(M.anti_magic_check())
+		if(M.can_block_magic())
 			flare()
 			return
 	if(charges <= 0)

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -339,7 +339,7 @@
 		if(QDELETED(G))
 			return
 
-		if(C.anti_magic_check(FALSE, FALSE, TRUE, 0))
+		if(C.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0))
 			to_chat(user, span_warning("Your target seems to have some sort of tinfoil protection on, blocking the message from being sent!"))
 			return
 
@@ -516,7 +516,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 
 /obj/item/abductor/baton/proc/SleepAttack(mob/living/L,mob/living/user)
 	if(L.incapacitated(TRUE, TRUE))
-		if(L.anti_magic_check(FALSE, FALSE, TRUE))
+		if(L.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0))
 			to_chat(user, span_warning("The specimen's tinfoil protection is interfering with the sleep inducement!"))
 			L.visible_message(span_danger("[user] tried to induced sleep in [L] with [src], but [L.p_their()] tinfoil protection [L.p_them()]!"), \
 								span_userdanger("You feel a strange wave of heavy drowsiness wash over you, but your tinfoil protection deflects most of it!"))
@@ -528,7 +528,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 		L.Sleeping(30 SECONDS)
 		log_combat(user, L, "put to sleep")
 	else
-		if(L.anti_magic_check(FALSE, FALSE, TRUE, 0))
+		if(L.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0))
 			to_chat(user, span_warning("The specimen's tinfoil protection is completely blocking our sleep inducement methods!"))
 			L.visible_message(span_danger("[user] tried to induce sleep in [L] with [src], but [L.p_their()] tinfoil protection completely protected [L.p_them()]!"), \
 								span_userdanger("Any sense of drowsiness is quickly diminished as your tinfoil protection deflects the effects!"))

--- a/code/modules/antagonists/abductor/machinery/console.dm
+++ b/code/modules/antagonists/abductor/machinery/console.dm
@@ -205,7 +205,7 @@
 			c.console = src
 
 /obj/machinery/abductor/console/proc/AddSnapshot(mob/living/carbon/human/target)
-	if(target.anti_magic_check(FALSE, FALSE, TRUE, 0))
+	if(target.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0))
 		say("Subject wearing specialized protective tinfoil gear, unable to get a proper scan!")
 		return
 	var/datum/icon_snapshot/entry = new

--- a/code/modules/antagonists/clockcult/clock_effects/clock_sigils.dm
+++ b/code/modules/antagonists/clockcult/clock_effects/clock_sigils.dm
@@ -12,7 +12,6 @@
 	var/sigil_name = "Sigil"
 	var/resist_string = "glows blinding white" //string for when a null rod blocks its effects, "glows [resist_string]"
 	var/check_antimagic = TRUE
-	var/check_holy = FALSE
 
 /obj/effect/clockwork/sigil/attackby(obj/item/I, mob/living/user, params)
 	if(I.force)
@@ -46,7 +45,7 @@
 		var/mob/living/L = AM
 		if(L.stat <= stat_affected)
 			if((!is_servant_of_ratvar(L) || (affects_servants && is_servant_of_ratvar(L))) && (L.mind || L.has_status_effect(STATUS_EFFECT_SIGILMARK)) && !isdrone(L))
-				var/atom/I = L.anti_magic_check(check_antimagic, check_holy)
+				var/atom/I = L.can_block_magic((check_antimagic ? MAGIC_RESISTANCE : NONE))
 				if(I)
 					if(isitem(I))
 						L.visible_message(span_warning("[L]'s [I.name] [resist_string], protecting [L.p_them()] from [src]'s effects!"), \

--- a/code/modules/antagonists/clockcult/clock_helpers/slab_abilities.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/slab_abilities.dm
@@ -183,7 +183,7 @@
 		var/mob/living/L = clicked_on
 		if(is_servant_of_ratvar(L) || L.stat || L.has_status_effect(STATUS_EFFECT_KINDLE))
 			return BULLET_ACT_HIT
-		var/atom/O = L.anti_magic_check()
+		var/atom/O = L.can_block_magic()
 		playsound(L, 'sound/magic/fireball.ogg', 50, TRUE, frequency = 1.25)
 		if(O)
 			if(isitem(O))

--- a/code/modules/antagonists/clockcult/clock_items/clock_weapons/ratvarian_spear.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clock_weapons/ratvarian_spear.dm
@@ -36,7 +36,7 @@
 
 /obj/item/clockwork/weapon/ratvarian_spear/attack(mob/living/target, mob/living/carbon/human/user)
 	. = ..()
-	if(!QDELETED(target) && target.stat != DEAD && !target.anti_magic_check(chargecost = 0) && !is_servant_of_ratvar(target)) //we do bonus damage on attacks unless they're a servant, have a null rod, or are dead
+	if(!QDELETED(target) && target.stat != DEAD && !target.can_block_magic(chargecost = 0) && !is_servant_of_ratvar(target)) //we do bonus damage on attacks unless they're a servant, have a null rod, or are dead
 		var/bonus_damage = bonus_burn //normally a total of 20 damage, 30 with ratvar
 		if(issilicon(target))
 			target.visible_message(span_warning("[target] shudders violently at [src]'s touch!"), span_userdanger("ERROR: Temperature rising!"))
@@ -56,7 +56,7 @@
 			else
 				L.visible_message(span_warning("[src] bounces off of [L], as if repelled by an unseen force!"))
 		else if(!..())
-			if(!L.anti_magic_check())
+			if(!L.can_block_magic())
 				if(issilicon(L) || iscultist(L))
 					L.Paralyze(100)
 				else

--- a/code/modules/antagonists/clockcult/clock_items/clock_weapons/ratvarian_spear.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clock_weapons/ratvarian_spear.dm
@@ -36,7 +36,7 @@
 
 /obj/item/clockwork/weapon/ratvarian_spear/attack(mob/living/target, mob/living/carbon/human/user)
 	. = ..()
-	if(!QDELETED(target) && target.stat != DEAD && !target.can_block_magic(chargecost = 0) && !is_servant_of_ratvar(target)) //we do bonus damage on attacks unless they're a servant, have a null rod, or are dead
+	if(!QDELETED(target) && target.stat != DEAD && !target.can_block_magic(charge_cost = 0) && !is_servant_of_ratvar(target)) //we do bonus damage on attacks unless they're a servant, have a null rod, or are dead
 		var/bonus_damage = bonus_burn //normally a total of 20 damage, 30 with ratvar
 		if(issilicon(target))
 			target.visible_message(span_warning("[target] shudders violently at [src]'s touch!"), span_userdanger("ERROR: Temperature rising!"))

--- a/code/modules/antagonists/clockcult/clock_items/judicial_visor.dm
+++ b/code/modules/antagonists/clockcult/clock_items/judicial_visor.dm
@@ -191,7 +191,7 @@
 	for(var/mob/living/L in range(1, src))
 		if(is_servant_of_ratvar(L))
 			continue
-		var/atom/I = L.anti_magic_check()
+		var/atom/I = L.can_block_magic()
 		if(I)
 			if(isitem(I))
 				L.visible_message(span_warning("Strange energy flows into [L]'s [I.name]!"), \

--- a/code/modules/antagonists/clockcult/clock_structures/ocular_warden.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ocular_warden.dm
@@ -63,7 +63,7 @@
 			if(last_process + time_between_shots < world.time)
 				if(isliving(target))
 					var/mob/living/L = target
-					if(!L.anti_magic_check(chargecost = 0))
+					if(!L.can_block_magic(chargecost = 0))
 						if(isrevenant(L))
 							var/mob/living/simple_animal/revenant/R = L
 							if(R.revealed)
@@ -109,7 +109,7 @@
 /obj/structure/destructible/clockwork/ocular_warden/proc/acquire_nearby_targets()
 	. = list()
 	for(var/mob/living/L in viewers(sight_range, src)) //Doesn't attack the blind
-		if(is_servant_of_ratvar(L) || (HAS_TRAIT(L, TRAIT_BLIND)) || L.anti_magic_check(TRUE, TRUE))
+		if(is_servant_of_ratvar(L) || (HAS_TRAIT(L, TRAIT_BLIND)) || L.can_block_magic(MAGIC_RESISTANCE_HOLY|MAGIC_RESISTANCE_MIND))
 			continue
 		var/obj/item/storage/book/bible/B = L.bible_check()
 		if(B)

--- a/code/modules/antagonists/clockcult/clock_structures/ocular_warden.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ocular_warden.dm
@@ -63,7 +63,7 @@
 			if(last_process + time_between_shots < world.time)
 				if(isliving(target))
 					var/mob/living/L = target
-					if(!L.can_block_magic(chargecost = 0))
+					if(!L.can_block_magic(charge_cost = 0))
 						if(isrevenant(L))
 							var/mob/living/simple_animal/revenant/R = L
 							if(R.revealed)

--- a/code/modules/antagonists/clockcult/clock_structures/taunting_trail.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/taunting_trail.dm
@@ -54,7 +54,7 @@
 
 /obj/structure/destructible/clockwork/taunting_trail/proc/affect_mob(mob/living/L)
 	if(istype(L) && !is_servant_of_ratvar(L))
-		if(!L.anti_magic_check(chargecost = 0))
+		if(!L.can_block_magic(chargecost = 0))
 			L.adjust_confusion_up_to(15 SECONDS, 50 SECONDS)
 			L.adjust_dizzy_up_to(15 SECONDS, 50 SECONDS)
 			L.Paralyze(FLOOR(L.get_timed_status_effect_duration(/datum/status_effect/confusion) * 0.8, 1))

--- a/code/modules/antagonists/clockcult/clock_structures/taunting_trail.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/taunting_trail.dm
@@ -54,7 +54,7 @@
 
 /obj/structure/destructible/clockwork/taunting_trail/proc/affect_mob(mob/living/L)
 	if(istype(L) && !is_servant_of_ratvar(L))
-		if(!L.can_block_magic(chargecost = 0))
+		if(!L.can_block_magic(charge_cost = 0))
 			L.adjust_confusion_up_to(15 SECONDS, 50 SECONDS)
 			L.adjust_dizzy_up_to(15 SECONDS, 50 SECONDS)
 			L.Paralyze(FLOOR(L.get_timed_status_effect_duration(/datum/status_effect/confusion) * 0.8, 1))

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -425,7 +425,7 @@
 
 		user.mob_light(_range = 3, _color = LIGHT_COLOR_BLOOD_MAGIC, _duration = 0.2 SECONDS)
 
-		var/anti_magic_source = L.anti_magic_check()
+		var/anti_magic_source = L.can_block_magic()
 		if(anti_magic_source)
 
 			L.mob_light(_range = 2, _color = LIGHT_COLOR_HOLY_MAGIC, _duration = 10 SECONDS)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -727,7 +727,7 @@ GLOBAL_VAR_INIT(curselimit, 0)
 	. = ..()
 	if(.)
 		return
-	if(!L.anti_magic_check())
+	if(!L.can_block_magic())
 		if(is_servant_of_ratvar(L))
 			L.Paralyze(20)
 		else
@@ -1018,7 +1018,7 @@ GLOBAL_VAR_INIT(curselimit, 0)
 			else
 				L.visible_message(span_warning("[src] bounces off of [L], as if repelled by an unseen force!"))
 		else if(!..())
-			if(!L.anti_magic_check())
+			if(!L.can_block_magic())
 				if(L.buckled)
 					L.buckled.unbuckle_mob(L)
 

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -105,7 +105,7 @@ Runes can either be invoked by one's self or with many different cultists. Each 
 
 /obj/effect/rune/attack_animal(mob/living/simple_animal/M)
 	if(istype(M, /mob/living/simple_animal/shade) || istype(M, /mob/living/simple_animal/hostile/construct) || istype(M, /mob/living/simple_animal/hostile/guardian))
-		if(istype(M, /mob/living/simple_animal/hostile/construct/wraith/angelic) || istype(M, /mob/living/simple_animal/hostile/construct/armored/angelic) || istype(M, /mob/living/simple_animal/hostile/construct/builder/angelic) || (istype(M, /mob/living/simple_animal/hostile/guardian) && M.anti_magic_check(TRUE, FALSE)))
+		if(istype(M, /mob/living/simple_animal/hostile/construct/wraith/angelic) || istype(M, /mob/living/simple_animal/hostile/construct/armored/angelic) || istype(M, /mob/living/simple_animal/hostile/construct/builder/angelic) || (istype(M, /mob/living/simple_animal/hostile/guardian) && M.can_block_magic()))
 			to_chat(M, span_warning("You purge the rune!"))
 			qdel(src)
 		else if(construct_invoke || !iscultist(M)) //if you're not a cult construct we want the normal fail message
@@ -268,7 +268,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 			to_chat(M, span_danger("You need at least two invokers to convert [convertee]!"))
 		log_game("Offer rune failed - tried conversion with one invoker")
 		return 0
-	if(convertee.anti_magic_check(TRUE, TRUE, FALSE, 0)) //Not chargecost because it can be spammed
+	if(convertee.can_block_magic((MAGIC_RESISTANCE_HOLY|MAGIC_RESISTANCE_MIND), charge_cost = 0)) //Not chargecost because it can be spammed
 		for(var/M in invokers)
 			to_chat(M, span_warning("Something is shielding [convertee]'s mind!"))
 		log_game("Offer rune failed - convertee had anti-magic")
@@ -841,7 +841,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	set_light(6, 1, color)
 	for(var/mob/living/L in viewers(T))
 		if(!iscultist(L) && L.blood_volume)
-			var/atom/I = L.anti_magic_check(chargecost = 0)
+			var/atom/I = L.can_block_magic(chargecost = 0)
 			if(I)
 				if(isitem(I))
 					to_chat(L, span_userdanger("[I] suddenly burns hotly before returning to normal!"))
@@ -871,7 +871,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	set_light(6, 1, color)
 	for(var/mob/living/L in viewers(T))
 		if(!iscultist(L) && L.blood_volume)
-			if(L.anti_magic_check(chargecost = 0))
+			if(L.can_block_magic(chargecost = 0))
 				continue
 			L.take_overall_damage(0, tick_damage*multiplier) //yogs: only burn damage since these like all runes can be placed and activated near freely
 			if(is_servant_of_ratvar(L))

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -268,7 +268,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 			to_chat(M, span_danger("You need at least two invokers to convert [convertee]!"))
 		log_game("Offer rune failed - tried conversion with one invoker")
 		return 0
-	if(convertee.can_block_magic((MAGIC_RESISTANCE_HOLY|MAGIC_RESISTANCE_MIND), charge_cost = 0)) //Not chargecost because it can be spammed
+	if(convertee.can_block_magic((MAGIC_RESISTANCE_HOLY|MAGIC_RESISTANCE_MIND), charge_cost = 0)) //Not charge_cost because it can be spammed
 		for(var/M in invokers)
 			to_chat(M, span_warning("Something is shielding [convertee]'s mind!"))
 		log_game("Offer rune failed - convertee had anti-magic")
@@ -841,7 +841,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	set_light(6, 1, color)
 	for(var/mob/living/L in viewers(T))
 		if(!iscultist(L) && L.blood_volume)
-			var/atom/I = L.can_block_magic(chargecost = 0)
+			var/atom/I = L.can_block_magic(charge_cost = 0)
 			if(I)
 				if(isitem(I))
 					to_chat(L, span_userdanger("[I] suddenly burns hotly before returning to normal!"))
@@ -871,7 +871,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 	set_light(6, 1, color)
 	for(var/mob/living/L in viewers(T))
 		if(!iscultist(L) && L.blood_volume)
-			if(L.can_block_magic(chargecost = 0))
+			if(L.can_block_magic(charge_cost = 0))
 				continue
 			L.take_overall_damage(0, tick_damage*multiplier) //yogs: only burn damage since these like all runes can be placed and activated near freely
 			if(is_servant_of_ratvar(L))

--- a/code/modules/antagonists/demon/general_powers.dm
+++ b/code/modules/antagonists/demon/general_powers.dm
@@ -59,7 +59,7 @@
 
 /mob/living/simple_animal/lesserdemon/UnarmedAttack(mob/living/L, proximity)//10 hp healed from landing a hit.
 	if(isliving(L))
-		if(L.stat != DEAD && !L.anti_magic_check(TRUE, TRUE)) //demons do not gain succor from the dead or holy 
+		if(L.stat != DEAD && !L.can_block_magic(MAGIC_RESISTANCE_HOLY|MAGIC_RESISTANCE_MIND)) //demons do not gain succor from the dead or holy 
 			adjustHealth(-maxHealth * 0.05)
 	return ..()
 
@@ -102,7 +102,7 @@
 	item_state = "hivemind"
 
 /datum/action/cooldown/spell/touch/torment/cast_on_hand_hit(obj/item/melee/touch_attack/hand, mob/living/victim, mob/living/carbon/caster)
-	if(victim.anti_magic_check())
+	if(victim.can_block_magic())
 		to_chat(caster, span_warning("[victim] resists your torment!"))
 		to_chat(victim, span_warning("A hideous feeling of agony dances around your mind before being suddenly dispelled."))
 		..()

--- a/code/modules/antagonists/demon/sins/envy.dm
+++ b/code/modules/antagonists/demon/sins/envy.dm
@@ -34,7 +34,7 @@
 /datum/action/cooldown/spell/touch/envy/cast_on_hand_hit(obj/item/melee/touch_attack/hand, mob/living/carbon/human/target, mob/living/carbon/human/caster)
 	if(!istype(target))
 		return FALSE
-	if(target.anti_magic_check())
+	if(target.can_block_magic())
 		to_chat(caster, span_warning("[target] resists your unholy jealousy!"))
 		to_chat(target, span_warning("A creeping feeling of jealousy dances around your mind before being suddenly dispelled."))
 		return FALSE

--- a/code/modules/antagonists/demon/sins/pride.dm
+++ b/code/modules/antagonists/demon/sins/pride.dm
@@ -39,7 +39,7 @@
 	item_state = "hivemind"
 
 /datum/action/cooldown/spell/touch/mend/cast_on_hand_hit(obj/item/melee/touch_attack/hand, mob/living/victim, mob/living/carbon/caster)
-	if(victim.anti_magic_check())
+	if(victim.can_block_magic())
 		to_chat(caster, span_warning("[victim] resists your pride!"))
 		to_chat(victim, span_warning("A deceptive feeling of pleasre dances around your mind before being suddenly dispelled."))
 		..()

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -468,7 +468,7 @@
 			break
 
 		for(var/mob/living/L in T.contents)
-			if(L.anti_magic_check())
+			if(L.can_block_magic())
 				L.visible_message(span_danger("The fire parts in front of [L]!"),span_danger("As the fire approaches it splits off to avoid contact with you!"))
 				continue
 			if(L in hit_list || L == source)
@@ -853,7 +853,7 @@
 
 /datum/action/cooldown/spell/cone/staggered/entropic_plume/do_mob_cone_effect(mob/living/victim, atom/caster, level)
 	. = ..()
-	if(victim.anti_magic_check() || IS_HERETIC(victim) || IS_HERETIC_MONSTER(victim))
+	if(victim.can_block_magic() || IS_HERETIC(victim) || IS_HERETIC_MONSTER(victim))
 		return
 	victim.apply_status_effect(STATUS_EFFECT_AMOK)
 	victim.apply_status_effect(STATUS_EFFECT_CLOUDSTRUCK, (level * 1 SECONDS))

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -65,7 +65,7 @@
 				reveal(46)
 				stun(46)
 				target.visible_message(span_warning("[target] suddenly rises slightly into the air, [target.p_their()] skin turning an ashy gray."))
-				if(target.anti_magic_check(FALSE, TRUE))
+				if(target.can_block_magic(MAGIC_RESISTANCE_HOLY))
 					to_chat(src, span_revenminor("Something's wrong! [target] seems to be resisting the siphoning, leaving you vulnerable!"))
 					target.visible_message(span_warning("[target] slumps onto the ground."), \
 											   span_revenwarning("Violet lights, dancing in your vision, receding--"))

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -296,17 +296,17 @@
 
 /obj/item/clothing/head/foilhat/Initialize(mapload)
 	. = ..()
-	if(!warped)
-		AddComponent(
-			/datum/component/anti_magic, \
-			antimagic_flags = MAGIC_RESISTANCE_MIND, \
-			inventory_flags = ITEM_SLOT_HEAD, \
-			charges = 6, \
-			drain_antimagic = CALLBACK(src, PROC_REF(drain_antimagic)), \
-			expiration = CALLBACK(src, PROC_REF(warp_up)) \
-		)
-	else
+	if(warped)
 		warp_up()
+		return
+	AddComponent(
+		/datum/component/anti_magic, \
+		antimagic_flags = MAGIC_RESISTANCE_MIND, \
+		inventory_flags = ITEM_SLOT_HEAD, \
+		charges = 6, \
+		drain_antimagic = CALLBACK(src, PROC_REF(drain_antimagic)), \
+		expiration = CALLBACK(src, PROC_REF(warp_up)) \
+	)
 
 /obj/item/clothing/head/foilhat/equipped(mob/living/carbon/human/user, slot)
 	. = ..()

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -297,7 +297,14 @@
 /obj/item/clothing/head/foilhat/Initialize(mapload)
 	. = ..()
 	if(!warped)
-		AddComponent(/datum/component/anti_magic, FALSE, FALSE, TRUE, ITEM_SLOT_HEAD,  6, TRUE, null, CALLBACK(src, PROC_REF(warp_up)))
+		AddComponent(
+			/datum/component/anti_magic, \
+			antimagic_flags = MAGIC_RESISTANCE_MIND, \
+			inventory_flags = ITEM_SLOT_HEAD, \
+			charges = 6, \
+			drain_antimagic = CALLBACK(src, PROC_REF(drain_antimagic)), \
+			expiration = CALLBACK(src, PROC_REF(warp_up)) \
+		)
 	else
 		warp_up()
 
@@ -327,6 +334,10 @@
 	. = ..()
 	if(paranoia)
 		QDEL_NULL(paranoia)
+
+/// When the foilhat is drained an anti-magic charge.
+/obj/item/clothing/head/foilhat/proc/drain_antimagic(mob/user)
+	to_chat(user, span_warning("[src] crumples slightly. Something is trying to get inside your mind!"))
 
 /obj/item/clothing/head/foilhat/proc/warp_up()
 	name = "scorched tinfoil hat"

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -564,7 +564,7 @@
 
 /obj/item/clothing/suit/space/hardsuit/wizard/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/anti_magic, TRUE, FALSE, FALSE, ITEM_SLOT_OCLOTHING, INFINITY, FALSE)
+	AddComponent(/datum/component/anti_magic, antimagic_flags = MAGIC_RESISTANCE, inventory_flags = ITEM_SLOT_OCLOTHING)
 
 
 	//Medical hardsuit
@@ -854,7 +854,7 @@
 
 /obj/item/clothing/suit/space/hardsuit/ert/paranormal/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/anti_magic, FALSE, FALSE, TRUE, ITEM_SLOT_OCLOTHING)
+	AddComponent(/datum/component/anti_magic, antimagic_flags = MAGIC_RESISTANCE_MIND, inventory_flags = ITEM_SLOT_OCLOTHING)
 
 /obj/item/clothing/suit/space/hardsuit/ert/paranormal
 	name = "paranormal response team hardsuit"
@@ -867,7 +867,7 @@
 
 /obj/item/clothing/suit/space/hardsuit/ert/paranormal/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/anti_magic, TRUE, TRUE, TRUE, ITEM_SLOT_OCLOTHING)
+	AddComponent(/datum/component/anti_magic, antimagic_flags = ALL, inventory_flags = ITEM_SLOT_OCLOTHING)
 
 /obj/item/clothing/suit/space/hardsuit/ert/paranormal/inquisitor
 	name = "inquisitor's hardsuit"

--- a/code/modules/fields/timestop.dm
+++ b/code/modules/fields/timestop.dm
@@ -16,7 +16,6 @@
 	var/datum/proximity_monitor/advanced/timestop/chronofield
 	alpha = 125
 	var/check_anti_magic = FALSE
-	var/check_holy = FALSE
 	var/start_sound = 'sound/magic/timeparadox2.ogg'
 	var/start_sound_len = 3.3 SECONDS
 
@@ -44,7 +43,7 @@
 /obj/effect/timestop/proc/timestop()
 	target = get_turf(src)
 	playsound(src, start_sound, 75, 1, -1)
-	chronofield = make_field(/datum/proximity_monitor/advanced/timestop, list("current_range" = freezerange, "host" = src, "immune" = immune, "check_anti_magic" = check_anti_magic, "check_holy" = check_holy))
+	chronofield = make_field(/datum/proximity_monitor/advanced/timestop, list("current_range" = freezerange, "host" = src, "immune" = immune, "check_anti_magic" = check_anti_magic))
 	if(duration - start_sound_len * 2 > 0) // Needs to have enough time for both sounds to play in full
 		addtimer(CALLBACK(src, PROC_REF(time_resumes)), duration - start_sound_len)
 	QDEL_IN(src, duration)
@@ -65,7 +64,6 @@
 	var/list/frozen_things = list()
 	var/list/frozen_mobs = list() //cached separately for processing
 	var/check_anti_magic = FALSE
-	var/check_holy = FALSE
 
 	var/static/list/global_frozen_atoms = list()
 
@@ -81,7 +79,7 @@
 		return FALSE
 	if(ismob(A))
 		var/mob/M = A
-		if(M.anti_magic_check(check_anti_magic, check_holy))
+		if(M.can_block_magic((check_anti_magic ? MAGIC_RESISTANCE : NONE)))
 			immune[A] = TRUE
 			return
 	var/frozen = TRUE

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -64,10 +64,16 @@
 
 /obj/item/reagent_containers/food/snacks/grown/holymelon/Initialize(mapload)
 	. = ..()
-	var/uses = 1
-	if(seed)
-		uses = round(seed.potency / 20)
-	AddComponent(/datum/component/anti_magic, TRUE, TRUE, FALSE, null, uses, TRUE, CALLBACK(src, PROC_REF(block_magic)), CALLBACK(src, PROC_REF(expire))) //deliver us from evil o melon god //speedport of TG's 44584 remove this yogs tag if that gets merged
+	if(!seed)
+		return
+	var/uses = round(seed.potency / 20)
+	AddComponent(
+		/datum/component/anti_magic, \
+		antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY, \
+		charges = uses, \
+		drain_antimagic = CALLBACK(src, PROC_REF(block_magic)), \
+		expiration = CALLBACK(src, PROC_REF(expire)) \
+	)
 
 /obj/item/reagent_containers/food/snacks/grown/holymelon/proc/block_magic(mob/user, major)
 	if(major)

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -64,9 +64,10 @@
 
 /obj/item/reagent_containers/food/snacks/grown/holymelon/Initialize(mapload)
 	. = ..()
-	if(!seed)
-		return
-	var/uses = round(seed.potency / 20)
+	var/uses = 1
+	if(seed)
+		uses = round(seed.potency / 20)
+
 	AddComponent(
 		/datum/component/anti_magic, \
 		antimagic_flags = MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY, \

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -463,7 +463,7 @@ GLOBAL_LIST_EMPTY(aide_list)
 
 /obj/item/immortality_talisman/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/anti_magic, TRUE, TRUE, TRUE)
+	AddComponent(/datum/component/anti_magic, ALL)
 
 /datum/action/item_action/immortality
 	name = "Immortality"

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -655,7 +655,7 @@
 		return FALSE
 	if(HAS_TRAIT(M, TRAIT_MINDSHIELD)) //mindshield implant, no dice
 		return FALSE
-	if(M.anti_magic_check(FALSE, FALSE, TRUE, 0))
+	if(M.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0))
 		return FALSE
 	if(M in linked_mobs)
 		return FALSE
@@ -743,12 +743,12 @@
 	var/mob/living/M = input("Select who to send your message to:","Send thought to?",null) as null|mob in options
 	if(!M)
 		return
-	if(M.anti_magic_check(FALSE, FALSE, TRUE, 0))
+	if(M.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0))
 		to_chat(H, span_notice("As you try to communicate with [M], you're suddenly stopped by a vision of a massive tinfoil wall that streches beyond visible range. It seems you've been foiled."))
 		return
 	var/msg = sanitize(input("Message:", "Telepathy") as text|null)
 	if(msg)
-		if(M.anti_magic_check(FALSE, FALSE, TRUE, 0))
+		if(M.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0))
 			to_chat(H, span_notice("As you try to communicate with [M], you're suddenly stopped by a vision of a massive tinfoil wall that streches beyond visible range. It seems you've been foiled."))
 			return
 		log_directed_talk(H, M, msg, LOG_SAY, "slime telepathy")

--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -166,7 +166,7 @@
 				to_chat(H, span_notice("[victim] doesn't have blood!"))
 				return
 			V.drain_cooldown = world.time + 30
-			if(victim.anti_magic_check(FALSE, TRUE, FALSE, 0))
+			if(victim.can_block_magic(MAGIC_RESISTANCE_HOLY, charge_cost = 0))
 				to_chat(victim, span_warning("[H] tries to bite you, but stops before touching you!"))
 				to_chat(H, span_warning("[victim] is blessed! You stop just in time to avoid catching fire."))
 				return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1134,19 +1134,6 @@
 
 	apply_effect((amount*RAD_MOB_COEFFICIENT)/max(1, (radiation**2)*RAD_OVERDOSE_REDUCTION), EFFECT_IRRADIATE, blocked)
 
-///Return any anti magic atom on this mob that matches the magic type
-/mob/living/anti_magic_check(magic = TRUE, holy = FALSE, tinfoil = FALSE, chargecost = 1, self = FALSE)
-	if(!magic && !holy && !tinfoil)
-		return
-	var/list/protection_sources = list()
-	if(SEND_SIGNAL(src, COMSIG_MOB_RECEIVE_MAGIC, src, magic, holy, tinfoil, chargecost, self, protection_sources) & COMPONENT_MAGIC_BLOCKED)
-		if(protection_sources.len)
-			return pick(protection_sources)
-		else
-			return src
-	if((magic && HAS_TRAIT(src, TRAIT_ANTIMAGIC)) || (holy && HAS_TRAIT(src, TRAIT_HOLY)))
-		return src
-
 /mob/living/proc/fakefireextinguish()
 	return
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1016,8 +1016,56 @@
 		is_magic_blocked = TRUE
 	if((casted_magic_flags & MAGIC_RESISTANCE_HOLY) && HAS_TRAIT(src, TRAIT_HOLY))
 		is_magic_blocked = TRUE
+	
+	if(is_magic_blocked && charge_cost > 0 && !HAS_TRAIT(src, TRAIT_RECENTLY_BLOCKED_MAGIC))
+		on_block_magic_effects(casted_magic_flags, antimagic_sources)
 
 	return is_magic_blocked
+
+/// Called whenever a magic effect with a charge cost is blocked and we haven't recently blocked magic.
+/mob/proc/on_block_magic_effects(magic_flags, list/antimagic_sources)
+	return
+
+/mob/living/on_block_magic_effects(magic_flags, list/antimagic_sources)
+	ADD_TRAIT(src, TRAIT_RECENTLY_BLOCKED_MAGIC, MAGIC_TRAIT)
+	addtimer(TRAIT_CALLBACK_REMOVE(src, TRAIT_RECENTLY_BLOCKED_MAGIC, MAGIC_TRAIT), 6 SECONDS)
+
+/* //comment this in if you want antimagic to have a visible effect.
+	var/mutable_appearance/antimagic_effect
+	var/antimagic_color
+	var/atom/antimagic_source = length(antimagic_sources) ? pick(antimagic_sources) : src
+
+	if(magic_flags & MAGIC_RESISTANCE)
+		visible_message(
+			span_warning("[src] pulses red as [ismob(antimagic_source) ? p_they() : antimagic_source] absorbs magic energy!"),
+			span_userdanger("An intense magical aura pulses around [ismob(antimagic_source) ? "you" : antimagic_source] as it dissipates into the air!"),
+		)
+		antimagic_effect = mutable_appearance('icons/effects/effects.dmi', "shield-red", MOB_SHIELD_LAYER)
+		antimagic_color = LIGHT_COLOR_BLOOD_MAGIC
+		playsound(src, 'sound/magic/magic_block.ogg', 50, TRUE)
+
+	else if(magic_flags & MAGIC_RESISTANCE_HOLY)
+		visible_message(
+			span_warning("[src] starts to glow as [ismob(antimagic_source) ? p_they() : antimagic_source] emits a halo of light!"),
+			span_userdanger("A feeling of warmth washes over [ismob(antimagic_source) ? "you" : antimagic_source] as rays of light surround your body and protect you!"),
+		)
+		antimagic_effect = mutable_appearance('icons/mob/effects/genetics.dmi', "servitude", -MUTATIONS_LAYER)
+		antimagic_color = LIGHT_COLOR_HOLY_MAGIC
+		playsound(src, 'sound/magic/magic_block_holy.ogg', 50, TRUE)
+
+	else if(magic_flags & MAGIC_RESISTANCE_MIND)
+		visible_message(
+			span_warning("[src] forehead shines as [ismob(antimagic_source) ? p_they() : antimagic_source] repulses magic from their mind!"),
+			span_userdanger("A feeling of cold splashes on [ismob(antimagic_source) ? "you" : antimagic_source] as your forehead reflects magic usering your mind!"),
+		)
+		antimagic_effect = mutable_appearance('icons/mob/effects/genetics.dmi', "telekinesishead", MOB_SHIELD_LAYER)
+		antimagic_color = LIGHT_COLOR_DARK_BLUE
+		playsound(src, 'sound/magic/magic_block_mind.ogg', 50, TRUE)
+
+	mob_light(range = 2, color = antimagic_color, duration = 5 SECONDS)
+	add_overlay(antimagic_effect)
+	addtimer(CALLBACK(src, TYPE_PROC_REF(/atom, cut_overlay), antimagic_effect), 5 SECONDS)
+*/
 
 /**
   * Buckle to another mob

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1006,19 +1006,18 @@
 	if(casted_magic_flags == NONE) // magic with the NONE flag is immune to blocking
 		return FALSE
 
-	var/list/protection_was_used = list() // this is a janky way of interrupting signals using lists
-	var/is_magic_blocked = SEND_SIGNAL(src, COMSIG_MOB_RECEIVE_MAGIC, casted_magic_flags, charge_cost, protection_was_used) & COMPONENT_MAGIC_BLOCKED
+	// A list of all things which are providing anti-magic to us
+	var/list/antimagic_sources = list()
+	var/is_magic_blocked = FALSE
 
-	if(casted_magic_flags && HAS_TRAIT(src, TRAIT_ANTIMAGIC))
+	if(SEND_SIGNAL(src, COMSIG_MOB_RECEIVE_MAGIC, casted_magic_flags, charge_cost, antimagic_sources) & COMPONENT_MAGIC_BLOCKED)
+		is_magic_blocked = TRUE
+	if(HAS_TRAIT(src, TRAIT_ANTIMAGIC))
 		is_magic_blocked = TRUE
 	if((casted_magic_flags & MAGIC_RESISTANCE_HOLY) && HAS_TRAIT(src, TRAIT_HOLY))
 		is_magic_blocked = TRUE
 
 	return is_magic_blocked
-
-///Return any anti magic atom on this mob that matches the magic type
-/mob/proc/anti_magic_check(magic = TRUE, holy = FALSE, tinfoil = FALSE, chargecost = 1, self = FALSE) //new system above, kept cause this is not the aim of the PR but to 
-	return																								//be changed later
 
 /**
   * Buckle to another mob

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1049,7 +1049,7 @@
 			span_warning("[src] starts to glow as [ismob(antimagic_source) ? p_they() : antimagic_source] emits a halo of light!"),
 			span_userdanger("A feeling of warmth washes over [ismob(antimagic_source) ? "you" : antimagic_source] as rays of light surround your body and protect you!"),
 		)
-		antimagic_effect = mutable_appearance('icons/mob/effects/genetics.dmi', "servitude", -MUTATIONS_LAYER)
+		antimagic_effect = mutable_appearance('icons/effects/genetics.dmi', "servitude", -MUTATIONS_LAYER)
 		antimagic_color = LIGHT_COLOR_HOLY_MAGIC
 		playsound(src, 'sound/magic/magic_block_holy.ogg', 50, TRUE)
 
@@ -1058,7 +1058,7 @@
 			span_warning("[src] forehead shines as [ismob(antimagic_source) ? p_they() : antimagic_source] repulses magic from their mind!"),
 			span_userdanger("A feeling of cold splashes on [ismob(antimagic_source) ? "you" : antimagic_source] as your forehead reflects magic usering your mind!"),
 		)
-		antimagic_effect = mutable_appearance('icons/mob/effects/genetics.dmi', "telekinesishead", MOB_SHIELD_LAYER)
+		antimagic_effect = mutable_appearance('icons/effects/genetics.dmi', "telekinesishead", MOB_SHIELD_LAYER)
 		antimagic_color = LIGHT_COLOR_DARK_BLUE
 		playsound(src, 'sound/magic/magic_block_mind.ogg', 50, TRUE)
 

--- a/code/modules/projectiles/ammunition/reusable/arrow.dm
+++ b/code/modules/projectiles/ammunition/reusable/arrow.dm
@@ -273,7 +273,7 @@
 	else
 		BB.set_homing_target(target)
 		var/mob/M = target
-		if(istype(M) && M.can_block_magic(chargecost = 0))
+		if(istype(M) && M.can_block_magic(charge_cost = 0))
 			BB.homing_away = TRUE // And there it goes!
 
 /obj/item/ammo_casing/reusable/arrow/magic/on_land(obj/item/projectile/old_projectile)

--- a/code/modules/projectiles/ammunition/reusable/arrow.dm
+++ b/code/modules/projectiles/ammunition/reusable/arrow.dm
@@ -273,7 +273,7 @@
 	else
 		BB.set_homing_target(target)
 		var/mob/M = target
-		if(istype(M) && M.anti_magic_check(chargecost = 0))
+		if(istype(M) && M.can_block_magic(chargecost = 0))
 			BB.homing_away = TRUE // And there it goes!
 
 /obj/item/ammo_casing/reusable/arrow/magic/on_land(obj/item/projectile/old_projectile)

--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -399,7 +399,7 @@
 		return
 
 	var/mob/holder = loc
-	if(istype(holder) && holder.anti_magic_check(TRUE, FALSE, FALSE, 0))
+	if(istype(holder) && holder.can_cast_magic())
 		to_chat(holder, span_notice("You feel [src] tugging on you."))
 		return
 

--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -63,7 +63,7 @@
 			return
 		else
 			no_den_usage = 0
-	if(checks_antimagic && user.anti_magic_check(TRUE, FALSE, FALSE, 0, TRUE))
+	if(checks_antimagic && user.can_cast_magic())
 		add_fingerprint(user)
 		to_chat(user, span_warning("Something is interfering with [src]."))
 		return

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -100,7 +100,7 @@
 		return
 	..()
 	charges--
-	if(user.anti_magic_check())
+	if(user.can_block_magic())
 		user.visible_message(span_warning("[src] has no effect on [user]!"))
 		return
 	user.revive(full_heal = 1)

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -89,7 +89,7 @@
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
-		if(L.anti_magic_check())
+		if(L.can_block_magic())
 			L.visible_message(span_warning("[src] vanishes on contact with [target]!"))
 			qdel(src)
 			return FALSE

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -540,7 +540,7 @@
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
-		if(L.anti_magic_check() || !firer)
+		if(L.can_block_magic() || !firer)
 			L.visible_message(span_warning("[src] vanishes on contact with [target]!"))
 			return BULLET_ACT_BLOCK
 		var/atom/throw_target = get_edge_target_turf(L, get_dir(L, firer))

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -611,7 +611,7 @@
 	newitem.name = "\improper Holy Medibot"
 	newitem.add_atom_colour(GLOB.freon_color_matrix, TEMPORARY_COLOUR_PRIORITY)
 	newitem.holy = TRUE
-	AddComponent(/datum/component/anti_magic, MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY)
+	newitem.AddComponent(/datum/component/anti_magic, MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY)
 	playsound(altar_turf, 'sound/magic/staff_healing.ogg', 50, TRUE)
 	return TRUE
 

--- a/code/modules/religion/rites.dm
+++ b/code/modules/religion/rites.dm
@@ -611,7 +611,7 @@
 	newitem.name = "\improper Holy Medibot"
 	newitem.add_atom_colour(GLOB.freon_color_matrix, TEMPORARY_COLOUR_PRIORITY)
 	newitem.holy = TRUE
-	newitem.AddComponent(/datum/component/anti_magic, TRUE, TRUE, FALSE, null, null, FALSE)
+	AddComponent(/datum/component/anti_magic, MAGIC_RESISTANCE|MAGIC_RESISTANCE_HOLY)
 	playsound(altar_turf, 'sound/magic/staff_healing.ogg', 50, TRUE)
 	return TRUE
 

--- a/code/modules/spells/spell_types/devil.dm
+++ b/code/modules/spells/spell_types/devil.dm
@@ -198,7 +198,7 @@
 		return
 	if(target_carbon.mind.has_antag_datum(/datum/antagonist/sintouched))
 		return
-	if(target_carbon.anti_magic_check(FALSE, TRUE))
+	if(target_carbon.can_block_magic(MAGIC_RESISTANCE_HOLY))
 		return
 	target_carbon.mind.add_antag_datum(/datum/antagonist/sintouched)
 	target_carbon.Paralyze(40 SECONDS)

--- a/code/modules/spells/spell_types/hivemind.dm
+++ b/code/modules/spells/spell_types/hivemind.dm
@@ -74,7 +74,7 @@
 	if(!target.mind || !target.client || target.stat == DEAD)
 		to_chat(owner, span_notice("We detect no neural activity in this body."))
 	var/shielded = HAS_TRAIT(target, TRAIT_MINDSHIELD)
-	var/foiled = target.anti_magic_check(FALSE, FALSE, TRUE, 0)
+	var/foiled = target.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0)
 	if(shielded && !bruteforce)
 		to_chat(owner, span_warning("Powerful technology protects [target.name]'s mind."))
 		return
@@ -93,7 +93,7 @@
 	hive.add_to_hive(target)
 	hive.threat_level = max(0, hive.threat_level-0.1)
 	if(bruteforce)
-		if(target.anti_magic_check(FALSE, FALSE, TRUE, 6))
+		if(target.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 6))
 			target.adjustOrganLoss(ORGAN_SLOT_BRAIN, 10)
 		to_chat(owner, span_warning("We are briefly exhausted by the effort required by our enhanced assimilation abilities."))
 		caster.Immobilize(5 SECONDS)
@@ -101,7 +101,7 @@
 		for(var/obj/item/implant/mindshield/M in target.implants)
 			qdel(M)
 	else
-		target.anti_magic_check(FALSE, FALSE, TRUE)
+		target.can_block_magic(MAGIC_RESISTANCE_MIND)
 
 /datum/action/cooldown/spell/aoe/target_hive/hive_remove
 	name = "Release Vessel"
@@ -151,7 +151,7 @@
 	if(!active)
 		vessel = victim
 		if(vessel)
-			if(vessel.anti_magic_check(FALSE, FALSE, TRUE, 0))
+			if(vessel.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 0))
 				if(get_dist(src, vessel) > 42)
 					to_chat(owner, span_warning("We were unable to link our view with [vessel.name]. A barrier of tinfoil prevents us to do so at this distance."))
 					return
@@ -207,7 +207,7 @@
 	var/mob/living/carbon/target = targets[1]
 	to_chat(owner, span_notice("We increase the psionic bandwidth between ourself and the target!"))
 	var/power = 1
-	if(target.anti_magic_check(FALSE, FALSE, TRUE))
+	if(target.can_block_magic(MAGIC_RESISTANCE_MIND))
 		power *= 0.5
 	if(!hive.is_carbon_member(target))
 		power *= 0.5
@@ -257,7 +257,7 @@
 		if(owner.z != L.z || L.stat == DEAD)
 			message += " could not be found."
 		else
-			var/multiplier = L.anti_magic_check(FALSE, FALSE, TRUE) ? rand(0.6, 1.4) : 1
+			var/multiplier = L.can_block_magic(MAGIC_RESISTANCE_MIND) ? rand(0.6, 1.4) : 1
 			switch(distance*multiplier)
 				if(0 to 2)
 					message += " is right next to us!"
@@ -275,14 +275,14 @@
 		var/mob/living/carbon/C = enemy.owner?.current
 		if(!C)
 			continue
-		var/multiplier = C.anti_magic_check(FALSE, FALSE, TRUE) ? rand(0.6, 1.4) : 1
+		var/multiplier = C.can_block_magic(MAGIC_RESISTANCE_MIND) ? rand(0.6, 1.4) : 1
 		var/mob/living/real_enemy = C.get_real_hivehost()
 		distance = get_dist(owner, real_enemy)
 		message = "A host that we can track for [(hive.individual_track_bonus[enemy])/10] extra seconds"
 		if(owner.z != real_enemy.z || real_enemy.stat == DEAD)
 			message += " could not be found."
 		else
-			multiplier = real_enemy.anti_magic_check(FALSE, FALSE, TRUE) ? rand(0.6, 1.4) : 1
+			multiplier = real_enemy.can_block_magic(MAGIC_RESISTANCE_MIND) ? rand(0.6, 1.4) : 1
 			switch(distance*multiplier)
 				if(0 to 2)
 					message += " is right next to us!"
@@ -332,7 +332,7 @@
 		if(!target)
 			to_chat(owner, span_warning("We have run out of vessels to drain."))
 			break
-		var/regen = target.anti_magic_check(FALSE, FALSE, TRUE) ? 5 : 10
+		var/regen = target.can_block_magic(MAGIC_RESISTANCE_MIND) ? 5 : 10
 		target.adjustOrganLoss(ORGAN_SLOT_BRAIN, regen/2)
 		if(owner.getBruteLoss() > owner.getFireLoss())
 			owner.heal_ordered_damage(regen, list(CLONE, BRUTE, BURN, STAMINA))
@@ -423,7 +423,7 @@
 		vessel = victim
 		to_chat(owner, span_notice("We begin merging our mind with [vessel.name]."))
 		var/timely = 50
-		if(vessel.anti_magic_check(FALSE, FALSE, TRUE))
+		if(vessel.can_block_magic(MAGIC_RESISTANCE_MIND))
 			timely = 100
 			restricted_range = TRUE
 		if(!do_after(owner, timely, owner, timed_action_flags = IGNORE_HELD_ITEM))
@@ -526,7 +526,7 @@
 			continue
 		target.adjust_jitter(14 SECONDS)
 		target.apply_damage(35 + rand(0,15), STAMINA, target.get_bodypart(BODY_ZONE_HEAD))
-		if(target.is_real_hivehost() || target.anti_magic_check(FALSE, FALSE, TRUE))
+		if(target.is_real_hivehost() || target.can_block_magic(MAGIC_RESISTANCE_MIND))
 			continue
 		if(prob(20))
 			var/text = pick(":h Help!!",":h Run!",":h They're here!",":h Get out!",":h Hide!",":h Kill them!",":h Cult!",":h Changeling!",":h Traitor!",":h Nuke ops!",":h Revolutionaries!",":h Wizard!",":h Zombies!",":h Ghosts!",":h AI rogue!",":h Borgs emagged!",":h Maint!!",":h Dying!!",":h AI lock down the borgs law 1!",":h I'm losing control of the situation!!")
@@ -610,7 +610,7 @@
 		to_chat(owner, span_notice("Our concentration has been broken!"))
 		return
 	to_chat(target, span_ownerdanger("You see dark smoke swirling around you!"))
-	if(target.anti_magic_check(FALSE, FALSE, TRUE))
+	if(target.can_block_magic(MAGIC_RESISTANCE_MIND))
 		to_chat(owner, span_notice("We begin bruteforcing the tinfoil barriers of [target.name] and pulling out their nightmares."))
 		if(!do_after(owner, 3 SECONDS, owner, timed_action_flags = IGNORE_HELD_ITEM) || !(target in view(aoe_radius)))
 			to_chat(owner, span_notice("Our concentration has been broken!"))
@@ -683,7 +683,7 @@
 
 	to_chat(owner, span_notice("We begin probing [target.name]'s mind!"))
 	if(do_after(owner, 10 SECONDS, target, timed_action_flags = IGNORE_HELD_ITEM))
-		var/foiled = target.anti_magic_check(FALSE, FALSE, TRUE)
+		var/foiled = target.can_block_magic(MAGIC_RESISTANCE_MIND)
 		if(!in_hive || foiled)
 			var/timely = !in_hive ? 200 : 100
 			to_chat(owner, span_notice("Their mind slowly opens up to us."))
@@ -796,7 +796,7 @@
 	var/list/valid_targets = list()
 	for(var/datum/mind/M in hive.hivemembers)
 		var/mob/living/carbon/C = M.current
-		if(!C || is_hivehost(C) || C.is_wokevessel() || C.stat == DEAD || C.InCritical() || C.anti_magic_check(FALSE, FALSE, TRUE, 4))
+		if(!C || is_hivehost(C) || C.is_wokevessel() || C.stat == DEAD || C.InCritical() || C.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 4))
 			continue
 		valid_targets += C
 
@@ -951,7 +951,8 @@
 			continue
 		C.adjust_jitter(15 SECONDS)
 		C.Unconscious(150)
-		C.anti_magic_check(FALSE, FALSE, TRUE, 6)
+		if(C.can_block_magic(MAGIC_RESISTANCE_MIND, charge_cost = 6))
+			continue
 		to_chat(C, span_boldwarning("Something's wrong..."))
 		addtimer(CALLBACK(GLOBAL_PROC, /proc/to_chat, C, span_boldwarning("...your memories are becoming fuzzy.")), 45)
 		addtimer(CALLBACK(GLOBAL_PROC, /proc/to_chat, C, span_boldwarning("You try to remember who you are...")), 90)

--- a/code/modules/spells/spell_types/madness_curse.dm
+++ b/code/modules/spells/spell_types/madness_curse.dm
@@ -16,7 +16,7 @@ GLOBAL_VAR_INIT(curse_of_madness_triggered, FALSE)
 		var/turf/T = get_turf(H)
 		if(T && !is_station_level(T.z))
 			continue
-		if(H.anti_magic_check(TRUE, FALSE, TRUE))
+		if(H.can_block_magic(MAGIC_RESISTANCE|MAGIC_RESISTANCE_MIND))
 			to_chat(H, span_notice("You have a strange feeling for a moment, but then it passes."))
 			continue
 		give_madness(H, message)

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -148,7 +148,7 @@
 
 	var/list/mob/living/listeners = list()
 	for(var/mob/living/L in get_hearers_in_view(max_range, user))
-		if(L.can_hear() && !L.anti_magic_check(FALSE, TRUE) && L.stat != DEAD)
+		if(L.can_hear() && !L.can_block_magic(MAGIC_RESISTANCE_HOLY) && L.stat != DEAD)
 			if(L == user && !include_speaker)
 				continue
 			if(ishuman(L))

--- a/yogstation/code/modules/spells/spell_types/pointed/cluwnecurse.dm
+++ b/yogstation/code/modules/spells/spell_types/pointed/cluwnecurse.dm
@@ -19,7 +19,7 @@
 		to_chat(owner, span_notice("You are unable to curse [cast_on]!"))
 		return FALSE
 	var/mob/living/target = cast_on
-	if(target.anti_magic_check())
+	if(target.can_block_magic())
 		to_chat(owner, span_notice("They didn't laugh!"))
 		return FALSE
 	return TRUE


### PR DESCRIPTION
# Document the changes in your pull request

Antimagic checks are currently split between the old barely functional strung together shitcode of ``anti_magic_check``, and the better version that currently doesn't work as good because the component doesn't take it into account of ``can_block_magic``. This updates all instances of anti_magic_check to its proper can_block_magic use, and updates the component to only take that one into account now.

I also reverted the stealth nerf of Bibles against Revenants/Devils/Conversion, and added messages to the tinfoil hat letting you know when it gets used (since it has limited use).

This will be made even better with https://github.com/yogstation13/Yogstation/pull/20569 which adds bitflag support for the component, but that's not the point of the PR.

Ports
https://github.com/tgstation/tgstation/pull/76616 (Mostly)
https://github.com/tgstation/tgstation/issues/64124

# Why is this good for the game?

# Testing

just trust me bro

# Spriting

# Wiki Documentation

# Changelog

:cl:  
bugfix: Bibles now protect against unholy stuff again.
bugfix: Antimagic protection now works properly and more consistently.
/:cl:
