### PR TITLE
Port TG's "Kills obj/item/projectile in favour of obj/projectile" and rename its flag var to armor_flag

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
+++ b/_maps/RandomRuins/SpaceRuins/hilbertshoteltestingsite.dmm
@@ -14,9 +14,9 @@
 "e" = (
 /obj/machinery/porta_turret/syndicate{
 	desc = "A ballistic machine gun auto-turret that fires bluespace bullets.";
-	lethal_projectile = /obj/item/projectile/magic/teleport;
+	lethal_projectile = /obj/projectile/magic/teleport;
 	name = "displacement turret";
-	stun_projectile = /obj/item/projectile/magic/teleport
+	stun_projectile = /obj/projectile/magic/teleport
 	},
 /turf/open/floor/plasteel/grimy{
 	icon_state = "engine"

--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -197,6 +197,10 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 ///ammo box will have a different state for full and empty; <icon_state>-max_ammo and <icon_state>-0
 #define AMMO_BOX_FULL_EMPTY 2
 
+#define SUPPRESSED_NONE 0
+#define SUPPRESSED_QUIET 1 ///standard suppressed
+#define SUPPRESSED_VERY 2 /// no message
+
 //Projectile Reflect
 #define REFLECT_NORMAL 				(1<<0)
 #define REFLECT_FAKEPROJECTILE		(1<<1)

--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_x_act.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_x_act.dm
@@ -8,7 +8,7 @@
 #define COMSIG_ATOM_EMP_ACT "atom_emp_act"
 ///from base of atom/fire_act(): (exposed_temperature, exposed_volume)
 #define COMSIG_ATOM_FIRE_ACT "atom_fire_act"
-///from base of atom/bullet_act(): (/obj/item/projectile, def_zone)
+///from base of atom/bullet_act(): (/obj/projectile, def_zone)
 #define COMSIG_ATOM_BULLET_ACT "atom_bullet_act"
 ///from base of atom/CheckParts(): (list/parts_list, datum/crafting_recipe/R)
 #define COMSIG_ATOM_CHECKPARTS "atom_checkparts"

--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -353,23 +353,23 @@
 ///called in /obj/item/gun/process_fire (user, target, params, zone_override)
 #define COMSIG_GRENADE_ARMED "grenade_armed"
 
-// /obj/item/projectile signals (sent to the firer)
+// /obj/projectile signals (sent to the firer)
 
-///from base of /obj/item/projectile/proc/on_hit(), like COMSIG_PROJECTILE_ON_HIT but on the projectile itself and with the hit limb (if any): (atom/movable/firer, atom/target, Angle, hit_limb)
+///from base of /obj/projectile/proc/on_hit(), like COMSIG_PROJECTILE_ON_HIT but on the projectile itself and with the hit limb (if any): (atom/movable/firer, atom/target, Angle, hit_limb)
 #define COMSIG_PROJECTILE_SELF_ON_HIT "projectile_self_on_hit"
-///from base of /obj/item/projectile/proc/on_hit(): (atom/movable/firer, atom/target, Angle)
+///from base of /obj/projectile/proc/on_hit(): (atom/movable/firer, atom/target, Angle)
 #define COMSIG_PROJECTILE_ON_HIT "projectile_on_hit"
-///from base of /obj/item/projectile/proc/fire(): (obj/item/projectile, atom/original_target)
+///from base of /obj/projectile/proc/fire(): (obj/projectile, atom/original_target)
 #define COMSIG_PROJECTILE_BEFORE_FIRE "projectile_before_fire"
-///from base of /obj/item/projectile/proc/fire(): (obj/item/projectile, atom/firer, atom/original_target)
+///from base of /obj/projectile/proc/fire(): (obj/projectile, atom/firer, atom/original_target)
 #define COMSIG_PROJECTILE_FIRER_BEFORE_FIRE "projectile_firer_before_fire"
-///from the base of /obj/item/projectile/proc/fire(): ()
+///from the base of /obj/projectile/proc/fire(): ()
 #define COMSIG_PROJECTILE_FIRE "projectile_fire"
 ///sent to targets during the process_hit proc of projectiles
 #define COMSIG_PROJECTILE_PREHIT "com_proj_prehit"
-///from the base of /obj/item/projectile/Range(): ()
+///from the base of /obj/projectile/Range(): ()
 #define COMSIG_PROJECTILE_RANGE "projectile_range"
-///from the base of /obj/item/projectile/on_range(): ()
+///from the base of /obj/projectile/on_range(): ()
 #define COMSIG_PROJECTILE_RANGE_OUT "projectile_range_out"
 ///from [/obj/item/proc/tryEmbed] sent when trying to force an embed (mainly for projectiles and eating glass)
 #define COMSIG_EMBED_TRY_FORCE "item_try_embed"

--- a/code/__DEFINES/dcs/signals/signals_spell.dm
+++ b/code/__DEFINES/dcs/signals/signals_spell.dm
@@ -33,7 +33,7 @@
 // Spell type signals
 
 // Pointed projectiles
-// Sent from /datum/action/cooldown/spell/pointed/projectile/fire_projectile() to the caster: (datum/action/cooldown/spell/spell, atom/cast_on, obj/item/projectile/to_fire)
+// Sent from /datum/action/cooldown/spell/pointed/projectile/fire_projectile() to the caster: (datum/action/cooldown/spell/spell, atom/cast_on, obj/projectile/to_fire)
 #define COMSIG_MOB_SPELL_PROJECTILE "mob_spell_projectile"
 /// Sent from /datum/action/cooldown/spell/pointed/projectile/on_cast_hit: (atom/firer, atom/target, atom/hit, angle, hit_limb)
 #define COMSIG_SPELL_PROJECTILE_HIT "spell_projectile_hit"

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -255,7 +255,7 @@ GLOBAL_LIST_INIT(heavyfootmob, typecacheof(list(
 
 #define isbodypart(A) (istype(A, /obj/item/bodypart))
 
-#define isprojectile(A) (istype(A, /obj/item/projectile))
+#define isprojectile(A) (istype(A, /obj/projectile))
 
 #define isgun(A) (istype(A, /obj/item/gun))
 

--- a/code/__HELPERS/radiation.dm
+++ b/code/__HELPERS/radiation.dm
@@ -8,7 +8,7 @@
 		/mob/living/silicon/ai,
 		/obj/effect,
 		/obj/docking_port,
-		/obj/item/projectile,
+		/obj/projectile,
 		/atom/movable/gravity_lens
 		))
 	var/list/processing_list = list(location)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -403,7 +403,7 @@
 /mob/living/LaserEyes(atom/A, params)
 	changeNext_move(CLICK_CD_RANGE)
 
-	var/obj/item/projectile/beam/LE = new /obj/item/projectile/beam( loc )
+	var/obj/projectile/beam/LE = new /obj/projectile/beam( loc )
 	LE.icon = 'icons/effects/genetics.dmi'
 	LE.icon_state = "eyelasers"
 	playsound(usr.loc, 'sound/weapons/taser2.ogg', 75, 1)

--- a/code/controllers/subsystem/processing/projectiles.dm
+++ b/code/controllers/subsystem/processing/projectiles.dm
@@ -10,7 +10,7 @@ PROCESSING_SUBSYSTEM_DEF(projectiles)
 /datum/controller/subsystem/processing/projectiles/proc/set_pixel_speed(new_speed)
 	global_pixel_speed = new_speed
 	for(var/i in processing)
-		var/obj/item/projectile/P = i
+		var/obj/projectile/P = i
 		if(istype(P))			//there's non projectiles on this too.
 			P.set_pixel_speed(new_speed)
 

--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -11,7 +11,7 @@
 		/obj/docking_port,
 		/obj/structure/lattice,
 		/obj/structure/stone_tile,
-		/obj/item/projectile,
+		/obj/projectile,
 		/obj/effect/projectile,
 		/obj/effect/portal,
 		/obj/effect/abstract,

--- a/code/datums/components/fantasy/suffixes.dm
+++ b/code/datums/components/fantasy/suffixes.dm
@@ -124,23 +124,23 @@
 /datum/fantasy_affix/shrapnel/apply(datum/component/fantasy/comp, newName)
 	. = ..()
 	// higher means more likely
-	var/list/weighted_projectile_types = list(/obj/item/projectile/meteor = 1,
-											  /obj/item/projectile/energy/nuclear_particle = 1,
-											  /obj/item/projectile/beam/pulse = 1,
-											  /obj/item/projectile/bullet/honker = 15,
-											  /obj/item/projectile/temp = 15,
-											  /obj/item/projectile/ion = 15,
-											  /obj/item/projectile/magic/door = 15,
-											  /obj/item/projectile/magic/locker = 15,
-											  /obj/item/projectile/magic/fetch = 15,
-											  /obj/item/projectile/beam/emitter = 15,
-											  /obj/item/projectile/magic/flying = 15,
-											  /obj/item/projectile/energy/net = 15,
-											  /obj/item/projectile/bullet/incendiary/c9mm = 15,
-											  /obj/item/projectile/temp/hot = 15,
-											  /obj/item/projectile/beam/disabler = 15)
+	var/list/weighted_projectile_types = list(/obj/projectile/meteor = 1,
+											  /obj/projectile/energy/nuclear_particle = 1,
+											  /obj/projectile/beam/pulse = 1,
+											  /obj/projectile/bullet/honker = 15,
+											  /obj/projectile/temp = 15,
+											  /obj/projectile/ion = 15,
+											  /obj/projectile/magic/door = 15,
+											  /obj/projectile/magic/locker = 15,
+											  /obj/projectile/magic/fetch = 15,
+											  /obj/projectile/beam/emitter = 15,
+											  /obj/projectile/magic/flying = 15,
+											  /obj/projectile/energy/net = 15,
+											  /obj/projectile/bullet/incendiary/c9mm = 15,
+											  /obj/projectile/temp/hot = 15,
+											  /obj/projectile/beam/disabler = 15)
 
-	var/obj/item/projectile/picked_projectiletype = pickweight(weighted_projectile_types)
+	var/obj/projectile/picked_projectiletype = pickweight(weighted_projectile_types)
 
 	var/obj/item/master = comp.parent
 	comp.appliedComponents += master.AddComponent(/datum/component/shrapnel, picked_projectiletype)

--- a/code/datums/components/shrapnel.dm
+++ b/code/datums/components/shrapnel.dm
@@ -26,7 +26,7 @@
 		return
 	var/turf/target_turf = get_turf(target)
 	for(var/turf/shootat_turf in RANGE_TURFS(radius, target) - RANGE_TURFS(radius-1, target))
-		var/obj/item/projectile/P = new projectile_type(target_turf)
+		var/obj/projectile/P = new projectile_type(target_turf)
 
 		//Shooting Code:
 		P.range = radius+1
@@ -34,5 +34,5 @@
 			P.range = override_projectile_range
 		P.preparePixelProjectile(shootat_turf, target)
 		P.firer = firer // don't hit ourself that would be really annoying
-		P.permutated += target // don't hit the target we hit already with the flak
+		P.impacted += target // don't hit the target we hit already with the flak
 		P.fire()

--- a/code/datums/martial/ultra_violence.dm
+++ b/code/datums/martial/ultra_violence.dm
@@ -157,10 +157,10 @@
 	name = ".357 sharpshooter bullet casing"
 	desc = "A .357 sharpshooter bullet casing."
 	caliber = "357"
-	projectile_type = /obj/item/projectile/bullet/ipcmartial
+	projectile_type = /obj/projectile/bullet/ipcmartial
 	click_cooldown_override = 0.1 //this gun shoots faster
 
-/obj/item/projectile/bullet/ipcmartial //literally just default 357 with mob piercing
+/obj/projectile/bullet/ipcmartial //literally just default 357 with mob piercing
 	name = ".357 sharpshooter bullet"
 	damage = 30 // can't 3-shot against sec armor
 	armour_penetration = 15
@@ -170,7 +170,7 @@
 	ricochet_chance = INFINITY // ALWAYS ricochet
 	penetrating = TRUE
 
-/obj/item/projectile/bullet/ipcmartial/on_hit(atom/target, blocked)
+/obj/projectile/bullet/ipcmartial/on_hit(atom/target, blocked)
 	. = ..()
 	if(!isliving(target)) // don't gain style from hitting an object
 		return .
@@ -193,16 +193,16 @@
 	if(damage <= 0)
 		qdel(src)
 
-/obj/item/projectile/bullet/ipcmartial/on_ricochet(atom/A)
+/obj/projectile/bullet/ipcmartial/on_ricochet(atom/A)
 	damage += 10 // more damage if you ricochet it, good luck hitting it consistently though
 	speed *= 0.5 // faster so it can hit more reliably
 	penetrating = FALSE
 	return ..()
 
-/obj/item/projectile/bullet/ipcmartial/check_ricochet()
+/obj/projectile/bullet/ipcmartial/check_ricochet()
 	return TRUE
 
-/obj/item/projectile/bullet/ipcmartial/check_ricochet_flag(atom/A)
+/obj/projectile/bullet/ipcmartial/check_ricochet_flag(atom/A)
 	return !ismob(A) // don't ricochet off of mobs, that would be weird
 
 /obj/item/gun/ballistic/revolver/ipcmartial/Initialize(mapload)
@@ -320,11 +320,11 @@
 			continue
 		for(var/thing in parried_tile.contents)
 			if(isprojectile(thing))
-				var/obj/item/projectile/P = thing
+				var/obj/projectile/P = thing
 				P.firer = H
 				P.damage *= 1.5
 				P.speed *= 0.5
-				P.permutated = list()
+				P.impacted = list()
 				P.fire(get_angle(H, A)) // parry the projectile towards wherever you clicked
 				successful_parry = TRUE
 	if(successful_parry)

--- a/code/datums/mutations/acid_spit.dm
+++ b/code/datums/mutations/acid_spit.dm
@@ -37,7 +37,7 @@
 	icon_state = "neurotoxin"
 	damage = 2
 	damage_type = BURN
-	flag = BIO
+	armor_flag = BIO
 	range = 7
 	speed = 1.8 // spit is not very fast
 

--- a/code/datums/mutations/acid_spit.dm
+++ b/code/datums/mutations/acid_spit.dm
@@ -24,7 +24,7 @@
 
 	active_msg = "You focus your acid spit!"
 	deactive_msg = "You relax."
-	projectile_type = /obj/item/projectile/bullet/acid
+	projectile_type = /obj/projectile/bullet/acid
 
 /datum/action/cooldown/spell/pointed/projectile/acid_spit/can_cast_spell(feedback)
 	. = ..()
@@ -32,7 +32,7 @@
 		to_chat(owner, span_notice("Something is covering your mouth!"))
 		return FALSE
 
-/obj/item/projectile/bullet/acid
+/obj/projectile/bullet/acid
 	name = "acid spit"
 	icon_state = "neurotoxin"
 	damage = 2
@@ -41,7 +41,7 @@
 	range = 7
 	speed = 1.8 // spit is not very fast
 
-obj/item/projectile/bullet/acid/on_hit(atom/target, blocked = FALSE)
+obj/projectile/bullet/acid/on_hit(atom/target, blocked = FALSE)
 	if(isalien(target)) // shouldn't work on xenos
 		nodamage = TRUE
 	else if(!isopenturf(target))

--- a/code/datums/mutations/cold.dm
+++ b/code/datums/mutations/cold.dm
@@ -41,5 +41,5 @@
 
 	active_msg = "You focus your cryokinesis!"
 	deactive_msg = "You relax."
-	projectile_type = /obj/item/projectile/temp/cryo
+	projectile_type = /obj/projectile/temp/cryo
 

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -730,7 +730,7 @@
 	set waitfor = FALSE
 	new/obj/effect/temp_visual/dir_setting/curse/grasp_portal(spawn_turf, owner.dir)
 	playsound(spawn_turf, 'sound/effects/curse2.ogg', 80, 1, -1)
-	var/obj/item/projectile/curse_hand/C = new (spawn_turf)
+	var/obj/projectile/curse_hand/C = new (spawn_turf)
 	C.preparePixelProjectile(owner, spawn_turf)
 	C.fire()
 
@@ -757,7 +757,7 @@
 	set waitfor = FALSE
 	new/obj/effect/temp_visual/dir_setting/curse/grasp_portal(spawn_turf, owner.dir)
 	playsound(spawn_turf, 'sound/effects/curse2.ogg', 80, 1, -1)
-	var/obj/item/projectile/curse_hand/progenitor/C = new (spawn_turf)
+	var/obj/projectile/curse_hand/progenitor/C = new (spawn_turf)
 	C.preparePixelProjectile(owner, spawn_turf)
 	C.fire()
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -242,7 +242,7 @@
 
 	return ..()
 
-/atom/proc/handle_ricochet(obj/item/projectile/P)
+/atom/proc/handle_ricochet(obj/projectile/P)
 	return
 
 ///Can the mover object pass this atom, while heading for the target turf
@@ -450,7 +450,7 @@
   *
   * Default behaviour is to send the COMSIG_ATOM_BULLET_ACT and then call on_hit() on the projectile
   */
-/atom/proc/bullet_act(obj/item/projectile/P, def_zone)
+/atom/proc/bullet_act(obj/projectile/P, def_zone)
 	var/sig_return = SEND_SIGNAL(src, COMSIG_ATOM_BULLET_ACT, P, def_zone)
 	if(sig_return != NONE)
 		return sig_return

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -42,10 +42,10 @@
 	. = ..()
 	if(locate(/obj/structure/barricade) in get_turf(mover))
 		return TRUE
-	else if(istype(mover, /obj/item/projectile))
+	else if(istype(mover, /obj/projectile))
 		if(!anchored)
 			return TRUE
-		var/obj/item/projectile/proj = mover
+		var/obj/projectile/proj = mover
 		if(proj.firer && Adjacent(proj.firer))
 			return TRUE
 		if(prob(proj_pass_rate))

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -544,7 +544,7 @@
 					break
 
 	update_appearance(UPDATE_ICON)
-	var/obj/item/projectile/A
+	var/obj/projectile/A
 	//any emagged turrets drains 2x power and uses a different projectile?
 	if(mode == TURRET_STUN)
 		use_power(reqpower)
@@ -646,8 +646,8 @@
 	scan_range = 9
 	req_access = list(ACCESS_SYNDICATE)
 	mode = TURRET_LETHAL
-	stun_projectile = /obj/item/projectile/bullet
-	lethal_projectile = /obj/item/projectile/bullet
+	stun_projectile = /obj/projectile/bullet
+	lethal_projectile = /obj/projectile/bullet
 	lethal_projectile_sound = 'sound/weapons/gunshot.ogg'
 	stun_projectile_sound = 'sound/weapons/gunshot.ogg'
 	icon_state = "syndie_off"
@@ -669,23 +669,23 @@
 /obj/machinery/porta_turret/syndicate/energy
 	icon_state = "standard_lethal"
 	base_icon_state = "standard"
-	stun_projectile = /obj/item/projectile/energy/electrode
+	stun_projectile = /obj/projectile/energy/electrode
 	stun_projectile_sound = 'sound/weapons/taser.ogg'
-	lethal_projectile = /obj/item/projectile/beam/laser
+	lethal_projectile = /obj/projectile/beam/laser
 	lethal_projectile_sound = 'sound/weapons/laser.ogg'
 	desc = "An energy blaster auto-turret."
 
 /obj/machinery/porta_turret/syndicate/energy/heavy
 	icon_state = "standard_lethal"
 	base_icon_state = "standard"
-	stun_projectile = /obj/item/projectile/energy/electrode
+	stun_projectile = /obj/projectile/energy/electrode
 	stun_projectile_sound = 'sound/weapons/taser.ogg'
-	lethal_projectile = /obj/item/projectile/beam/laser/heavylaser
+	lethal_projectile = /obj/projectile/beam/laser/heavylaser
 	lethal_projectile_sound = 'sound/weapons/lasercannonfire.ogg'
 	desc = "An energy blaster auto-turret."
 
 /obj/machinery/porta_turret/syndicate/energy/raven
-	stun_projectile =  /obj/item/projectile/beam/laser
+	stun_projectile =  /obj/projectile/beam/laser
 	stun_projectile_sound = 'sound/weapons/laser.ogg'
 	faction = list("neutral","silicon","turret")
 
@@ -693,14 +693,14 @@
 /obj/machinery/porta_turret/syndicate/pod
 	integrity_failure = 20
 	max_integrity = 40
-	stun_projectile = /obj/item/projectile/bullet/syndicate_turret
-	lethal_projectile = /obj/item/projectile/bullet/syndicate_turret
+	stun_projectile = /obj/projectile/bullet/syndicate_turret
+	lethal_projectile = /obj/projectile/bullet/syndicate_turret
 
 /obj/machinery/porta_turret/syndicate/shuttle
 	scan_range = 9
 	shot_delay = 3
-	stun_projectile = /obj/item/projectile/bullet/p50/penetrator/shuttle
-	lethal_projectile = /obj/item/projectile/bullet/p50/penetrator/shuttle
+	stun_projectile = /obj/projectile/bullet/p50/penetrator/shuttle
+	lethal_projectile = /obj/projectile/bullet/p50/penetrator/shuttle
 	lethal_projectile_sound = 'sound/weapons/gunshot_smg.ogg'
 	stun_projectile_sound = 'sound/weapons/gunshot_smg.ogg'
 	armor = list(MELEE = 50, BULLET = 30, LASER = 30, ENERGY = 30, BOMB = 80, BIO = 0, RAD = 0, FIRE = 90, ACID = 90)
@@ -729,7 +729,7 @@
 	name = "perimeter defense turret"
 	desc = "A plasma beam turret calibrated to defend outposts against non-humanoid fauna. It is more effective when exposed to the environment."
 	installation = null
-	lethal_projectile = /obj/item/projectile/plasma/turret
+	lethal_projectile = /obj/projectile/plasma/turret
 	lethal_projectile_sound = 'sound/weapons/plasma_cutter.ogg'
 	mode = TURRET_LETHAL //It would be useless in stun mode anyway
 	faction = list("neutral","silicon","turret") //Minebots, medibots, etc that should not be shot.
@@ -755,8 +755,8 @@
 	use_power = NO_POWER_USE
 	has_cover = 0
 	scan_range = 9
-	stun_projectile = /obj/item/projectile/beam/laser
-	lethal_projectile = /obj/item/projectile/beam/laser
+	stun_projectile = /obj/projectile/beam/laser
+	lethal_projectile = /obj/projectile/beam/laser
 	lethal_projectile_sound = 'sound/weapons/plasma_cutter.ogg'
 	stun_projectile_sound = 'sound/weapons/plasma_cutter.ogg'
 	icon_state = "syndie_off"
@@ -780,8 +780,8 @@
 	integrity_failure = 60
 	name = "Old Laser Turret"
 	desc = "A turret built with substandard parts and run down further with age. Still capable of delivering lethal lasers to the odd space carp, but not much else."
-	stun_projectile = /obj/item/projectile/beam/weak
-	lethal_projectile = /obj/item/projectile/beam/weak
+	stun_projectile = /obj/projectile/beam/weak
+	lethal_projectile = /obj/projectile/beam/weak
 	faction = list("neutral","silicon","turret")
 
 ////////////////////////
@@ -1000,16 +1000,16 @@
 
 /obj/item/gun/energy/laser/bluetag/get_turret_properties()
 	. = ..()
-	.["stun_projectile"] = /obj/item/projectile/beam/lasertag/bluetag
-	.["lethal_projectile"] = /obj/item/projectile/beam/lasertag/bluetag
+	.["stun_projectile"] = /obj/projectile/beam/lasertag/bluetag
+	.["lethal_projectile"] = /obj/projectile/beam/lasertag/bluetag
 	.["base_icon_state"] = "blue"
 	.["shot_delay"] = 30
 	.["team_color"] = "blue"
 
 /obj/item/gun/energy/laser/redtag/get_turret_properties()
 	. = ..()
-	.["stun_projectile"] = /obj/item/projectile/beam/lasertag/redtag
-	.["lethal_projectile"] = /obj/item/projectile/beam/lasertag/redtag
+	.["stun_projectile"] = /obj/projectile/beam/lasertag/redtag
+	.["lethal_projectile"] = /obj/projectile/beam/lasertag/redtag
 	.["base_icon_state"] = "red"
 	.["shot_delay"] = 30
 	.["team_color"] = "red"
@@ -1075,16 +1075,16 @@
 	installation = /obj/item/gun/energy/laser/bluetag
 	team_color = "blue"
 
-/obj/machinery/porta_turret/lasertag/bullet_act(obj/item/projectile/P)
+/obj/machinery/porta_turret/lasertag/bullet_act(obj/projectile/P)
 	. = ..()
 	if(on)
 		if(team_color == "blue")
-			if(istype(P, /obj/item/projectile/beam/lasertag/redtag))
+			if(istype(P, /obj/projectile/beam/lasertag/redtag))
 				on = FALSE
 				spawn(100)
 					on = TRUE
 		else if(team_color == "red")
-			if(istype(P, /obj/item/projectile/beam/lasertag/bluetag))
+			if(istype(P, /obj/projectile/beam/lasertag/bluetag))
 				on = FALSE
 				spawn(100)
 					on = TRUE

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -459,5 +459,5 @@
 	if(istype(mover) && (mover.pass_flags & PASSGLASS))
 		return prob(20)
 	else
-		if(istype(mover, /obj/item/projectile))
+		if(istype(mover, /obj/projectile))
 			return prob(10)

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -45,7 +45,7 @@
 
 	set_ready_state(0)
 	for(var/i=1 to get_shot_amount())
-		var/obj/item/projectile/A = new projectile(curloc)
+		var/obj/projectile/A = new projectile(curloc)
 		A.firer = chassis.occupant
 		A.original = target
 		if(!A.suppressed && firing_effect_type)
@@ -89,7 +89,7 @@
 	desc = "A weapon for combat exosuits. Shoots basic lasers."
 	icon_state = "mecha_laser"
 	energy_drain = 30
-	projectile = /obj/item/projectile/beam/laser
+	projectile = /obj/projectile/beam/laser
 	fire_sound = 'sound/weapons/laser.ogg'
 	harmful = TRUE
 
@@ -99,7 +99,7 @@
 	desc = "A weapon for combat exosuits. Shoots basic disablers."
 	icon_state = "mecha_disabler"
 	energy_drain = 30
-	projectile = /obj/item/projectile/beam/disabler
+	projectile = /obj/projectile/beam/disabler
 	fire_sound = 'sound/weapons/taser2.ogg'
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy
@@ -108,7 +108,7 @@
 	desc = "A weapon for combat exosuits. Shoots heavy lasers."
 	icon_state = "mecha_laser"
 	energy_drain = 60
-	projectile = /obj/item/projectile/beam/laser/heavylaser
+	projectile = /obj/projectile/beam/laser/heavylaser
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/xray
@@ -117,7 +117,7 @@
 	desc = "A weapon for combat exosuits. Shoots concentrated X-ray blasts."
 	icon_state = "mecha_xray"
 	energy_drain = 60
-	projectile = /obj/item/projectile/beam/xray
+	projectile = /obj/projectile/beam/xray
 	fire_sound = 'sound/weapons/laser3.ogg'
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/ion
@@ -126,7 +126,7 @@
 	desc = "A weapon for combat exosuits. Shoots technology-disabling ion beams. Don't catch yourself in the blast!"
 	icon_state = "mecha_ion"
 	energy_drain = 200
-	projectile = /obj/item/projectile/ion/heavy	//Big boy 2/2 EMP bolts
+	projectile = /obj/projectile/ion/heavy	//Big boy 2/2 EMP bolts
 	fire_sound = 'sound/weapons/laser.ogg'
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/tesla
@@ -135,7 +135,7 @@
 	desc = "A weapon for combat exosuits. Fires bolts of electricity similar to the experimental tesla engine."
 	icon_state = "mecha_ion"
 	energy_drain = 500
-	projectile = /obj/item/projectile/energy/tesla/cannon
+	projectile = /obj/projectile/energy/tesla/cannon
 	fire_sound = 'sound/magic/lightningbolt.ogg'
 	harmful = TRUE
 
@@ -145,7 +145,7 @@
 	desc = "A weapon for combat exosuits. Shoots powerful destructive blasts capable of demolishing obstacles."
 	icon_state = "mecha_pulse"
 	energy_drain = 120
-	projectile = /obj/item/projectile/beam/pulse/heavy
+	projectile = /obj/projectile/beam/pulse/heavy
 	fire_sound = 'sound/weapons/marauder.ogg'
 	harmful = TRUE
 
@@ -158,7 +158,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
 	energy_drain = 30
-	projectile = /obj/item/projectile/plasma/adv/mech
+	projectile = /obj/projectile/plasma/adv/mech
 	fire_sound = 'sound/weapons/plasma_cutter.ogg'
 	harmful = FALSE
 
@@ -177,7 +177,7 @@
 	desc = "An exosuit-mounted mining tool that does increased damage in low pressure. Drawing from an onboard power source allows it to project further than the handheld version."
 	icon_state = "mecha_kineticgun"
 	energy_drain = 30
-	projectile = /obj/item/projectile/kinetic/mech
+	projectile = /obj/projectile/kinetic/mech
 	fire_sound = 'sound/weapons/kenetic_accel.ogg'
 	harmful = FALSE
 
@@ -197,7 +197,7 @@
 	icon_state = "mecha_taser"
 	energy_drain = 20
 	equip_cooldown = 8
-	projectile = /obj/item/projectile/energy/electrode
+	projectile = /obj/projectile/energy/electrode
 	fire_sound = 'sound/weapons/taser.ogg'
 
 
@@ -321,7 +321,7 @@
 	desc = "A weapon for combat exosuits. Shoots incendiary bullets."
 	icon_state = "mecha_carbine"
 	equip_cooldown = 10
-	projectile = /obj/item/projectile/bullet/incendiary/fnx99
+	projectile = /obj/projectile/bullet/incendiary/fnx99
 	projectiles = 24
 	projectiles_cache = 24
 	projectiles_cache_max = 96
@@ -334,7 +334,7 @@
 	fire_sound = null
 	icon_state = "mecha_mime"
 	equip_cooldown = 30
-	projectile = /obj/item/projectile/bullet/mime
+	projectile = /obj/projectile/bullet/mime
 	projectiles = 6
 	projectile_energy_cost = 50
 	harmful = TRUE
@@ -344,7 +344,7 @@
 	desc = "A weapon for combat exosuits. Shoots a spread of pellets."
 	icon_state = "mecha_scatter"
 	equip_cooldown = 20
-	projectile = /obj/item/projectile/bullet/scattershot
+	projectile = /obj/projectile/bullet/scattershot
 	projectiles = 72
 	projectiles_cache = 72
 	projectiles_cache_max = 288
@@ -358,7 +358,7 @@
 	desc = "A weapon for combat exosuits. Shoots a rapid, three shot burst."
 	icon_state = "mecha_uac2"
 	equip_cooldown = 10
-	projectile = /obj/item/projectile/bullet/lmg
+	projectile = /obj/projectile/bullet/lmg
 	projectiles = 300
 	projectiles_cache = 300
 	projectiles_cache_max = 1200
@@ -374,7 +374,7 @@
 	desc = "A weapon for combat exosuits. Shoots an incredibly hot beam surrounded by a field of plasma."
 	icon_state = "mecha_laser"
 	equip_cooldown = 2 SECONDS
-	projectile = /obj/item/projectile/beam/bfg
+	projectile = /obj/projectile/beam/bfg
 	projectiles = 5
 	projectiles_cache = 0
 	projectiles_cache_max = 10
@@ -386,7 +386,7 @@
 	name = "\improper SRM-8 missile rack"
 	desc = "A weapon for combat exosuits. Launches light explosive missiles."
 	icon_state = "mecha_missilerack"
-	projectile = /obj/item/projectile/bullet/a84mm_he
+	projectile = /obj/projectile/bullet/a84mm_he
 	fire_sound = 'sound/weapons/grenadelaunch.ogg'
 	projectiles = 8
 	projectiles_cache = 0
@@ -400,7 +400,7 @@
 	name = "\improper BRM-6 missile rack"
 	desc = "A weapon for combat exosuits. Launches low-explosive breaching missiles designed to explode only when striking a sturdy target."
 	icon_state = "mecha_missilerack_six"
-	projectile = /obj/item/projectile/bullet/a84mm_br
+	projectile = /obj/projectile/bullet/a84mm_br
 	fire_sound = 'sound/weapons/grenadelaunch.ogg'
 	projectiles = 6
 	projectiles_cache = 0

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -117,7 +117,7 @@
 	if ((!enclosed || istype(Proj, /obj/projectile/bullet/shotgun/slug/uranium))&& occupant && !silicon_pilot && !Proj.force_hit && (Proj.def_zone == BODY_ZONE_HEAD || Proj.def_zone == BODY_ZONE_CHEST)) //allows bullets to hit the pilot of open-canopy mechs
 		occupant.bullet_act(Proj) //If the sides are open, the occupant can be hit
 		return BULLET_ACT_HIT
-	log_message("Hit by projectile. Type: [Proj.name]([Proj.flag]).", LOG_MECHA, color="red")
+	log_message("Hit by projectile. Type: [Proj.name]([Proj.armor_flag]).", LOG_MECHA, color="red")
 	. = ..()
 
 /obj/mecha/ex_act(severity, target)

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -113,8 +113,8 @@
 	. = ..()
 
 
-/obj/mecha/bullet_act(obj/item/projectile/Proj) //wrapper
-	if ((!enclosed || istype(Proj, /obj/item/projectile/bullet/shotgun/slug/uranium))&& occupant && !silicon_pilot && !Proj.force_hit && (Proj.def_zone == BODY_ZONE_HEAD || Proj.def_zone == BODY_ZONE_CHEST)) //allows bullets to hit the pilot of open-canopy mechs
+/obj/mecha/bullet_act(obj/projectile/Proj) //wrapper
+	if ((!enclosed || istype(Proj, /obj/projectile/bullet/shotgun/slug/uranium))&& occupant && !silicon_pilot && !Proj.force_hit && (Proj.def_zone == BODY_ZONE_HEAD || Proj.def_zone == BODY_ZONE_CHEST)) //allows bullets to hit the pilot of open-canopy mechs
 		occupant.bullet_act(Proj) //If the sides are open, the occupant can be hit
 		return BULLET_ACT_HIT
 	log_message("Hit by projectile. Type: [Proj.name]([Proj.flag]).", LOG_MECHA, color="red")

--- a/code/game/objects/effects/custom_portals.dm
+++ b/code/game/objects/effects/custom_portals.dm
@@ -42,7 +42,7 @@ GLOBAL_LIST_EMPTY(custom_portals)
 	var/turf/real_target = get_link_target_turf()
 	if(!real_target)
 		to_chat(M, span_warning("This portal has no linked portal!"))
-	if(!force && (!ismecha(M) && !istype(M, /obj/item/projectile) && M.anchored))
+	if(!force && (!ismecha(M) && !istype(M, /obj/projectile) && M.anchored))
 		return
 	if(ismegafauna(M))
 		message_admins("[M] has used a portal at [ADMIN_VERBOSEJMP(src)] made by [usr].")
@@ -52,8 +52,8 @@ GLOBAL_LIST_EMPTY(custom_portals)
 	else
 		last_effect = world.time
 	if(do_teleport(M, real_target, 0, no_effects = no_effect, channel = TELEPORT_CHANNEL_QUANTUM, forced = TRUE))
-		if(istype(M, /obj/item/projectile))
-			var/obj/item/projectile/P = M
+		if(istype(M, /obj/projectile))
+			var/obj/projectile/P = M
 			P.ignore_source_check = TRUE
 		return TRUE
 	return FALSE

--- a/code/game/objects/effects/effect_system/fluid_spread/effects_smoke.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_smoke.dm
@@ -220,8 +220,8 @@
  */
 /obj/effect/particle_effect/fluid/smoke/bad/proc/on_entered(datum/source, atom/movable/arrived, atom/oldloc)
 	SIGNAL_HANDLER
-	if(istype(arrived, /obj/item/projectile/beam))
-		var/obj/item/projectile/beam/beam = arrived
+	if(istype(arrived, /obj/projectile/beam))
+		var/obj/projectile/beam/beam = arrived
 		beam.damage = (beam.damage/2)
 
 /// A factory which produces smoke that makes you cough.

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -115,7 +115,7 @@
 			if(!(MM.movement_type & FLYING))
 				checksmartmine(AM)
 		else
-			if(istype(AM, /obj/item/projectile))
+			if(istype(AM, /obj/projectile))
 				return
 			triggermine(AM)
 

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -156,7 +156,7 @@
 	var/turf/real_target = get_link_target_turf()
 	if(!istype(real_target))
 		return FALSE
-	if(!force && (!ismecha(M) && !istype(M, /obj/item/projectile) && M.anchored && !allow_anchored))
+	if(!force && (!ismecha(M) && !istype(M, /obj/projectile) && M.anchored && !allow_anchored))
 		return
 	if(ismegafauna(M))
 		message_admins("[M] has used a portal at [ADMIN_VERBOSEJMP(src)] made by [usr].")
@@ -166,8 +166,8 @@
 	else
 		last_effect = world.time
 	if(do_teleport(M, real_target, innate_accuracy_penalty, no_effects = no_effect, channel = teleport_channel))
-		if(istype(M, /obj/item/projectile))
-			var/obj/item/projectile/P = M
+		if(istype(M, /obj/projectile))
+			var/obj/projectile/P = M
 			P.ignore_source_check = TRUE
 		return TRUE
 	return FALSE

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -45,7 +45,7 @@
 		if(prob(50))
 			to_chat(mover, span_danger("You get stuck in \the [src] for a moment."))
 			return FALSE
-	else if(istype(mover, /obj/item/projectile))
+	else if(istype(mover, /obj/projectile))
 		return prob(30)
 
 /obj/structure/spider/eggcluster

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -183,7 +183,7 @@
 		if(EAST)
 			icon_state = "beam_splash_e"
 
-/obj/item/projectile/curse_hand/update_icon_state()
+/obj/projectile/curse_hand/update_icon_state()
 	. = ..()
 	icon_state = "[icon_state][handedness]"
 

--- a/code/game/objects/items/cardboard_cutouts.dm
+++ b/code/game/objects/items/cardboard_cutouts.dm
@@ -83,8 +83,8 @@
 		if(prob(I.force))
 			push_over()
 
-/obj/item/cardboard_cutout/bullet_act(obj/item/projectile/P)
-	if(istype(P, /obj/item/projectile/bullet/reusable))
+/obj/item/cardboard_cutout/bullet_act(obj/projectile/P)
+	if(istype(P, /obj/projectile/bullet/reusable))
 		P.on_hit(src, 0)
 	visible_message(span_danger("[src] has been hit by [P]!"))
 	playsound(src, 'sound/weapons/slice.ogg', 50, 1)

--- a/code/game/objects/items/chrono_eraser.dm
+++ b/code/game/objects/items/chrono_eraser.dm
@@ -118,24 +118,24 @@
 		TED.pass_mind(M)
 
 
-/obj/item/projectile/energy/chrono_beam
+/obj/projectile/energy/chrono_beam
 	name = "eradication beam"
 	icon_state = "chronobolt"
 	range = CHRONO_BEAM_RANGE
 	nodamage = TRUE
 	var/obj/item/gun/energy/chrono_gun/gun = null
 
-/obj/item/projectile/energy/chrono_beam/Initialize(mapload)
+/obj/projectile/energy/chrono_beam/Initialize(mapload)
 	. = ..()
 	var/obj/item/ammo_casing/energy/chrono_beam/C = loc
 	if(istype(C))
 		gun = C.gun
 
-/obj/item/projectile/energy/chrono_beam/Destroy()
+/obj/projectile/energy/chrono_beam/Destroy()
 	gun = null
 	return ..()
 
-/obj/item/projectile/energy/chrono_beam/on_hit(atom/target)
+/obj/projectile/energy/chrono_beam/on_hit(atom/target)
 	if(target && gun && isliving(target))
 		var/obj/structure/chrono_field/F = new(target.loc, target, gun)
 		gun.field_connect(F)
@@ -143,7 +143,7 @@
 
 /obj/item/ammo_casing/energy/chrono_beam
 	name = "eradication beam"
-	projectile_type = /obj/item/projectile/energy/chrono_beam
+	projectile_type = /obj/projectile/energy/chrono_beam
 	icon_state = "chronobolt"
 	e_cost = 0
 	var/obj/item/gun/energy/chrono_gun/gun
@@ -243,9 +243,9 @@
 	else
 		qdel(src)
 
-/obj/structure/chrono_field/bullet_act(obj/item/projectile/P)
-	if(istype(P, /obj/item/projectile/energy/chrono_beam))
-		var/obj/item/projectile/energy/chrono_beam/beam = P
+/obj/structure/chrono_field/bullet_act(obj/projectile/P)
+	if(istype(P, /obj/projectile/energy/chrono_beam))
+		var/obj/projectile/energy/chrono_beam/beam = P
 		var/obj/item/gun/energy/chrono_gun/Pgun = beam.gun
 		if(Pgun && istype(Pgun))
 			Pgun.field_connect(src)

--- a/code/game/objects/items/devices/busterarm/wire_snatch.dm
+++ b/code/game/objects/items/devices/busterarm/wire_snatch.dm
@@ -94,12 +94,12 @@
 /obj/item/ammo_casing/magic/wire
 	name = "hook"
 	desc = "A hook."
-	projectile_type = /obj/item/projectile/wire
+	projectile_type = /obj/projectile/wire
 	caliber = "hook"
 	icon_state = "hook"
 
 /// Projectile
-/obj/item/projectile/wire
+/obj/projectile/wire
 	name = "hook"
 	icon_state = "hook"
 	icon = 'icons/obj/lavaland/artefacts.dmi'
@@ -113,19 +113,19 @@
 	knockdown = 0
 	var/wire
 
-/obj/item/projectile/wire/fire(setAngle)
+/obj/projectile/wire/fire(setAngle)
 	if(firer)
 		wire = firer.Beam(src, icon_state = "chain", time = INFINITY, maxdistance = INFINITY)
 	..()
 
 /// Helper proc exclusively used for pulling the buster arm USER towards something anchored
-/obj/item/projectile/wire/proc/zip(mob/living/user, turf/open/target)
+/obj/projectile/wire/proc/zip(mob/living/user, turf/open/target)
 	to_chat(user, span_warning("You pull yourself towards [target]."))
 	playsound(user, 'sound/magic/tail_swing.ogg', 10, TRUE)
 	user.Immobilize(0.2 SECONDS)//so it's not cut short by walking
 	user.forceMove(get_step_towards(target, user))
 
-/obj/item/projectile/wire/on_hit(atom/target)
+/obj/projectile/wire/on_hit(atom/target)
 	var/mob/living/carbon/human/H = firer
 	if(!H)
 		return
@@ -177,6 +177,6 @@
 		var/turf/W = target
 		zip(H, W)
 
-/obj/item/projectile/wire/Destroy()
+/obj/projectile/wire/Destroy()
 	qdel(wire) // Cleans up the beam that we generate once we hit something
 	return ..()

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -330,7 +330,7 @@
 	create_with_tank = TRUE
 
 /obj/item/flamethrower/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	var/obj/item/projectile/P = hitby
+	var/obj/projectile/P = hitby
 	if(damage && attack_type == PROJECTILE_ATTACK && P.damage_type != STAMINA && prob(5))
 		owner.visible_message(span_danger("\The [attack_text] hits the fueltank on [owner]'s [name], rupturing it! What a shot!"))
 		var/target_turf = get_turf(owner)
@@ -348,13 +348,13 @@
 ///////////////////// Flamethrower as an energy weapon /////////////////////
 // Currently used exclusively in /obj/item/gun/energy/printer/flamethrower
 /obj/item/ammo_casing/energy/flamethrower
-	projectile_type = /obj/item/projectile/bullet/incendiary/flamethrower
+	projectile_type = /obj/projectile/bullet/incendiary/flamethrower
 	select_name = "fire"
 	fire_sound = null
 	firing_effect_type = null
 	e_cost = 50
 
-/obj/item/projectile/bullet/incendiary/flamethrower
+/obj/projectile/bullet/incendiary/flamethrower
 	name = "waft of flames"
 	icon_state = null
 	damage = 0

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -122,7 +122,7 @@
 	return attack_hand(user)
 
 /obj/item/grenade/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	var/obj/item/projectile/P = hitby
+	var/obj/projectile/P = hitby
 	if(damage && attack_type == PROJECTILE_ATTACK && P.damage_type != STAMINA && prob(5))
 		owner.visible_message(span_danger("[attack_text] hits [owner]'s [src], setting it off! What a shot!"))
 		prime()

--- a/code/game/objects/items/latexballoon.dm
+++ b/code/game/objects/items/latexballoon.dm
@@ -41,7 +41,7 @@
 			if (prob(50))
 				qdel(src)
 
-/obj/item/latexballon/bullet_act(obj/item/projectile/P)
+/obj/item/latexballon/bullet_act(obj/projectile/P)
 	if(!P.nodamage)
 		burst()
 	return ..()

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -598,7 +598,7 @@
 	span_italics("You hear a loud crack as you are washed with a wave of heat."))
 	consume_everything()
 
-/obj/item/melee/supermatter_sword/bullet_act(obj/item/projectile/P)
+/obj/item/melee/supermatter_sword/bullet_act(obj/projectile/P)
 	visible_message(span_danger("[P] smacks into [src] and rapidly flashes to ash."),\
 	span_italics("You hear a loud crack as you are washed with a wave of heat."))
 	consume_everything(P)

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -537,7 +537,7 @@
 	var/projectile_damage_tick_ecost_coefficient = 10	//Lasers get half their damage chopped off, drains 50 power/tick. Note that fields are processed 5 times per second.
 	var/projectile_speed_coefficient = 1.5		//Higher the coefficient slower the projectile.
 	var/projectile_tick_speed_ecost = 75
-	var/list/obj/item/projectile/tracked
+	var/list/obj/projectile/tracked
 	var/image/projectile_effect
 	var/field_radius = 3
 	var/active = FALSE
@@ -631,7 +631,7 @@
 /obj/item/borg/projectile_dampen/proc/process_usage(delta_time)
 	var/usage = 0
 	for(var/I in tracked)
-		var/obj/item/projectile/P = I
+		var/obj/projectile/P = I
 		if(!P.stun && P.nodamage)	//No damage
 			continue
 		usage += projectile_tick_speed_ecost * delta_time
@@ -652,7 +652,7 @@
 		host.cell.use(energy_recharge * delta_time * energy_recharge_cyborg_drain_coefficient)
 		energy += energy_recharge * delta_time
 
-/obj/item/borg/projectile_dampen/proc/dampen_projectile(obj/item/projectile/P, track_projectile = TRUE)
+/obj/item/borg/projectile_dampen/proc/dampen_projectile(obj/projectile/P, track_projectile = TRUE)
 	if(tracked[P])
 		return
 	if(track_projectile)
@@ -661,7 +661,7 @@
 	P.speed *= projectile_speed_coefficient
 	P.add_overlay(projectile_effect)
 
-/obj/item/borg/projectile_dampen/proc/restore_projectile(obj/item/projectile/P)
+/obj/item/borg/projectile_dampen/proc/restore_projectile(obj/projectile/P)
 	tracked -= P
 	P.damage *= (1/projectile_damage_coefficient)
 	P.speed *= (1/projectile_speed_coefficient)

--- a/code/game/objects/items/shooting_range.dm
+++ b/code/game/objects/items/shooting_range.dm
@@ -59,17 +59,17 @@
 #define DECALTYPE_SCORCH 1
 #define DECALTYPE_BULLET 2
 
-/obj/item/target/clown/bullet_act(obj/item/projectile/P)
+/obj/item/target/clown/bullet_act(obj/projectile/P)
 	. = ..()
 	playsound(src.loc, 'sound/items/bikehorn.ogg', 50, 1)
 
-/obj/item/target/bullet_act(obj/item/projectile/P)
-	if(istype(P, /obj/item/projectile/bullet/reusable)) // If it's a foam dart, don't bother with any of this other shit
+/obj/item/target/bullet_act(obj/projectile/P)
+	if(istype(P, /obj/projectile/bullet/reusable)) // If it's a foam dart, don't bother with any of this other shit
 		return P.on_hit(src, 0)
 	var/p_x = P.p_x + pick(0,0,0,0,0,-1,1) // really ugly way of coding "sometimes offset P.p_x!"
 	var/p_y = P.p_y + pick(0,0,0,0,0,-1,1)
 	var/decaltype = DECALTYPE_SCORCH
-	if(istype(P, /obj/item/projectile/bullet))
+	if(istype(P, /obj/projectile/bullet))
 		decaltype = DECALTYPE_BULLET
 	var/icon/C = icon(icon,icon_state)
 	if(C.GetPixel(p_x, p_y) && P.original == src && overlays.len <= 35) // if the located pixel isn't blank (null)
@@ -82,7 +82,7 @@
 		bullet_hole.pixel_y = p_y - 1
 		if(decaltype == DECALTYPE_SCORCH)
 			bullet_hole.setDir(pick(NORTH,SOUTH,EAST,WEST))// random scorch design
-			if(P.damage >= 20 || istype(P, /obj/item/projectile/beam/practice))
+			if(P.damage >= 20 || istype(P, /obj/projectile/beam/practice))
 				bullet_hole.setDir(pick(NORTH,SOUTH,EAST,WEST))
 			else
 				bullet_hole.icon_state = "light_scorch"

--- a/code/game/objects/items/syndicateReverseCard.dm
+++ b/code/game/objects/items/syndicateReverseCard.dm
@@ -22,8 +22,8 @@
 /obj/item/syndicateReverseCard/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(!(attack_type == PROJECTILE_ATTACK))
 		return FALSE //this means the attack goes through
-	if(istype(hitby, /obj/item/projectile))
-		var/obj/item/projectile/P = hitby
+	if(istype(hitby, /obj/projectile))
+		var/obj/projectile/P = hitby
 		if(P?.firer && P.fired_from && (P.firer != P.fired_from)) //if the projectile comes from YOU, like your spit or some shit, you can't steal that bro. Also protects mechs
 			if(iscarbon(P.firer)) //You can't switcharoo with turrets or simplemobs, or borgs
 				switcharoo(P.firer, owner, P.fired_from)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -1750,9 +1750,9 @@ obj/item/toy/turn_tracker
 	to_chat(user, span_warning("The [name] grumbles quietly. It is not yet ready to fire again!"))
 
 /obj/item/ammo_casing/magic/sickly_blade_toy
-	projectile_type = /obj/item/projectile/sickly_blade_toy
+	projectile_type = /obj/projectile/sickly_blade_toy
 	harmful = FALSE
-/obj/item/projectile/sickly_blade_toy
+/obj/projectile/sickly_blade_toy
 	name = "hook"
 	icon_state = "hook"
 	icon = 'icons/obj/lavaland/artefacts.dmi'
@@ -1765,7 +1765,7 @@ obj/item/toy/turn_tracker
 	knockdown = 0
 	hitsound = 'sound/effects/gravhit.ogg'
 
-/obj/item/projectile/sickly_blade_toy/on_hit(atom/target, blocked)
+/obj/projectile/sickly_blade_toy/on_hit(atom/target, blocked)
 	. = ..()
 	if(ismovable(target) && blocked != 100)
 		var/atom/movable/A = target

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -75,7 +75,7 @@
 		if(3)
 			take_damage(rand(10, 90), BRUTE, BOMB, 0)
 
-/obj/bullet_act(obj/item/projectile/P)
+/obj/bullet_act(obj/projectile/P)
 	. = ..()
 	playsound(src, P.hitsound, 50, 1)
 	visible_message(span_danger("[src] is hit by \a [P]!"), null, null, COMBAT_MESSAGE_RANGE)

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -80,7 +80,7 @@
 	playsound(src, P.hitsound, 50, 1)
 	visible_message(span_danger("[src] is hit by \a [P]!"), null, null, COMBAT_MESSAGE_RANGE)
 	if(!QDELETED(src)) //Bullet on_hit effect might have already destroyed this object
-		take_damage(P.damage, P.damage_type, P.flag, 0, turn(P.dir, 180), P.armour_penetration)
+		take_damage(P.damage, P.damage_type, P.armor_flag, 0, turn(P.dir, 180), P.armour_penetration)
 
 ///Called to get the damage that hulks will deal to the obj.
 /obj/proc/hulk_damage()

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -273,7 +273,7 @@
 
 /obj/structure/girder/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()
-	if((mover.pass_flags & PASSGRILLE) || istype(mover, /obj/item/projectile))
+	if((mover.pass_flags & PASSGRILLE) || istype(mover, /obj/projectile))
 		return prob(girderpasschance)
 
 /obj/structure/girder/CanAStarPass(ID, dir, caller)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -138,7 +138,7 @@
 	. = ..()
 	if(mover.pass_flags & PASSGRILLE)
 		return TRUE
-	else if(!. && istype(mover, /obj/item/projectile))
+	else if(!. && istype(mover, /obj/projectile))
 		return prob(30)
 
 /obj/structure/grille/CanAStarPass(ID, dir, caller)

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -139,11 +139,11 @@
 	max_integrity = 10
 	allow_walk = 0
 
-/obj/structure/holosign/barrier/cyborg/bullet_act(obj/item/projectile/P)
+/obj/structure/holosign/barrier/cyborg/bullet_act(obj/projectile/P)
 	take_damage((P.damage / 5) , BRUTE, MELEE, 1)	//Doesn't really matter what damage flag it is.
-	if(istype(P, /obj/item/projectile/energy/electrode))
+	if(istype(P, /obj/projectile/energy/electrode))
 		take_damage(10, BRUTE, MELEE, 1)	//Tasers aren't harmful.
-	if(istype(P, /obj/item/projectile/beam/disabler))
+	if(istype(P, /obj/projectile/beam/disabler))
 		take_damage(5, BRUTE, MELEE, 1)	//Disablers aren't harmful.
 	return BULLET_ACT_HIT
 
@@ -266,7 +266,7 @@
 	max_integrity = 20
 	var/shockcd = 0
 
-/obj/structure/holosign/barrier/cyborg/hacked/bullet_act(obj/item/projectile/P)
+/obj/structure/holosign/barrier/cyborg/hacked/bullet_act(obj/projectile/P)
 	take_damage(P.damage, BRUTE, MELEE, 1)	//Yeah no this doesn't get projectile resistance.
 	return BULLET_ACT_HIT
 

--- a/code/game/objects/structures/manned_turret.dm
+++ b/code/game/objects/structures/manned_turret.dm
@@ -13,7 +13,7 @@
 	layer = ABOVE_MOB_LAYER
 	var/view_range = 2.5
 	var/cooldown = 0
-	var/projectile_type = /obj/item/projectile/bullet/manned_turret
+	var/projectile_type = /obj/projectile/bullet/manned_turret
 	var/rate_of_fire = 1
 	var/number_of_shots = 40
 	var/cooldown_duration = 90
@@ -152,7 +152,7 @@
 	var/turf/targets_from = get_turf(src)
 	if(QDELETED(target))
 		target = target_turf
-	var/obj/item/projectile/P = new projectile_type(targets_from)
+	var/obj/projectile/P = new projectile_type(targets_from)
 	P.starting = targets_from
 	P.firer = user
 	P.original = target
@@ -167,7 +167,7 @@
 /obj/machinery/manned_turret/ultimate  // Admin-only proof of concept for autoclicker automatics
 	name = "Infinity Gun"
 	view_range = 12
-	projectile_type = /obj/item/projectile/bullet/manned_turret
+	projectile_type = /obj/projectile/bullet/manned_turret
 
 /obj/machinery/manned_turret/ultimate/checkfire(atom/targeted_atom, mob/user)
 	target = targeted_atom

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -14,7 +14,7 @@
 	var/framebuildstackamount = 5
 	var/buildstacktype = /obj/item/stack/sheet/metal
 	var/buildstackamount = 0
-	var/list/allowed_projectile_typecache = list(/obj/item/projectile/beam, /obj/item/projectile/energy/nuclear_particle)
+	var/list/allowed_projectile_typecache = list(/obj/projectile/beam, /obj/projectile/energy/nuclear_particle)
 	var/rotation_angle = -1
 
 /obj/structure/reflector/Initialize(mapload)
@@ -58,7 +58,7 @@
 /obj/structure/reflector/proc/dir_map_to_angle(dir)
 	return 0
 
-/obj/structure/reflector/bullet_act(obj/item/projectile/P)
+/obj/structure/reflector/bullet_act(obj/projectile/P)
 	var/pdir = P.dir
 	var/pangle = P.Angle
 	var/ploc = get_turf(P)
@@ -68,7 +68,7 @@
 		return ..()
 	return BULLET_ACT_FORCE_PIERCE
 
-/obj/structure/reflector/proc/auto_reflect(obj/item/projectile/P, pdir, turf/ploc, pangle)
+/obj/structure/reflector/proc/auto_reflect(obj/projectile/P, pdir, turf/ploc, pangle)
 	P.ignore_source_check = TRUE
 	P.range = P.decayedRange
 	P.decayedRange = max(P.decayedRange--, 0)
@@ -193,7 +193,7 @@
 	admin = TRUE
 	anchored = TRUE
 
-/obj/structure/reflector/single/auto_reflect(obj/item/projectile/P, pdir, turf/ploc, pangle)
+/obj/structure/reflector/single/auto_reflect(obj/projectile/P, pdir, turf/ploc, pangle)
 	var/incidence = GET_ANGLE_OF_INCIDENCE(rotation_angle, (P.Angle + 180))
 	if(abs(incidence) > 90 && abs(incidence) < 270)
 		return FALSE
@@ -219,7 +219,7 @@
 	admin = TRUE
 	anchored = TRUE
 
-/obj/structure/reflector/double/auto_reflect(obj/item/projectile/P, pdir, turf/ploc, pangle)
+/obj/structure/reflector/double/auto_reflect(obj/projectile/P, pdir, turf/ploc, pangle)
 	var/incidence = GET_ANGLE_OF_INCIDENCE(rotation_angle, (P.Angle + 180))
 	var/new_angle = SIMPLIFY_DEGREES(rotation_angle + incidence)
 	P.setAngle(new_angle)
@@ -243,7 +243,7 @@
 	admin = TRUE
 	anchored = TRUE
 
-/obj/structure/reflector/box/auto_reflect(obj/item/projectile/P)
+/obj/structure/reflector/box/auto_reflect(obj/projectile/P)
 	P.setAngle(rotation_angle)
 	return ..()
 

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -117,7 +117,7 @@
 		PlasmaBurn(exposed_temperature)
 
 
-/obj/structure/statue/plasma/bullet_act(obj/item/projectile/Proj)
+/obj/structure/statue/plasma/bullet_act(obj/projectile/Proj)
 	var/burn = FALSE
 	if(!(Proj.nodamage) && Proj.damage_type == BURN && !QDELETED(src))
 		burn = TRUE

--- a/code/game/objects/structures/target_stake.dm
+++ b/code/game/objects/structures/target_stake.dm
@@ -69,7 +69,7 @@
 		pinned_target.forceMove(user.drop_location())
 		to_chat(user, span_notice("You take the target out of the stake."))
 
-/obj/structure/target_stake/bullet_act(obj/item/projectile/P)
+/obj/structure/target_stake/bullet_act(obj/projectile/P)
 	if(pinned_target)
 		pinned_target.bullet_act(P)
 	else

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -498,7 +498,7 @@
 
 /obj/structure/window/plasma/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()
-	if(istype(mover, /obj/item/projectile/energy/nuclear_particle))
+	if(istype(mover, /obj/projectile/energy/nuclear_particle))
 		return FALSE
 
 /obj/structure/window/plasma/spawnDebris(location)
@@ -762,7 +762,7 @@
 
 /obj/structure/window/plastitanium/CanAllowThrough(atom/movable/mover, turf/target)
 	. = ..()
-	if(istype(mover, /obj/item/projectile/energy/nuclear_particle))
+	if(istype(mover, /obj/projectile/energy/nuclear_particle))
 		return FALSE
 
 /obj/structure/window/plastitanium/unanchored

--- a/code/game/turfs/simulated/reebe_void.dm
+++ b/code/game/turfs/simulated/reebe_void.dm
@@ -42,7 +42,7 @@
 	else
 		if(istype(AM, /obj/structure/window))
 			return FALSE
-		if(istype(AM, /obj/item/projectile))
+		if(istype(AM, /obj/projectile))
 			return TRUE
 		if((locate(/obj/structure/lattice) in src))
 			return TRUE

--- a/code/game/turfs/simulated/wall/mineral_walls.dm
+++ b/code/game/turfs/simulated/wall/mineral_walls.dm
@@ -119,10 +119,10 @@
 	if(exposed_temperature > 300)
 		PlasmaBurn(exposed_temperature)
 
-/turf/closed/wall/mineral/plasma/bullet_act(obj/item/projectile/Proj)
-	if(istype(Proj, /obj/item/projectile/beam))
+/turf/closed/wall/mineral/plasma/bullet_act(obj/projectile/Proj)
+	if(istype(Proj, /obj/projectile/beam))
 		PlasmaBurn(2500)
-	else if(istype(Proj, /obj/item/projectile/ion))
+	else if(istype(Proj, /obj/projectile/ion))
 		PlasmaBurn(500)
 	. = ..()
 

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -56,7 +56,7 @@
 /turf/closed/wall/attack_tk()
 	return
 
-/turf/closed/wall/handle_ricochet(obj/item/projectile/P)			//A huge pile of shitcode!
+/turf/closed/wall/handle_ricochet(obj/projectile/P)			//A huge pile of shitcode!
 	var/turf/p_turf = get_turf(P)
 	var/face_direction = get_dir(src, p_turf)
 	var/face_angle = dir2angle(face_direction)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -606,7 +606,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 /turf/proc/Melt()
 	return ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
 
-/turf/bullet_act(obj/item/projectile/P)
+/turf/bullet_act(obj/projectile/P)
 	. = ..()
 	if(. != BULLET_ACT_FORCE_PIERCE)
 		. =  BULLET_ACT_TURF

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1392,7 +1392,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!target.get_bodypart(body_zone))
 		return
 	playsound(target, 'sound/weapons/revolver357shot.ogg', 100)
-	var/obj/item/projectile/bullet/smite/divine_wrath = new(source_turf)
+	var/obj/projectile/bullet/smite/divine_wrath = new(source_turf)
 	divine_wrath.damage = damage
 	divine_wrath.wound_bonus = wound_bonus
 	divine_wrath.original = target

--- a/code/modules/antagonists/blob/structures/shield.dm
+++ b/code/modules/antagonists/blob/structures/shield.dm
@@ -44,7 +44,7 @@
 	brute_resist = 0.5
 	explosion_block = 2
 
-/obj/structure/blob/shield/reflective/handle_ricochet(obj/item/projectile/P)
+/obj/structure/blob/shield/reflective/handle_ricochet(obj/projectile/P)
 	var/turf/p_turf = get_turf(P)
 	var/face_direction = get_dir(src, p_turf)
 	var/face_angle = dir2angle(face_direction)

--- a/code/modules/antagonists/bloodsuckers/powers/gangrel.dm
+++ b/code/modules/antagonists/bloodsuckers/powers/gangrel.dm
@@ -188,23 +188,23 @@
 	to_chat(user, span_warning("You fire a blood bolt!"))
 	user.changeNext_move(CLICK_CD_RANGE)
 	user.newtonian_move(get_dir(target_atom, user))
-	var/obj/item/projectile/magic/arcane_barrage/bloodsucker/magic_9ball = new(user.loc)
+	var/obj/projectile/magic/arcane_barrage/bloodsucker/magic_9ball = new(user.loc)
 	magic_9ball.bloodsucker_power = src
 	magic_9ball.firer = user
 	magic_9ball.def_zone = ran_zone(user.zone_selected)
 	magic_9ball.preparePixelProjectile(target_atom, user)
-	INVOKE_ASYNC(magic_9ball, TYPE_PROC_REF(/obj/item/projectile, fire))
+	INVOKE_ASYNC(magic_9ball, TYPE_PROC_REF(/obj/projectile, fire))
 	playsound(user, 'sound/magic/wand_teleport.ogg', 60, TRUE)
 	power_activated_sucessfully()
 
-/obj/item/projectile/magic/arcane_barrage/bloodsucker
+/obj/projectile/magic/arcane_barrage/bloodsucker
 	name = "blood bolt"
 	icon_state = "bloodbolt"
 	damage_type = BURN
 	damage = 30
 	var/datum/action/cooldown/bloodsucker/targeted/bloodbolt/bloodsucker_power
 
-/obj/item/projectile/magic/arcane_barrage/bloodsucker/on_hit(target)
+/obj/projectile/magic/arcane_barrage/bloodsucker/on_hit(target)
 	if(ismob(target))
 		qdel(src)
 		if(iscarbon(target))

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -287,7 +287,7 @@
 /obj/item/ammo_casing/magic/tentacle
 	name = "tentacle"
 	desc = "A tentacle."
-	projectile_type = /obj/item/projectile/tentacle
+	projectile_type = /obj/projectile/tentacle
 	caliber = "tentacle"
 	icon_state = "tentacle_end"
 	firing_effect_type = null
@@ -301,7 +301,7 @@
 	gun = null
 	return ..()
 
-/obj/item/projectile/tentacle
+/obj/projectile/tentacle
 	name = "tentacle"
 	icon_state = "tentacle_end"
 	pass_flags = PASSTABLE
@@ -312,20 +312,20 @@
 	var/chain
 	var/obj/item/ammo_casing/magic/tentacle/source //the item that shot it
 
-/obj/item/projectile/tentacle/Initialize(mapload)
+/obj/projectile/tentacle/Initialize(mapload)
 	source = loc
 	. = ..()
 
-/obj/item/projectile/tentacle/fire(setAngle)
+/obj/projectile/tentacle/fire(setAngle)
 	if(firer)
 		chain = firer.Beam(src, icon_state = "tentacle", time = INFINITY, maxdistance = INFINITY, beam_sleep_time = 1)
 	..()
 
-/obj/item/projectile/tentacle/proc/reset_throw(mob/living/carbon/human/H)
+/obj/projectile/tentacle/proc/reset_throw(mob/living/carbon/human/H)
 	if(H.in_throw_mode)
 		H.throw_mode_off() //Don't annoy the changeling if he doesn't catch the item
 
-/obj/item/projectile/tentacle/proc/tentacle_grab(mob/living/carbon/human/H, mob/living/carbon/C)
+/obj/projectile/tentacle/proc/tentacle_grab(mob/living/carbon/human/H, mob/living/carbon/C)
 	if(H.Adjacent(C))
 		if(H.get_active_held_item() && !H.get_inactive_held_item())
 			H.swap_hand()
@@ -335,7 +335,7 @@
 			C.grabbedby(H)
 			C.grippedby(H, instant = TRUE) //instant aggro grab
 
-/obj/item/projectile/tentacle/proc/tentacle_stab(mob/living/carbon/human/H, mob/living/carbon/C)
+/obj/projectile/tentacle/proc/tentacle_stab(mob/living/carbon/human/H, mob/living/carbon/C)
 	if(H.Adjacent(C))
 		for(var/obj/item/I in H.held_items)
 			if(I.is_sharp())
@@ -346,7 +346,7 @@
 				playsound(get_turf(H),I.hitsound,75,1)
 				return
 
-/obj/item/projectile/tentacle/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/tentacle/on_hit(atom/target, blocked = FALSE)
 	var/mob/living/carbon/human/H = firer
 	if(blocked >= 100)
 		return BULLET_ACT_BLOCK
@@ -402,7 +402,7 @@
 				L.throw_at(get_step_towards(H,L), 8, 2)
 				. = BULLET_ACT_HIT
 
-/obj/item/projectile/tentacle/Destroy()
+/obj/projectile/tentacle/Destroy()
 	qdel(chain)
 	source = null
 	return ..()

--- a/code/modules/antagonists/clockcult/clock_helpers/slab_abilities.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/slab_abilities.dm
@@ -158,13 +158,13 @@
 		clockwork_say(caller, text2ratvar("Purge all untruths and honor Engine!"))
 		log_combat(caller, U, "fired at with Kindle")
 		playsound(caller, 'sound/magic/blink.ogg', 50, TRUE, frequency = 0.5)
-		var/obj/item/projectile/kindle/A = new(T)
+		var/obj/projectile/kindle/A = new(T)
 		A.preparePixelProjectile(clicked_on, caller, params)
 		A.fire()
 
 	return TRUE
 
-/obj/item/projectile/kindle
+/obj/projectile/kindle
 	name = "kindled flame"
 	icon_state = "pulse0"
 	nodamage = TRUE
@@ -174,11 +174,11 @@
 	range = 3
 	log_override = TRUE
 
-/obj/item/projectile/kindle/Destroy()
+/obj/projectile/kindle/Destroy()
 	visible_message(span_warning("[src] flickers out!"))
 	. = ..()
 
-/obj/item/projectile/kindle/on_hit(atom/clicked_on, blocked = FALSE)
+/obj/projectile/kindle/on_hit(atom/clicked_on, blocked = FALSE)
 	if(isliving(clicked_on))
 		var/mob/living/L = clicked_on
 		if(is_servant_of_ratvar(L) || L.stat || L.has_status_effect(STATUS_EFFECT_KINDLE))

--- a/code/modules/antagonists/clockcult/clock_helpers/slab_abilities.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/slab_abilities.dm
@@ -170,7 +170,7 @@
 	nodamage = TRUE
 	damage = 0 //We're just here for the stunning!
 	damage_type = BURN
-	flag = BOMB
+	armor_flag = BOMB
 	range = 3
 	log_override = TRUE
 

--- a/code/modules/antagonists/clockcult/clock_mobs/clockwork_marauder.dm
+++ b/code/modules/antagonists/clockcult/clock_mobs/clockwork_marauder.dm
@@ -80,15 +80,15 @@
 				break
 	. = ..()
 
-/mob/living/simple_animal/hostile/clockwork/marauder/bullet_act(obj/item/projectile/P)
+/mob/living/simple_animal/hostile/clockwork/marauder/bullet_act(obj/projectile/P)
 	if(deflect_projectile(P))
 		return BULLET_ACT_BLOCK
 	return ..()
 
-/mob/living/simple_animal/hostile/clockwork/marauder/proc/deflect_projectile(obj/item/projectile/P)
+/mob/living/simple_animal/hostile/clockwork/marauder/proc/deflect_projectile(obj/projectile/P)
 	if(!shield_health)
 		return
-	var/energy_projectile = istype(P, /obj/item/projectile/energy) || istype(P, /obj/item/projectile/beam)
+	var/energy_projectile = istype(P, /obj/projectile/energy) || istype(P, /obj/projectile/beam)
 	visible_message(span_danger("[src] deflects [P] with [p_their()] shield!"), \
 	span_danger("You block [P] with your shield! <i>Blocks left:</i> <b>[shield_health - 1]</b>"))
 	if(energy_projectile)

--- a/code/modules/antagonists/clockcult/clock_structures/traps/brass_skewer.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/traps/brass_skewer.dm
@@ -40,7 +40,7 @@
 		return
 	..()
 
-/obj/structure/destructible/clockwork/trap/brass_skewer/bullet_act(obj/item/projectile/P)
+/obj/structure/destructible/clockwork/trap/brass_skewer/bullet_act(obj/projectile/P)
 	if(buckled_mobs && LAZYLEN(buckled_mobs))
 		var/mob/living/L = buckled_mobs[1]
 		return L.bullet_act(P)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -173,7 +173,7 @@
 
 	user.visible_message(span_warning("[user]'s hand flashes a bright blue!"), \
 						 span_cultitalic("You speak the cursed words, emitting an EMP blast from your hand."))
-	var/obj/item/projectile/magic/ion/A = new /obj/item/projectile/magic/ion(user.loc)
+	var/obj/projectile/magic/ion/A = new /obj/projectile/magic/ion(user.loc)
 	A.firer = user
 	A.preparePixelProjectile(target, user, params)
 	A.fire()

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -789,10 +789,10 @@ GLOBAL_VAR_INIT(curselimit, 0)
 	ammo_type = /obj/item/ammo_casing/magic/arcane_barrage/blood
 
 /obj/item/ammo_casing/magic/arcane_barrage/blood
-	projectile_type = /obj/item/projectile/magic/arcane_barrage/blood
+	projectile_type = /obj/projectile/magic/arcane_barrage/blood
 	firing_effect_type = /obj/effect/temp_visual/cult/sparks
 
-/obj/item/projectile/magic/arcane_barrage/blood
+/obj/projectile/magic/arcane_barrage/blood
 	name = "blood bolt"
 	icon_state = "mini_leaper"
 	nondirectional_sprite = TRUE
@@ -801,7 +801,7 @@ GLOBAL_VAR_INIT(curselimit, 0)
 	damage = 20
 	armour_penetration = 0
 
-/obj/item/projectile/magic/arcane_barrage/blood/Bump(atom/target)
+/obj/projectile/magic/arcane_barrage/blood/Bump(atom/target)
 	var/turf/T = get_turf(target)
 	playsound(T, 'sound/effects/splat.ogg', 50, TRUE)
 	if(iscultist(target))
@@ -950,8 +950,8 @@ GLOBAL_VAR_INIT(curselimit, 0)
 
 /obj/item/shield/mirror/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(iscultist(owner))
-		if(istype(hitby, /obj/item/projectile))
-			var/obj/item/projectile/P = hitby
+		if(istype(hitby, /obj/projectile))
+			var/obj/projectile/P = hitby
 			if(P.damage_type == BRUTE || P.damage_type == BURN)
 				if(P.damage >= 30)
 					var/turf/T = get_turf(owner)

--- a/code/modules/antagonists/eldritch_cult/eldritch_items.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_items.dm
@@ -128,9 +128,9 @@
 	to_chat(user, span_warning("The [name] grumbles quietly. It is not yet ready to fire again!"))
 
 /obj/item/ammo_casing/magic/hook/sickly_blade
-	projectile_type = /obj/item/projectile/hook/sickly_blade
+	projectile_type = /obj/projectile/hook/sickly_blade
 
-/obj/item/projectile/hook/sickly_blade
+/obj/projectile/hook/sickly_blade
 	damage = 0
 	knockdown = 0
 	immobilize = 2 // there's no escape
@@ -138,7 +138,7 @@
 	armour_penetration = 0 // no piercing shields
 	hitsound = 'sound/effects/gravhit.ogg'
 
-/obj/item/projectile/hook/sickly_blade/on_hit(atom/target, blocked)
+/obj/projectile/hook/sickly_blade/on_hit(atom/target, blocked)
 	. = ..()
 	if(iscarbon(target) && blocked != 100)
 		var/mob/living/carbon/C = target
@@ -415,7 +415,7 @@
 	if(update_signals(user))
 		set_cloak(cloak - cloak_move_loss)
 
-/obj/item/clothing/suit/cultrobes/void/proc/on_projectile_hit(mob/living/carbon/human/user, obj/item/projectile/P, def_zone)
+/obj/item/clothing/suit/cultrobes/void/proc/on_projectile_hit(mob/living/carbon/human/user, obj/projectile/P, def_zone)
 	if(dodge(user, P, "[P]"))
 		return BULLET_ACT_FORCE_PIERCE
 

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -286,9 +286,9 @@
 	invocation_type = INVOCATION_WHISPER
 	spell_requirements = SPELL_CASTABLE_WITHOUT_INVOCATION
 
-	projectile_type = /obj/item/projectile/magic/aoe/rust_wave
+	projectile_type = /obj/projectile/magic/aoe/rust_wave
 
-/obj/item/projectile/magic/aoe/rust_wave
+/obj/projectile/magic/aoe/rust_wave
 	name = "Patron's Reach"
 	icon_state = "eldritch_projectile"
 	alpha = 180
@@ -300,7 +300,7 @@
 	range = 15
 	speed = 1
 
-/obj/item/projectile/magic/aoe/rust_wave/Moved(atom/OldLoc, Dir)
+/obj/projectile/magic/aoe/rust_wave/Moved(atom/OldLoc, Dir)
 	. = ..()
 	playsound(src, 'sound/items/welder.ogg', 75, TRUE)
 	var/list/turflist = list()
@@ -320,9 +320,9 @@
 
 /datum/action/cooldown/spell/basic_projectile/rust_wave/short
 	name = "Lesser Patron's Reach"
-	projectile_type = /obj/item/projectile/magic/aoe/rust_wave/short
+	projectile_type = /obj/projectile/magic/aoe/rust_wave/short
 
-/obj/item/projectile/magic/aoe/rust_wave/short
+/obj/projectile/magic/aoe/rust_wave/short
 	range = 7
 	speed = 2
 
@@ -972,7 +972,7 @@
 	base_icon_state = "lightning"
 	active_msg = "You energize your hands with raw power!"
 	deactive_msg = "You let the energy flow out of your hands back into yourself..."
-	projectile_type = /obj/item/projectile/magic/aoe/lightning/eldritch
+	projectile_type = /obj/projectile/magic/aoe/lightning/eldritch
 	
 	bolt_range = 7
 	bolt_power = 1000
@@ -1012,7 +1012,7 @@
 	invocation = "D'O'DGE TH'IS!"
 	invocation_type = INVOCATION_SHOUT
 
-	projectile_type = /obj/item/projectile/heretic_assault
+	projectile_type = /obj/projectile/heretic_assault
 
 /datum/action/cooldown/spell/pointed/void_phase
 	name = "Void Phase"

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -326,7 +326,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/AI_Module))
 /datum/AI_Module/upgrade/upgrade_turrets/upgrade(mob/living/silicon/ai/AI)
 	for(var/obj/machinery/porta_turret/ai/turret in GLOB.machines)
 		turret.obj_integrity += 30
-		turret.lethal_projectile = /obj/item/projectile/beam/laser/heavylaser //Once you see it, you will know what it means to FEAR.
+		turret.lethal_projectile = /obj/projectile/beam/laser/heavylaser //Once you see it, you will know what it means to FEAR.
 		turret.lethal_projectile_sound = 'sound/weapons/lasercannonfire.ogg'
 
 

--- a/code/modules/antagonists/zombie/abilities/spit.dm
+++ b/code/modules/antagonists/zombie/abilities/spit.dm
@@ -37,7 +37,7 @@
 		return FALSE
 
 	user.visible_message("<span class='danger'>[user] spits neurotoxin!", span_alertalien("You spit neurotoxin."))
-	var/obj/item/projectile/bullet/neurotoxin/spitter/A = new /obj/item/projectile/bullet/neurotoxin/spitter(user.loc)
+	var/obj/projectile/bullet/neurotoxin/spitter/A = new /obj/projectile/bullet/neurotoxin/spitter(user.loc)
 	A.preparePixelProjectile(target, user, params)
 	A.fire()
 	user.newtonian_move(get_dir(U, T))
@@ -45,14 +45,14 @@
 
 	return TRUE
 
-/obj/item/projectile/bullet/neurotoxin/spitter
+/obj/projectile/bullet/neurotoxin/spitter
 	name = "neurotoxin spit"
 	icon_state = "neurotoxin"
 	damage = 2
 	damage_type = TOX
 	paralyze = 50
 
-/obj/item/projectile/bullet/neurotoxin/spitter/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/neurotoxin/spitter/on_hit(atom/target, blocked = FALSE)
 	if(isinfected(target))
 		paralyze = 0
 		nodamage = TRUE

--- a/code/modules/awaymissions/capture_the_flag.dm
+++ b/code/modules/awaymissions/capture_the_flag.dm
@@ -390,12 +390,12 @@
 	ammo_type = /obj/item/ammo_casing/a50/ctf
 
 /obj/item/ammo_casing/a50/ctf
-	projectile_type = /obj/item/projectile/bullet/ctf
+	projectile_type = /obj/projectile/bullet/ctf
 
-/obj/item/projectile/bullet/ctf
+/obj/projectile/bullet/ctf
 	damage = 0
 
-/obj/item/projectile/bullet/ctf/prehit(atom/target)
+/obj/projectile/bullet/ctf/prehit(atom/target)
 	if(is_ctf_target(target))
 		damage = 60
 	. = ..()
@@ -425,13 +425,13 @@
 		qdel(src)
 
 /obj/item/ammo_casing/caseless/laser/ctf
-	projectile_type = /obj/item/projectile/beam/ctf
+	projectile_type = /obj/projectile/beam/ctf
 
-/obj/item/projectile/beam/ctf
+/obj/projectile/beam/ctf
 	damage = 0
 	icon_state = "omnilaser"
 
-/obj/item/projectile/beam/ctf/prehit(atom/target)
+/obj/projectile/beam/ctf/prehit(atom/target)
 	if(is_ctf_target(target))
 		damage = 150
 	. = ..()
@@ -454,9 +454,9 @@
 	ammo_type = /obj/item/ammo_casing/caseless/laser/ctf/red
 
 /obj/item/ammo_casing/caseless/laser/ctf/red
-	projectile_type = /obj/item/projectile/beam/ctf/red
+	projectile_type = /obj/projectile/beam/ctf/red
 
-/obj/item/projectile/beam/ctf/red
+/obj/projectile/beam/ctf/red
 	icon_state = "laser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
 
@@ -469,9 +469,9 @@
 	ammo_type = /obj/item/ammo_casing/caseless/laser/ctf/blue
 
 /obj/item/ammo_casing/caseless/laser/ctf/blue
-	projectile_type = /obj/item/projectile/beam/ctf/blue
+	projectile_type = /obj/projectile/beam/ctf/blue
 
-/obj/item/projectile/beam/ctf/blue
+/obj/projectile/beam/ctf/blue
 	icon_state = "bluelaser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 

--- a/code/modules/awaymissions/cordon.dm
+++ b/code/modules/awaymissions/cordon.dm
@@ -35,7 +35,7 @@
 /turf/cordon/ScrapeAway(amount, flags)
 	return src // :devilcat:
 
-/turf/cordon/bullet_act(obj/item/projectile/hitting_projectile, def_zone, piercing_hit)
+/turf/cordon/bullet_act(obj/projectile/hitting_projectile, def_zone, piercing_hit)
 	return BULLET_ACT_HIT
 
 /turf/cordon/Adjacent(atom/neighbor, atom/target, atom/movable/mover)

--- a/code/modules/awaymissions/mission_code/stationCollision.dm
+++ b/code/modules/awaymissions/mission_code/stationCollision.dm
@@ -43,7 +43,7 @@
 	name ="retro laser"
 	icon_state = "retro"
 	desc = "An older model of the basic lasergun, no longer used by Nanotrasen's security or military forces."
-//	projectile_type = "/obj/item/projectile/practice"
+//	projectile_type = "/obj/projectile/practice"
 	clumsy_check = 0 //No sense in having a harmless gun blow up in the clowns face
 
 //Syndicate sub-machine guns.

--- a/code/modules/cargo/centcom_podlauncher.dm
+++ b/code/modules/cargo/centcom_podlauncher.dm
@@ -348,7 +348,7 @@
 			if (temp_pod.effectShrapnel == TRUE) //If already doing custom damage, set back to default (no shrapnel)
 				temp_pod.effectShrapnel = FALSE
 				return
-			var/shrapnelInput = input("Please enter the type of pellet cloud you'd like to create on landing (Can be any projectile!)", "Projectile Typepath",  0) in sortList(subtypesof(/obj/item/projectile), /proc/cmp_typepaths_asc)
+			var/shrapnelInput = input("Please enter the type of pellet cloud you'd like to create on landing (Can be any projectile!)", "Projectile Typepath",  0) in sortList(subtypesof(/obj/projectile), /proc/cmp_typepaths_asc)
 			if (isnull(shrapnelInput))
 				return
 			var/shrapnelMagnitude = input("Enter the magnitude of the pellet cloud. This is usually a value around 1-5. Please note that Ryll-Ryll has asked me to tell you that if you go too crazy with the projectiles you might crash the server. So uh, be gentle!", "Shrapnel Magnitude", 0) as null|num

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -47,7 +47,7 @@
 	var/stay_after_drop = FALSE
 	var/specialised = FALSE // It's not a general use pod for cargo/admin use
 	var/effectShrapnel = FALSE
-	//var/shrapnel_type = /obj/item/projectile/bullet/shrapnel
+	//var/shrapnel_type = /obj/projectile/bullet/shrapnel
 	var/shrapnel_magnitude = 3
 	var/rubble_type //Rubble effect associated with this supplypod
 	var/decal = "default" //What kind of extra decals we add to the pod to make it look nice

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -453,7 +453,7 @@
 	if(update_signals(user))
 		set_cloak(cloak - cloak_move_loss)
 
-/obj/item/clothing/neck/cloak/ranger/proc/on_projectile_hit(mob/living/carbon/human/user, obj/item/projectile/P, def_zone)
+/obj/item/clothing/neck/cloak/ranger/proc/on_projectile_hit(mob/living/carbon/human/user, obj/projectile/P, def_zone)
 	if(dodge(user, P, "[P]"))
 		return BULLET_ACT_FORCE_PIERCE
 

--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -32,15 +32,15 @@
 	ranged = 1
 	retreat_distance = 2
 	minimum_distance = 0 //Between shots they can and will close in to nash
-	projectiletype = /obj/item/projectile/magic
+	projectiletype = /obj/projectile/magic
 	projectilesound = 'sound/weapons/emitter.ogg'
 	maxHealth = 50
 	health = 50
 	gold_core_spawnable = NO_SPAWN //yogs - fuck this shit
 	random_color = FALSE
-	var/allowed_projectile_types = list(/obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
-	/obj/item/projectile/magic/death, /obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/fireball,
-	/obj/item/projectile/magic/spellblade, /obj/item/projectile/magic/arcane_barrage)
+	var/allowed_projectile_types = list(/obj/projectile/magic/animate, /obj/projectile/magic/resurrection,
+	/obj/projectile/magic/death, /obj/projectile/magic/teleport, /obj/projectile/magic/door, /obj/projectile/magic/fireball,
+	/obj/projectile/magic/spellblade, /obj/projectile/magic/arcane_barrage)
 
 /mob/living/simple_animal/hostile/carp/ranged/Initialize(mapload)
 	projectiletype = pick(allowed_projectile_types)

--- a/code/modules/fields/peaceborg_dampener.dm
+++ b/code/modules/fields/peaceborg_dampener.dm
@@ -17,8 +17,8 @@
 	var/static/image/southeast_corner = image('icons/effects/fields.dmi', icon_state = "projectile_dampen_southeast")
 	var/static/image/generic_edge = image('icons/effects/fields.dmi', icon_state = "projectile_dampen_generic")
 	var/obj/item/borg/projectile_dampen/projector = null
-	var/list/obj/item/projectile/tracked
-	var/list/obj/item/projectile/staging
+	var/list/obj/projectile/tracked
+	var/list/obj/projectile/staging
 	use_host_turf = TRUE
 
 /datum/proximity_monitor/advanced/peaceborg_dampener/New()
@@ -33,9 +33,9 @@
 	if(!istype(projector))
 		qdel(src)
 	var/list/ranged = list()
-	for(var/obj/item/projectile/P in range(current_range, get_turf(host)))
+	for(var/obj/projectile/P in range(current_range, get_turf(host)))
 		ranged += P
-	for(var/obj/item/projectile/P in tracked)
+	for(var/obj/projectile/P in tracked)
 		if(!(P in ranged) || !P.loc)
 			release_projectile(P)
 	for(var/mob/living/silicon/robot/R in range(current_range, get_turf(host)))
@@ -80,20 +80,20 @@
 		else
 			return generic_edge
 
-/datum/proximity_monitor/advanced/peaceborg_dampener/proc/capture_projectile(obj/item/projectile/P, track_projectile = TRUE)
+/datum/proximity_monitor/advanced/peaceborg_dampener/proc/capture_projectile(obj/projectile/P, track_projectile = TRUE)
 	if(P in tracked)
 		return
 	projector.dampen_projectile(P, track_projectile)
 	if(track_projectile)
 		tracked += P
 
-/datum/proximity_monitor/advanced/peaceborg_dampener/proc/release_projectile(obj/item/projectile/P)
+/datum/proximity_monitor/advanced/peaceborg_dampener/proc/release_projectile(obj/projectile/P)
 	projector.restore_projectile(P)
 	tracked -= P
 
 /datum/proximity_monitor/advanced/peaceborg_dampener/field_edge_uncrossed(atom/movable/AM, obj/effect/abstract/proximity_checker/advanced/field_edge/F)
 	if(!is_turf_in_field(get_turf(AM), src))
-		if(istype(AM, /obj/item/projectile))
+		if(istype(AM, /obj/projectile))
 			if(AM in tracked)
 				release_projectile(AM)
 			else
@@ -101,12 +101,12 @@
 	return ..()
 
 /datum/proximity_monitor/advanced/peaceborg_dampener/field_edge_crossed(atom/movable/AM, obj/effect/abstract/proximity_checker/advanced/field_edge/F)
-	if(istype(AM, /obj/item/projectile) && !(AM in tracked) && staging[AM] && !is_turf_in_field(staging[AM], src))
+	if(istype(AM, /obj/projectile) && !(AM in tracked) && staging[AM] && !is_turf_in_field(staging[AM], src))
 		capture_projectile(AM)
 	staging -= AM
 	return ..()
 
 /datum/proximity_monitor/advanced/peaceborg_dampener/field_edge_canpass(atom/movable/AM, obj/effect/abstract/proximity_checker/advanced/field_edge/F, turf/entering)
 	. = ..()
-	if(. && istype(AM, /obj/item/projectile))
+	if(. && istype(AM, /obj/projectile))
 		staging[AM] = get_turf(AM)

--- a/code/modules/fields/timestop.dm
+++ b/code/modules/fields/timestop.dm
@@ -87,7 +87,7 @@
 	var/frozen = TRUE
 	if(isliving(A))
 		freeze_mob(A)
-	else if(istype(A, /obj/item/projectile))
+	else if(istype(A, /obj/projectile))
 		freeze_projectile(A)
 	else if(istype(A, /obj/mecha))
 		freeze_mecha(A)
@@ -117,7 +117,7 @@
 		unfreeze_throwing(A)
 	if(isliving(A))
 		unfreeze_mob(A)
-	else if(istype(A, /obj/item/projectile))
+	else if(istype(A, /obj/projectile))
 		unfreeze_projectile(A)
 	else if(istype(A, /obj/mecha))
 		unfreeze_mecha(A)
@@ -157,10 +157,10 @@
 	return ..()
 
 
-/datum/proximity_monitor/advanced/timestop/proc/freeze_projectile(obj/item/projectile/P)
+/datum/proximity_monitor/advanced/timestop/proc/freeze_projectile(obj/projectile/P)
 	P.paused = TRUE
 
-/datum/proximity_monitor/advanced/timestop/proc/unfreeze_projectile(obj/item/projectile/P)
+/datum/proximity_monitor/advanced/timestop/proc/unfreeze_projectile(obj/projectile/P)
 	P.paused = FALSE
 
 /datum/proximity_monitor/advanced/timestop/proc/freeze_mob(mob/living/L)

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -1321,9 +1321,9 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 		qdel(src)
 		return
 	var/turf/start = pick(startlocs)
-	var/proj_type = pick(subtypesof(/obj/item/projectile/hallucination))
+	var/proj_type = pick(subtypesof(/obj/projectile/hallucination))
 	feedback_details += "Type: [proj_type]"
-	var/obj/item/projectile/hallucination/H = new proj_type(start)
+	var/obj/projectile/hallucination/H = new proj_type(start)
 	target.playsound_local(start, H.hal_fire_sound, 60, 1)
 	H.hal_target = target
 	H.preparePixelProjectile(target, start)

--- a/code/modules/holodeck/items.dm
+++ b/code/modules/holodeck/items.dm
@@ -127,7 +127,7 @@
 		..()
 
 /obj/structure/holohoop/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
-	if (isitem(AM) && !istype(AM,/obj/item/projectile))
+	if (isitem(AM) && !istype(AM,/obj/projectile))
 		if(prob(50))
 			AM.forceMove(get_turf(src))
 			visible_message(span_warning("Swish! [AM] lands in [src]."))

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -91,12 +91,12 @@
 	return connected
 
 
-/obj/machinery/hydroponics/bullet_act(obj/item/projectile/Proj) //Works with the Somatoray to modify plant variables.
+/obj/machinery/hydroponics/bullet_act(obj/projectile/Proj) //Works with the Somatoray to modify plant variables.
 	if(!myseed)
 		return ..()
-	if(istype(Proj , /obj/item/projectile/energy/floramut))
+	if(istype(Proj , /obj/projectile/energy/floramut))
 		mutate()
-	else if(istype(Proj , /obj/item/projectile/energy/florayield))
+	else if(istype(Proj , /obj/projectile/energy/florayield))
 		return myseed.bullet_act(Proj)
 	else
 		return ..()

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -112,8 +112,8 @@
 
 
 
-/obj/item/seeds/bullet_act(obj/item/projectile/Proj) //Works with the Somatoray to modify plant variables.
-	if(istype(Proj, /obj/item/projectile/energy/florayield))
+/obj/item/seeds/bullet_act(obj/projectile/Proj) //Works with the Somatoray to modify plant variables.
+	if(istype(Proj, /obj/projectile/energy/florayield))
 		var/rating = 1
 		if(istype(loc, /obj/machinery/hydroponics))
 			var/obj/machinery/hydroponics/H = loc

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -141,7 +141,7 @@
 	nodamage = TRUE
 	damage = 0 //We're just here to mark people. This is still a melee weapon.
 	damage_type = BRUTE
-	flag = BOMB
+	armor_flag = BOMB
 	range = 6
 	log_override = TRUE
 	var/obj/item/kinetic_crusher/hammer_synced

--- a/code/modules/mining/equipment/kinetic_crusher.dm
+++ b/code/modules/mining/equipment/kinetic_crusher.dm
@@ -27,7 +27,7 @@
 	var/charge_time = 15
 	var/detonation_damage = 50
 	var/backstab_bonus = 30
-	var/projectile_type = /obj/item/projectile/destabilizer
+	var/projectile_type = /obj/projectile/destabilizer
 
 /obj/item/kinetic_crusher/update_icon_state()
 	. = ..()
@@ -88,7 +88,7 @@
 		var/turf/proj_turf = user.loc
 		if(!isturf(proj_turf))
 			return
-		var/obj/item/projectile/destabilizer/D = new projectile_type(proj_turf)
+		var/obj/projectile/destabilizer/D = new projectile_type(proj_turf)
 		for(var/obj/item/crusher_trophy/T as anything in trophies)
 			T.on_projectile_fire(D, user)
 		D.preparePixelProjectile(target, user, clickparams)
@@ -135,7 +135,7 @@
 		playsound(src.loc, 'sound/weapons/kenetic_reload.ogg', 60, 1)
 
 //destablizing force
-/obj/item/projectile/destabilizer
+/obj/projectile/destabilizer
 	name = "destabilizing force"
 	icon_state = "pulse1"
 	nodamage = TRUE
@@ -146,11 +146,11 @@
 	log_override = TRUE
 	var/obj/item/kinetic_crusher/hammer_synced
 
-/obj/item/projectile/destabilizer/Destroy()
+/obj/projectile/destabilizer/Destroy()
 	hammer_synced = null
 	return ..()
 
-/obj/item/projectile/destabilizer/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/destabilizer/on_hit(atom/target, blocked = FALSE)
 	if(isliving(target))
 		var/mob/living/L = target
 		var/had_effect = (L.has_status_effect(STATUS_EFFECT_CRUSHERMARK)) //used as a boolean
@@ -166,11 +166,11 @@
 		M.attempt_drill(firer)
 	return ..()
 
-/obj/item/projectile/destabilizer/mega
+/obj/projectile/destabilizer/mega
 	icon_state = "pulse0"
 	var/mine_range = 4
 
-/obj/item/projectile/destabilizer/mega/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/destabilizer/mega/on_hit(atom/target, blocked = FALSE)
 	var/target_turf = get_turf(target)
 	if(ismineralturf(target_turf))
 		var/turf/closed/mineral/M = target_turf
@@ -222,7 +222,7 @@
 	return TRUE
 
 /obj/item/crusher_trophy/proc/on_melee_hit(mob/living/target, mob/living/user) //the target and the user
-/obj/item/crusher_trophy/proc/on_projectile_fire(obj/item/projectile/destabilizer/marker, mob/living/user) //the projectile fired and the user
+/obj/item/crusher_trophy/proc/on_projectile_fire(obj/projectile/destabilizer/marker, mob/living/user) //the projectile fired and the user
 /obj/item/crusher_trophy/proc/on_mark_application(mob/living/target, datum/status_effect/crusher_mark/mark, had_mark) //the target, the mark applied, and if the target had a mark before
 /obj/item/crusher_trophy/proc/on_mark_detonation(mob/living/target, mob/living/user) //the target and the user
 
@@ -277,7 +277,7 @@
 /obj/item/crusher_trophy/blaster_tubes/magma_wing/effect_desc()
 	return "mark detonation to make the next destabilizer shot deal <b>[bonus_value]</b> damage"
 
-/obj/item/crusher_trophy/blaster_tubes/magma_wing/on_projectile_fire(obj/item/projectile/destabilizer/marker, mob/living/user)
+/obj/item/crusher_trophy/blaster_tubes/magma_wing/on_projectile_fire(obj/projectile/destabilizer/marker, mob/living/user)
 	if(deadly_shot)
 		marker.name = "heated [marker.name]"
 		marker.icon_state = "lava"
@@ -431,7 +431,7 @@
 /obj/item/crusher_trophy/blaster_tubes/effect_desc()
 	return "mark detonation to make the next destabilizer shot deal <b>[bonus_value]</b> damage but move slower"
 
-/obj/item/crusher_trophy/blaster_tubes/on_projectile_fire(obj/item/projectile/destabilizer/marker, mob/living/user)
+/obj/item/crusher_trophy/blaster_tubes/on_projectile_fire(obj/projectile/destabilizer/marker, mob/living/user)
 	if(deadly_shot)
 		marker.name = "deadly [marker.name]"
 		marker.icon_state = "chronobolt"
@@ -493,4 +493,4 @@
 	desc = "An early design of the proto-kinetic accelerator, it is now a combination of various mining tools infused with magmite, forming a high-tech club, increasing its capacity as a mining tool. \
 		It does little to aid any but the most skilled and/or suicidal miners against local fauna."
 
-	projectile_type = /obj/item/projectile/destabilizer/mega
+	projectile_type = /obj/projectile/destabilizer/mega

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -412,11 +412,11 @@ GLOBAL_LIST_EMPTY(aide_list)
 /obj/item/ammo_casing/magic/hook
 	name = "hook"
 	desc = "A hook."
-	projectile_type = /obj/item/projectile/hook
+	projectile_type = /obj/projectile/hook
 	caliber = "hook"
 	icon_state = "hook"
 
-/obj/item/projectile/hook
+/obj/projectile/hook
 	name = "hook"
 	icon_state = "hook"
 	icon = 'icons/obj/lavaland/artefacts.dmi'
@@ -428,13 +428,13 @@ GLOBAL_LIST_EMPTY(aide_list)
 	knockdown = 30
 	var/chain
 
-/obj/item/projectile/hook/fire(setAngle)
+/obj/projectile/hook/fire(setAngle)
 	if(firer)
 		chain = firer.Beam(src, icon_state = "chain", time = INFINITY, maxdistance = INFINITY)
 	..()
 	//TODO: root the firer until the chain returns
 
-/obj/item/projectile/hook/on_hit(atom/target, blocked)
+/obj/projectile/hook/on_hit(atom/target, blocked)
 	. = ..()
 	if(ismovable(target) && blocked != 100)
 		var/atom/movable/A = target
@@ -445,7 +445,7 @@ GLOBAL_LIST_EMPTY(aide_list)
 		//TODO: keep the chain beamed to A
 		//TODO: needs a callback to delete the chain
 
-/obj/item/projectile/hook/Destroy()
+/obj/projectile/hook/Destroy()
 	qdel(chain)
 	return ..()
 
@@ -1407,8 +1407,8 @@ GLOBAL_LIST_EMPTY(aide_list)
 /obj/structure/closet/crate/necropolis/colossus
 	name = "colossus chest"
 
-/obj/structure/closet/crate/necropolis/colossus/bullet_act(obj/item/projectile/P)
-	if(istype(P, /obj/item/projectile/colossus))
+/obj/structure/closet/crate/necropolis/colossus/bullet_act(obj/projectile/P)
+	if(istype(P, /obj/projectile/colossus))
 		return BULLET_ACT_FORCE_PIERCE
 	return ..()
 

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -133,14 +133,14 @@
 
 /mob/living/simple_animal/hostile/mining_drone/CanAllowThrough(atom/movable/O)
 	. = ..()
-	if(istype(O, /obj/item/projectile/kinetic))
-		var/obj/item/projectile/kinetic/K = O
+	if(istype(O, /obj/projectile/kinetic))
+		var/obj/projectile/kinetic/K = O
 		if(K.kinetic_gun)
 			for(var/A in K.kinetic_gun.get_modkits())
 				var/obj/item/borg/upgrade/modkit/M = A
 				if(istype(M, /obj/item/borg/upgrade/modkit/minebot_passthrough))
 					return TRUE
-	if(istype(O, /obj/item/projectile/destabilizer))
+	if(istype(O, /obj/projectile/destabilizer))
 		return TRUE
 
 /mob/living/simple_animal/hostile/mining_drone/proc/SetCollectBehavior()

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -624,7 +624,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	transform = initial(transform)
 
 /obj/item/coin/bullet_act(obj/projectile/P)
-	if(P.flag != LASER && P.flag != ENERGY && !is_type_in_list(P, allowed_ricochet_types)) //only energy projectiles get deflected (also revolvers because damn thats cool)
+	if(P.armor_flag != LASER && P.armor_flag != ENERGY && !is_type_in_list(P, allowed_ricochet_types)) //only energy projectiles get deflected (also revolvers because damn thats cool)
 		return ..()
 
 	if(cooldown >= world.time || istype(P, /obj/projectile/bullet/ipcmartial))//we ricochet the projectile

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -344,7 +344,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	else
 		..()
 
-/obj/item/melee/gibtonite/bullet_act(obj/item/projectile/P)
+/obj/item/melee/gibtonite/bullet_act(obj/projectile/P)
 	GibtoniteReaction(P.firer)
 	. = ..()
 
@@ -415,7 +415,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	var/value = 1
 	var/coinflip
 	var/coin_stack_icon_state = "coin_stack"
-	var/list/allowed_ricochet_types = list(/obj/item/projectile/bullet/c38, /obj/item/projectile/bullet/a357, /obj/item/projectile/bullet/ipcmartial)
+	var/list/allowed_ricochet_types = list(/obj/projectile/bullet/c38, /obj/projectile/bullet/a357, /obj/projectile/bullet/ipcmartial)
 
 /obj/item/coin/get_item_credit_value()
 	return value
@@ -623,11 +623,11 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	. = ..()
 	transform = initial(transform)
 
-/obj/item/coin/bullet_act(obj/item/projectile/P)
+/obj/item/coin/bullet_act(obj/projectile/P)
 	if(P.flag != LASER && P.flag != ENERGY && !is_type_in_list(P, allowed_ricochet_types)) //only energy projectiles get deflected (also revolvers because damn thats cool)
 		return ..()
 
-	if(cooldown >= world.time || istype(P, /obj/item/projectile/bullet/ipcmartial))//we ricochet the projectile
+	if(cooldown >= world.time || istype(P, /obj/projectile/bullet/ipcmartial))//we ricochet the projectile
 		var/list/targets = list()
 		for(var/mob/living/T in viewers(5, src))
 			if(istype(T) && T != P.firer && T.stat != DEAD) //don't fire at someone if they're dead or if we already hit them
@@ -636,7 +636,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 		P.speed *= 0.5
 		P.ricochets++
 		P.on_ricochet(src)
-		P.permutated = list(src)
+		P.impacted = list(src)
 		P.pixel_x = pixel_x
 		P.pixel_y = pixel_y
 		if(!targets.len)

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -284,7 +284,7 @@ Doesn't work on other aliens/AI.*/
 		span_alertalien("You spit neurotoxin."),
 	)
 
-	var/obj/item/projectile/bullet/neurotoxin/neurotoxin = new /obj/item/projectile/bullet/neurotoxin(caller.loc)
+	var/obj/projectile/bullet/neurotoxin/neurotoxin = new /obj/projectile/bullet/neurotoxin(caller.loc)
 	neurotoxin.preparePixelProjectile(target, caller, params)
 	neurotoxin.firer = caller
 	neurotoxin.fire()

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -34,7 +34,7 @@
 	if(check_glasses && glasses && (glasses.flags_cover & GLASSESCOVERSEYES))
 		return glasses
 
-/mob/living/carbon/check_projectile_dismemberment(obj/item/projectile/P, def_zone)
+/mob/living/carbon/check_projectile_dismemberment(obj/projectile/P, def_zone)
 	var/obj/item/bodypart/affecting = get_bodypart(def_zone)
 	if(affecting && affecting.dismemberable && affecting.get_damage() >= (affecting.max_damage - P.dismemberment))
 		affecting.dismember(P.damtype)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -50,12 +50,12 @@
 				covering_part += C
 	return covering_part
 
-/mob/living/carbon/human/on_hit(obj/item/projectile/P)
+/mob/living/carbon/human/on_hit(obj/projectile/P)
 	if(dna && dna.species)
 		dna.species.on_hit(P, src)
 
 
-/mob/living/carbon/human/bullet_act(obj/item/projectile/P, def_zone)
+/mob/living/carbon/human/bullet_act(obj/projectile/P, def_zone)
 	if(dna && dna.species)
 		var/spec_return = dna.species.bullet_act(P, src)
 		if(spec_return)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1940,15 +1940,15 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			sitter.take_damage(damage, damagetype)
 	return 1
 
-/datum/species/proc/on_hit(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/proc/on_hit(obj/projectile/P, mob/living/carbon/human/H)
 	// called when hit by a projectile
 	switch(P.type)
-		if(/obj/item/projectile/energy/floramut) // overwritten by plants/pods
+		if(/obj/projectile/energy/floramut) // overwritten by plants/pods
 			H.show_message(span_notice("The radiation beam dissipates harmlessly through your body."))
-		if(/obj/item/projectile/energy/florayield)
+		if(/obj/projectile/energy/florayield)
 			H.show_message(span_notice("The radiation beam dissipates harmlessly through your body."))
 
-/datum/species/proc/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/proc/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	// called before a projectile hit
 	return 0
 

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -140,9 +140,9 @@
 		return
 	H.adjust_nutrition(min(amount / 2500, 5) * rad_percent)
 
-/datum/species/ethereal/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/ethereal/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	. = ..()
-	if(istype(P, /obj/item/projectile/energy/nuclear_particle))
+	if(istype(P, /obj/projectile/energy/nuclear_particle))
 		H.visible_message(span_warning("[H] absorbs [P]!"), span_userdanger("You absorb [P]!"))
 		H.adjust_nutrition(P.damage * (1 - (H.getarmor(null, RAD) / 100)))
 		return TRUE

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -433,7 +433,7 @@
 
 /datum/species/golem/sand/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	if(!(P.original == H && P.firer == H))
-		if(P.flag == BULLET || P.flag == BOMB)
+		if(P.armor_flag == BULLET || P.armor_flag == BOMB)
 			playsound(H, 'sound/effects/shovel_dig.ogg', 70, 1)
 			H.visible_message(span_danger("The [P.name] sinks harmlessly in [H]'s sandy body!"), \
 			span_userdanger("The [P.name] sinks harmlessly in [H]'s sandy body!"))
@@ -468,7 +468,7 @@
 
 /datum/species/golem/glass/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	if(!(P.original == H && P.firer == H)) //self-shots don't reflect
-		if(P.flag == LASER || P.flag == ENERGY)
+		if(P.armor_flag == LASER || P.armor_flag == ENERGY)
 			H.visible_message(span_danger("The [P.name] gets reflected by [H]'s glass skin!"), \
 			span_userdanger("The [P.name] gets reflected by [H]'s glass skin!"))
 			if(P.starting)
@@ -930,7 +930,7 @@
 /datum/species/golem/bronze/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	if(!(world.time > last_gong_time + gong_cooldown))
 		return BULLET_ACT_HIT
-	if(P.flag == BULLET || P.flag == BOMB)
+	if(P.armor_flag == BULLET || P.armor_flag == BOMB)
 		gong(H)
 		return BULLET_ACT_HIT
 
@@ -1572,7 +1572,7 @@
 
 /datum/species/golem/supermatter/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	. = ..()
-	if(istype(P, /obj/projectile/magic) || P.flag == LASER || P.flag == ENERGY)
+	if(istype(P, /obj/projectile/magic) || P.armor_flag == LASER || P.armor_flag == ENERGY)
 		return .
 	H.visible_message(span_danger("[P] melts on collision with [H]!"))
 	playsound(get_turf(src), 'sound/effects/supermatter.ogg', 10, TRUE)

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -402,7 +402,7 @@
 	if(COOLDOWN_FINISHED(src, radiation_emission_cooldown) && user != H)
 		radiation_emission(H)
 
-/datum/species/golem/uranium/on_hit(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/golem/uranium/on_hit(obj/projectile/P, mob/living/carbon/human/H)
 	..()
 	if(COOLDOWN_FINISHED(src, radiation_emission_cooldown))
 		radiation_emission(H)
@@ -431,7 +431,7 @@
 		new /obj/item/stack/ore/glass(get_turf(H))
 	qdel(H)
 
-/datum/species/golem/sand/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/golem/sand/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	if(!(P.original == H && P.firer == H))
 		if(P.flag == BULLET || P.flag == BOMB)
 			playsound(H, 'sound/effects/shovel_dig.ogg', 70, 1)
@@ -466,7 +466,7 @@
 		new /obj/item/shard(get_turf(H))
 	qdel(H)
 
-/datum/species/golem/glass/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/golem/glass/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	if(!(P.original == H && P.firer == H)) //self-shots don't reflect
 		if(P.flag == LASER || P.flag == ENERGY)
 			H.visible_message(span_danger("The [P.name] gets reflected by [H]'s glass skin!"), \
@@ -525,7 +525,7 @@
 	if(world.time > last_teleport + teleport_cooldown && user != H)
 		reactive_teleport(H)
 
-/datum/species/golem/bluespace/on_hit(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/golem/bluespace/on_hit(obj/projectile/P, mob/living/carbon/human/H)
 	..()
 	if(world.time > last_teleport + teleport_cooldown)
 		reactive_teleport(H)
@@ -624,7 +624,7 @@
 		new/obj/item/grown/bananapeel/specialpeel(get_turf(H))
 		last_banana = world.time
 
-/datum/species/golem/bananium/on_hit(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/golem/bananium/on_hit(obj/projectile/P, mob/living/carbon/human/H)
 	..()
 	if(world.time > last_banana + banana_cooldown)
 		new/obj/item/grown/bananapeel/specialpeel(get_turf(H))
@@ -927,7 +927,7 @@
 	var/last_gong_time = 0
 	var/gong_cooldown = 150
 
-/datum/species/golem/bronze/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/golem/bronze/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	if(!(world.time > last_gong_time + gong_cooldown))
 		return BULLET_ACT_HIT
 	if(P.flag == BULLET || P.flag == BOMB)
@@ -949,7 +949,7 @@
 	if(world.time > last_gong_time + gong_cooldown)
 		gong(H)
 
-/datum/species/golem/bronze/on_hit(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/golem/bronze/on_hit(obj/projectile/P, mob/living/carbon/human/H)
 	..()
 	if(world.time > last_gong_time + gong_cooldown)
 		gong(H)
@@ -1570,9 +1570,9 @@
 	qdel(I)
 	
 
-/datum/species/golem/supermatter/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/golem/supermatter/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	. = ..()
-	if(istype(P, /obj/item/projectile/magic) || P.flag == LASER || P.flag == ENERGY)
+	if(istype(P, /obj/projectile/magic) || P.flag == LASER || P.flag == ENERGY)
 		return .
 	H.visible_message(span_danger("[P] melts on collision with [H]!"))
 	playsound(get_turf(src), 'sound/effects/supermatter.ogg', 10, TRUE)

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -102,7 +102,7 @@
 
 	C.fully_replace_character_name("[C.real_name]","[pick(GLOB.nightmare_names)]") // Yogs -- fixes nightmares not having special spooky names. this proc takes the old name first, and *THEN* the new name!
 
-/datum/species/shadow/nightmare/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/shadow/nightmare/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	var/turf/T = H.loc
 	if(istype(T))
 		var/light_amount = T.get_lumcount()

--- a/code/modules/mob/living/carbon/monkey/combat.dm
+++ b/code/modules/mob/living/carbon/monkey/combat.dm
@@ -397,8 +397,8 @@
 	if((W.force) && (!target) && (W.damtype != STAMINA) )
 		retaliate(user)
 
-/mob/living/carbon/monkey/bullet_act(obj/item/projectile/Proj)
-	if(istype(Proj , /obj/item/projectile/beam)||istype(Proj, /obj/item/projectile/bullet))
+/mob/living/carbon/monkey/bullet_act(obj/projectile/Proj)
+	if(istype(Proj , /obj/projectile/beam)||istype(Proj, /obj/projectile/bullet))
 		if((Proj.damage_type == BURN) || (Proj.damage_type == BRUTE))
 			if(!Proj.nodamage && Proj.damage < src.health && isliving(Proj.firer))
 				retaliate(Proj.firer)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -52,7 +52,7 @@
 	return BULLET_ACT_HIT
 
 /mob/living/bullet_act(obj/projectile/P, def_zone)
-	var/armor = run_armor_check(def_zone, P.flag, "","",P.armour_penetration)
+	var/armor = run_armor_check(def_zone, P.armor_flag, "","",P.armour_penetration)
 
 	// "Projectiles now ignore the holopara's master or any of their other holoparas."
 	var/guardian_pass = FALSE

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -48,16 +48,16 @@
 /mob/living/proc/is_eyes_covered(check_glasses = 1, check_head = 1, check_mask = 1)
 	return FALSE
 
-/mob/living/proc/on_hit(obj/item/projectile/P)
+/mob/living/proc/on_hit(obj/projectile/P)
 	return BULLET_ACT_HIT
 
-/mob/living/bullet_act(obj/item/projectile/P, def_zone)
+/mob/living/bullet_act(obj/projectile/P, def_zone)
 	var/armor = run_armor_check(def_zone, P.flag, "","",P.armour_penetration)
 
 	// "Projectiles now ignore the holopara's master or any of their other holoparas."
 	var/guardian_pass = FALSE
-	if(istype(P, /obj/item/projectile/guardian))
-		var/obj/item/projectile/guardian/G = P
+	if(istype(P, /obj/projectile/guardian))
+		var/obj/projectile/guardian/G = P
 		var/datum/mind/guardian_master = G.guardian_master
 		if(guardian_master?.current)
 			var/list/safe = list(guardian_master.current)
@@ -72,11 +72,11 @@
 	
 	if(!P.nodamage)
 		last_damage = P.name
-		if((istype(P, /obj/item/projectile/energy/nuclear_particle)) && (getarmor(null, RAD) >= 100))
+		if((istype(P, /obj/projectile/energy/nuclear_particle)) && (getarmor(null, RAD) >= 100))
 			P.damage = 0
 		else
 			var/attack_direction = get_dir(P.starting, src)
-			apply_damage(P.damage, P.damage_type, def_zone, armor, wound_bonus = P.wound_bonus, bare_wound_bonus = P.bare_wound_bonus, sharpness = P.get_sharpness(), attack_direction = attack_direction)
+			apply_damage(P.damage, P.damage_type, def_zone, armor, wound_bonus = P.wound_bonus, bare_wound_bonus = P.bare_wound_bonus, sharpness = P.sharpness, attack_direction = attack_direction)
 		if(P.dismemberment)
 			check_projectile_dismemberment(P, def_zone)
 	if(P.penetrating && (P.penetration_type == 0 || P.penetration_type == 2) && P.penetrations > 0)
@@ -84,7 +84,7 @@
 		return P.on_hit(src, armor) && BULLET_ACT_FORCE_PIERCE
 	return P.on_hit(src, armor)? BULLET_ACT_HIT : BULLET_ACT_BLOCK
 
-/mob/living/proc/check_projectile_dismemberment(obj/item/projectile/P, def_zone)
+/mob/living/proc/check_projectile_dismemberment(obj/projectile/P, def_zone)
 	return 0
 
 /obj/item/proc/get_volume_by_throwforce_and_or_w_class()

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -132,5 +132,5 @@
 	//Allergies
 	var/allergies
 
-	//Last item/projectile that damaged this mob, not including surgery
+	//Last projectile that damaged this mob, not including surgery
 	var/last_damage = ""

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -10,9 +10,9 @@
 	. = ..()
 	if((mover.pass_flags & PASSMOB))
 		return TRUE
-	if(istype(mover, /obj/item/projectile))
-		var/obj/item/projectile/P = mover
-		return !P.can_hit_target(src, P.permutated, src == P.original, TRUE)
+	if(istype(mover, /obj/projectile))
+		var/obj/projectile/P = mover
+		return !P.can_hit_target(src, P.impacted, src == P.original, TRUE)
 	if(mover.throwing)
 		return (!density || !(mobility_flags & MOBILITY_STAND) || (mover.throwing.thrower == src && !ismob(mover)))
 	if(buckled == mover)

--- a/code/modules/mob/living/silicon/ai/ai_defense.dm
+++ b/code/modules/mob/living/silicon/ai/ai_defense.dm
@@ -17,7 +17,7 @@
 /mob/living/silicon/ai/ex_act(severity, target)
 	return 
 
-/mob/living/silicon/ai/bullet_act(obj/item/projectile/Proj)
+/mob/living/silicon/ai/bullet_act(obj/projectile/Proj)
 	return 
 
 /mob/living/silicon/ai/flash_act(intensity = 1, override_blindness_check = 0, affect_silicon = 0)

--- a/code/modules/mob/living/silicon/pai/pai_defense.dm
+++ b/code/modules/mob/living/silicon/pai/pai_defense.dm
@@ -58,7 +58,7 @@
 				visible_message(span_danger("[user] stomps on [src]!."))
 				take_holo_damage(2)
 
-/mob/living/silicon/pai/bullet_act(obj/item/projectile/Proj)
+/mob/living/silicon/pai/bullet_act(obj/projectile/Proj)
 	if(Proj.stun)
 		fold_in(force = TRUE)
 		src.visible_message(span_warning("The electrically-charged projectile disrupts [src]'s holomatrix, forcing [src] to fold in!"))

--- a/code/modules/mob/living/silicon/robot/robot_defense.dm
+++ b/code/modules/mob/living/silicon/robot/robot_defense.dm
@@ -195,7 +195,7 @@
 			if (stat != DEAD)
 				adjustBruteLoss(run_armor(30, BRUTE, BOMB))
 
-/mob/living/silicon/robot/bullet_act(obj/item/projectile/Proj, def_zone)
+/mob/living/silicon/robot/bullet_act(obj/projectile/Proj, def_zone)
 	. = ..()
 	updatehealth()
 	if(prob(75) && Proj.damage > 0)

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -122,7 +122,7 @@
 			M.visible_message(span_boldwarning("[M] is thrown off of [src]!"))
 	flash_act(affect_silicon = 1)
 
-/mob/living/silicon/bullet_act(obj/item/projectile/Proj, def_zone)
+/mob/living/silicon/bullet_act(obj/projectile/Proj, def_zone)
 	SEND_SIGNAL(src, COMSIG_ATOM_BULLET_ACT, Proj, def_zone)
 	if((Proj.damage_type == BRUTE || Proj.damage_type == BURN))
 		var/damage = run_armor(Proj.damage, Proj.damage_type, Proj.flag, Proj.armour_penetration)

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -125,7 +125,7 @@
 /mob/living/silicon/bullet_act(obj/projectile/Proj, def_zone)
 	SEND_SIGNAL(src, COMSIG_ATOM_BULLET_ACT, Proj, def_zone)
 	if((Proj.damage_type == BRUTE || Proj.damage_type == BURN))
-		var/damage = run_armor(Proj.damage, Proj.damage_type, Proj.flag, Proj.armour_penetration)
+		var/damage = run_armor(Proj.damage, Proj.damage_type, Proj.armor_flag, Proj.armour_penetration)
 		adjustBruteLoss(damage)
 		if(prob(damage*1.5))
 			for(var/mob/living/M in buckled_mobs)

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -121,7 +121,7 @@
 		apply_damage(damage, damagetype, null, getarmor(null, armorcheck))
 		return TRUE
 
-/mob/living/simple_animal/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/bullet_act(obj/projectile/Proj)
 	apply_damage(Proj.damage, Proj.damage_type)
 	last_damage = Proj.name
 	Proj.on_hit(src)

--- a/code/modules/mob/living/simple_animal/bot/SuperBeepsky.dm
+++ b/code/modules/mob/living/simple_animal/bot/SuperBeepsky.dm
@@ -18,7 +18,7 @@
 	maxHealth = 50
 	baton_type = /obj/item/toy/sword
 
-/mob/living/simple_animal/bot/secbot/grievous/bullet_act(obj/item/projectile/P)
+/mob/living/simple_animal/bot/secbot/grievous/bullet_act(obj/projectile/P)
 	visible_message("[src] deflects [P] with its energy swords!")
 	playsound(src, 'sound/weapons/blade1.ogg', 50, TRUE)
 	return BULLET_ACT_BLOCK

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -345,7 +345,7 @@
 	if(Adjacent(user))
 		togglelock(user)
 
-/mob/living/simple_animal/bot/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/bot/bullet_act(obj/projectile/Proj)
 	if(Proj && (Proj.damage_type == BRUTE || Proj.damage_type == BURN))
 		if(prob(75) && Proj.damage > 0)
 			do_sparks(5, TRUE, src)

--- a/code/modules/mob/living/simple_animal/bot/ed209bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/ed209bot.dm
@@ -39,7 +39,7 @@
 	var/weaponscheck = TRUE //If true, arrest people for weapons if they don't have access
 	var/check_records = TRUE //Does it check security records?
 	var/arrest_type = FALSE //If true, don't handcuff
-	var/projectile = /obj/item/projectile/energy/electrode //Holder for projectile type
+	var/projectile = /obj/projectile/energy/electrode //Holder for projectile type
 	var/shoot_sound = 'sound/weapons/taser.ogg'
 	var/cell_type = /obj/item/stock_parts/cell
 	var/vest_type = /obj/item/clothing/suit/armor/vest
@@ -205,8 +205,8 @@ Auto Patrol[]"},
 		icon_state = "[lasercolor]ed209[on]"
 		set_weapon()
 
-/mob/living/simple_animal/bot/ed209/bullet_act(obj/item/projectile/Proj)
-	if(istype(Proj , /obj/item/projectile/beam/laser)||istype(Proj, /obj/item/projectile/bullet))
+/mob/living/simple_animal/bot/ed209/bullet_act(obj/projectile/Proj)
+	if(istype(Proj , /obj/projectile/beam/laser)||istype(Proj, /obj/projectile/bullet))
 		if((Proj.damage_type == BURN) || (Proj.damage_type == BRUTE))
 			if(!Proj.nodamage && Proj.damage < src.health && ishuman(Proj.firer))
 				retaliate(Proj.firer)
@@ -422,17 +422,17 @@ Auto Patrol[]"},
 	shoot_sound = 'sound/weapons/laser.ogg'
 	if(emagged == 2)
 		if(lasercolor)
-			projectile = /obj/item/projectile/beam/lasertag
+			projectile = /obj/projectile/beam/lasertag
 		else
-			projectile = /obj/item/projectile/beam
+			projectile = /obj/projectile/beam
 	else
 		if(!lasercolor)
 			shoot_sound = 'sound/weapons/laser.ogg'
-			projectile = /obj/item/projectile/energy/trap
+			projectile = /obj/projectile/energy/trap
 		else if(lasercolor == "b")
-			projectile = /obj/item/projectile/beam/lasertag/bluetag
+			projectile = /obj/projectile/beam/lasertag/bluetag
 		else if(lasercolor == "r")
-			projectile = /obj/item/projectile/beam/lasertag/redtag
+			projectile = /obj/projectile/beam/lasertag/redtag
 
 /mob/living/simple_animal/bot/ed209/proc/shootAt(mob/target)
 	if(world.time <= lastfired + shot_delay)
@@ -448,7 +448,7 @@ Auto Patrol[]"},
 	if(!projectile)
 		return
 
-	var/obj/item/projectile/A = new projectile (loc)
+	var/obj/projectile/A = new projectile (loc)
 	playsound(src, shoot_sound, 50, TRUE)
 	A.preparePixelProjectile(target, src)
 	A.fire()
@@ -494,14 +494,14 @@ Auto Patrol[]"},
 						mode = BOT_HUNT
 
 
-/mob/living/simple_animal/bot/ed209/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/bot/ed209/bullet_act(obj/projectile/Proj)
 	if(!disabled)
 		var/lasertag_check = 0
 		if((lasercolor == "b"))
-			if(istype(Proj, /obj/item/projectile/beam/lasertag/redtag))
+			if(istype(Proj, /obj/projectile/beam/lasertag/redtag))
 				lasertag_check++
 		else if((lasercolor == "r"))
-			if(istype(Proj, /obj/item/projectile/beam/lasertag/bluetag))
+			if(istype(Proj, /obj/projectile/beam/lasertag/bluetag))
 				lasertag_check++
 		if(lasertag_check)
 			icon_state = "[lasercolor]ed2090"

--- a/code/modules/mob/living/simple_animal/bot/honkbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/honkbot.dm
@@ -135,8 +135,8 @@ Maintenance panel panel is [open ? "opened" : "closed"]"},
 		playsound(src, 'sound/machines/honkbot_evil_laugh.ogg', 75, 1, -1) // evil laughter
 		update_appearance(UPDATE_ICON)
 
-/mob/living/simple_animal/bot/honkbot/bullet_act(obj/item/projectile/Proj)
-	if((istype(Proj,/obj/item/projectile/beam)) || (istype(Proj,/obj/item/projectile/bullet) && (Proj.damage_type == BURN))||(Proj.damage_type == BRUTE) && (!Proj.nodamage && Proj.damage < health && ishuman(Proj.firer)))
+/mob/living/simple_animal/bot/honkbot/bullet_act(obj/projectile/Proj)
+	if((istype(Proj,/obj/projectile/beam)) || (istype(Proj,/obj/projectile/bullet) && (Proj.damage_type == BURN))||(Proj.damage_type == BRUTE) && (!Proj.nodamage && Proj.damage < health && ishuman(Proj.firer)))
 		retaliate(Proj.firer)
 	return ..()
 

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -151,7 +151,7 @@
 			wires.cut_random()
 	return
 
-/mob/living/simple_animal/bot/mulebot/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/bot/mulebot/bullet_act(obj/projectile/Proj)
 	. = ..()
 	if(.)
 		if(prob(50) && !isnull(load))

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -210,8 +210,8 @@ Auto Patrol: []"},
 		declare_arrests = FALSE
 		update_appearance(UPDATE_ICON)
 
-/mob/living/simple_animal/bot/secbot/bullet_act(obj/item/projectile/Proj)
-	if(istype(Proj , /obj/item/projectile/beam)||istype(Proj, /obj/item/projectile/bullet))
+/mob/living/simple_animal/bot/secbot/bullet_act(obj/projectile/Proj)
+	if(istype(Proj , /obj/projectile/beam)||istype(Proj, /obj/projectile/bullet))
 		if((Proj.damage_type == BURN) || (Proj.damage_type == BRUTE))
 			if(!Proj.nodamage && Proj.damage < src.health && ishuman(Proj.firer))
 				retaliate(Proj.firer)

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -160,8 +160,8 @@ mob/living/simple_animal/hostile/construct/attackby(obj/item/W, mob/living/user,
 	AIStatus = AI_ON
 	environment_smash = ENVIRONMENT_SMASH_STRUCTURES //only token destruction, don't smash the cult wall NO STOP
 
-/mob/living/simple_animal/hostile/construct/armored/bullet_act(obj/item/projectile/P)
-	if(istype(P, /obj/item/projectile/energy) || istype(P, /obj/item/projectile/beam))
+/mob/living/simple_animal/hostile/construct/armored/bullet_act(obj/projectile/P)
+	if(istype(P, /obj/projectile/energy) || istype(P, /obj/projectile/beam))
 		var/reflectchance = 40 - round(P.damage/3)
 		if(prob(reflectchance))
 			apply_damage(P.damage * 0.5, P.damage_type)

--- a/code/modules/mob/living/simple_animal/friendly/turtle.dm
+++ b/code/modules/mob/living/simple_animal/friendly/turtle.dm
@@ -62,7 +62,7 @@
 	return ..()
 
 //Bullets
-/mob/living/simple_animal/turtle/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/turtle/bullet_act(obj/projectile/Proj)
 	if(!stat && !client)
 		if(icon_state == icon_hiding)
 			turtle_hide_dur = turtle_hide_max //Reset its hiding timer

--- a/code/modules/mob/living/simple_animal/guardian/types/ranged.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/ranged.dm
@@ -1,5 +1,5 @@
 //Ranged
-/obj/item/projectile/guardian
+/obj/projectile/guardian
 	name = "crystal spray"
 	icon_state = "guardian"
 	damage = 5
@@ -12,7 +12,7 @@
 	melee_damage_lower = 10
 	melee_damage_upper = 10
 	damage_coeff = list(BRUTE = 0.9, BURN = 0.9, TOX = 0.9, CLONE = 0.9, STAMINA = 0, OXY = 0.9)
-	projectiletype = /obj/item/projectile/guardian
+	projectiletype = /obj/projectile/guardian
 	ranged_cooldown_time = 1 //fast!
 	projectilesound = 'sound/effects/hit_on_shattered_glass.ogg'
 	ranged = 1
@@ -58,8 +58,8 @@
 
 /mob/living/simple_animal/hostile/guardian/ranged/Shoot(atom/targeted_atom)
 	. = ..()
-	if(istype(., /obj/item/projectile))
-		var/obj/item/projectile/P = .
+	if(istype(., /obj/projectile))
+		var/obj/projectile/P = .
 		if(namedatum)
 			P.color = namedatum.color
 

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -71,7 +71,7 @@
 	ranged = 1
 	retreat_distance = 5
 	minimum_distance = 5
-	projectiletype = /obj/item/projectile/neurotox
+	projectiletype = /obj/projectile/neurotox
 	projectilesound = 'sound/weapons/pierce.ogg'
 
 
@@ -90,7 +90,7 @@
 	move_to_delay = 4
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/xeno = 4,
 							/obj/item/stack/sheet/animalhide/xeno = 1)
-	projectiletype = /obj/item/projectile/neurotox
+	projectiletype = /obj/projectile/neurotox
 	projectilesound = 'sound/weapons/pierce.ogg'
 	status_flags = 0
 	unique_name = 0
@@ -143,7 +143,7 @@
 	mob_size = MOB_SIZE_LARGE
 	gold_core_spawnable = NO_SPAWN
 
-/obj/item/projectile/neurotox
+/obj/projectile/neurotox
 	name = "neurotoxin"
 	damage = 30
 	icon_state = "toxin"

--- a/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
@@ -19,7 +19,7 @@
 	maxHealth = 1000
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	loot = list(/obj/effect/temp_visual/paperwiz_dying)
-	projectiletype = /obj/item/projectile/temp
+	projectiletype = /obj/projectile/temp
 	projectilesound = 'sound/weapons/emitter.ogg'
 	attack_sound = 'sound/hallucinations/growl1.ogg'
 	var/list/copies = list()

--- a/code/modules/mob/living/simple_animal/hostile/glockroach.dm
+++ b/code/modules/mob/living/simple_animal/hostile/glockroach.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/glockroachbullet
+/obj/projectile/glockroachbullet
 	damage = 10 //same damage as a hivebot
 	damage_type = BRUTE
 
@@ -6,7 +6,7 @@
 /obj/item/ammo_casing/glockroach
 	name = "0.9mm bullet casing"
 	desc = "A... 0.9mm bullet casing? What?"
-	projectile_type = /obj/item/projectile/glockroachbullet
+	projectile_type = /obj/projectile/glockroachbullet
 
 /mob/living/simple_animal/hostile/glockroach //copypasted from cockroach.dm so i could use the shooting code in hostile.dm
 	name = "glockroach"
@@ -31,7 +31,7 @@
 	verb_exclaim = "chitters loudly"
 	verb_yell = "chitters loudly"
 	projectilesound = 'sound/weapons/shot.ogg'
-	projectiletype = /obj/item/projectile/glockroachbullet
+	projectiletype = /obj/projectile/glockroachbullet
 	casingtype = /obj/item/ammo_casing/glockroach
 	ranged = 1
 	retreat_distance = 3

--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/hivebotbullet
+/obj/projectile/hivebotbullet
 	damage = 10
 	damage_type = BRUTE
 
@@ -19,7 +19,7 @@
 	attacktext = "claws"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	projectilesound = 'sound/weapons/gunshot.ogg'
-	projectiletype = /obj/item/projectile/hivebotbullet
+	projectiletype = /obj/projectile/hivebotbullet
 	faction = list("hivebot")
 	check_friendly_fire = 1
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -117,7 +117,7 @@
 		FindTarget(list(user), 1)
 	return ..()
 
-/mob/living/simple_animal/hostile/bullet_act(obj/item/projectile/P)
+/mob/living/simple_animal/hostile/bullet_act(obj/projectile/P)
 	if(stat == CONSCIOUS && !target && AIStatus != AI_OFF && !client)
 		if(P.firer && get_dist(src, P.firer) <= aggro_vision_range)
 			FindTarget(list(P.firer), 1)
@@ -406,7 +406,7 @@
 		playsound(src, projectilesound, 100, 1)
 		casing.fire_casing(targeted_atom, src, null, null, null, ran_zone(), 0,  src)
 	else if(projectiletype)
-		var/obj/item/projectile/P = new projectiletype(startloc)
+		var/obj/projectile/P = new projectiletype(startloc)
 		playsound(src, projectilesound, 100, 1)
 		P.starting = startloc
 		P.firer = src

--- a/code/modules/mob/living/simple_animal/hostile/jungle/leaper.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/leaper.dm
@@ -14,7 +14,7 @@
 	maxHealth = 300
 	health = 300
 	ranged = TRUE
-	projectiletype = /obj/item/projectile/leaper
+	projectiletype = /obj/projectile/leaper
 	projectilesound = 'sound/weapons/pierce.ogg'
 	ranged_cooldown_time = 30
 	pixel_x = -16
@@ -28,7 +28,7 @@
 
 	do_footstep = TRUE
 
-/obj/item/projectile/leaper
+/obj/projectile/leaper
 	name = "leaper bubble"
 	icon_state = "leaper"
 	paralyze = 50
@@ -38,7 +38,7 @@
 	nondirectional_sprite = TRUE
 	impact_effect_type = /obj/effect/temp_visual/leaper_projectile_impact
 
-/obj/item/projectile/leaper/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/leaper/on_hit(atom/target, blocked = FALSE)
 	..()
 	if(iscarbon(target))
 		var/mob/living/carbon/C = target
@@ -48,7 +48,7 @@
 		var/mob/living/simple_animal/L = target
 		L.adjustHealth(25)
 
-/obj/item/projectile/leaper/on_range()
+/obj/projectile/leaper/on_range()
 	var/turf/T = get_turf(src)
 	..()
 	new /obj/structure/leaper_bubble(T)

--- a/code/modules/mob/living/simple_animal/hostile/jungle/mega_arachnid.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/mega_arachnid.dm
@@ -20,7 +20,7 @@
 	speak_emote = list("chitters")
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	ranged_cooldown_time = 60
-	projectiletype = /obj/item/projectile/mega_arachnid
+	projectiletype = /obj/projectile/mega_arachnid
 	projectilesound = 'sound/weapons/pierce.ogg'
 	alpha = 50
 
@@ -48,13 +48,13 @@
 	..()
 	alpha = 50
 
-/obj/item/projectile/mega_arachnid
+/obj/projectile/mega_arachnid
 	name = "flesh snare"
 	nodamage = TRUE
 	damage = 0
 	icon_state = "tentacle_end"
 
-/obj/item/projectile/mega_arachnid/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/mega_arachnid/on_hit(atom/target, blocked = FALSE)
 	if(iscarbon(target) && blocked < 100)
 		var/obj/item/restraints/legcuffs/beartrap/mega_arachnid/B = new /obj/item/restraints/legcuffs/beartrap/mega_arachnid(get_turf(target))
 		B.Crossed(target)

--- a/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
@@ -40,7 +40,7 @@
 	damage = 10
 	damage_type = BURN
 	light_range = 2
-	flag = ENERGY
+	armor_flag = ENERGY
 	light_color = LIGHT_COLOR_YELLOW
 	hitsound = 'sound/weapons/sear.ogg'
 	hitsound_wall = 'sound/weapons/effects/searwall.ogg'

--- a/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/jungle/seedling.dm
@@ -25,7 +25,7 @@
 	aggro_vision_range = 15
 	ranged = TRUE
 	ranged_cooldown_time = 10
-	projectiletype = /obj/item/projectile/seedling
+	projectiletype = /obj/projectile/seedling
 	projectilesound = 'sound/weapons/pierce.ogg'
 	robust_searching = TRUE
 	stat_attack = UNCONSCIOUS
@@ -34,7 +34,7 @@
 	var/mob/living/beam_debuff_target
 	var/solar_beam_identifier = 0
 
-/obj/item/projectile/seedling
+/obj/projectile/seedling
 	name = "solar energy"
 	icon_state = "seedling"
 	damage = 10
@@ -46,7 +46,7 @@
 	hitsound_wall = 'sound/weapons/effects/searwall.ogg'
 	nondirectional_sprite = TRUE
 
-/obj/item/projectile/seedling/Bump(atom/A)//Stops seedlings from destroying other jungle mobs through FF
+/obj/projectile/seedling/Bump(atom/A)//Stops seedlings from destroying other jungle mobs through FF
 	if(isliving(A))
 		var/mob/living/L = A
 		if("jungle" in L.faction)
@@ -180,7 +180,7 @@
 			Shoot(target)
 			return
 		var/turf/our_turf = get_turf(src)
-		var/obj/item/projectile/seedling/readied_shot = new /obj/item/projectile/seedling(our_turf)
+		var/obj/projectile/seedling/readied_shot = new /obj/projectile/seedling(our_turf)
 		readied_shot.preparePixelProjectile(target, src, null, rand(-10, 10))
 		readied_shot.fire()
 		playsound(src, projectilesound, 100, 1)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -35,7 +35,7 @@ Difficulty: Medium
 	speak_emote = list("roars")
 	speed = 3
 	move_to_delay = 3
-	projectiletype = /obj/item/projectile/kinetic/miner
+	projectiletype = /obj/projectile/kinetic/miner
 	projectilesound = 'sound/weapons/kenetic_accel.ogg'
 	ranged = TRUE
 	ranged_cooldown_time = 16
@@ -111,7 +111,7 @@ Difficulty: Medium
 	..()
 	target.stun_absorption -= "miner"
 
-/obj/item/projectile/kinetic/miner
+/obj/projectile/kinetic/miner
 	damage = 20
 	speed = 0.9
 	icon_state = "ka_tracer"

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -430,7 +430,7 @@ Difficulty: Hard
 		if(.)
 			recovery_time = world.time + 20 // can only attack melee once every 2 seconds but rapid_melee gives higher priority
 
-/mob/living/simple_animal/hostile/megafauna/bubblegum/bullet_act(obj/item/projectile/P)
+/mob/living/simple_animal/hostile/megafauna/bubblegum/bullet_act(obj/projectile/P)
 	if(BUBBLEGUM_IS_ENRAGED)
 		visible_message(span_danger("[src] deflects the projectile; [p_they()] can't be hit with ranged weapons while enraged!"), span_userdanger("You deflect the projectile!"))
 		playsound(src, pick('sound/weapons/bulletflyby.ogg', 'sound/weapons/bulletflyby2.ogg', 'sound/weapons/bulletflyby3.ogg'), 300, 1)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -453,7 +453,7 @@ Difficulty: Very Hard
 	if(istype(P, /obj/projectile/magic))
 		ActivationReaction(P.firer, ACTIVATE_MAGIC, P.damage_type)
 		return
-	ActivationReaction(P.firer, P.flag, P.damage_type)
+	ActivationReaction(P.firer, P.armor_flag, P.damage_type)
 
 /obj/machinery/anomalous_crystal/proc/ActivationReaction(mob/user, method, damtype)
 	if(world.time < last_use_timer)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -175,7 +175,7 @@ Difficulty: Very Hard
 	if(!isnum(set_angle) && (!marker || marker == loc))
 		return
 	var/turf/startloc = get_turf(src)
-	var/obj/item/projectile/P = new /obj/item/projectile/colossus(startloc)
+	var/obj/projectile/P = new /obj/projectile/colossus(startloc)
 	P.preparePixelProjectile(marker, startloc)
 	P.firer = src
 	if(target)
@@ -244,7 +244,7 @@ Difficulty: Very Hard
 	target = new_target
 	INVOKE_ASYNC(src, TYPE_PROC_REF(/atom/movable/, orbit), target, 0, FALSE, 0, 0, FALSE, TRUE)
 
-/mob/living/simple_animal/hostile/megafauna/colossus/bullet_act(obj/item/projectile/P)
+/mob/living/simple_animal/hostile/megafauna/colossus/bullet_act(obj/projectile/P)
 	if(!stat)
 		var/obj/effect/temp_visual/at_shield/AT = new /obj/effect/temp_visual/at_shield(loc, src)
 		var/random_x = rand(-32, 32)
@@ -254,7 +254,7 @@ Difficulty: Very Hard
 		AT.pixel_y += random_y
 	return ..()
 
-/obj/item/projectile/colossus
+/obj/projectile/colossus
 	name ="death bolt"
 	icon_state= "chronobolt"
 	damage = 25
@@ -264,7 +264,7 @@ Difficulty: Very Hard
 	damage_type = BRUTE
 	pass_flags = PASSTABLE
 
-/obj/item/projectile/colossus/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/colossus/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(isturf(target) || isobj(target))
 		if(isobj(target))
@@ -448,9 +448,9 @@ Difficulty: Very Hard
 		ActivationReaction(user, ACTIVATE_WEAPON)
 	..()
 
-/obj/machinery/anomalous_crystal/bullet_act(obj/item/projectile/P, def_zone)
+/obj/machinery/anomalous_crystal/bullet_act(obj/projectile/P, def_zone)
 	. = ..()
-	if(istype(P, /obj/item/projectile/magic))
+	if(istype(P, /obj/projectile/magic))
 		ActivationReaction(P.firer, ACTIVATE_MAGIC, P.damage_type)
 		return
 	ActivationReaction(P.firer, P.flag, P.damage_type)
@@ -548,18 +548,18 @@ Difficulty: Very Hard
 	observer_desc = "This crystal generates a projectile when activated."
 	activation_method = ACTIVATE_TOUCH
 	cooldown_add = 50
-	var/obj/item/projectile/generated_projectile = /obj/item/projectile/beam/emitter
+	var/obj/projectile/generated_projectile = /obj/projectile/beam/emitter
 
 /obj/machinery/anomalous_crystal/emitter/Initialize(mapload)
 	. = ..()
-	generated_projectile = pick(/obj/item/projectile/colossus)
+	generated_projectile = pick(/obj/projectile/colossus)
 
 	var/proj_name = initial(generated_projectile.name)
 	observer_desc = "This crystal generates \a [proj_name] when activated."
 
 /obj/machinery/anomalous_crystal/emitter/ActivationReaction(mob/user, method)
 	if(..())
-		var/obj/item/projectile/P = new generated_projectile(get_turf(src))
+		var/obj/projectile/P = new generated_projectile(get_turf(src))
 		P.setDir(dir)
 		switch(dir)
 			if(NORTH)
@@ -776,7 +776,7 @@ Difficulty: Very Hard
 	activation_method = ACTIVATE_TOUCH
 	cooldown_add = 50
 	activation_sound = 'sound/magic/timeparadox2.ogg'
-	var/static/list/banned_items_typecache = typecacheof(list(/obj/item/storage, /obj/item/implant, /obj/item/implanter, /obj/item/disk/nuclear, /obj/item/projectile, /obj/item/spellbook))
+	var/static/list/banned_items_typecache = typecacheof(list(/obj/item/storage, /obj/item/implant, /obj/item/implanter, /obj/item/disk/nuclear, /obj/projectile, /obj/item/spellbook))
 
 /obj/machinery/anomalous_crystal/refresher/ActivationReaction(mob/user, method)
 	if(..())

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
@@ -102,7 +102,7 @@ Difficulty: Extremely Hard
 			else
 				ice_shotgun(5, list(list(0, 30, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330), list(-30, -15, 0, 15, 30)))
 
-/obj/item/projectile/frost_orb
+/obj/projectile/frost_orb
 	name = "frost orb"
 	icon_state = "ice_1"
 	damage = 20
@@ -111,12 +111,12 @@ Difficulty: Extremely Hard
 	homing_turn_speed = 30
 	damage_type = BURN
 
-/obj/item/projectile/frost_orb/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/frost_orb/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(isturf(target) || isobj(target))
 		target.ex_act(EXPLODE_HEAVY)
 
-/obj/item/projectile/snowball
+/obj/projectile/snowball
 	name = "machine-gun snowball"
 	icon_state = "nuclear_particle"
 	damage = 5
@@ -124,10 +124,10 @@ Difficulty: Extremely Hard
 	speed = 4
 	damage_type = BRUTE
 
-/obj/item/projectile/snowball/fast
+/obj/projectile/snowball/fast
 	speed = 2
 
-/obj/item/projectile/ice_blast
+/obj/projectile/ice_blast
 	name = "ice blast"
 	icon_state = "ice_2"
 	damage = 15
@@ -135,7 +135,7 @@ Difficulty: Extremely Hard
 	speed = 4
 	damage_type = BRUTE
 
-/obj/item/projectile/ice_blast/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/ice_blast/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(isturf(target) || isobj(target))
 		target.ex_act(EXPLODE_HEAVY)
@@ -163,25 +163,25 @@ Difficulty: Extremely Hard
 		var/turf/endloc = get_turf(target)
 		if(!endloc)
 			break
-		var/obj/item/projectile/frost_orb/P = new /obj/item/projectile/frost_orb(startloc)
+		var/obj/projectile/frost_orb/P = new /obj/projectile/frost_orb(startloc)
 		P.preparePixelProjectile(endloc, startloc)
 		P.firer = src
 		if(target)
 			P.original = target
 		P.set_homing_target(target)
 		P.fire(rand(0, 360))
-		addtimer(CALLBACK(P, /obj/item/projectile/frost_orb/proc/orb_explosion, projectile_speed_multiplier), 20) // make the orbs home in after a second
+		addtimer(CALLBACK(P, /obj/projectile/frost_orb/proc/orb_explosion, projectile_speed_multiplier), 20) // make the orbs home in after a second
 		SLEEP_CHECK_DEATH(added_delay)
 	SetRecoveryTime(40, 60)
 
-/obj/item/projectile/frost_orb/proc/orb_explosion(projectile_speed_multiplier)
+/obj/projectile/frost_orb/proc/orb_explosion(projectile_speed_multiplier)
 	var/list/spread = list(0, 60, 120, 180, 240, 300)
 	for(var/angle in spread)
 		var/turf/startloc = get_turf(src)
 		var/turf/endloc = get_turf(original)
 		if(!startloc || !endloc)
 			break
-		var/obj/item/projectile/P = new /obj/item/projectile/ice_blast(startloc)
+		var/obj/projectile/P = new /obj/projectile/ice_blast(startloc)
 		P.speed /= projectile_speed_multiplier
 		P.preparePixelProjectile(endloc, startloc, null, angle + rand(-10, 10))
 		P.firer = firer
@@ -196,7 +196,7 @@ Difficulty: Extremely Hard
 		var/turf/endloc = get_turf(target)
 		if(!endloc)
 			break
-		var/obj/item/projectile/P = new /obj/item/projectile/snowball(startloc)
+		var/obj/projectile/P = new /obj/projectile/snowball(startloc)
 		P.speed /= projectile_speed_multiplier
 		P.preparePixelProjectile(endloc, startloc, null, rand(-spread, spread))
 		P.firer = src
@@ -214,7 +214,7 @@ Difficulty: Extremely Hard
 			var/turf/endloc = get_turf(target)
 			if(!endloc)
 				break
-			var/obj/item/projectile/P = new /obj/item/projectile/ice_blast(startloc)
+			var/obj/projectile/P = new /obj/projectile/ice_blast(startloc)
 			P.speed /= projectile_speed_multiplier
 			P.preparePixelProjectile(endloc, startloc, null, spread)
 			P.firer = src
@@ -271,7 +271,7 @@ Difficulty: Extremely Hard
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
 /obj/item/ammo_casing/energy/snowball
-	projectile_type = /obj/item/projectile/snowball/fast
+	projectile_type = /obj/projectile/snowball/fast
 	select_name = "freeze"
 	e_cost = 20
 	delay = 0.5

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -533,8 +533,8 @@ Difficulty: Hard
 		return FALSE
 	if(mover == caster.pulledby)
 		return TRUE
-	if(istype(mover, /obj/item/projectile))
-		var/obj/item/projectile/P = mover
+	if(istype(mover, /obj/projectile))
+		var/obj/projectile/P = mover
 		if(P.firer == caster)
 			return TRUE
 	if(mover == caster)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/stalwart.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/stalwart.dm
@@ -123,7 +123,7 @@
 	if(!isnum(set_angle) && (!marker || marker == loc))
 		return
 	var/turf/startloc = get_turf(src)
-	var/obj/item/projectile/P = new /obj/item/projectile/stalpike(startloc)
+	var/obj/projectile/P = new /obj/projectile/stalpike(startloc)
 	P.preparePixelProjectile(marker, startloc)
 	P.firer = src
 	if(target)
@@ -135,7 +135,7 @@
 	if(!isnum(set_angle) && (!marker || marker == loc))
 		return
 	var/turf/startloc = get_turf(src)
-	var/obj/item/projectile/P = new /obj/item/projectile/stalpike/spiral(startloc)
+	var/obj/projectile/P = new /obj/projectile/stalpike/spiral(startloc)
 	P.preparePixelProjectile(marker, startloc)
 	P.firer = src
 	if(target)
@@ -147,7 +147,7 @@
 	if(!isnum(set_angle) && (!marker || marker == loc))
 		return
 	var/turf/startloc = get_turf(src)
-	var/obj/item/projectile/P = new /obj/item/projectile/stalnade(startloc)
+	var/obj/projectile/P = new /obj/projectile/stalnade(startloc)
 	P.preparePixelProjectile(marker, startloc)
 	P.firer = src
 	if(target)
@@ -202,7 +202,7 @@
 	if(!isnum(set_angle) && (!marker || marker == loc))
 		return
 	var/turf/startloc = get_turf(src)
-	var/obj/item/projectile/P = new /obj/item/projectile/stalnade(startloc)
+	var/obj/projectile/P = new /obj/projectile/stalnade(startloc)
 	P.preparePixelProjectile(marker, startloc)
 	P.firer = src
 	if(target)
@@ -321,7 +321,7 @@
 	move_to_delay = 2
 	speed = 1
 	ranged_cooldown_time = 30
-	projectiletype = /obj/item/projectile/stalpike/weak
+	projectiletype = /obj/projectile/stalpike/weak
 	projectilesound = 'sound/weapons/ionrifle.ogg'
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/staldrone/ranged/GiveTarget(new_target)
@@ -335,7 +335,7 @@
 	desc = "Bzz bizzop boop blip beep"
 	invisibility = 100
 
-/obj/item/projectile/stalpike
+/obj/projectile/stalpike
 	name = "energy pike"
 	icon_state = "arcane_barrage_greyscale"
 	damage = 30
@@ -349,7 +349,7 @@
 	light_power = 6
 	light_color = "#00e1ff"
 
-/obj/item/projectile/stalpike/spiral
+/obj/projectile/stalpike/spiral
 	name = "resonant energy pike"
 	icon_state = "arcane_barrage_greyscale"
 	damage = 30
@@ -363,7 +363,7 @@
 	light_power = 6
 	light_color = "#4851ce"
 
-/obj/item/projectile/stalpike/weak
+/obj/projectile/stalpike/weak
 	name = "lesser energy pike"
 	icon_state = "arcane_barrage_greyscale"
 	damage = 10
@@ -377,7 +377,7 @@
 	light_power = 6
 	light_color = "#9a9fdb"
 
-/obj/item/projectile/stalnade
+/obj/projectile/stalnade
 	name = "volatile orb"
 	icon_state = "wipe"
 	damage = 40
@@ -390,7 +390,7 @@
 	light_power = 10
 	light_color = "#0077ff"
 
-/obj/item/projectile/stalnade/on_hit(target)
+/obj/projectile/stalnade/on_hit(target)
 	if(!iscarbon(target))
 		return BULLET_ACT_PENETRATE
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -253,7 +253,7 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 /mob/living/simple_animal/hostile/swarmer/ai/ranged_combat
 	icon_state = "swarmer_ranged"
 	icon_living = "swarmer_ranged"
-	projectiletype = /obj/item/projectile/beam/laser
+	projectiletype = /obj/projectile/beam/laser
 	projectilesound = 'sound/weapons/laser.ogg'
 	check_friendly_fire = TRUE //you're supposed to protect the resource swarmers, you poop
 	retreat_distance = 3

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -42,7 +42,7 @@
 	damage = 0
 	damage_type = BURN
 	nodamage = TRUE
-	flag = ENERGY
+	armor_flag = ENERGY
 	temperature = 50
 
 /mob/living/simple_animal/hostile/asteroid/basilisk/GiveTarget(new_target)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/basilisk.dm
@@ -10,7 +10,7 @@
 	icon_gib = "syndicate_gib"
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
 	move_to_delay = 20
-	projectiletype = /obj/item/projectile/temp/basilisk
+	projectiletype = /obj/projectile/temp/basilisk
 	projectilesound = 'sound/weapons/pierce.ogg'
 	ranged = 1
 	ranged_message = "stares"
@@ -36,7 +36,7 @@
 	loot = list(/obj/item/stack/ore/diamond{layer = ABOVE_MOB_LAYER},
 				/obj/item/stack/ore/diamond{layer = ABOVE_MOB_LAYER})
 
-/obj/item/projectile/temp/basilisk
+/obj/projectile/temp/basilisk
 	name = "freezing blast"
 	icon_state = "ice_2"
 	damage = 0
@@ -105,7 +105,7 @@
 	light_range = 3
 	light_power = 2.5
 	light_color = LIGHT_COLOR_LAVA
-	projectiletype = /obj/item/projectile/temp/basilisk/magmawing
+	projectiletype = /obj/projectile/temp/basilisk/magmawing
 	crusher_loot = /obj/item/crusher_trophy/blaster_tubes/magma_wing
 	crusher_drop_mod = 10
 	loot = list()
@@ -120,12 +120,12 @@
 	icon_dead = "watcher_icewing_dead"
 	maxHealth = 170
 	health = 170
-	projectiletype = /obj/item/projectile/temp/basilisk/icewing
+	projectiletype = /obj/projectile/temp/basilisk/icewing
 	butcher_results = list(/obj/item/stack/ore/diamond = 5, /obj/item/stack/sheet/bone = 1) //No sinew; the wings are too fragile to be usable
 	crusher_loot = /obj/item/crusher_trophy/watcher_wing/ice_wing
 	crusher_drop_mod = 10
 
-/obj/item/projectile/temp/basilisk/magmawing
+/obj/projectile/temp/basilisk/magmawing
 	name = "scorching blast"
 	icon_state = "lava"
 	damage = 10
@@ -133,7 +133,7 @@
 	nodamage = FALSE
 	temperature = 500 //Heats you up!
 
-/obj/item/projectile/temp/basilisk/magmawing/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/temp/basilisk/magmawing/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(.)
 		var/mob/living/L = target
@@ -141,12 +141,12 @@
 			L.adjust_fire_stacks(0.1)
 			L.ignite_mob()
 
-/obj/item/projectile/temp/basilisk/icewing
+/obj/projectile/temp/basilisk/icewing
 	damage = 5
 	damage_type = BURN
 	nodamage = FALSE
 
-/obj/item/projectile/temp/basilisk/icewing/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/temp/basilisk/icewing/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(.)
 		var/mob/living/L = target

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/curse_blob.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/curse_blob.dm
@@ -75,8 +75,8 @@
 	. = ..()
 	if(mover == set_target)
 		return FALSE
-	if(istype(mover, /obj/item/projectile))
-		var/obj/item/projectile/P = mover
+	if(istype(mover, /obj/projectile))
+		var/obj/projectile/P = mover
 		if(P.firer == set_target)
 			return FALSE
 
@@ -96,7 +96,7 @@ IGNORE_PROC_IF_NOT_TARGET(attack_animal)
 
 IGNORE_PROC_IF_NOT_TARGET(attack_slime)
 
-/mob/living/simple_animal/hostile/asteroid/curseblob/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/hostile/asteroid/curseblob/bullet_act(obj/projectile/Proj)
 	if(Proj.firer != set_target)
 		return
 	return ..()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/drakeling.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/drakeling.dm
@@ -214,7 +214,7 @@
 	cooldown_time = 1 SECONDS //adv cutter
 	active_msg = span_notice("You ready the wings.")
 	deactive_msg = span_notice("You stop the flapping.")
-	var/shootie = /obj/item/projectile/wing
+	var/shootie = /obj/projectile/wing
 
 /datum/action/cooldown/spell/pointed/drakeling/wing_flap/InterceptClickOn(mob/living/L, params, atom/A)
 	. = ..()
@@ -230,13 +230,13 @@
 		shooties += new shootie(get_step(drake, NORTH))
 		shooties += new shootie(get_step(drake, SOUTH))
 	for(var/S in shooties)
-		var/obj/item/projectile/wing/shooted = S
+		var/obj/projectile/wing/shooted = S
 		shooted.firer = L
 		shooted.fire(dir2angle(drake.dir))
 
 	return TRUE
 
-/obj/item/projectile/wing
+/obj/projectile/wing
 	name = "wing blast"
 	damage = 0
 	range = 5
@@ -244,7 +244,7 @@
 	icon_state = "energy2"
 	var/mine_range = 5 //same as an advanced cutter but there's three of them
 
-/obj/item/projectile/wing/on_hit(atom/target)
+/obj/projectile/wing/on_hit(atom/target)
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
@@ -126,11 +126,11 @@
 
 /mob/living/simple_animal/hostile/asteroid/elite/herald/proc/shoot_projectile(turf/marker, set_angle, is_teleshot)
 	var/turf/startloc = get_turf(src)
-	var/obj/item/projectile/herald/H = null
+	var/obj/projectile/herald/H = null
 	if(!is_teleshot)
-		H = new /obj/item/projectile/herald(startloc)
+		H = new /obj/projectile/herald(startloc)
 	else
-		H = new /obj/item/projectile/herald/teleshot(startloc)
+		H = new /obj/projectile/herald/teleshot(startloc)
 	H.preparePixelProjectile(marker, startloc)
 	H.firer = src
 	if(target)
@@ -223,7 +223,7 @@
 		my_master.my_mirror = null
 	. = ..()
 
-/obj/item/projectile/herald
+/obj/projectile/herald
 	name ="death bolt"
 	icon_state= "chronobolt"
 	damage = 15
@@ -233,12 +233,12 @@
 	damage_type = BRUTE
 	pass_flags = PASSTABLE
 
-/obj/item/projectile/herald/teleshot
+/obj/projectile/herald/teleshot
 	name ="golden bolt"
 	damage = 0
 	color = rgb(255,255,102)
 
-/obj/item/projectile/herald/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/herald/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(ismineralturf(target))
 		var/turf/closed/mineral/M = target
@@ -250,7 +250,7 @@
 		if(F != null && istype(F, /mob/living/simple_animal/hostile/asteroid/elite) && F.faction_check_mob(L))
 			L.heal_overall_damage(damage)
 
-/obj/item/projectile/herald/teleshot/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/herald/teleshot/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	firer.forceMove(get_turf(src))
 
@@ -272,8 +272,8 @@
 
 /obj/item/clothing/neck/cloak/herald_cloak/proc/shoot_projectile(turf/marker, set_angle, mob/living/carbon/owner)
 	var/turf/startloc = get_turf(owner)
-	var/obj/item/projectile/herald/H = null
-	H = new /obj/item/projectile/herald(startloc)
+	var/obj/projectile/herald/H = null
+	H = new /obj/projectile/herald(startloc)
 	H.preparePixelProjectile(marker, startloc)
 	H.firer = owner
 	H.fire(set_angle)

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
@@ -77,7 +77,7 @@
 		visible_message(span_danger("\The [name] buries into the ground, vanishing from sight!"))
 		qdel(src)
 
-/mob/living/simple_animal/hostile/asteroid/goldgrub/bullet_act(obj/item/projectile/P)
+/mob/living/simple_animal/hostile/asteroid/goldgrub/bullet_act(obj/projectile/P)
 	visible_message(span_danger("\The [P.name] was repelled by [name]'s blubberous girth!"))
 	return BULLET_ACT_BLOCK
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/mining_mobs.dm
@@ -33,7 +33,7 @@
 		return
 	icon_state = icon_living
 
-/mob/living/simple_animal/hostile/asteroid/bullet_act(obj/item/projectile/P)//Reduces damage from most projectiles to curb off-screen kills
+/mob/living/simple_animal/hostile/asteroid/bullet_act(obj/projectile/P)//Reduces damage from most projectiles to curb off-screen kills
 	if(!stat)
 		Aggro()
 	if(P.damage < 30 && P.damage_type != BRUTE)

--- a/code/modules/mob/living/simple_animal/hostile/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mushroom.dm
@@ -179,7 +179,7 @@
 		if(T.throwforce)
 			Bruise()
 
-/mob/living/simple_animal/hostile/mushroom/bullet_act(obj/item/projectile/P)
+/mob/living/simple_animal/hostile/mushroom/bullet_act(obj/projectile/P)
 	. = ..()
 	if(P.nodamage)
 		Bruise()

--- a/code/modules/mob/living/simple_animal/hostile/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pirate.dm
@@ -66,7 +66,7 @@
 	rapid_fire_delay = 6
 	retreat_distance = 5
 	minimum_distance = 5
-	projectiletype = /obj/item/projectile/beam/laser
+	projectiletype = /obj/projectile/beam/laser
 	loot = list(/obj/effect/mob_spawn/human/corpse/pirate/ranged)
 
 /mob/living/simple_animal/hostile/pirate/ranged/space

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -134,7 +134,7 @@
 	QDEL_NULL(sord)
 	return ..()
 
-/mob/living/simple_animal/hostile/syndicate/melee/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/hostile/syndicate/melee/bullet_act(obj/projectile/Proj)
 	if(prob(projectile_deflect_chance))
 		visible_message(span_danger("[src] blocks [Proj] with its shield!"))
 		return BULLET_ACT_BLOCK

--- a/code/modules/mob/living/simple_animal/hostile/winter_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/winter_mobs.dm
@@ -31,7 +31,7 @@
 	ranged = 1
 	retreat_distance = 5
 	minimum_distance = 5
-	projectiletype = /obj/item/projectile/snowball
+	projectiletype = /obj/projectile/snowball
 	
 /mob/living/simple_animal/snowman
 	desc = "A very friendly snowman."

--- a/code/modules/mob/living/simple_animal/hostile/wizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wizard.dm
@@ -115,7 +115,7 @@
 	ranged = 1
 	retreat_distance = 4
 	minimum_distance = 4
-	projectiletype = /obj/item/projectile/magic/arcane_barrage
+	projectiletype = /obj/projectile/magic/arcane_barrage
 	projectilesound = 'sound/weapons/emitter.ogg'
 	loot = list(/obj/effect/mob_spawn/human/corpse/wizard, /obj/item/staff)
 	del_on_death = 1
@@ -143,10 +143,10 @@
 /mob/living/simple_animal/hostile/academywizard/chaos //chaotic wizard, not too powerful overall
 	name = "Chaos Wizard"
 	desc = "Unfortunately, he cannot Chaos Control."
-	projectiletype = /obj/item/projectile/magic
-	var/allowed_projectile_types = list(/obj/item/projectile/magic/animate, /obj/item/projectile/magic/runic_honk,
-	/obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door,
-	/obj/item/projectile/magic/spellblade, /obj/item/projectile/magic/arcane_barrage)
+	projectiletype = /obj/projectile/magic
+	var/allowed_projectile_types = list(/obj/projectile/magic/animate, /obj/projectile/magic/runic_honk,
+	/obj/projectile/magic/teleport, /obj/projectile/magic/door,
+	/obj/projectile/magic/spellblade, /obj/projectile/magic/arcane_barrage)
 
 /mob/living/simple_animal/hostile/academywizard/chaos/Initialize(mapload)
 	projectiletype = pick(allowed_projectile_types)
@@ -159,4 +159,4 @@
 /mob/living/simple_animal/hostile/academywizard/botanist //super weak garbage wizard, for memes
 	name = "Academy Botanist"
 	desc = "Will destroy you with the power of... making you grow larger?"
-	projectiletype = /obj/item/projectile/magic/runic_resizement
+	projectiletype = /obj/projectile/magic/runic_resizement

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -332,7 +332,7 @@
 	return
 
 //Bullets
-/mob/living/simple_animal/parrot/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/parrot/bullet_act(obj/projectile/Proj)
 	. = ..()
 	if(!stat && !client)
 		if(parrot_state == PARROT_PERCH)

--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -283,7 +283,7 @@
 		amount = -abs(amount)
 	return ..() //Heals them
 
-/mob/living/simple_animal/slime/bullet_act(obj/item/projectile/Proj)
+/mob/living/simple_animal/slime/bullet_act(obj/projectile/Proj)
 	attacked += 10
 	if((Proj.damage_type == BURN))
 		adjustBruteLoss(-abs(Proj.damage)) //fire projectiles heals slimes.

--- a/code/modules/modular_computers/computers/machinery/modular_computer.dm
+++ b/code/modules/modular_computers/computers/machinery/modular_computer.dm
@@ -150,6 +150,6 @@
 // "Stun" weapons can cause minor damage to components (short-circuits?)
 // "Burn" damage is equally strong against internal components and exterior casing
 // "Brute" damage mostly damages the casing.
-/obj/machinery/modular_computer/bullet_act(obj/item/projectile/Proj)
+/obj/machinery/modular_computer/bullet_act(obj/projectile/Proj)
 	if(cpu)
 		cpu.bullet_act(Proj)

--- a/code/modules/pai/defense.dm
+++ b/code/modules/pai/defense.dm
@@ -54,7 +54,7 @@
 	if(user.put_in_hands(card))
 		user.visible_message(span_notice("[user] promptly scoops up [user.p_their()] pAI's card."))
 
-/mob/living/silicon/pai/bullet_act(obj/item/projectile/Proj)
+/mob/living/silicon/pai/bullet_act(obj/projectile/Proj)
 	if(Proj.stun)
 		fold_in(force = TRUE)
 		src.visible_message(span_warning("The electrically-charged projectile disrupts [src]'s holomatrix, forcing [src] to fold in!"))

--- a/code/modules/power/rtg.dm
+++ b/code/modules/power/rtg.dm
@@ -78,7 +78,7 @@
 	tesla_zap(src, 5, power_gen * 0.05)
 	addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(explosion), get_turf(src), 2, 3, 4, 8), 100) // Not a normal explosion.
 
-/obj/machinery/power/rtg/abductor/bullet_act(obj/item/projectile/Proj)
+/obj/machinery/power/rtg/abductor/bullet_act(obj/projectile/Proj)
 	. = ..()
 	if(!going_kaboom && istype(Proj) && !Proj.nodamage && ((Proj.damage_type == BURN) || (Proj.damage_type == BRUTE)))
 		log_bomber(Proj.firer, "triggered a", src, "explosion via projectile")

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -329,8 +329,8 @@
 		flick("ca_deactive", src)
 	update_appearance(UPDATE_ICON)
 
-/obj/machinery/power/rad_collector/bullet_act(obj/item/projectile/P)
-	if(istype(P, /obj/item/projectile/energy/nuclear_particle))
+/obj/machinery/power/rad_collector/bullet_act(obj/projectile/P)
+	if(istype(P, /obj/projectile/energy/nuclear_particle))
 		rad_act(P.irradiate * P.damage) // equivalent of a 2000 strength rad pulse for each particle
 		P.damage = 0
 	..()

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -33,7 +33,7 @@
 	var/locked = FALSE
 	var/allow_switch_interact = TRUE
 
-	var/projectile_type = /obj/item/projectile/beam/emitter
+	var/projectile_type = /obj/projectile/beam/emitter
 	var/projectile_sound = 'sound/weapons/emitter.ogg'
 	var/datum/effect_system/spark_spread/sparks
 
@@ -215,7 +215,7 @@
 	var/obj/item/K = new projectile_type(get_turf(src))
 
 	/// If it isn't a projectile, throw it
-	if(!istype(K, /obj/item/projectile))
+	if(!istype(K, /obj/projectile))
 		if(istype(K, /obj/item/grenade))
 			var/obj/item/grenade/I = K
 			I.preprime()
@@ -225,7 +225,7 @@
 			sparks.start()
 		return K
 
-	var/obj/item/projectile/P = K
+	var/obj/projectile/P = K
 	playsound(get_turf(src), projectile_sound, 50, TRUE)
 	if(prob(35))
 		sparks.start()
@@ -390,7 +390,7 @@
 		to_chat(user, span_warning("[src] ejects [gun] as you disable the power limiter."))
 		remove_gun(user)
 	active_power_usage *= 5
-	projectile_type = /obj/item/projectile/beam/emitter/pulse
+	projectile_type = /obj/projectile/beam/emitter/pulse
 	projectile_sound = 'sound/weapons/pulse.ogg'
 	return TRUE
 
@@ -411,7 +411,7 @@
 	icon_state = "sci-emitter"
 	icon_state_on = "sci-emitter_+a"
 	icon_state_underpowered = "sci-emitter_+u"
-	projectile_type = /obj/item/projectile/energy/nuclear_particle
+	projectile_type = /obj/projectile/energy/nuclear_particle
 	idle_power_usage = 0 // powered by tritium gas (and scientists don't have insulated gloves for wiring things)
 	active_power_usage = 0
 	var/obj/item/tank/tank
@@ -456,7 +456,7 @@
 
 /obj/machinery/power/emitter/particle/emag_act(mob/user)
 	if(..()) // stronger particles
-		projectile_type = /obj/item/projectile/energy/nuclear_particle/strong
+		projectile_type = /obj/projectile/energy/nuclear_particle/strong
 
 /obj/machinery/power/emitter/particle/update_icon_state()
 	. = ..()

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -156,7 +156,7 @@ field_generator power level display
 		..()
 
 /obj/machinery/field/generator/bullet_act(obj/projectile/Proj)
-	if(Proj.flag != BULLET)
+	if(Proj.armor_flag != BULLET)
 		power = min(power + Proj.damage, field_generator_max_power)
 		check_power_level()
 	. = ..()

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -155,7 +155,7 @@ field_generator power level display
 	else
 		..()
 
-/obj/machinery/field/generator/bullet_act(obj/item/projectile/Proj)
+/obj/machinery/field/generator/bullet_act(obj/projectile/Proj)
 	if(Proj.flag != BULLET)
 		power = min(power + Proj.damage, field_generator_max_power)
 		check_power_level()

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -148,7 +148,7 @@
 		return
 
 
-/obj/singularity/bullet_act(obj/item/projectile/P)
+/obj/singularity/bullet_act(obj/projectile/P)
 	qdel(P)
 	return BULLET_ACT_HIT //Will there be an impact? Who knows.  Will we see it? No.
 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -792,7 +792,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		return FALSE
 	if(istype(Proj.firer, /mob/living)) //yogs start - supermatter stuff
 		investigate_log("has been hit by [Proj] fired by [key_name(Proj.firer)]", INVESTIGATE_SUPERMATTER) // yogs end
-	if(Proj.flag != BULLET)
+	if(Proj.armor_flag != BULLET)
 		power += Proj.damage * config_bullet_energy
 		if(!has_been_powered)
 			investigate_log("has been powered for the first time.", INVESTIGATE_SUPERMATTER)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -786,7 +786,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 				empulse(src, 10-support_integrity, (10-support_integrity)*2) //EMPs must always be spewing every so often to ensure that containment is guaranteed to fail.
 	return 1
 
-/obj/machinery/power/supermatter_crystal/bullet_act(obj/item/projectile/Proj)
+/obj/machinery/power/supermatter_crystal/bullet_act(obj/projectile/Proj)
 	var/turf/L = loc
 	if(!istype(L))
 		return FALSE

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -13,7 +13,7 @@
 	var/fire_sound = null						//What sound should play when this ammo is fired
 	var/caliber = null							//Which kind of guns it can be loaded into
 	var/projectile_type = null					//The bullet type to create when New() is called
-	var/obj/item/projectile/BB = null 			//The loaded bullet
+	var/obj/projectile/BB = null 			//The loaded bullet
 	var/pellets = 1								//Pellets for spreadshot
 	var/variance = 0							//Variance for inaccuracy fundamental to the casing
 	var/randomspread = 0						//Randomspread for automatics

--- a/code/modules/projectiles/ammunition/_firing.dm
+++ b/code/modules/projectiles/ammunition/_firing.dm
@@ -55,7 +55,7 @@
 			direct_target = target
 	if(!direct_target)
 		BB.preparePixelProjectile(target, user, params, spread)
-	var/obj/item/projectile/old_BB = BB // Need to set BB to null first, otherwise casings that create new projectiles when they land witll break if fired point blank
+	var/obj/projectile/old_BB = BB // Need to set BB to null first, otherwise casings that create new projectiles when they land witll break if fired point blank
 	BB = null
 	old_BB.fire(null, direct_target)
 	return TRUE

--- a/code/modules/projectiles/ammunition/ballistic/lmg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/lmg.dm
@@ -5,19 +5,19 @@
 	desc = "A 7.12x82mm bullet casing."
 	icon_state = "762-casing"
 	caliber = "mm71282"
-	projectile_type = /obj/item/projectile/bullet/mm712x82
+	projectile_type = /obj/projectile/bullet/mm712x82
 
 /obj/item/ammo_casing/mm712x82/ap
 	name = "7.12x82mm armor-piercing bullet casing"
 	desc = "A 7.12x82mm bullet casing designed with a hardened-tipped core to help penetrate armored targets."
-	projectile_type = /obj/item/projectile/bullet/mm712x82/ap
+	projectile_type = /obj/projectile/bullet/mm712x82/ap
 
 /obj/item/ammo_casing/mm712x82/hollow
 	name = "7.12x82mm hollow-point bullet casing"
 	desc = "A 7.12x82mm bullet casing designed to cause more damage to unarmored targets."
-	projectile_type = /obj/item/projectile/bullet/mm712x82/hp
+	projectile_type = /obj/projectile/bullet/mm712x82/hp
 
 /obj/item/ammo_casing/mm712x82/inc
 	name = "7.12x82mm incendiary bullet casing"
 	desc = "A 7.12x82mm bullet casing designed with a chemical-filled capsule on the tip that when bursted, reacts with the atmosphere to produce a fireball, engulfing the target in flames."
-	projectile_type = /obj/item/projectile/bullet/incendiary/mm712x82
+	projectile_type = /obj/projectile/bullet/incendiary/mm712x82

--- a/code/modules/projectiles/ammunition/ballistic/minigun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/minigun.dm
@@ -5,4 +5,4 @@
 	desc = "A 5.46mm bullet casing. Wait, the fuck is a 5.46"
 	icon_state = "556-casing" // Most bullets use this casing and this gun does not even drop any so...
 	caliber = "a546"
-	projectile_type = /obj/item/projectile/bullet/a546
+	projectile_type = /obj/projectile/bullet/a546

--- a/code/modules/projectiles/ammunition/ballistic/pistol.dm
+++ b/code/modules/projectiles/ammunition/ballistic/pistol.dm
@@ -4,39 +4,39 @@
 	name = "10mm bullet casing"
 	desc = "A 10mm bullet casing."
 	caliber = "10mm"
-	projectile_type = /obj/item/projectile/bullet/c10mm
+	projectile_type = /obj/projectile/bullet/c10mm
 
 /obj/item/ammo_casing/caseless/c10mm/cs
 	name = "10mm caseless bullet"
 	desc = "A 10mm caseless bullet."
 	caliber = "10mm"
-	projectile_type = /obj/item/projectile/bullet/c10mm/cs
+	projectile_type = /obj/projectile/bullet/c10mm/cs
 
 /obj/item/ammo_casing/c10mm/ap
 	name = "10mm armor-piercing bullet casing"
 	desc = "A 10mm armor-piercing bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c10mm/ap
+	projectile_type = /obj/projectile/bullet/c10mm/ap
 
 /obj/item/ammo_casing/c10mm/hp
 	name = "10mm hollow-point bullet casing"
 	desc = "A 10mm hollow-point bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c10mm/hp
+	projectile_type = /obj/projectile/bullet/c10mm/hp
 
 /obj/item/ammo_casing/c10mm/sp
 	name = "10mm soporific bullet casing"
 	desc = "A 10mm soporific bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c10mm/sp
+	projectile_type = /obj/projectile/bullet/c10mm/sp
 	harmful = FALSE
 
 /obj/item/ammo_casing/c10mm/inc
 	name = "10mm incendiary bullet casing"
 	desc = "A 10mm incendiary bullet casing."
-	projectile_type = /obj/item/projectile/bullet/incendiary/c10mm
+	projectile_type = /obj/projectile/bullet/incendiary/c10mm
 
 /obj/item/ammo_casing/c10mm/emp
 	name = "10mm EMP bullet casing"
 	desc = "A 10mm EMP bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c10mm/emp
+	projectile_type = /obj/projectile/bullet/c10mm/emp
 
 // 9mm (Stechkin APS)
 
@@ -44,17 +44,17 @@
 	name = "9mm bullet casing"
 	desc = "A 9mm bullet casing."
 	caliber = "9mm"
-	projectile_type = /obj/item/projectile/bullet/c9mm
+	projectile_type = /obj/projectile/bullet/c9mm
 
 /obj/item/ammo_casing/c9mm/ap
 	name = "9mm armor-piercing bullet casing"
 	desc = "A 9mm armor-piercing bullet casing."
-	projectile_type =/obj/item/projectile/bullet/c9mm/ap
+	projectile_type =/obj/projectile/bullet/c9mm/ap
 
 /obj/item/ammo_casing/c9mm/inc
 	name = "9mm incendiary bullet casing"
 	desc = "A 9mm incendiary bullet casing."
-	projectile_type = /obj/item/projectile/bullet/incendiary/c9mm
+	projectile_type = /obj/projectile/bullet/incendiary/c9mm
 
 
 // .50 AE (Desert Eagle)
@@ -63,7 +63,7 @@
 	name = ".50 AE bullet casing"
 	desc = "A .50 AE bullet casing."
 	caliber = ".50ae"
-	projectile_type = /obj/item/projectile/bullet/a50AE
+	projectile_type = /obj/projectile/bullet/a50AE
 
 // Bolt Pistol
 
@@ -71,11 +71,11 @@
 	name = ".75 bolt round casing"
 	desc = "A .75 bolt round casing."
 	caliber = ".75"
-	projectile_type = /obj/item/projectile/bullet/boltpistol
+	projectile_type = /obj/projectile/bullet/boltpistol
 
 /obj/item/ammo_casing/boltpistol/admin
 	name = ".75 bolt round casing"
 	desc = "A .75 bolt round casing. This one feels more powerful somehow..."
 	caliber = ".75"
-	projectile_type = /obj/item/projectile/bullet/boltpistol/admin
+	projectile_type = /obj/projectile/bullet/boltpistol/admin
 

--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -4,34 +4,34 @@
 	name = ".357 magnum bullet casing"
 	desc = "A .357 magnum bullet casing."
 	caliber = "357"
-	projectile_type = /obj/item/projectile/bullet/a357
+	projectile_type = /obj/projectile/bullet/a357
 
 /obj/item/ammo_casing/a357/ironfeather
 	name = ".357 Ironfeather shell"
 	desc = "A .357 Ironfeather shell that contains six pellets."
-	projectile_type = /obj/item/projectile/bullet/pellet/a357_ironfeather
+	projectile_type = /obj/projectile/bullet/pellet/a357_ironfeather
 	pellets = 6
 	variance = 20 //Same spread and pellets as buckshot
 
 /obj/item/ammo_casing/a357/nutcracker
 	name = ".357 Nutcracker bullet casing"
 	desc = "A .357 Nutcracker bullet casing."
-	projectile_type = /obj/item/projectile/bullet/a357/nutcracker
+	projectile_type = /obj/projectile/bullet/a357/nutcracker
 
 /obj/item/ammo_casing/a357/metalshock
 	name = ".357 Metalshock bullet casing"
 	desc = "A .357 Metalshock bullet casing."
-	projectile_type = /obj/item/projectile/bullet/a357/metalshock
+	projectile_type = /obj/projectile/bullet/a357/metalshock
 
 /obj/item/ammo_casing/a357/heartpiercer
 	name = ".357 Heartpiercer bullet casing"
 	desc = "A .357 Heartpiercer bullet casing."
-	projectile_type = /obj/item/projectile/bullet/a357/heartpiercer
+	projectile_type = /obj/projectile/bullet/a357/heartpiercer
 
 /obj/item/ammo_casing/a357/wallstake
 	name = ".357 Wallstake bullet casing"
 	desc = "A .357 Wallstake bullet casing."
-	projectile_type = /obj/item/projectile/bullet/a357/wallstake
+	projectile_type = /obj/projectile/bullet/a357/wallstake
 
 // .44 (Mateba)
 
@@ -40,7 +40,7 @@
 	desc = "A .44 magnum bullet casing."
 	icon_state = "44-casing"
 	caliber = "44"
-	projectile_type = /obj/item/projectile/bullet/m44
+	projectile_type = /obj/projectile/bullet/m44
 
 // 7.62x38mmR (Nagant Revolver)
 
@@ -48,7 +48,7 @@
 	name = "7.62x38mmR bullet casing"
 	desc = "A 7.62x38mmR bullet casing."
 	caliber = "n762"
-	projectile_type = /obj/item/projectile/bullet/n762
+	projectile_type = /obj/projectile/bullet/n762
 
 // .38 (Colt Detective Special + Vatra M38)
 
@@ -56,32 +56,32 @@
 	name = ".38 special bullet casing"
 	desc = "A .38 special bullet casing."
 	caliber = "38"
-	projectile_type = /obj/item/projectile/bullet/c38
+	projectile_type = /obj/projectile/bullet/c38
 
 /obj/item/ammo_casing/c38/rubber
 	name = ".38 rubber bullet casing"
 	desc = "A .38 rubber bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c38/rubber
+	projectile_type = /obj/projectile/bullet/c38/rubber
 
 /obj/item/ammo_casing/c38/ap
 	name = ".38 armor-piercing bullet casing"
 	desc = "A .38 armor-piercing bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c38/ap
+	projectile_type = /obj/projectile/bullet/c38/ap
 
 /obj/item/ammo_casing/c38/frost
 	name = ".38 frost bullet casing"
 	desc = "A .38 frost bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c38/frost
+	projectile_type = /obj/projectile/bullet/c38/frost
 
 /obj/item/ammo_casing/c38/talon
 	name = ".38 talon bullet casing"
 	desc = "A .38 talon bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c38/talon
+	projectile_type = /obj/projectile/bullet/c38/talon
 
 /obj/item/ammo_casing/c38/bluespace
 	name = ".38 bluespace bullet casing"
 	desc = "A .38 bluespace bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c38/bluespace
+	projectile_type = /obj/projectile/bullet/c38/bluespace
 
 // .32 (Caldwell Tracking Revolver)
 
@@ -89,4 +89,4 @@
 	name = ".32 TRAC bullet casing"
 	desc = "A .32 TRAC bullet casing."
 	caliber = "32trac"
-	projectile_type = /obj/item/projectile/bullet/tra32
+	projectile_type = /obj/projectile/bullet/tra32

--- a/code/modules/projectiles/ammunition/ballistic/rifle.dm
+++ b/code/modules/projectiles/ammunition/ballistic/rifle.dm
@@ -5,28 +5,28 @@
 	desc = "A 7.62mm bullet casing."
 	icon_state = "762-casing"
 	caliber = "a762"
-	projectile_type = /obj/item/projectile/bullet/a762
+	projectile_type = /obj/projectile/bullet/a762
 
 /obj/item/ammo_casing/a762/raze
 	name = "7.62mm Raze bullet casing"
 	desc = "A 7.62mm Raze bullet casing."
 	icon_state = "762R-casing"
-	projectile_type = /obj/item/projectile/bullet/a762/raze
+	projectile_type = /obj/projectile/bullet/a762/raze
 
 /obj/item/ammo_casing/a762/pen
 	name = "7.62mm anti-material bullet casing"
 	desc = "A 7.62mm anti-material bullet casing."
 	icon_state = "762P-casing"
-	projectile_type = /obj/item/projectile/bullet/a762/pen
+	projectile_type = /obj/projectile/bullet/a762/pen
 
 /obj/item/ammo_casing/a762/vulcan
 	name = "7.62mm Vulcan bullet casing"
 	desc = "A 7.62mm Vulcan bullet casing."
 	icon_state = "762I-casing"
-	projectile_type = /obj/item/projectile/bullet/a762/vulcan
+	projectile_type = /obj/projectile/bullet/a762/vulcan
 
 /obj/item/ammo_casing/a762/enchanted
-	projectile_type = /obj/item/projectile/bullet/a762_enchanted
+	projectile_type = /obj/projectile/bullet/a762_enchanted
 
 // 5.56mm (M-90gl Rifle + NT ARG)
 
@@ -35,25 +35,25 @@
 	desc = "A 5.56mm bullet casing."
 	icon_state = "556-casing"
 	caliber = "a556"
-	projectile_type = /obj/item/projectile/bullet/a556
+	projectile_type = /obj/projectile/bullet/a556
 
 /obj/item/ammo_casing/a556/ap
 	name = "5.56mm armor-piercing bullet casing"
 	desc = "A 5.56mm armor-piercing bullet casing."
 	icon_state = "556ap-casing"
-	projectile_type = /obj/item/projectile/bullet/a556/ap
+	projectile_type = /obj/projectile/bullet/a556/ap
 
 /obj/item/ammo_casing/a556/inc
 	name = "5.56mm incendiary bullet casing"
 	desc = "A 5.56mm incendiary bullet casing."
 	icon_state = "556i-casing"
-	projectile_type = /obj/item/projectile/bullet/incendiary/a556
+	projectile_type = /obj/projectile/bullet/incendiary/a556
 
 /obj/item/ammo_casing/a556/rubber
 	name = "5.56mm rubber bullet casing"
 	desc = "A 5.56mm rubber bullet casing."
 	icon_state = "556r-casing"
-	projectile_type = /obj/item/projectile/bullet/a556/rubber
+	projectile_type = /obj/projectile/bullet/a556/rubber
 
 // .308 (Winton Mk. VI Repeating Rifle + LWT-650 DMR)
 
@@ -62,19 +62,19 @@
 	desc = "A .308 bullet casing."
 	icon_state = "556-casing"
 	caliber = "m308"
-	projectile_type = /obj/item/projectile/bullet/m308
+	projectile_type = /obj/projectile/bullet/m308
 
 /obj/item/ammo_casing/m308/pen
 	name = ".308 penetrator bullet casing"
 	desc = "A .308 penetrator bullet casing."
 	icon_state = "556pen-casing"
-	projectile_type = /obj/item/projectile/bullet/m308/pen
+	projectile_type = /obj/projectile/bullet/m308/pen
 
 /obj/item/ammo_casing/m308/laser
 	name = ".308 heavy laser bullet casing"
 	desc = "A .308 heavy laser bullet casing."
 	icon_state = "556l-casing"
-	projectile_type = /obj/item/projectile/beam/laser/heavylaser
+	projectile_type = /obj/projectile/beam/laser/heavylaser
 
 // 40mm (Grenade Launcher)
 
@@ -83,4 +83,4 @@
 	desc = "A cased high explosive grenade that can only be activated once fired out of a grenade launcher."
 	caliber = "40mm"
 	icon_state = "40mmHE"
-	projectile_type = /obj/item/projectile/bullet/a40mm
+	projectile_type = /obj/projectile/bullet/a40mm

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -5,33 +5,33 @@
 	desc = "A 12-gauge lead slug."
 	icon_state = "blshell"
 	caliber = "shotgun"
-	projectile_type = /obj/item/projectile/bullet/shotgun/slug
+	projectile_type = /obj/projectile/bullet/shotgun/slug
 	materials = list(/datum/material/iron=4000)
 
 /obj/item/ammo_casing/shotgun/syndie
 	name = "syndicate shotgun slug"
 	desc = "An illegal 12-gauge slug produced by the Syndicate."
 	icon_state = "sblshell"
-	projectile_type = /obj/item/projectile/bullet/shotgun/slug/syndie
+	projectile_type = /obj/projectile/bullet/shotgun/slug/syndie
 
 /obj/item/ammo_casing/shotgun/beanbag
 	name = "beanbag slug"
 	desc = "A weak beanbag slug for riot control."
 	icon_state = "bshell"
-	projectile_type = /obj/item/projectile/bullet/shotgun/slug/beanbag
+	projectile_type = /obj/projectile/bullet/shotgun/slug/beanbag
 	materials = list(/datum/material/iron=250)
 
 /obj/item/ammo_casing/shotgun/incendiary
 	name = "incendiary slug"
 	desc = "An incendiary-coated shotgun slug."
 	icon_state = "ishell"
-	projectile_type = /obj/item/projectile/bullet/incendiary/shotgun
+	projectile_type = /obj/projectile/bullet/incendiary/shotgun
 
 /obj/item/ammo_casing/shotgun/dragonsbreath
 	name = "dragonsbreath shell"
 	desc = "A shotgun shell which fires a spread of incendiary pellets."
 	icon_state = "ishell2"
-	projectile_type = /obj/item/projectile/bullet/incendiary/shotgun/dragonsbreath
+	projectile_type = /obj/projectile/bullet/incendiary/shotgun/dragonsbreath
 	pellets = 5
 	variance = 30
 
@@ -39,14 +39,14 @@
 	name = "taser slug"
 	desc = "A stunning taser slug."
 	icon_state = "stunshell"
-	projectile_type = /obj/item/projectile/bullet/shotgun/slug/stun
+	projectile_type = /obj/projectile/bullet/shotgun/slug/stun
 	materials = list(/datum/material/iron=250)
 
 /obj/item/ammo_casing/shotgun/meteorslug
 	name = "meteorslug shell"
 	desc = "A shotgun shell rigged with CMC technology, which launches a massive slug when fired."
 	icon_state = "mshell"
-	projectile_type = /obj/item/projectile/bullet/shotgun/slug/meteor
+	projectile_type = /obj/projectile/bullet/shotgun/slug/meteor
 
 /obj/item/ammo_casing/shotgun/pulseslug
 	name = "pulse slug"
@@ -54,19 +54,19 @@
 	energy blast. While the heat and power drain limit it to one use, it can still allow an operator to engage targets that ballistic ammunition \
 	would have difficulty with."
 	icon_state = "pshell"
-	projectile_type = /obj/item/projectile/beam/pulse/shotgun
+	projectile_type = /obj/projectile/beam/pulse/shotgun
 
 /obj/item/ammo_casing/shotgun/frag12
 	name = "FRAG-12 slug"
 	desc = "A high-explosive breaching round for a 12 gauge shotgun."
 	icon_state = "heshell"
-	projectile_type = /obj/item/projectile/bullet/shotgun/slug/frag12
+	projectile_type = /obj/projectile/bullet/shotgun/slug/frag12
 
 /obj/item/ammo_casing/shotgun/buckshot
 	name = "buckshot shell"
 	desc = "A 12-gauge buckshot shell."
 	icon_state = "gshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_buckshot
+	projectile_type = /obj/projectile/bullet/pellet/shotgun_buckshot
 	pellets = 6
 	variance = 20
 
@@ -74,13 +74,13 @@
 	name = "syndicate buckshot shell"
 	desc = "An illegal 12-gauge buckshot shell produced by the Syndicate."
 	icon_state = "sgshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_buckshot/syndie
+	projectile_type = /obj/projectile/bullet/pellet/shotgun_buckshot/syndie
 
 /obj/item/ammo_casing/shotgun/flechette
 	name = "flechette shell"
 	desc = "A 12-gauge flechette shell."
 	icon_state = "flshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_flechette
+	projectile_type = /obj/projectile/bullet/pellet/shotgun_flechette
 	pellets = 6
 	variance = 10
 
@@ -88,7 +88,7 @@
 	name = "buckshot shell..?"
 	desc = "This feels a little light for a buckshot shell."
 	icon_state = "gshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_clownshot
+	projectile_type = /obj/projectile/bullet/pellet/shotgun_clownshot
 	pellets = 20
 	variance = 35
 
@@ -96,7 +96,7 @@
 	name = "rubber shot"
 	desc = "A shotgun casing filled with densely-packed rubber balls, used to incapacitate crowds from a distance."
 	icon_state = "bshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_rubbershot
+	projectile_type = /obj/projectile/bullet/pellet/shotgun_rubbershot
 	pellets = 6
 	variance = 20
 	materials = list(/datum/material/iron=4000)
@@ -105,7 +105,7 @@
 	name = "improvised shell"
 	desc = "An extremely weak shotgun shell with multiple small pellets made out of metal shards."
 	icon_state = "improvshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_improvised
+	projectile_type = /obj/projectile/bullet/pellet/shotgun_improvised
 	materials = list(/datum/material/iron=250)
 	pellets = 10
 	variance = 20
@@ -115,7 +115,7 @@
 	desc = "An advanced shotgun shell which uses a subspace ansible crystal to produce an effect similar to a standard ion rifle. \
 	The unique properties of the crystal split the pulse into a spread of individually weaker bolts."
 	icon_state = "ionshell"
-	projectile_type = /obj/item/projectile/ion/weak
+	projectile_type = /obj/projectile/ion/weak
 	pellets = 4
 	variance = 30
 
@@ -123,7 +123,7 @@
 	name = "laser buckshot"
 	desc = "An advanced shotgun shell that uses  micro lasers to replicate the effects of a laser weapon in a ballistic package."
 	icon_state = "lshell"
-	projectile_type = /obj/item/projectile/beam/laser/buckshot
+	projectile_type = /obj/projectile/beam/laser/buckshot
 	pellets = 5
 	variance = 30
 
@@ -132,14 +132,14 @@
 	desc = "A relatively low-tech shell, utilizing the unique properties of Uranium, and possessing \
 	very impressive armor penetration capabilities."
 	icon_state = "dushell" 
-	projectile_type = /obj/item/projectile/bullet/shotgun/slug/uranium
+	projectile_type = /obj/projectile/bullet/shotgun/slug/uranium
 
 /obj/item/ammo_casing/shotgun/cryoshot
 	name = "cryoshot shell"
 	desc = "A state-of-the-art shell which uses the cooling power of Rhigoxane to snap freeze a target, without causing \
 	them much harm."
 	icon_state = "fshell" 
-	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_cryoshot
+	projectile_type = /obj/projectile/bullet/pellet/shotgun_cryoshot
 	pellets = 4
 	variance = 30
 
@@ -153,7 +153,7 @@
 	name = "shotgun dart"
 	desc = "A dart for use in shotguns. Can be injected with up to 30 units of any chemical."
 	icon_state = "cshell"
-	projectile_type = /obj/item/projectile/bullet/reusable/dart
+	projectile_type = /obj/projectile/bullet/reusable/dart
 	var/reagent_amount = 30
 	var/no_react = FALSE
 
@@ -167,7 +167,7 @@
 	name = "beanbag slug"
 	desc = "A weak beanbag slug for riot control."
 	icon_state = "bshell"
-	projectile_type = /obj/item/projectile/bullet/reusable/dart/hidden
+	projectile_type = /obj/projectile/bullet/reusable/dart/hidden
 
 /obj/item/ammo_casing/shotgun/dart/hidden/Initialize(mapload)
 	. = ..()
@@ -178,7 +178,7 @@
 		return
 	if(reagents.total_volume < 0)
 		return
-	var/obj/item/projectile/bullet/reusable/dart/D = BB
+	var/obj/projectile/bullet/reusable/dart/D = BB
 	var/obj/item/reagent_containers/syringe/dart/temp/new_dart = new(D)
 
 	new_dart.volume = reagents.total_volume
@@ -206,7 +206,7 @@
 	name = "breaching slug"
 	desc = "A 12-gauge anti-material slug. Great for breaching airlocks and windows with minimal shots. Only fits in tactical breaching shotguns."
 	icon_state = "breacher"
-	projectile_type = /obj/item/projectile/bullet/shotgun/slug/breaching
+	projectile_type = /obj/projectile/bullet/shotgun/slug/breaching
 	materials = list(/datum/material/iron=4000)
 	caliber = "breaching"
 
@@ -217,13 +217,13 @@
 	icon_state = "Thshell"
 	pellets = 3
 	variance = 25
-	projectile_type = /obj/item/projectile/bullet/pellet/shotgun_thundershot
+	projectile_type = /obj/projectile/bullet/pellet/shotgun_thundershot
 
 /obj/item/ammo_casing/shotgun/hardlight
 	name = "hardlight shell"
 	desc = "An advanced shotgun shell that fires a hardlight beam and scatters it."
 	icon_state = "hshell"
-	projectile_type = /obj/item/projectile/bullet/pellet/hardlight
+	projectile_type = /obj/projectile/bullet/pellet/hardlight
 	harmful = FALSE
 	pellets = 6
 	variance = 20

--- a/code/modules/projectiles/ammunition/ballistic/smg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/smg.dm
@@ -4,44 +4,44 @@
 	name = "4.6x30mm bullet casing"
 	desc = "A 4.6x30mm bullet casing."
 	caliber = "4.6x30mm"
-	projectile_type = /obj/item/projectile/bullet/c46x30mm
+	projectile_type = /obj/projectile/bullet/c46x30mm
 
 /obj/item/ammo_casing/c46x30mm/ap
 	name = "4.6x30mm armor-piercing bullet casing"
 	desc = "A 4.6x30mm armor-piercing bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c46x30mm/ap
+	projectile_type = /obj/projectile/bullet/c46x30mm/ap
 
 /obj/item/ammo_casing/c46x30mm/inc
 	name = "4.6x30mm incendiary bullet casing"
 	desc = "A 4.6x30mm incendiary bullet casing."
-	projectile_type = /obj/item/projectile/bullet/incendiary/c46x30mm
+	projectile_type = /obj/projectile/bullet/incendiary/c46x30mm
 
 /obj/item/ammo_casing/c46x30mm/rubber
 	name = "4.6x30mm rubber bullet casing"
 	desc = "A 4.6x30mm rubber bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c46x30mm/rubber
+	projectile_type = /obj/projectile/bullet/c46x30mm/rubber
 
 /obj/item/ammo_casing/c46x30mm/snakebite
 	name = "4.6x30mm snakebite bullet casing"
 	desc = "A 4.6x30mm snakebite bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c46x30mm/snakebite
+	projectile_type = /obj/projectile/bullet/c46x30mm/snakebite
 
 /obj/item/ammo_casing/c46x30mm/kraken
 	name = "4.6x30mm kraken bullet casing"
 	desc = "A 4.6x30mm kraken bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c46x30mm/kraken
+	projectile_type = /obj/projectile/bullet/c46x30mm/kraken
 
 /obj/item/ammo_casing/c46x30mm/airburst
 	name = "4.6x30mm airburst bullet casing"
 	desc = "A 4.6x30mm airburst bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c46x30mm/airburst
+	projectile_type = /obj/projectile/bullet/c46x30mm/airburst
 	
 /obj/item/ammo_casing/c46x30mm/airburst_pellet
 	name = "4.6x30mm airburst casing"
 	desc = "A 4.6x30mm airburst casing."
 	pellets = 5
 	variance = 30
-	projectile_type = /obj/item/projectile/bullet/c46x30mm/airburst_pellet
+	projectile_type = /obj/projectile/bullet/c46x30mm/airburst_pellet
 
 // .45 (M1911 + Surplus Carbine + C20r)
 
@@ -49,19 +49,19 @@
 	name = ".45 ACP bullet casing"
 	desc = "A .45 ACP bullet casing."
 	caliber = ".45"
-	projectile_type = /obj/item/projectile/bullet/c45
+	projectile_type = /obj/projectile/bullet/c45
 
 /obj/item/ammo_casing/c45/ap
 	name = ".45 armor-piercing bullet casing"
 	desc = "A .45 armor-piercing bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c45/ap
+	projectile_type = /obj/projectile/bullet/c45/ap
 
 /obj/item/ammo_casing/c45/hp
 	name = ".45 hollow-point bullet casing"
 	desc = "A .45 hollow-point bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c45/hp
+	projectile_type = /obj/projectile/bullet/c45/hp
 
 /obj/item/ammo_casing/c45/venom
 	name = ".45 venom bullet casing"
 	desc = "A .45 venom bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c45/venom
+	projectile_type = /obj/projectile/bullet/c45/venom

--- a/code/modules/projectiles/ammunition/ballistic/sniper.dm
+++ b/code/modules/projectiles/ammunition/ballistic/sniper.dm
@@ -4,17 +4,17 @@
 	name = ".50 BMG bullet casing"
 	desc = "A .50 BMG bullet casing."
 	caliber = ".50bmg"
-	projectile_type = /obj/item/projectile/bullet/p50
+	projectile_type = /obj/projectile/bullet/p50
 	icon_state = ".50"
 
 /obj/item/ammo_casing/p50/soporific
 	name = ".50 BMG soporific bullet casing"
 	desc = "A .50 BMG bullet casing, specialised in sending the target to sleep, instead of hell."
-	projectile_type = /obj/item/projectile/bullet/p50/soporific
+	projectile_type = /obj/projectile/bullet/p50/soporific
 	icon_state = "sleeper"
 	harmful = FALSE
 
 /obj/item/ammo_casing/p50/penetrator
 	name = ".50 BMG penetrator round bullet casing"
 	desc = "A .50 BMG penetrator bullet casing."
-	projectile_type = /obj/item/projectile/bullet/p50/penetrator
+	projectile_type = /obj/projectile/bullet/p50/penetrator

--- a/code/modules/projectiles/ammunition/caseless/misc.dm
+++ b/code/modules/projectiles/ammunition/caseless/misc.dm
@@ -3,23 +3,23 @@
 	desc = "You shouldn't be seeing this."
 	caliber = LASER
 	icon_state = "s-casing-live"
-	projectile_type = /obj/item/projectile/beam
+	projectile_type = /obj/projectile/beam
 	fire_sound = 'sound/weapons/laser.ogg'
 	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect/energy
 
 /obj/item/ammo_casing/caseless/laser/gatling
-	projectile_type = /obj/item/projectile/beam/weak
+	projectile_type = /obj/projectile/beam/weak
 	variance = 0.8
 	click_cooldown_override = 1
 
 /obj/item/ammo_casing/caseless/laser/lasgun
-	projectile_type = /obj/item/projectile/beam/laser/lasgun
+	projectile_type = /obj/projectile/beam/laser/lasgun
 
 /obj/item/ammo_casing/caseless/laser/longlas
-	projectile_type = /obj/item/projectile/beam/laser/lasgun/longlas
+	projectile_type = /obj/projectile/beam/laser/lasgun/longlas
 
 /obj/item/ammo_casing/caseless/laser/laspistol
-	projectile_type = /obj/item/projectile/beam/laser/lasgun/hotshot
+	projectile_type = /obj/projectile/beam/laser/lasgun/hotshot
 
 /obj/item/ammo_casing/caseless/laser/hotshot
-	projectile_type = /obj/item/projectile/beam/laser/lasgun/laspistol
+	projectile_type = /obj/projectile/beam/laser/lasgun/laspistol

--- a/code/modules/projectiles/ammunition/caseless/rocket.dm
+++ b/code/modules/projectiles/ammunition/caseless/rocket.dm
@@ -3,20 +3,20 @@
 	desc = "An 84mm High Explosive rocket. Fire at people and pray."
 	caliber = "84mm"
 	icon_state = "srm-8"
-	projectile_type = /obj/item/projectile/bullet/a84mm_he
+	projectile_type = /obj/projectile/bullet/a84mm_he
 
 /obj/item/ammo_casing/caseless/rocket/hedp
 	name = "\improper PM-9HEDP"
 	desc = "An 84mm High Explosive Dual Purpose rocket. Pointy end toward mechs."
 	caliber = "84mm"
 	icon_state = "84mm-hedp"
-	projectile_type = /obj/item/projectile/bullet/a84mm
+	projectile_type = /obj/projectile/bullet/a84mm
 
 /obj/item/ammo_casing/caseless/a75
 	desc = "A .75 bullet casing."
 	caliber = "75"
 	icon_state = "s-casing-live"
-	projectile_type = /obj/item/projectile/bullet/gyro
+	projectile_type = /obj/projectile/bullet/gyro
 
 
 /obj/item/ammo_casing/caseless/cannonball
@@ -25,7 +25,7 @@
 	caliber = "100mm"
 	icon = 'icons/obj/ammo.dmi'
 	icon_state = "cannonball"
-	projectile_type = /obj/item/projectile/bullet/cball
+	projectile_type = /obj/projectile/bullet/cball
 	w_class = WEIGHT_CLASS_NORMAL //cannonballs hefty
 
 /obj/item/ammo_casing/caseless/bolts
@@ -34,6 +34,6 @@
 	caliber = null
 	icon = 'icons/obj/ammo.dmi'
 	icon_state = "bolt"
-	projectile_type = /obj/item/projectile/bullet/bolt
+	projectile_type = /obj/projectile/bullet/bolt
 	firing_effect_type = /obj/effect/particle_effect/sparks/electricity
 	w_class = WEIGHT_CLASS_TINY

--- a/code/modules/projectiles/ammunition/energy/_energy.dm
+++ b/code/modules/projectiles/ammunition/energy/_energy.dm
@@ -2,7 +2,7 @@
 	name = "energy weapon lens"
 	desc = "The part of the gun that makes the laser go pew."
 	caliber = ENERGY
-	projectile_type = /obj/item/projectile/energy
+	projectile_type = /obj/projectile/energy
 	var/e_cost = 100 //The amount of energy a cell needs to expend to create this shot.
 	var/select_name = "energy"
 	fire_sound = 'sound/weapons/laser.ogg'

--- a/code/modules/projectiles/ammunition/energy/ebow.dm
+++ b/code/modules/projectiles/ammunition/energy/ebow.dm
@@ -1,8 +1,8 @@
 /obj/item/ammo_casing/energy/bolt
-	projectile_type = /obj/item/projectile/energy/bolt
+	projectile_type = /obj/projectile/energy/bolt
 	select_name = "bolt"
 	e_cost = 500
 	fire_sound = 'sound/weapons/genhit.ogg'
 
 /obj/item/ammo_casing/energy/bolt/halloween
-	projectile_type = /obj/item/projectile/energy/bolt/halloween
+	projectile_type = /obj/projectile/energy/bolt/halloween

--- a/code/modules/projectiles/ammunition/energy/gravity.dm
+++ b/code/modules/projectiles/ammunition/energy/gravity.dm
@@ -15,15 +15,15 @@
 	. = ..()
 
 /obj/item/ammo_casing/energy/gravity/repulse
-	projectile_type = /obj/item/projectile/gravityrepulse
+	projectile_type = /obj/projectile/gravityrepulse
 	select_name = "repulse"
 
 /obj/item/ammo_casing/energy/gravity/attract
-	projectile_type = /obj/item/projectile/gravityattract
+	projectile_type = /obj/projectile/gravityattract
 	select_name = "attract"
 
 /obj/item/ammo_casing/energy/gravity/chaos
-	projectile_type = /obj/item/projectile/gravitychaos
+	projectile_type = /obj/projectile/gravitychaos
 	select_name = "chaos"
 
 

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -1,73 +1,73 @@
 /obj/item/ammo_casing/energy/laser
-	projectile_type = /obj/item/projectile/beam/laser
+	projectile_type = /obj/projectile/beam/laser
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/laser/hellfire
-	projectile_type = /obj/item/projectile/beam/laser/hellfire
+	projectile_type = /obj/projectile/beam/laser/hellfire
 	e_cost = 130
 	select_name = "maim"
 
 /obj/item/ammo_casing/energy/lasergun
-	projectile_type = /obj/item/projectile/beam/laser
+	projectile_type = /obj/projectile/beam/laser
 	e_cost = 83
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/lasergun/old
-	projectile_type = /obj/item/projectile/beam/laser
+	projectile_type = /obj/projectile/beam/laser
 	e_cost = 200
 	select_name = "kill"
 
 /obj/item/ammo_casing/energy/laser/practice
-	projectile_type = /obj/item/projectile/beam/practice
+	projectile_type = /obj/projectile/beam/practice
 	select_name = "practice"
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/laser/scatter
-	projectile_type = /obj/item/projectile/beam/scatter
+	projectile_type = /obj/projectile/beam/scatter
 	pellets = 5
 	variance = 25
 	select_name = "scatter"
 
 /obj/item/ammo_casing/energy/laser/scatter/disabler
-	projectile_type = /obj/item/projectile/beam/disabler
+	projectile_type = /obj/projectile/beam/disabler
 	pellets = 3
 	variance = 15
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/laser/cyborg
-	projectile_type = /obj/item/projectile/beam/laser
+	projectile_type = /obj/projectile/beam/laser
 	select_name = "kill"
 	e_cost = 125
 
 /obj/item/ammo_casing/energy/laser/heavy
-	projectile_type = /obj/item/projectile/beam/laser/heavylaser
+	projectile_type = /obj/projectile/beam/laser/heavylaser
 	select_name = "anti-vehicle"
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 
 /obj/item/ammo_casing/energy/laser/pulse
-	projectile_type = /obj/item/projectile/beam/pulse
+	projectile_type = /obj/projectile/beam/pulse
 	e_cost = 200
 	select_name = "DESTROY"
 	fire_sound = 'sound/weapons/pulse.ogg'
 
 /obj/item/ammo_casing/energy/laser/bluetag
-	projectile_type = /obj/item/projectile/beam/lasertag/bluetag
+	projectile_type = /obj/projectile/beam/lasertag/bluetag
 	select_name = "bluetag"
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/laser/bluetag/hitscan
-	projectile_type = /obj/item/projectile/beam/lasertag/bluetag/hitscan
+	projectile_type = /obj/projectile/beam/lasertag/bluetag/hitscan
 
 /obj/item/ammo_casing/energy/laser/redtag
-	projectile_type = /obj/item/projectile/beam/lasertag/redtag
+	projectile_type = /obj/projectile/beam/lasertag/redtag
 	select_name = "redtag"
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/laser/redtag/hitscan
-	projectile_type = /obj/item/projectile/beam/lasertag/redtag/hitscan
+	projectile_type = /obj/projectile/beam/lasertag/redtag/hitscan
 
 /obj/item/ammo_casing/energy/xray
-	projectile_type = /obj/item/projectile/beam/xray
+	projectile_type = /obj/projectile/beam/xray
 	select_name = "irradiate"
 	e_cost = 100
 	fire_sound = 'sound/weapons/laser3.ogg'
@@ -76,16 +76,16 @@
 	e_cost = 70 //14 shots
 
 /obj/item/ammo_casing/energy/mindflayer
-	projectile_type = /obj/item/projectile/beam/anoxia/mindflayer
+	projectile_type = /obj/projectile/beam/anoxia/mindflayer
 	select_name = "MINDFUCK"
 	fire_sound = 'sound/weapons/laser.ogg'
 
 /obj/item/ammo_casing/energy/anoxia
-	projectile_type = /obj/item/projectile/beam/anoxia
+	projectile_type = /obj/projectile/beam/anoxia
 	select_name = "suffocate"
 	e_cost = 50
 	fire_sound = 'sound/weapons/laser.ogg'
 
 /obj/item/ammo_casing/energy/anoxia/bounce
-	projectile_type = /obj/item/projectile/beam/anoxia/bounce
+	projectile_type = /obj/projectile/beam/anoxia/bounce
 	e_cost = 62

--- a/code/modules/projectiles/ammunition/energy/lmg.dm
+++ b/code/modules/projectiles/ammunition/energy/lmg.dm
@@ -1,5 +1,5 @@
 /obj/item/ammo_casing/energy/c3dbullet
-	projectile_type = /obj/item/projectile/bullet/c3d
+	projectile_type = /obj/projectile/bullet/c3d
 	select_name = "spraydown"
 	fire_sound = 'sound/weapons/gunshot_smg.ogg'
 	e_cost = 20

--- a/code/modules/projectiles/ammunition/energy/plasma.dm
+++ b/code/modules/projectiles/ammunition/energy/plasma.dm
@@ -1,24 +1,24 @@
 /obj/item/ammo_casing/energy/plasma
-	projectile_type = /obj/item/projectile/plasma
+	projectile_type = /obj/projectile/plasma
 	select_name = "plasma burst"
 	fire_sound = 'sound/weapons/plasma_cutter.ogg'
 	delay = 15
 	e_cost = 25
 
 /obj/item/ammo_casing/energy/plasma/weak
-	projectile_type = /obj/item/projectile/plasma/weak
+	projectile_type = /obj/projectile/plasma/weak
 	select_name = "weak plasma burst"
 	fire_sound = 'sound/weapons/plasma_cutter.ogg'
 	e_cost = 65
 
 /obj/item/ammo_casing/energy/plasma/adv
-	projectile_type = /obj/item/projectile/plasma/adv
+	projectile_type = /obj/projectile/plasma/adv
 	delay = 10
 	e_cost = 10
 
 //cool alien plasma beams
 /obj/item/ammo_casing/energy/plasma/stalwart
-	projectile_type = /obj/item/projectile/plasma/scatter/adv/stalwart
+	projectile_type = /obj/projectile/plasma/scatter/adv/stalwart
 	fire_sound = 'sound/weapons/pulse.ogg'
 	delay = 5
 	e_cost = 50
@@ -26,26 +26,26 @@
 	variance = 22
 
 /obj/item/ammo_casing/energy/plasma/adv/mega
-	projectile_type = /obj/item/projectile/plasma/adv/mega
+	projectile_type = /obj/projectile/plasma/adv/mega
 
 /obj/item/ammo_casing/energy/plasma/scatter
-	projectile_type = /obj/item/projectile/plasma/scatter
+	projectile_type = /obj/projectile/plasma/scatter
 	delay = 15
 	e_cost = 35
 	pellets = 6
 	variance = 30
 
 /obj/item/ammo_casing/energy/plasma/scatter/adv
-	projectile_type = /obj/item/projectile/plasma/scatter/adv
+	projectile_type = /obj/projectile/plasma/scatter/adv
 
 /obj/item/ammo_casing/energy/plasma/scatter/adv/mega
-	projectile_type = /obj/item/projectile/plasma/scatter/adv/mega
+	projectile_type = /obj/projectile/plasma/scatter/adv/mega
 
 /obj/item/ammo_casing/energy/plasma/adv/cyborg
-	projectile_type = /obj/item/projectile/plasma/adv
+	projectile_type = /obj/projectile/plasma/adv
 	delay = 10
 	e_cost = 15 // Might need nerfing
 
 /obj/item/ammo_casing/energy/plasma/adv/cyborg/malf
-	projectile_type = /obj/item/projectile/plasma/adv/malf
+	projectile_type = /obj/projectile/plasma/adv/malf
 	e_cost = 50

--- a/code/modules/projectiles/ammunition/energy/portal.dm
+++ b/code/modules/projectiles/ammunition/energy/portal.dm
@@ -1,5 +1,5 @@
 /obj/item/ammo_casing/energy/wormhole
-	projectile_type = /obj/item/projectile/beam/wormhole
+	projectile_type = /obj/projectile/beam/wormhole
 	e_cost = 0
 	harmful = FALSE
 	fire_sound = 'sound/weapons/pulse3.ogg'
@@ -7,14 +7,14 @@
 	var/obj/item/gun/energy/wormhole_projector/gun
 
 /obj/item/ammo_casing/energy/wormhole/orange
-	projectile_type = /obj/item/projectile/beam/wormhole/orange
+	projectile_type = /obj/projectile/beam/wormhole/orange
 	select_name = "orange"
 
 /obj/item/ammo_casing/energy/wormhole/upgraded
-	projectile_type = /obj/item/projectile/beam/wormhole/upgraded
+	projectile_type = /obj/projectile/beam/wormhole/upgraded
 
 /obj/item/ammo_casing/energy/wormhole/orange/upgraded
-	projectile_type = /obj/item/projectile/beam/wormhole/orange/upgraded
+	projectile_type = /obj/projectile/beam/wormhole/orange/upgraded
 
 /obj/item/ammo_casing/energy/wormhole/Initialize(mapload, obj/item/gun/energy/wormhole_projector/wh)
 	. = ..()
@@ -22,6 +22,6 @@
 
 /obj/item/ammo_casing/energy/wormhole/throw_proj()
 	. = ..()
-	if(istype(BB, /obj/item/projectile/beam/wormhole))
-		var/obj/item/projectile/beam/wormhole/WH = BB
+	if(istype(BB, /obj/projectile/beam/wormhole))
+		var/obj/projectile/beam/wormhole/WH = BB
 		WH.gun = gun

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -1,54 +1,54 @@
 /obj/item/ammo_casing/energy/ion
-	projectile_type = /obj/item/projectile/ion
+	projectile_type = /obj/projectile/ion
 	select_name = "ion"
 	fire_sound = 'sound/weapons/ionrifle.ogg'
 
 /obj/item/ammo_casing/energy/ion/hos
-	projectile_type = /obj/item/projectile/ion/light
+	projectile_type = /obj/projectile/ion/light
 	e_cost = 200
 
 /obj/item/ammo_casing/energy/ion/weak
-	projectile_type = /obj/item/projectile/ion/weak
+	projectile_type = /obj/projectile/ion/weak
 
 /obj/item/ammo_casing/energy/declone
-	projectile_type = /obj/item/projectile/energy/declone
+	projectile_type = /obj/projectile/energy/declone
 	select_name = "declone"
 	fire_sound = 'sound/weapons/pulse3.ogg'
 
 /obj/item/ammo_casing/energy/declone/weak
-	projectile_type = /obj/item/projectile/energy/declone/weak
+	projectile_type = /obj/projectile/energy/declone/weak
 
 /obj/item/ammo_casing/energy/flora
 	fire_sound = 'sound/effects/stealthoff.ogg'
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/flora/yield
-	projectile_type = /obj/item/projectile/energy/florayield
+	projectile_type = /obj/projectile/energy/florayield
 	select_name = "yield"
 
 /obj/item/ammo_casing/energy/flora/mut
-	projectile_type = /obj/item/projectile/energy/floramut
+	projectile_type = /obj/projectile/energy/floramut
 	select_name = "mutation"
 
 /obj/item/ammo_casing/energy/temp
-	projectile_type = /obj/item/projectile/temp
+	projectile_type = /obj/projectile/temp
 	select_name = "freeze"
 	e_cost = 250
 	fire_sound = 'sound/weapons/pulse3.ogg'
 
 /obj/item/ammo_casing/energy/temp/bounce
-	projectile_type = /obj/item/projectile/temp/bounce
+	projectile_type = /obj/projectile/temp/bounce
 
 /obj/item/ammo_casing/energy/temp/hot
-	projectile_type = /obj/item/projectile/temp/hot
+	projectile_type = /obj/projectile/temp/hot
 	select_name = "bake"
 
 /obj/item/ammo_casing/energy/meteor
-	projectile_type = /obj/item/projectile/meteor
+	projectile_type = /obj/projectile/meteor
 	select_name = "goddamn meteor"
 
 /obj/item/ammo_casing/energy/net
-	projectile_type = /obj/item/projectile/energy/net
+	projectile_type = /obj/projectile/energy/net
 	select_name = "netting"
 	pellets = 6
 	variance = 26
@@ -61,33 +61,33 @@
 		DR.modify_projectile(BB)
 
 /obj/item/ammo_casing/energy/trap
-	projectile_type = /obj/item/projectile/energy/trap
+	projectile_type = /obj/projectile/energy/trap
 	select_name = "snare"
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/instakill
-	projectile_type = /obj/item/projectile/beam/instakill
+	projectile_type = /obj/projectile/beam/instakill
 	e_cost = 0
 	select_name = "DESTROY"
 
 /obj/item/ammo_casing/energy/instakill/blue
-	projectile_type = /obj/item/projectile/beam/instakill/blue
+	projectile_type = /obj/projectile/beam/instakill/blue
 
 /obj/item/ammo_casing/energy/instakill/red
-	projectile_type = /obj/item/projectile/beam/instakill/red
+	projectile_type = /obj/projectile/beam/instakill/red
 
 /obj/item/ammo_casing/energy/tesla_revolver
 	fire_sound = 'sound/magic/lightningbolt.ogg'
 	e_cost = 200
 	select_name = "stun"
-	projectile_type = /obj/item/projectile/energy/tesla/revolver
+	projectile_type = /obj/projectile/energy/tesla/revolver
 
 /obj/item/ammo_casing/energy/grimdark
-	projectile_type = /obj/item/projectile/beam/grimdark
+	projectile_type = /obj/projectile/beam/grimdark
 	select_name = "plasma round"
 	fire_sound = 'sound/weapons/plasma.ogg'
 	e_cost = 800
 
 /obj/item/ammo_casing/energy/grimdark/pistol
-	projectile_type = /obj/item/projectile/beam/grimdark/pistol
+	projectile_type = /obj/projectile/beam/grimdark/pistol
 	e_cost = 500

--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -1,5 +1,5 @@
 /obj/item/ammo_casing/energy/electrode
-	projectile_type = /obj/item/projectile/energy/electrode
+	projectile_type = /obj/projectile/energy/electrode
 	select_name = "stun"
 	fire_sound = 'sound/weapons/taser.ogg'
 	e_cost = 200
@@ -16,14 +16,14 @@
 	e_cost = 1000
 
 /obj/item/ammo_casing/energy/disabler
-	projectile_type = /obj/item/projectile/beam/disabler
+	projectile_type = /obj/projectile/beam/disabler
 	select_name  = "disable"
 	e_cost = 50
 	fire_sound = 'sound/weapons/taser2.ogg'
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/disabler/bounce
-	projectile_type = /obj/item/projectile/beam/disabler/bounce
+	projectile_type = /obj/projectile/beam/disabler/bounce
 	e_cost = 62
 
 /obj/item/ammo_casing/energy/disabler/cyborg

--- a/code/modules/projectiles/ammunition/reusable/_reusable.dm
+++ b/code/modules/projectiles/ammunition/reusable/_reusable.dm
@@ -1,6 +1,6 @@
 // For casing that are dropped when the projectile has hit, usually for casing that are the projectiles like foam darts or arrows.
 // They don't get deleted when fire and instead are moved to the projectile until it lands, where it is then dropped.
-// Intended to be used with '/obj/item/projectile/bullet/reusable'.
+// Intended to be used with '/obj/projectile/bullet/reusable'.
 /obj/item/ammo_casing/reusable
 	desc = "A reusable bullet casing."
 	firing_effect_type = null
@@ -15,13 +15,13 @@
 	..()
 	if(!BB)
 		newshot() // Just in case it wasn't replaced. Should be replaced when the projectile landed in case a subtype wants to change it, this is just a failsafe.
-	var/obj/item/projectile/bullet/reusable/reusable_projectile = BB
+	var/obj/projectile/bullet/reusable/reusable_projectile = BB
 	if(istype(reusable_projectile))
 		reusable_projectile.ammo_type = src
 	forceMove(BB)
 	in_air = TRUE
 
-/obj/item/ammo_casing/reusable/proc/on_land(obj/item/projectile/old_projectile)
+/obj/item/ammo_casing/reusable/proc/on_land(obj/projectile/old_projectile)
 	if(istype(old_projectile))
 		pixel_x = old_projectile.pixel_x
 		pixel_y = old_projectile.pixel_y

--- a/code/modules/projectiles/ammunition/reusable/arrow.dm
+++ b/code/modules/projectiles/ammunition/reusable/arrow.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_casing/reusable/arrow
 	name = "arrow"
 	desc = "An arrow, typically fired from a bow."
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow
+	projectile_type = /obj/projectile/bullet/reusable/arrow
 	caliber = "arrow"
 	icon_state = "arrow"
 	item_state = "arrow"
@@ -79,7 +79,7 @@
 	return ..()
 
 /obj/item/ammo_casing/reusable/arrow/wirecutter_act(mob/living/user, obj/item/I)
-	var/obj/item/projectile/bullet/reusable/arrow/arrow = BB
+	var/obj/projectile/bullet/reusable/arrow/arrow = BB
 	if(!istype(arrow))
 		return
 	if(!LAZYLEN(attached_parts))
@@ -162,7 +162,7 @@
 /obj/item/ammo_casing/reusable/arrow/wood
 	name = "wooden arrow"
 	desc = "A wooden arrow, quickly made."
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/wood
+	projectile_type = /obj/projectile/bullet/reusable/arrow/wood
 
 /obj/item/ammo_casing/reusable/arrow/ash
 	name = "ashen arrow"
@@ -172,7 +172,7 @@
 	force = 7
 	throwforce = 7
 	embedding = list("embed_chance" = 15, "embedded_fall_chance" = 0)
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/ash
+	projectile_type = /obj/projectile/bullet/reusable/arrow/ash
 
 /obj/item/ammo_casing/reusable/arrow/bone_tipped
 	name = "bone-tipped arrow"
@@ -181,7 +181,7 @@
 	item_state = "bonetippedarrow"
 	force = 9
 	throwforce = 9
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/bone_tipped
+	projectile_type = /obj/projectile/bullet/reusable/arrow/bone_tipped
 
 /obj/item/ammo_casing/reusable/arrow/bone
 	name = "bone arrow"
@@ -191,7 +191,7 @@
 	force = 4
 	throwforce = 4
 	embedding = list("embed_chance" = 20, "embedded_fall_chance" = 0)
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/bone
+	projectile_type = /obj/projectile/bullet/reusable/arrow/bone
 
 /obj/item/ammo_casing/reusable/arrow/chitin
 	name = "chitin-tipped arrow"
@@ -199,7 +199,7 @@
 	icon_state = "chitinarrow"
 	item_state = "chitinarrow"
 	armour_penetration = 25 //Ah yes the 25 AP on a 5 force hit
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/chitin
+	projectile_type = /obj/projectile/bullet/reusable/arrow/chitin
 
 /obj/item/ammo_casing/reusable/arrow/bamboo
 	name = "bamboo arrow"
@@ -211,7 +211,7 @@
 	armour_penetration = -10
 	embedding = list("embed_chance" = 35, "embedded_fall_chance" = 0)
 	variance = 10
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/bamboo
+	projectile_type = /obj/projectile/bullet/reusable/arrow/bamboo
 
 /obj/item/ammo_casing/reusable/arrow/bronze
 	name = "bronze arrow"
@@ -219,7 +219,7 @@
 	icon_state = "bronzearrow"
 	item_state = "bronzearrow"
 	armour_penetration = 10 
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/bronze
+	projectile_type = /obj/projectile/bullet/reusable/arrow/bronze
 
 /obj/item/ammo_casing/reusable/arrow/glass
 	name = "glass arrow"
@@ -230,7 +230,7 @@
 	throwforce = 4
 	embedding = list("embed_chance" = 15, "embedded_fall_chance" = 0)
 	variance = 5
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/glass
+	projectile_type = /obj/projectile/bullet/reusable/arrow/glass
 
 /obj/item/ammo_casing/reusable/arrow/glass/plasma
 	name = "plasmaglass arrow"
@@ -240,14 +240,14 @@
 	armour_penetration = 40 //Ah yes the 40 AP on a 4 force hit
 	embedding = list("embed_chance" = 25, "embedded_fall_chance" = 0)
 	variance = 5
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/glass/plasma
+	projectile_type = /obj/projectile/bullet/reusable/arrow/glass/plasma
 
 /obj/item/ammo_casing/reusable/arrow/magic
 	name = "magic arrow"
 	desc = "An arrow made of magic that can track targets, though it can't track those under the effects of anti-magic. Can make a good throwing weapon in a pinch!"
 	icon_state = "arrow_magic"
 	item_state = "arrow_magic"
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/magic
+	projectile_type = /obj/projectile/bullet/reusable/arrow/magic
 	force = 12
 	throwforce = 20
 	embedding = list("embed_chance" = 50, "embedded_fall_chance" = 0)
@@ -267,7 +267,7 @@
 	if(dulled)
 		BB.damage = 20
 		BB.armour_penetration = -25
-		var/obj/item/projectile/bullet/reusable/arrow/arrow = BB
+		var/obj/projectile/bullet/reusable/arrow/arrow = BB
 		if(!istype(arrow))
 			arrow.embed_chance = 0
 	else
@@ -276,7 +276,7 @@
 		if(istype(M) && M.anti_magic_check(chargecost = 0))
 			BB.homing_away = TRUE // And there it goes!
 
-/obj/item/ammo_casing/reusable/arrow/magic/on_land(obj/item/projectile/old_projectile)
+/obj/item/ammo_casing/reusable/arrow/magic/on_land(obj/projectile/old_projectile)
 	dulled = TRUE
 	force = 3
 	throwforce = 0
@@ -289,7 +289,7 @@
 /obj/item/ammo_casing/reusable/arrow/toy
 	name = "toy arrow"
 	desc = "A plastic arrow with a blunt tip covered in velcro to allow it to stick to whoever it hits."
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/toy
+	projectile_type = /obj/projectile/bullet/reusable/arrow/toy
 	force = 0
 	throwforce = 0
 	sharpness = SHARP_NONE
@@ -301,42 +301,42 @@
 	desc = "A deceiving arrow that looks to be lethal, but is a velcro-tipped toy. For use with toy bows."
 	icon_state = "arrow_energy"
 	item_state = "arrow_toy_energy"
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/toy/energy
+	projectile_type = /obj/projectile/bullet/reusable/arrow/toy/energy
 
 /obj/item/ammo_casing/reusable/arrow/toy/disabler
 	name = "toy disabler bolt"
 	desc = "A toy arrow that looks like a disabler bolt fabricated from a hardlight bow. Tipped with velcro to allow it to stick to targets."
 	icon_state = "arrow_disable"
 	item_state = "arrow_toy_disable"
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/toy/disabler
+	projectile_type = /obj/projectile/bullet/reusable/arrow/toy/disabler
 
 /obj/item/ammo_casing/reusable/arrow/toy/pulse
 	name = "toy pulse bolt"
 	desc = "A plastic, fake arrow that looks like a pulse bolt. A velcro head lets it stick to targets."
 	icon_state = "arrow_pulse"
 	item_state = "arrow_toy_pulse"
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/toy/pulse
+	projectile_type = /obj/projectile/bullet/reusable/arrow/toy/pulse
 
 /obj/item/ammo_casing/reusable/arrow/toy/xray
 	name = "toy X-ray bolt"
 	desc = "A plastic arrow with a blunt tip covered in velcro to allow it to stick to whoever it hits. This one is made to resemble a X-ray bolt from a hardlight bow."
 	icon_state = "arrow_xray"
 	item_state = "arrow_toy_xray"
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/toy/xray
+	projectile_type = /obj/projectile/bullet/reusable/arrow/toy/xray
 
 /obj/item/ammo_casing/reusable/arrow/toy/shock
 	name = "toy shock bolt"
 	desc = "A plastic arrow with a blunt tip covered in velcro to allow it to stick to whoever it hits. This one is made to resemble a shock bolt from a hardlight bow."
 	icon_state = "arrow_shock"
 	item_state = "arrow_toy_shock"
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/toy/shock
+	projectile_type = /obj/projectile/bullet/reusable/arrow/toy/shock
 
 /obj/item/ammo_casing/reusable/arrow/toy/magic
 	name = "toy magic arrow"
 	desc = "A plastic arrow with a blunt tip covered in velcro to allow it to stick to whoever it hits. This one is made to resemble a magic arrow used by wizards."
 	icon_state = "arrow_magic"
 	item_state = "arrow_magic"
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/toy/magic
+	projectile_type = /obj/projectile/bullet/reusable/arrow/toy/magic
 
 
 // Utility //
@@ -362,7 +362,7 @@
 	desc = "An arrow made of a hypernoblium-tipped rod, a shard of supermatter, and poor decision making."
 	icon_state = "supermatterarrow"
 	item_state = "supermatterarrow"
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/supermatter
+	projectile_type = /obj/projectile/bullet/reusable/arrow/supermatter
 
 /obj/item/ammo_casing/reusable/arrow/supermatter/proc/disintigrate(atom/dusting)
 	if(isliving(dusting))
@@ -414,7 +414,7 @@
 	throwforce = 4
 	embedding = list("embed_chance" = 15, "embedded_fall_chance" = 0)
 	variance = 5
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/singulo
+	projectile_type = /obj/projectile/bullet/reusable/arrow/singulo
 	/// The shard currently in the arrow
 	var/obj/item/singularity_shard/shard
 
@@ -508,7 +508,7 @@
 	icon_state = "arrow_energy"
 	item_flags = DROPDEL
 	embedding = list("embedded_pain_chance" = 0, "embedded_pain_multiplier" = 0, "embedded_unsafe_removal_pain_multiplier" = 0, "embedded_fall_chance" = 0, "embedded_bleed_rate" = 0)
-	projectile_type = /obj/item/projectile/energy/arrow
+	projectile_type = /obj/projectile/energy/arrow
 
 	// Embed tick damage vars //
 	/// How many embed ticks have passed
@@ -544,7 +544,7 @@
 	name = "disabler bolt"
 	desc = "An arrow made from hardlight. This one stuns the victim in a non-lethal way."
 	icon_state = "arrow_disable"
-	projectile_type = /obj/item/projectile/energy/arrow/disabler
+	projectile_type = /obj/projectile/energy/arrow/disabler
 	harmful = FALSE
 	tick_damage_type = STAMINA
 	
@@ -552,14 +552,14 @@
 	name = "pulse bolt"
 	desc = "An arrow made from hardlight. This one eliminates any obstructions it hits."
 	icon_state = "arrow_pulse"
-	projectile_type = /obj/item/projectile/energy/arrow/pulse
+	projectile_type = /obj/projectile/energy/arrow/pulse
 	tick_damage = 5
 
 /obj/item/ammo_casing/reusable/arrow/energy/xray
 	name = "X-ray bolt"
 	desc = "An arrow made from hardlight. This one can pass through obstructions."
 	icon_state = "arrow_xray"
-	projectile_type = /obj/item/projectile/energy/arrow/xray
+	projectile_type = /obj/projectile/energy/arrow/xray
 	tick_damage_type = TOX
 
 /obj/item/ammo_casing/reusable/arrow/energy/xray/embed_tick(target, mob/living/carbon/human/embedde, obj/item/bodypart/part)
@@ -570,11 +570,11 @@
 	name = "shock bolt"
 	desc = "An arrow made from hardlight. This one shocks the victim with harmless energy capable of stunning them."
 	icon_state = "arrow_shock"
-	projectile_type = /obj/item/projectile/energy/arrow/shock
+	projectile_type = /obj/projectile/energy/arrow/shock
 	harmful = FALSE
 	tick_damage_type = STAMINA
 
 /obj/item/ammo_casing/reusable/arrow/energy/clockbolt
 	name = "redlight bolt"
 	desc = "An arrow made from a strange energy."
-	projectile_type = /obj/item/projectile/energy/arrow/clockbolt
+	projectile_type = /obj/projectile/energy/arrow/clockbolt

--- a/code/modules/projectiles/ammunition/reusable/foam.dm
+++ b/code/modules/projectiles/ammunition/reusable/foam.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_casing/reusable/foam_dart
 	name = "foam dart"
 	desc = "It's nerf or nothing! Ages 8 and up."
-	projectile_type = /obj/item/projectile/bullet/reusable/foam_dart
+	projectile_type = /obj/projectile/bullet/reusable/foam_dart
 	caliber = "foam_force"
 	icon = 'icons/obj/guns/toy.dmi'
 	icon_state = "foamdart"
@@ -61,6 +61,6 @@
 /obj/item/ammo_casing/reusable/foam_dart/riot
 	name = "riot foam dart"
 	desc = "Whose smart idea was it to use toys as crowd control? Ages 18 and up."
-	projectile_type = /obj/item/projectile/bullet/reusable/foam_dart/riot
+	projectile_type = /obj/projectile/bullet/reusable/foam_dart/riot
 	icon_state = "foamdart_riot"
 	materials = list(/datum/material/iron = 1125)

--- a/code/modules/projectiles/ammunition/special/magic.dm
+++ b/code/modules/projectiles/ammunition/special/magic.dm
@@ -1,116 +1,116 @@
 /obj/item/ammo_casing/magic
 	name = "magic casing"
 	desc = "I didn't even know magic needed ammo..."
-	projectile_type = /obj/item/projectile/magic
+	projectile_type = /obj/projectile/magic
 	firing_effect_type = /obj/effect/temp_visual/dir_setting/firing_effect/magic
 	casing_flags = CASINGFLAG_NOT_HEAVY_METAL
 
 /obj/item/ammo_casing/magic/change
-	projectile_type = /obj/item/projectile/magic/change
+	projectile_type = /obj/projectile/magic/change
 
 /obj/item/ammo_casing/magic/cheese
-	projectile_type = /obj/item/projectile/magic/cheese
+	projectile_type = /obj/projectile/magic/cheese
 
 /obj/item/ammo_casing/magic/animate
-	projectile_type = /obj/item/projectile/magic/animate
+	projectile_type = /obj/projectile/magic/animate
 
 /obj/item/ammo_casing/magic/heal
-	projectile_type = /obj/item/projectile/magic/resurrection
+	projectile_type = /obj/projectile/magic/resurrection
 	harmful = FALSE
 
 /obj/item/ammo_casing/magic/death
-	projectile_type = /obj/item/projectile/magic/death
+	projectile_type = /obj/projectile/magic/death
 
 /obj/item/ammo_casing/magic/teleport
-	projectile_type = /obj/item/projectile/magic/teleport
+	projectile_type = /obj/projectile/magic/teleport
 	harmful = FALSE
 
 /obj/item/ammo_casing/magic/safety
-	projectile_type = /obj/item/projectile/magic/safety
+	projectile_type = /obj/projectile/magic/safety
 	harmful = FALSE
 
 /obj/item/ammo_casing/magic/door
-	projectile_type = /obj/item/projectile/magic/door
+	projectile_type = /obj/projectile/magic/door
 	harmful = FALSE
 
 /obj/item/ammo_casing/magic/fireball
-	projectile_type = /obj/item/projectile/magic/fireball
+	projectile_type = /obj/projectile/magic/fireball
 
 /obj/item/ammo_casing/magic/chaos
-	projectile_type = /obj/item/projectile/magic
+	projectile_type = /obj/projectile/magic
 
 /obj/item/ammo_casing/magic/spellblade
-	projectile_type = /obj/item/projectile/magic/spellblade
+	projectile_type = /obj/projectile/magic/spellblade
 
 /obj/item/ammo_casing/magic/spellblade/weak
-	projectile_type = /obj/item/projectile/magic/spellblade/weak
+	projectile_type = /obj/projectile/magic/spellblade/weak
 	
 /obj/item/ammo_casing/magic/spellblade/beesword
-	projectile_type = /obj/item/projectile/magic/spellblade/beesword
+	projectile_type = /obj/projectile/magic/spellblade/beesword
 
 /obj/item/ammo_casing/magic/arcane_barrage
-	projectile_type = /obj/item/projectile/magic/arcane_barrage
+	projectile_type = /obj/projectile/magic/arcane_barrage
 
 /obj/item/ammo_casing/magic/honk
-	projectile_type = /obj/item/projectile/bullet/honker
+	projectile_type = /obj/projectile/bullet/honker
 
 /obj/item/ammo_casing/magic/locker
-	projectile_type = /obj/item/projectile/magic/locker
+	projectile_type = /obj/projectile/magic/locker
 
 /obj/item/ammo_casing/magic/flying
-	projectile_type = /obj/item/projectile/magic/flying
+	projectile_type = /obj/projectile/magic/flying
 
 /obj/item/ammo_casing/magic/bounty
-	projectile_type = /obj/item/projectile/magic/bounty
+	projectile_type = /obj/projectile/magic/bounty
 
 /obj/item/ammo_casing/magic/antimagic
-	projectile_type = /obj/item/projectile/magic/antimagic
+	projectile_type = /obj/projectile/magic/antimagic
 
 /obj/item/ammo_casing/magic/sapping
-	projectile_type = /obj/item/projectile/magic/sapping
+	projectile_type = /obj/projectile/magic/sapping
 
 /obj/item/ammo_casing/magic/necropotence
-	projectile_type = /obj/item/projectile/magic/necropotence
+	projectile_type = /obj/projectile/magic/necropotence
 
 /obj/item/ammo_casing/magic/wipe
-	projectile_type = /obj/item/projectile/magic/wipe
+	projectile_type = /obj/projectile/magic/wipe
 
 /obj/item/ammo_casing/magic/runic_icycle
-	projectile_type = /obj/item/projectile/temp/runic_icycle
+	projectile_type = /obj/projectile/temp/runic_icycle
 
 /obj/item/ammo_casing/magic/runic_tentacle
-	projectile_type = /obj/item/projectile/magic/runic_tentacle
+	projectile_type = /obj/projectile/magic/runic_tentacle
 
 /obj/item/ammo_casing/magic/runic_heal
-	projectile_type = /obj/item/projectile/magic/runic_heal
+	projectile_type = /obj/projectile/magic/runic_heal
 	harmful = FALSE
 
 /obj/item/ammo_casing/magic/runic_fire
-	projectile_type = /obj/item/projectile/magic/runic_fire
+	projectile_type = /obj/projectile/magic/runic_fire
 
 /obj/item/ammo_casing/magic/runic_honk
-	projectile_type = /obj/item/projectile/magic/runic_honk
+	projectile_type = /obj/projectile/magic/runic_honk
 	harmful = FALSE
 
 /obj/item/ammo_casing/magic/runic_chaos
-	projectile_type = /obj/item/projectile/magic
+	projectile_type = /obj/projectile/magic
 
 /obj/item/ammo_casing/magic/runic_bomb
-	projectile_type = /obj/item/projectile/magic/runic_bomb
+	projectile_type = /obj/projectile/magic/runic_bomb
 
 /obj/item/ammo_casing/magic/runic_toxin
-	projectile_type = /obj/item/projectile/magic/runic_toxin
+	projectile_type = /obj/projectile/magic/runic_toxin
 
 /obj/item/ammo_casing/magic/runic_death
-	projectile_type = /obj/item/projectile/magic/runic_death
+	projectile_type = /obj/projectile/magic/runic_death
 
 /obj/item/ammo_casing/magic/runic_bullet
-	projectile_type = /obj/item/projectile/magic/shotgun/slug //is bullet but actually no
+	projectile_type = /obj/projectile/magic/shotgun/slug //is bullet but actually no
 	pellets = 3
 	variance = 35
 
 /obj/item/ammo_casing/magic/runic_mutation
-	projectile_type = /obj/item/projectile/magic/runic_mutation
+	projectile_type = /obj/projectile/magic/runic_mutation
 
 /obj/item/ammo_casing/magic/runic_resizement
-	projectile_type = /obj/item/projectile/magic/runic_resizement
+	projectile_type = /obj/projectile/magic/runic_resizement

--- a/code/modules/projectiles/ammunition/special/syringe.dm
+++ b/code/modules/projectiles/ammunition/special/syringe.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_casing/syringegun
 	name = "syringe gun spring"
 	desc = "A high-power spring that throws syringes."
-	projectile_type = /obj/item/projectile/bullet/reusable/dart/syringe
+	projectile_type = /obj/projectile/bullet/reusable/dart/syringe
 	firing_effect_type = null
 
 /obj/item/ammo_casing/syringegun/ready_proj(atom/target, mob/living/user, quiet, zone_override = "")
@@ -9,7 +9,7 @@
 		return
 	if(istype(loc, /obj/item/gun/syringe))
 		var/obj/item/gun/syringe/SG = loc
-		var/obj/item/projectile/bullet/reusable/dart/D = BB
+		var/obj/projectile/bullet/reusable/dart/D = BB
 		if(!SG.syringes.len)
 			return
 
@@ -23,7 +23,7 @@
 /obj/item/ammo_casing/chemgun
 	name = "dart synthesiser"
 	desc = "A high-power spring, linked to an energy-based dart synthesiser."
-	projectile_type = /obj/item/projectile/bullet/reusable/dart
+	projectile_type = /obj/projectile/bullet/reusable/dart
 	firing_effect_type = null
 
 /obj/item/ammo_casing/chemgun/ready_proj(atom/target, mob/living/user, quiet, zone_override = "")
@@ -33,7 +33,7 @@
 		var/obj/item/gun/chem/CG = loc
 		if(CG.syringes_left <= 0)
 			return
-		var/obj/item/projectile/bullet/reusable/dart/D = BB
+		var/obj/projectile/bullet/reusable/dart/D = BB
 		var/obj/item/reagent_containers/syringe/dart/temp/new_dart = new(D)
 
 		CG.reagents.trans_to(new_dart, 15, transfered_by = user)
@@ -44,7 +44,7 @@
 /obj/item/ammo_casing/dnainjector
 	name = "rigged syringe gun spring"
 	desc = "A high-power spring that throws DNA injectors."
-	projectile_type = /obj/item/projectile/bullet/dnainjector
+	projectile_type = /obj/projectile/bullet/dnainjector
 	firing_effect_type = null
 
 /obj/item/ammo_casing/dnainjector/ready_proj(atom/target, mob/living/user, quiet, zone_override = "")
@@ -56,7 +56,7 @@
 			return
 
 		var/obj/item/dnainjector/S = popleft(SG.syringes)
-		var/obj/item/projectile/bullet/dnainjector/D = BB
+		var/obj/projectile/bullet/dnainjector/D = BB
 		S.forceMove(D)
 		D.injector = S
 	..()
@@ -64,7 +64,7 @@
 /obj/item/ammo_casing/blowgun
 	name = "blow gun spring"
 	desc = "A low-power spring that throws syringes a short distance." // how does a blowgun have a spring
-	projectile_type = /obj/item/projectile/bullet/reusable/dart/syringe/blowgun
+	projectile_type = /obj/projectile/bullet/reusable/dart/syringe/blowgun
 	firing_effect_type = null
 
 /obj/item/ammo_casing/blowgun/ready_proj(atom/target, mob/living/user, quiet, zone_override = "")
@@ -72,7 +72,7 @@
 		return
 	if(istype(loc, /obj/item/gun/syringe/blowgun))
 		var/obj/item/gun/syringe/BG = loc
-		var/obj/item/projectile/bullet/reusable/dart/D = BB
+		var/obj/projectile/bullet/reusable/dart/D = BB
 		if(!BG.syringes.len)
 			return
 

--- a/code/modules/projectiles/attachments/laser_sight.dm
+++ b/code/modules/projectiles/attachments/laser_sight.dm
@@ -8,7 +8,7 @@
 	var/aiming_time_left = 12
 	var/laser_color = rgb(255,0,0)
 	var/listeningTo = null
-	var/obj/item/projectile/beam/beam_rifle/hitscan/aiming_beam/last_beam
+	var/obj/projectile/beam/beam_rifle/hitscan/aiming_beam/last_beam
 	actions_list = list(/datum/action/item_action/toggle_laser_sight, /datum/action/item_action/change_laser_sight_color)
 
 /obj/item/attachment/laser_sight/examine(mob/user)
@@ -67,7 +67,7 @@
 	if(diff < 0.1 && !force_update)
 		return
 	aiming_lastangle = lastangle
-	var/obj/item/projectile/beam/beam_rifle/hitscan/aiming_beam/P = new
+	var/obj/projectile/beam/beam_rifle/hitscan/aiming_beam/P = new
 	P.gun = attached_gun
 	P.color = laser_color
 	var/turf/curloc = get_turf(src)

--- a/code/modules/projectiles/boxes_magazines/external/rechargable.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rechargable.dm
@@ -123,7 +123,7 @@
 /obj/projectile/bullet/c22hl //.22 HL
 	name = "hardlight beam"
 	icon_state = "disabler_bullet"
-	flag = ENERGY
+	armor_flag = ENERGY
 	damage = 0 // maybe don't do actual damage so pacifists can use it and silicons won't be mad
 	damage_type = BURN
 	stamina = 25
@@ -156,7 +156,7 @@
 /obj/projectile/bullet/c22ls //.22 LS
 	name = "laser beam"
 	icon_state = "disabler_bullet"
-	flag = LASER
+	armor_flag = LASER
 	damage = 18
 	damage_type = BURN
 	color = "#ff0000"

--- a/code/modules/projectiles/boxes_magazines/external/rechargable.dm
+++ b/code/modules/projectiles/boxes_magazines/external/rechargable.dm
@@ -118,9 +118,9 @@
 /obj/item/ammo_casing/caseless/c22hl
 	caliber = ENERGY
 	harmful = FALSE
-	projectile_type = /obj/item/projectile/bullet/c22hl
+	projectile_type = /obj/projectile/bullet/c22hl
 
-/obj/item/projectile/bullet/c22hl //.22 HL
+/obj/projectile/bullet/c22hl //.22 HL
 	name = "hardlight beam"
 	icon_state = "disabler_bullet"
 	flag = ENERGY
@@ -151,9 +151,9 @@
 /obj/item/ammo_casing/caseless/c22ls
 	caliber = LASER
 	harmful = TRUE
-	projectile_type = /obj/item/projectile/bullet/c22ls
+	projectile_type = /obj/projectile/bullet/c22ls
 
-/obj/item/projectile/bullet/c22ls //.22 LS
+/obj/projectile/bullet/c22ls //.22 LS
 	name = "laser beam"
 	icon_state = "disabler_bullet"
 	flag = LASER

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -235,7 +235,7 @@
 		. = ""
 	else
 		var/obj/item/ammo_casing/energy/E = ammo_type[select]
-		var/obj/item/projectile/energy/BB = E.BB
+		var/obj/projectile/energy/BB = E.BB
 		if(!BB)
 			. = ""
 		else if(BB.nodamage || !BB.damage || BB.damage_type == STAMINA)

--- a/code/modules/projectiles/guns/energy/dueling.dm
+++ b/code/modules/projectiles/guns/energy/dueling.dm
@@ -243,12 +243,12 @@
 
 /obj/item/ammo_casing/energy/duel
 	e_cost = 0
-	projectile_type = /obj/item/projectile/energy/duel
+	projectile_type = /obj/projectile/energy/duel
 	var/setting
 
 /obj/item/ammo_casing/energy/duel/ready_proj(atom/target, mob/living/user, quiet, zone_override)
 	. = ..()
-	var/obj/item/projectile/energy/duel/D = BB
+	var/obj/projectile/energy/duel/D = BB
 	D.setting = setting
 	D.update_appearance(UPDATE_ICON)
 
@@ -260,14 +260,14 @@
 
 //Projectile
 
-/obj/item/projectile/energy/duel
+/obj/projectile/energy/duel
 	name = "dueling beam"
 	icon_state = "declone"
 	reflectable = FALSE
 	homing = TRUE
 	var/setting
 
-/obj/item/projectile/energy/duel/update_icon(updates=ALL)
+/obj/projectile/energy/duel/update_icon(updates=ALL)
 	. = ..()
 	switch(setting)
 		if(DUEL_SETTING_A)
@@ -277,7 +277,7 @@
 		if(DUEL_SETTING_C)
 			color = "blue"
 
-/obj/item/projectile/energy/duel/on_hit(atom/target, blocked)
+/obj/projectile/energy/duel/on_hit(atom/target, blocked)
 	. = ..()
 	var/turf/T = get_turf(target)
 	var/obj/effect/temp_visual/dueling_chaff/C = locate() in T

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -113,7 +113,7 @@
 		teletarget = T
 		user.show_message(span_notice("Locked In."), MSG_AUDIBLE)
 
-/obj/item/gun/energy/e_gun/dragnet/proc/modify_projectile(obj/item/projectile/energy/net/N)
+/obj/item/gun/energy/e_gun/dragnet/proc/modify_projectile(obj/projectile/energy/net/N)
 	N.teletarget = teletarget
 
 /obj/item/gun/energy/e_gun/dragnet/snare

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -185,7 +185,7 @@
 	icon_state = null
 	damage = 40
 	damage_type = BRUTE
-	flag = BOMB
+	armor_flag = BOMB
 	range = 3
 	log_override = TRUE
 	var/power = 1
@@ -424,7 +424,7 @@
 				M.attempt_drill(K.firer)
 	if(modifier)
 		for(var/mob/living/L in range(1, target_turf) - K.firer - target)
-			var/armor = L.run_armor_check(K.def_zone, K.flag, "", "", K.armour_penetration)
+			var/armor = L.run_armor_check(K.def_zone, K.armor_flag, "", "", K.armour_penetration)
 			var/effective_modifier = modifier
 			if(K.pressure_decrease_active)
 				effective_modifier *= K.pressure_decrease
@@ -533,7 +533,7 @@
 			var/kill_modifier = 1
 			if(K.pressure_decrease_active)
 				kill_modifier *= K.pressure_decrease
-			var/armor = L.run_armor_check(K.def_zone, K.flag, "", "", K.armour_penetration)
+			var/armor = L.run_armor_check(K.def_zone, K.armor_flag, "", "", K.armour_penetration)
 			L.apply_damage(bounties_reaped[L.type]*kill_modifier, K.damage_type, K.def_zone, armor)
 
 /obj/item/borg/upgrade/modkit/bounty/proc/get_kill(mob/living/L)

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -63,7 +63,7 @@
 	for(var/A in modkits)
 		. += A
 
-/obj/item/gun/energy/kinetic_accelerator/proc/modify_projectile(obj/item/projectile/kinetic/K)
+/obj/item/gun/energy/kinetic_accelerator/proc/modify_projectile(obj/projectile/kinetic/K)
 	K.kinetic_gun = src //do something special on-hit, easy!
 	for(var/A in get_modkits())
 		var/obj/item/borg/upgrade/modkit/M = A
@@ -168,7 +168,7 @@
 
 //Casing
 /obj/item/ammo_casing/energy/kinetic
-	projectile_type = /obj/item/projectile/kinetic
+	projectile_type = /obj/projectile/kinetic
 	select_name = "kinetic"
 	e_cost = 500
 	fire_sound = 'sound/weapons/kenetic_accel.ogg' // fine spelling there chap
@@ -180,7 +180,7 @@
 		KA.modify_projectile(BB)
 
 //Projectiles
-/obj/item/projectile/kinetic
+/obj/projectile/kinetic
 	name = "kinetic force"
 	icon_state = null
 	damage = 40
@@ -194,14 +194,14 @@
 	var/pressure_decrease = 0.25
 	var/obj/item/gun/energy/kinetic_accelerator/kinetic_gun
 
-/obj/item/projectile/kinetic/mech
+/obj/projectile/kinetic/mech
 	range = 5
 
-/obj/item/projectile/kinetic/Destroy()
+/obj/projectile/kinetic/Destroy()
 	kinetic_gun = null
 	return ..()
 
-/obj/item/projectile/kinetic/prehit(atom/target)
+/obj/projectile/kinetic/prehit(atom/target)
 	. = ..()
 	if(.)
 		if(!lavaland_equipment_pressure_check(get_turf(target)))
@@ -218,15 +218,15 @@
 			for(var/obj/item/borg/upgrade/modkit/M in mods)
 				M.projectile_prehit(src, target, kinetic_gun)
 
-/obj/item/projectile/kinetic/on_range()
+/obj/projectile/kinetic/on_range()
 	strike_thing()
 	..()
 
-/obj/item/projectile/kinetic/on_hit(atom/target)
+/obj/projectile/kinetic/on_hit(atom/target)
 	strike_thing(target)
 	. = ..()
 
-/obj/item/projectile/kinetic/proc/strike_thing(atom/target)
+/obj/projectile/kinetic/proc/strike_thing(atom/target)
 	var/turf/target_turf = get_turf(target)
 	if(!target_turf)
 		target_turf = get_turf(src)
@@ -320,14 +320,14 @@
 /obj/item/borg/upgrade/modkit/proc/uninstall(obj/item/gun/energy/kinetic_accelerator/KA)
 	KA.modkits -= src
 
-/obj/item/borg/upgrade/modkit/proc/modify_projectile(obj/item/projectile/kinetic/K)
+/obj/item/borg/upgrade/modkit/proc/modify_projectile(obj/projectile/kinetic/K)
 
 //use this one for effects you want to trigger before any damage is done at all and before damage is decreased by pressure
-/obj/item/borg/upgrade/modkit/proc/projectile_prehit(obj/item/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/proc/projectile_prehit(obj/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 //use this one for effects you want to trigger before mods that do damage
-/obj/item/borg/upgrade/modkit/proc/projectile_strike_predamage(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/proc/projectile_strike_predamage(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 //and this one for things that don't need to trigger before other damage-dealing mods
-/obj/item/borg/upgrade/modkit/proc/projectile_strike(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/proc/projectile_strike(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 
 //Range
 /obj/item/borg/upgrade/modkit/range
@@ -336,7 +336,7 @@
 	modifier = 1
 	cost = 25
 
-/obj/item/borg/upgrade/modkit/range/modify_projectile(obj/item/projectile/kinetic/K)
+/obj/item/borg/upgrade/modkit/range/modify_projectile(obj/projectile/kinetic/K)
 	K.range += modifier
 
 
@@ -346,7 +346,7 @@
 	desc = "Increases the damage of kinetic accelerator when installed."
 	modifier = 10
 
-/obj/item/borg/upgrade/modkit/damage/modify_projectile(obj/item/projectile/kinetic/K)
+/obj/item/borg/upgrade/modkit/damage/modify_projectile(obj/projectile/kinetic/K)
 	K.damage += modifier
 
 
@@ -383,7 +383,7 @@
 	desc = "Increases the maximum piercing power of a kinetic accelerator when installed."
 	cost = 10
 
-/obj/item/borg/upgrade/modkit/hardness/modify_projectile(obj/item/projectile/kinetic/K)
+/obj/item/borg/upgrade/modkit/hardness/modify_projectile(obj/projectile/kinetic/K)
 	K.power += modifier
 
 //AoE blasts
@@ -410,10 +410,10 @@
 	turf_aoe = initial(turf_aoe)
 	stats_stolen = FALSE
 
-/obj/item/borg/upgrade/modkit/aoe/modify_projectile(obj/item/projectile/kinetic/K)
+/obj/item/borg/upgrade/modkit/aoe/modify_projectile(obj/projectile/kinetic/K)
 	K.name = "kinetic explosion"
 
-/obj/item/borg/upgrade/modkit/aoe/projectile_strike(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/aoe/projectile_strike(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	if(stats_stolen)
 		return
 	new /obj/effect/temp_visual/explosion/fast(target_turf)
@@ -462,7 +462,7 @@
 	modifier = 1.875 //Makes the cooldown 3 seconds(with no cooldown mods) if you miss. Don't miss.
 	cost = 50
 
-/obj/item/borg/upgrade/modkit/cooldown/repeater/projectile_strike_predamage(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/cooldown/repeater/projectile_strike_predamage(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	var/valid_repeat = FALSE
 	if(isliving(target))
 		var/mob/living/L = target
@@ -482,7 +482,7 @@
 	cost = 20
 	var/static/list/damage_heal_order = list(BRUTE, BURN, OXY)
 
-/obj/item/borg/upgrade/modkit/lifesteal/projectile_prehit(obj/item/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/lifesteal/projectile_prehit(obj/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	if(isliving(target) && isliving(K.firer))
 		var/mob/living/L = target
 		if(L.stat == DEAD)
@@ -497,7 +497,7 @@
 	cost = 30
 	modifier = 0.25 //A bonus 15 damage if you burst the field on a target, 60 if you lure them into it.
 
-/obj/item/borg/upgrade/modkit/resonator_blasts/projectile_strike(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/resonator_blasts/projectile_strike(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	if(target_turf && !ismineralturf(target_turf)) //Don't make fields on mineral turfs.
 		var/obj/effect/temp_visual/resonance/R = locate(/obj/effect/temp_visual/resonance) in target_turf
 		if(R)
@@ -515,7 +515,7 @@
 	var/maximum_bounty = 25
 	var/list/bounties_reaped = list()
 
-/obj/item/borg/upgrade/modkit/bounty/projectile_prehit(obj/item/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/bounty/projectile_prehit(obj/projectile/kinetic/K, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	if(isliving(target))
 		var/mob/living/L = target
 		var/list/existing_marks = L.has_status_effect_list(STATUS_EFFECT_SYPHONMARK)
@@ -526,7 +526,7 @@
 				qdel(SM)
 		L.apply_status_effect(STATUS_EFFECT_SYPHONMARK, src)
 
-/obj/item/borg/upgrade/modkit/bounty/projectile_strike(obj/item/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
+/obj/item/borg/upgrade/modkit/bounty/projectile_strike(obj/projectile/kinetic/K, turf/target_turf, atom/target, obj/item/gun/energy/kinetic_accelerator/KA)
 	if(isliving(target))
 		var/mob/living/L = target
 		if(bounties_reaped[L.type])
@@ -554,7 +554,7 @@
 	maximum_of_type = 2
 	cost = 35
 
-/obj/item/borg/upgrade/modkit/indoors/modify_projectile(obj/item/projectile/kinetic/K)
+/obj/item/borg/upgrade/modkit/indoors/modify_projectile(obj/projectile/kinetic/K)
 	K.pressure_decrease *= modifier
 
 
@@ -609,7 +609,7 @@
 	denied_type = /obj/item/borg/upgrade/modkit/tracer
 	var/bolt_color = "#FFFFFF"
 
-/obj/item/borg/upgrade/modkit/tracer/modify_projectile(obj/item/projectile/kinetic/K)
+/obj/item/borg/upgrade/modkit/tracer/modify_projectile(obj/projectile/kinetic/K)
 	K.icon_state = "ka_tracer"
 	K.color = bolt_color
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -94,17 +94,17 @@
 	ammo_x_offset = 3
 
 /obj/item/ammo_casing/energy/laser/accelerator
-	projectile_type = /obj/item/projectile/beam/laser/accelerator
+	projectile_type = /obj/projectile/beam/laser/accelerator
 	select_name = "accelerator"
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 
-/obj/item/projectile/beam/laser/accelerator
+/obj/projectile/beam/laser/accelerator
 	name = "accelerator laser"
 	icon_state = "scatterlaser"
 	range = 255
 	damage = 6
 
-/obj/item/projectile/beam/laser/accelerator/Range()
+/obj/projectile/beam/laser/accelerator/Range()
 	..()
 	damage += 7
 	transform *= 1 + ((damage/7) * 0.2)//20% larger per tile
@@ -166,22 +166,22 @@
 
 /obj/item/ammo_casing/energy/laser/makeshiftlasrifle
 	e_cost = 1000 //The amount of energy a cell needs to expend to create this shot.
-	projectile_type = /obj/item/projectile/beam/laser/makeshiftlasrifle
+	projectile_type = /obj/projectile/beam/laser/makeshiftlasrifle
 	select_name = "strong"
 	variance = 2
 
-/obj/item/projectile/beam/laser/makeshiftlasrifle
+/obj/projectile/beam/laser/makeshiftlasrifle
 	damage = 17
 
 /obj/item/ammo_casing/energy/laser/makeshiftlasrifle/weak
 	e_cost = 100 //The amount of energy a cell needs to expend to create this shot.
-	projectile_type = /obj/item/projectile/beam/laser/makeshiftlasrifle/weak
+	projectile_type = /obj/projectile/beam/laser/makeshiftlasrifle/weak
 	select_name = "weak"
 	fire_sound = 'sound/weapons/laser2.ogg'
 
-/obj/item/projectile/beam/laser/makeshiftlasrifle/weak
+/obj/projectile/beam/laser/makeshiftlasrifle/weak
 	name = "weak laser"
 	damage = 5
 
-/obj/item/projectile/beam/laser/buckshot
+/obj/projectile/beam/laser/buckshot
 	damage = 10

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -315,7 +315,7 @@
 		var/obj/item/ammo_casing/energy/wormhole/W = ammo_type[i]
 		if(istype(W))
 			W.gun = src
-			var/obj/item/projectile/beam/wormhole/WH = W.BB
+			var/obj/projectile/beam/wormhole/WH = W.BB
 			if(istype(WH))
 				WH.gun = src
 
@@ -351,9 +351,9 @@
 	p_orange.link_portal(p_blue)
 	p_blue.link_portal(p_orange)
 
-/obj/item/gun/energy/wormhole_projector/proc/create_portal(obj/item/projectile/beam/wormhole/W, turf/target)
+/obj/item/gun/energy/wormhole_projector/proc/create_portal(obj/projectile/beam/wormhole/W, turf/target)
 	var/obj/effect/portal/P = new /obj/effect/portal(target, src, 300, null, FALSE, null, atmos_link)
-	if(istype(W, /obj/item/projectile/beam/wormhole/orange))
+	if(istype(W, /obj/projectile/beam/wormhole/orange))
 		qdel(p_orange)
 		p_orange = P
 		P.icon_state = "portal1"

--- a/code/modules/projectiles/guns/magic/rune.dm
+++ b/code/modules/projectiles/guns/magic/rune.dm
@@ -81,7 +81,7 @@
 	recharge_rate = 1.11
 
 	//Please update the var below with more projectiles if they get added
-	var/allowed_projectile_types = list(/obj/item/projectile/magic/runic_honk, /obj/item/projectile/magic/runic_fire, /obj/item/projectile/magic/runic_tentacle, /obj/item/projectile/magic/runic_bomb, /obj/item/projectile/magic/runic_heal, /obj/item/projectile/temp/runic_icycle, /obj/item/projectile/magic/runic_toxin, /obj/item/projectile/magic/runic_death, /obj/item/projectile/magic/runic_mutation, /obj/item/projectile/magic/runic_resizement)
+	var/allowed_projectile_types = list(/obj/projectile/magic/runic_honk, /obj/projectile/magic/runic_fire, /obj/projectile/magic/runic_tentacle, /obj/projectile/magic/runic_bomb, /obj/projectile/magic/runic_heal, /obj/projectile/temp/runic_icycle, /obj/projectile/magic/runic_toxin, /obj/projectile/magic/runic_death, /obj/projectile/magic/runic_mutation, /obj/projectile/magic/runic_resizement)
 
 //shamelessly stolen from chaos staff honk
 /obj/item/gun/magic/rune/chaos_rune/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
@@ -138,7 +138,7 @@
 	charges = 5
 	recharge_rate = 2.66
 	spread = 1
-	var/allowed_projectile_types = list(/obj/item/projectile/magic/shotgun/slug, /obj/item/projectile/magic/incediary_slug)
+	var/allowed_projectile_types = list(/obj/projectile/magic/shotgun/slug, /obj/projectile/magic/incediary_slug)
 
 
 /obj/item/gun/magic/rune/bullet_rune/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -49,11 +49,11 @@
 	max_charges = 10
 	recharge_rate = 2
 	no_den_usage = 1
-	var/allowed_projectile_types = list(/obj/item/projectile/magic/change, /obj/item/projectile/magic/animate, /obj/item/projectile/magic/resurrection,
-	/obj/item/projectile/magic/teleport, /obj/item/projectile/magic/door, /obj/item/projectile/magic/fireball,
-	/obj/item/projectile/magic/spellblade, /obj/item/projectile/magic/arcane_barrage, /obj/item/projectile/magic/locker, /obj/item/projectile/magic/flying,
-	/obj/item/projectile/magic/bounty, /obj/item/projectile/magic/antimagic, /obj/item/projectile/magic/fetch, /obj/item/projectile/magic/sapping,
-	/obj/item/projectile/magic/necropotence, /obj/item/projectile/magic, /obj/item/projectile/temp/chill, /obj/item/projectile/magic/wipe)
+	var/allowed_projectile_types = list(/obj/projectile/magic/change, /obj/projectile/magic/animate, /obj/projectile/magic/resurrection,
+	/obj/projectile/magic/teleport, /obj/projectile/magic/door, /obj/projectile/magic/fireball,
+	/obj/projectile/magic/spellblade, /obj/projectile/magic/arcane_barrage, /obj/projectile/magic/locker, /obj/projectile/magic/flying,
+	/obj/projectile/magic/bounty, /obj/projectile/magic/antimagic, /obj/projectile/magic/fetch, /obj/projectile/magic/sapping,
+	/obj/projectile/magic/necropotence, /obj/projectile/magic, /obj/projectile/temp/chill, /obj/projectile/magic/wipe)
 
 /obj/item/gun/magic/staff/chaos/process_fire(atom/target, mob/living/user, message = TRUE, params = null, zone_override = "", bonus_spread = 0)
 	chambered.projectile_type = pick(allowed_projectile_types)

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -422,7 +422,7 @@
 	hitsound = 'sound/effects/explosion3.ogg'
 	damage = 0				//Handled manually.
 	damage_type = BURN
-	flag = ENERGY
+	armor_flag = ENERGY
 	range = 150
 	jitter = 10
 	var/obj/item/gun/gun

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -192,7 +192,7 @@
 	if(diff < AIMING_BEAM_ANGLE_CHANGE_THRESHOLD && !force_update)
 		return
 	aiming_lastangle = lastangle
-	var/obj/item/projectile/beam/beam_rifle/hitscan/aiming_beam/P = new
+	var/obj/projectile/beam/beam_rifle/hitscan/aiming_beam/P = new
 	P.gun = src
 	P.wall_pierce_amount = wall_pierce_amount
 	P.structure_pierce_amount = structure_piercing
@@ -372,7 +372,7 @@
 
 /obj/item/ammo_casing/energy/beam_rifle/ready_proj(atom/target, mob/living/user, quiet, zone_override = "")
 	. = ..()
-	var/obj/item/projectile/beam/beam_rifle/hitscan/HS_BB = BB
+	var/obj/projectile/beam/beam_rifle/hitscan/HS_BB = BB
 	if(!istype(HS_BB))
 		return
 	HS_BB.impact_direct_damage = projectile_damage
@@ -411,12 +411,12 @@
 	return TRUE
 
 /obj/item/ammo_casing/energy/beam_rifle/hitscan
-	projectile_type = /obj/item/projectile/beam/beam_rifle/hitscan
+	projectile_type = /obj/projectile/beam/beam_rifle/hitscan
 	select_name = "beam"
 	e_cost = 10000
 	fire_sound = 'sound/weapons/beam_sniper.ogg'
 
-/obj/item/projectile/beam/beam_rifle
+/obj/projectile/beam/beam_rifle
 	name = "particle beam"
 	icon = null
 	hitsound = 'sound/effects/explosion3.ogg'
@@ -444,7 +444,7 @@
 	var/turf/cached
 	var/list/pierced = list()
 
-/obj/item/projectile/beam/beam_rifle/proc/AOE(turf/epicenter)
+/obj/projectile/beam/beam_rifle/proc/AOE(turf/epicenter)
 	set waitfor = FALSE
 	if(!epicenter)
 		return
@@ -461,7 +461,7 @@
 				continue
 			O.take_damage(aoe_structure_damage * get_damage_coeff(O), BURN, LASER, FALSE)
 
-/obj/item/projectile/beam/beam_rifle/proc/check_pierce(atom/target)
+/obj/projectile/beam/beam_rifle/proc/check_pierce(atom/target)
 	if(!do_pierce)
 		return FALSE
 	if(pierced[target])		//we already pierced them go away
@@ -487,14 +487,14 @@
 				return TRUE
 	return FALSE
 
-/obj/item/projectile/beam/beam_rifle/proc/get_damage_coeff(atom/target)
+/obj/projectile/beam/beam_rifle/proc/get_damage_coeff(atom/target)
 	if(istype(target, /obj/machinery/door))
 		return 0.4
 	if(istype(target, /obj/structure/window))
 		return 0.5
 	return 1
 
-/obj/item/projectile/beam/beam_rifle/proc/handle_impact(atom/target)
+/obj/projectile/beam/beam_rifle/proc/handle_impact(atom/target)
 	if(isobj(target))
 		var/obj/O = target
 		O.take_damage(impact_structure_damage * get_damage_coeff(target), BURN, LASER, FALSE)
@@ -503,7 +503,7 @@
 		L.adjustFireLoss(impact_direct_damage)
 		L.emote("scream")
 
-/obj/item/projectile/beam/beam_rifle/proc/handle_hit(atom/target)
+/obj/projectile/beam/beam_rifle/proc/handle_hit(atom/target)
 	set waitfor = FALSE
 	if(!cached && !QDELETED(target))
 		cached = get_turf(target)
@@ -514,9 +514,9 @@
 	if(!QDELETED(target))
 		handle_impact(target)
 
-/obj/item/projectile/beam/beam_rifle/Bump(atom/target)
+/obj/projectile/beam/beam_rifle/Bump(atom/target)
 	if(check_pierce(target))
-		permutated += target
+		impacted += target
 		trajectory_ignore_forcemove = TRUE
 		forceMove(target.loc)
 		trajectory_ignore_forcemove = FALSE
@@ -525,19 +525,19 @@
 		cached = get_turf(target)
 	return ..()
 
-/obj/item/projectile/beam/beam_rifle/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/beam/beam_rifle/on_hit(atom/target, blocked = FALSE)
 	if(!QDELETED(target))
 		cached = get_turf(target)
 	handle_hit(target)
 	return ..()
 
-/obj/item/projectile/beam/beam_rifle/hitscan
+/obj/projectile/beam/beam_rifle/hitscan
 	icon_state = ""
 	hitscan = TRUE
 	tracer_type = /obj/effect/projectile/tracer/tracer/beam_rifle
 	var/constant_tracer = FALSE
 
-/obj/item/projectile/beam/beam_rifle/hitscan/generate_hitscan_tracers(cleanup = TRUE, duration = 5, impacting = TRUE, highlander)
+/obj/projectile/beam/beam_rifle/hitscan/generate_hitscan_tracers(cleanup = TRUE, duration = 5, impacting = TRUE, highlander)
 	set waitfor = FALSE
 	if(isnull(highlander))
 		highlander = constant_tracer
@@ -553,7 +553,7 @@
 		beam_segments = null
 		QDEL_NULL(beam_index)
 
-/obj/item/projectile/beam/beam_rifle/hitscan/aiming_beam
+/obj/projectile/beam/beam_rifle/hitscan/aiming_beam
 	tracer_type = /obj/effect/projectile/tracer/tracer/aiming
 	name = "aiming beam"
 	hitsound = null
@@ -566,10 +566,10 @@
 	hitscan_light_color_override = "#99ff99"
 	reflectable = REFLECT_FAKEPROJECTILE
 
-/obj/item/projectile/beam/beam_rifle/hitscan/aiming_beam/prehit(atom/target)
+/obj/projectile/beam/beam_rifle/hitscan/aiming_beam/prehit(atom/target)
 	qdel(src)
 	return FALSE
 
-/obj/item/projectile/beam/beam_rifle/hitscan/aiming_beam/on_hit()
+/obj/projectile/beam/beam_rifle/hitscan/aiming_beam/on_hit()
 	qdel(src)
 	return BULLET_ACT_HIT

--- a/code/modules/projectiles/guns/misc/blastcannon.dm
+++ b/code/modules/projectiles/guns/misc/blastcannon.dm
@@ -105,12 +105,12 @@
 	var/turf/targturf = get_turf(target)
 	message_admins("Blast wave fired from [ADMIN_VERBOSEJMP(starting)] at [ADMIN_VERBOSEJMP(targturf)] ([target.name]) by [ADMIN_LOOKUPFLW(user)] with power [heavy]/[medium]/[light].")
 	log_game("Blast wave fired from [AREACOORD(starting)] at [AREACOORD(targturf)] ([target.name]) by [key_name(user)] with power [heavy]/[medium]/[light].")
-	var/obj/item/projectile/blastwave/BW = new(loc, heavy, medium, light)
+	var/obj/projectile/blastwave/BW = new(loc, heavy, medium, light)
 	BW.hugbox = hugbox
 	BW.preparePixelProjectile(target, get_turf(src), params, 0)
 	BW.fire()
 
-/obj/item/projectile/blastwave
+/obj/projectile/blastwave
 	name = "blast wave"
 	icon_state = "blastwave"
 	damage = 0
@@ -122,13 +122,13 @@
 	var/hugbox = TRUE
 	range = 150
 
-/obj/item/projectile/blastwave/Initialize(mapload, _h, _m, _l)
+/obj/projectile/blastwave/Initialize(mapload, _h, _m, _l)
 	heavyr = _h
 	mediumr = _m
 	lightr = _l
 	return ..()
 
-/obj/item/projectile/blastwave/Range()
+/obj/projectile/blastwave/Range()
 	..()
 	var/amount_destruction = EXPLODE_NONE
 	var/wallbreak_chance = 0
@@ -163,5 +163,5 @@
 	mediumr = max(mediumr - 1, 0)
 	lightr = max(lightr - 1, 0)
 
-/obj/item/projectile/blastwave/ex_act()
+/obj/projectile/blastwave/ex_act()
 	return

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -92,7 +92,7 @@
 	///Determines if the projectile will skip any damage inflictions
 	var/nodamage = FALSE
 	///Defines what armor to use when it hits things.  Must be set to bullet, laser, energy, or bomb
-	var/flag = BULLET
+	var/armor_flag = BULLET
 	///How much armor this projectile pierces.
 	var/armour_penetration = 0
 	///How much armor this projectile pierces.

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -2,18 +2,18 @@
 #define MOVES_HITSCAN -1		//Not actually hitscan but close as we get without actual hitscan.
 #define MUZZLE_EFFECT_PIXEL_INCREMENT 17	//How many pixels to move the muzzle flash up so your character doesn't look like they're shitting out lasers.
 
-/obj/item/projectile
+/obj/projectile
 	name = "projectile"
 	icon = 'icons/obj/projectiles.dmi'
 	icon_state = "bullet"
 	density = FALSE
 	anchored = TRUE
-	item_flags = ABSTRACT
+	var/item_flags = ABSTRACT
 	pass_flags = PASSTABLE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	movement_type = FLYING
 	wound_bonus = CANT_WOUND // can't wound by default
-	hitsound = 'sound/weapons/pierce.ogg'
+	var/hitsound = 'sound/weapons/pierce.ogg'
 	var/hitsound_wall = ""
 
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
@@ -25,7 +25,7 @@
 	var/xo = null
 	var/atom/original = null // the original target clicked
 	var/turf/starting = null // the projectile's starting turf
-	var/list/permutated = list() // we've passed through these atoms, don't try to hit them again
+	var/list/impacted = list() // we've passed through these atoms, don't try to hit them again
 	var/p_x = 16
 	var/p_y = 16			// the pixel location of the tile that the player clicked. Default is the center
 
@@ -88,45 +88,77 @@
 
 	var/damage = 10
 	var/damage_type = BRUTE //BRUTE, BURN, TOX, OXY, CLONE are the only things that should be in here
-	var/nodamage = FALSE //Determines if the projectile will skip any damage inflictions
-	var/flag = "bullet" //Defines what armor to use when it hits things.  Must be set to bullet, laser, energy,or bomb
-	var/projectile_type = /obj/item/projectile
-	var/range = 50 //This will de-increment every step. When 0, it will deletze the projectile.
+
+	///Determines if the projectile will skip any damage inflictions
+	var/nodamage = FALSE
+	///Defines what armor to use when it hits things.  Must be set to bullet, laser, energy, or bomb
+	var/flag = BULLET
+	///How much armor this projectile pierces.
+	var/armour_penetration = 0
+	///How much armor this projectile pierces.
+	var/projectile_type = /obj/projectile
+	///This will de-increment every step. When 0, it will deletze the projectile.
+	var/range = 50 
 	var/decayedRange			//stores original range
 	var/reflect_range_decrease = 5			//amount of original range that falls off when reflecting, so it doesn't go forever
 	var/reflectable = NONE // Can it be reflected or not?
-		//Effects
+	// Status effects applied on hit
 	var/stun = 0
 	var/knockdown = 0
 	var/paralyze = 0
 	var/immobilize = 0
 	var/unconscious = 0
-	var/irradiate = 0
-	var/stutter = 0
-	var/slur = 0
 	var/eyeblur = 0
-	var/drowsy = 0
+	/// Drowsiness applied on projectile hit
+	var/drowsy = 0 SECONDS
+	/// Jittering applied on projectile hit
+	var/jitter = 0 SECONDS
+	/// Extra stamina damage applied on projectile hit (in addition to the main damage)
 	var/stamina = 0
-	var/jitter = 0
+	/// Stuttering applied on projectile hit
+	var/stutter = 0 SECONDS
+	/// Slurring applied on projectile hit
+	var/slur = 0 SECONDS
+	
+	
+	var/irradiate = 0 //yog radiation
+	
 	var/dismemberment = 0 //The higher the number, the greater the bonus to dismembering. 0 will not dismember at all.
+	var/catastropic_dismemberment = FALSE //If TRUE, this projectile deals its damage to the chest if it dismembers a limb.
+
 	var/impact_effect_type //what type of impact effect to show when hitting something
 	var/log_override = FALSE //is this type spammed enough to not log? (KAs)
 	/// We ignore mobs with these factions.
 	var/list/ignored_factions
-
+	
+	///If defined, on hit we create an item of this type then call hitby() on the hit target with this, mainly used for embedding items (bullets) in targets
+	var/shrapnel_type
+	///If we have a shrapnel_type defined, these embedding stats will be passed to the spawned shrapnel type, which will roll for embedding on the target
+	var/list/embedding
+	///If TRUE, hit mobs even if they're on the floor and not our target
+	var/hit_prone_targets = FALSE
+	///For what kind of brute wounds we're rolling for, if we're doing such a thing. Lasers obviously don't care since they do burn instead.
 	var/temporary_unstoppable_movement = FALSE
-
+	///For what kind of brute wounds we're rolling for, if we're doing such a thing. Lasers obviously don't care since they do burn instead.
+	var/sharpness = NONE
 	///How much we want to drop both wound_bonus and bare_wound_bonus (to a minimum of 0 for the latter) per tile, for falloff purposes
 	var/wound_falloff_tile
+	///How much we want to drop the embed_chance value, if we can embed, per tile, for falloff purposes
+	var/embed_falloff_tile
+
+	/// If true directly targeted turfs can be hit
+	var/can_hit_turfs = FALSE
+	/// If this projectile has been parried before
+	var/parried = FALSE
 
 	var/splatter = FALSE // Make a cool splatter effect even if it doesn't do brute damage
 
-/obj/item/projectile/Initialize(mapload)
+/obj/projectile/Initialize(mapload)
 	. = ..()
-	permutated = list()
+	impacted = list()
 	decayedRange = range
 
-/obj/item/projectile/proc/Range()
+/obj/projectile/proc/Range()
 	range--
 	if(wound_bonus != CANT_WOUND)
 		wound_bonus += wound_falloff_tile
@@ -134,7 +166,7 @@
 	if(range <= 0 && loc)
 		on_range()
 
-/obj/item/projectile/proc/on_range() //if we want there to be effects when they reach the end of their range
+/obj/projectile/proc/on_range() //if we want there to be effects when they reach the end of their range
 	qdel(src)
 
 //to get the correct limb (if any) for the projectile hit message
@@ -148,10 +180,10 @@
 	else //when a limb is missing the damage is actually passed to the chest
 		return BODY_ZONE_CHEST
 
-/obj/item/projectile/proc/prehit(atom/target)
+/obj/projectile/proc/prehit(atom/target)
 	return TRUE
 
-/obj/item/projectile/proc/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/proc/on_hit(atom/target, blocked = FALSE)
 	if(fired_from)
 		SEND_SIGNAL(fired_from, COMSIG_PROJECTILE_ON_HIT, firer, target, Angle)
 	var/turf/target_loca = get_turf(target)
@@ -257,21 +289,21 @@
 
 	return L.apply_effects(stun, knockdown, unconscious, irradiate, slur, stutter, eyeblur, drowsy, blocked, stamina, jitter, paralyze, immobilize)
 
-/obj/item/projectile/proc/vol_by_damage()
+/obj/projectile/proc/vol_by_damage()
 	if(src.damage)
 		return clamp((src.damage) * 0.67, 30, 100)// Multiply projectile damage by 0.67, then CLAMP the value between 30 and 100
 	else
 		return 50 //if the projectile doesn't do damage, play its hitsound at 50% volume
 
-/obj/item/projectile/proc/on_ricochet(atom/A)
+/obj/projectile/proc/on_ricochet(atom/A)
 	return
 
-/obj/item/projectile/proc/store_hitscan_collision(datum/point/pcache)
+/obj/projectile/proc/store_hitscan_collision(datum/point/pcache)
 	beam_segments[beam_index] = pcache
 	beam_index = pcache
 	beam_segments[beam_index] = null
 
-/obj/item/projectile/Bump(atom/A)
+/obj/projectile/Bump(atom/A)
 	if(!trajectory)
 		qdel(src)
 		return
@@ -303,12 +335,12 @@
 #define DO_NOT_QDEL 2		//Pass through.
 #define FORCE_QDEL 3		//Force deletion.
 
-/obj/item/projectile/proc/process_hit(turf/T, atom/target, qdel_self, hit_something = FALSE)		//probably needs to be reworked entirely when pixel movement is done.
+/obj/projectile/proc/process_hit(turf/T, atom/target, qdel_self, hit_something = FALSE)		//probably needs to be reworked entirely when pixel movement is done.
 	if(QDELETED(src) || !T || !target)		//We're done, nothing's left.
 		if((qdel_self == FORCE_QDEL) || ((qdel_self == QDEL_SELF) && !temporary_unstoppable_movement && !CHECK_BITFIELD(movement_type, UNSTOPPABLE)))
 			qdel(src)
 		return hit_something
-	permutated |= target		//Make sure we're never hitting it again. If we ever run into weirdness with piercing projectiles needing to hit something multiple times.. well.. that's a to-do.
+	impacted |= target		//Make sure we're never hitting it again. If we ever run into weirdness with piercing projectiles needing to hit something multiple times.. well.. that's a to-do.
 	if(!prehit(target))
 		return process_hit(T, select_target(T), qdel_self, hit_something)		//Hit whatever else we can since that didn't work.
 	var/result = target.bullet_act(src, def_zone)
@@ -332,15 +364,15 @@
 #undef DO_NOT_QDEL
 #undef FORCE_QDEL
 
-/obj/item/projectile/proc/select_target(turf/T, atom/target)			//Select a target from a turf.
-	if((original in T) && can_hit_target(original, permutated, TRUE, TRUE))
+/obj/projectile/proc/select_target(turf/T, atom/target)			//Select a target from a turf.
+	if((original in T) && can_hit_target(original, impacted, TRUE, TRUE))
 		return original
-	if(target && can_hit_target(target, permutated, target == original, TRUE))
+	if(target && can_hit_target(target, impacted, target == original, TRUE))
 		return target
 	var/list/mob/living/possible_mobs = typecache_filter_list(T, GLOB.typecache_mob)
 	var/list/mob/mobs = list()
 	for(var/mob/living/M in possible_mobs)
-		if(!can_hit_target(M, permutated, M == original, TRUE))
+		if(!can_hit_target(M, impacted, M == original, TRUE))
 			continue
 		mobs += M
 	if(LAZYLEN(mobs))
@@ -349,28 +381,28 @@
 	var/list/obj/possible_objs = typecache_filter_list(T, GLOB.typecache_machine_or_structure)
 	var/list/obj/objs = list()
 	for(var/obj/O in possible_objs)
-		if(!can_hit_target(O, permutated, O == original, TRUE))
+		if(!can_hit_target(O, impacted, O == original, TRUE))
 			continue
 		objs += O
 	if(LAZYLEN(objs))
 		var/obj/object_chosen = pick(objs)
 		return object_chosen
 	//Nothing else is here that we can hit, hit the turf if we haven't.
-	if(!(T in permutated) && can_hit_target(T, permutated, T == original, TRUE))
+	if(!(T in impacted) && can_hit_target(T, impacted, T == original, TRUE))
 		return T
 	//Returns null if nothing at all was found.
 
-/obj/item/projectile/proc/check_ricochet()
+/obj/projectile/proc/check_ricochet()
 	if(prob(ricochet_chance))
 		return TRUE
 	return FALSE
 
-/obj/item/projectile/proc/check_ricochet_flag(atom/A)
+/obj/projectile/proc/check_ricochet_flag(atom/A)
 	if(A.flags_1 & CHECK_RICOCHET_1)
 		return TRUE
 	return FALSE
 
-/obj/item/projectile/proc/return_predicted_turf_after_moves(moves, forced_angle)		//I say predicted because there's no telling that the projectile won't change direction/location in flight.
+/obj/projectile/proc/return_predicted_turf_after_moves(moves, forced_angle)		//I say predicted because there's no telling that the projectile won't change direction/location in flight.
 	if(!trajectory && isnull(forced_angle) && isnull(Angle))
 		return FALSE
 	var/datum/point/vector/current = trajectory
@@ -380,15 +412,15 @@
 	var/datum/point/vector/v = current.return_vector_after_increments(moves * SSprojectiles.global_iterations_per_move)
 	return v.return_turf()
 
-/obj/item/projectile/proc/return_pathing_turfs_in_moves(moves, forced_angle)
+/obj/projectile/proc/return_pathing_turfs_in_moves(moves, forced_angle)
 	var/turf/current = get_turf(src)
 	var/turf/ending = return_predicted_turf_after_moves(moves, forced_angle)
 	return getline(current, ending)
 
-/obj/item/projectile/Process_Spacemove(movement_dir = 0)
+/obj/projectile/Process_Spacemove(movement_dir = 0)
 	return TRUE	//Bullets don't drift in space
 
-/obj/item/projectile/process()
+/obj/projectile/process()
 	last_process = world.time
 	if(!loc || !fired || !trajectory)
 		fired = FALSE
@@ -411,7 +443,7 @@
 	for(var/i in 1 to required_moves)
 		pixel_move(1, FALSE)
 
-/obj/item/projectile/proc/fire(angle, atom/direct_target)
+/obj/projectile/proc/fire(angle, atom/direct_target)
 	if(fired_from)
 		SEND_SIGNAL(fired_from, COMSIG_PROJECTILE_BEFORE_FIRE, src, original)
 	//If no angle needs to resolve it from xo/yo!
@@ -451,7 +483,7 @@
 		START_PROCESSING(SSprojectiles, src)
 	pixel_move(1, FALSE)	//move it now!
 
-/obj/item/projectile/proc/setAngle(new_angle)	//wrapper for overrides.
+/obj/projectile/proc/setAngle(new_angle)	//wrapper for overrides.
 	Angle = new_angle
 	if(!nondirectional_sprite)
 		var/matrix/M = new
@@ -461,7 +493,7 @@
 		trajectory.set_angle(new_angle)
 	return TRUE
 
-/obj/item/projectile/forceMove(atom/target)
+/obj/projectile/forceMove(atom/target)
 	if(!isloc(target) || !isloc(loc) || !z)
 		return ..()
 	var/zc = target.z != z
@@ -478,11 +510,11 @@
 	if(zc)
 		after_z_change(old, target)
 
-/obj/item/projectile/proc/after_z_change(atom/olcloc, atom/newloc)
+/obj/projectile/proc/after_z_change(atom/olcloc, atom/newloc)
 
-/obj/item/projectile/proc/before_z_change(atom/oldloc, atom/newloc)
+/obj/projectile/proc/before_z_change(atom/oldloc, atom/newloc)
 
-/obj/item/projectile/vv_edit_var(var_name, var_value)
+/obj/projectile/vv_edit_var(var_name, var_value)
 	switch(var_name)
 		if(NAMEOF(src, Angle))
 			setAngle(var_value)
@@ -490,19 +522,19 @@
 		else
 			return ..()
 
-/obj/item/projectile/proc/set_pixel_speed(new_speed)
+/obj/projectile/proc/set_pixel_speed(new_speed)
 	if(trajectory)
 		trajectory.set_speed(new_speed)
 		return TRUE
 	return FALSE
 
-/obj/item/projectile/proc/record_hitscan_start(datum/point/pcache)
+/obj/projectile/proc/record_hitscan_start(datum/point/pcache)
 	if(pcache)
 		beam_segments = list()
 		beam_index = pcache
 		beam_segments[beam_index] = null	//record start.
 
-/obj/item/projectile/proc/process_hitscan()
+/obj/projectile/proc/process_hitscan()
 	var/safety = range * 3
 	record_hitscan_start(RETURN_POINT_VECTOR_INCREMENT(src, Angle, MUZZLE_EFFECT_PIXEL_INCREMENT, 1))
 	while(loc && !QDELETED(src))
@@ -517,7 +549,7 @@
 			return	//Kill!
 		pixel_move(1, TRUE)
 
-/obj/item/projectile/proc/pixel_move(trajectory_multiplier, hitscanning = FALSE)
+/obj/projectile/proc/pixel_move(trajectory_multiplier, hitscanning = FALSE)
 	if(!loc || !trajectory)
 		return
 	last_projectile_move = world.time
@@ -557,7 +589,7 @@
 		animate(src, pixel_x = trajectory.return_px(), pixel_y = trajectory.return_py(), time = 0.1 SECONDS, flags = ANIMATION_END_NOW)
 	Range()
 
-/obj/item/projectile/proc/process_homing()			//may need speeding up in the future performance wise.
+/obj/projectile/proc/process_homing()			//may need speeding up in the future performance wise.
 	if(!homing_target)
 		return FALSE
 	var/datum/point/PT = RETURN_PRECISE_POINT(homing_target)
@@ -566,7 +598,7 @@
 	var/angle = closer_angle_difference(Angle, angle_between_points(RETURN_PRECISE_POINT(src), PT))
 	setAngle(Angle + clamp(homing_away ? -angle : angle, -homing_turn_speed, homing_turn_speed))
 
-/obj/item/projectile/proc/set_homing_target(atom/A)
+/obj/projectile/proc/set_homing_target(atom/A)
 	if(!A || (!isturf(A) && !isturf(A.loc)))
 		return FALSE
 	homing = TRUE
@@ -580,7 +612,7 @@
 
 //Returns true if the target atom is on our current turf and above the right layer
 //If direct target is true it's the originally clicked target.
-/obj/item/projectile/proc/can_hit_target(atom/target, list/passthrough, direct_target = FALSE, ignore_loc = FALSE)
+/obj/projectile/proc/can_hit_target(atom/target, list/passthrough, direct_target = FALSE, ignore_loc = FALSE)
 	if(QDELETED(target))
 		return FALSE
 	if(!ignore_source_check && firer)
@@ -614,7 +646,7 @@
 	return TRUE
 
 //Spread is FORCED!
-/obj/item/projectile/proc/preparePixelProjectile(atom/target, atom/source, params, spread = 0)
+/obj/projectile/proc/preparePixelProjectile(atom/target, atom/source, params, spread = 0)
 	var/turf/curloc = get_turf(source)
 	var/turf/targloc = get_turf(target)
 	trajectory_ignore_forcemove = TRUE
@@ -670,23 +702,23 @@
 		angle = ATAN2(y - oy, x - ox)
 	return list(angle, p_x, p_y)
 
-/obj/item/projectile/Crossed(atom/movable/AM) //A mob moving on a tile with a projectile is hit by it.
+/obj/projectile/Crossed(atom/movable/AM) //A mob moving on a tile with a projectile is hit by it.
 	. = ..()
 	if(isliving(AM) && !(pass_flags & PASSMOB))
 		var/mob/living/L = AM
-		if(can_hit_target(L, permutated, (AM == original)))
+		if(can_hit_target(L, impacted, (AM == original)))
 			Bump(AM)
 
-/obj/item/projectile/Move(atom/newloc, dir = NONE)
+/obj/projectile/Move(atom/newloc, dir = NONE)
 	. = ..()
 	if(.)
 		if(temporary_unstoppable_movement)
 			temporary_unstoppable_movement = FALSE
 			DISABLE_BITFIELD(movement_type, UNSTOPPABLE)
-		if(fired && can_hit_target(original, permutated, TRUE))
+		if(fired && can_hit_target(original, impacted, TRUE))
 			Bump(original)
 
-/obj/item/projectile/Destroy()
+/obj/projectile/Destroy()
 	if(hitscan)
 		finalize_hitscan_and_generate_tracers()
 	STOP_PROCESSING(SSprojectiles, src)
@@ -694,18 +726,18 @@
 	qdel(trajectory)
 	return ..()
 
-/obj/item/projectile/proc/cleanup_beam_segments()
+/obj/projectile/proc/cleanup_beam_segments()
 	QDEL_LIST_ASSOC(beam_segments)
 	beam_segments = list()
 	qdel(beam_index)
 
-/obj/item/projectile/proc/finalize_hitscan_and_generate_tracers(impacting = TRUE)
+/obj/projectile/proc/finalize_hitscan_and_generate_tracers(impacting = TRUE)
 	if(trajectory && beam_index)
 		var/datum/point/pcache = trajectory.copy_to()
 		beam_segments[beam_index] = pcache
 	generate_hitscan_tracers(null, null, impacting)
 
-/obj/item/projectile/proc/generate_hitscan_tracers(cleanup = TRUE, duration = 3, impacting = TRUE)
+/obj/projectile/proc/generate_hitscan_tracers(cleanup = TRUE, duration = 3, impacting = TRUE)
 	if(!length(beam_segments))
 		return
 	if(tracer_type)
@@ -735,5 +767,5 @@
 	if(cleanup)
 		cleanup_beam_segments()
 
-/obj/item/projectile/experience_pressure_difference()
+/obj/projectile/experience_pressure_difference()
 	return

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/beam
+/obj/projectile/beam
 	name = "laser"
 	icon_state = "laser"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
@@ -19,7 +19,7 @@
 	ricochet_chance = 80
 	reflectable = REFLECT_NORMAL
 
-/obj/item/projectile/beam/laser
+/obj/projectile/beam/laser
 	tracer_type = /obj/effect/projectile/tracer/laser
 	muzzle_type = /obj/effect/projectile/muzzle/laser
 	impact_type = /obj/effect/projectile/impact/laser
@@ -28,18 +28,18 @@
 	var/fire_hazard = FALSE
 
 //overclocked laser, does a bit more damage but has much higher wound power (-0 vs -20)
-/obj/item/projectile/beam/laser/hellfire
+/obj/projectile/beam/laser/hellfire
 	name = "hellfire laser"
 	damage = 25
 	wound_bonus = 0
 	speed = 0.6 // higher power = faster, that's how light works right
 	fire_hazard = TRUE
 
-/obj/item/projectile/beam/laser/hellfire/Initialize(mapload)
+/obj/projectile/beam/laser/hellfire/Initialize(mapload)
 	. = ..()
 	transform *= 2
 
-/obj/item/projectile/beam/laser/heavylaser
+/obj/projectile/beam/laser/heavylaser
 	name = "heavy laser"
 	icon_state = "heavylaser"
 	damage = 40
@@ -49,7 +49,7 @@
 	muzzle_type = /obj/effect/projectile/muzzle/heavy_laser
 	impact_type = /obj/effect/projectile/impact/heavy_laser
 
-/obj/item/projectile/beam/laser/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/beam/laser/on_hit(atom/target, blocked = FALSE)
 	if((blocked != 100) && iscarbon(target))
 		var/mob/living/carbon/M = target
 		M.ignite_mob()
@@ -61,21 +61,21 @@
 			target_turf.IgniteTurf(rand(8, 16))
 	return ..()
 
-/obj/item/projectile/beam/weak
+/obj/projectile/beam/weak
 	damage = 15
 	armour_penetration = 50
 
-/obj/item/projectile/beam/practice
+/obj/projectile/beam/practice
 	name = "practice laser"
 	damage = 0
 	nodamage = TRUE
 
-/obj/item/projectile/beam/scatter
+/obj/projectile/beam/scatter
 	name = "laser pellet"
 	icon_state = "scatterlaser"
 	damage = 5
 
-/obj/item/projectile/beam/xray
+/obj/projectile/beam/xray
 	name = "\improper X-ray beam"
 	icon_state = "xray"
 	damage = 10
@@ -89,7 +89,7 @@
 	muzzle_type = /obj/effect/projectile/muzzle/xray
 	impact_type = /obj/effect/projectile/impact/xray
 
-/obj/item/projectile/beam/disabler
+/obj/projectile/beam/disabler
 	name = "disabler beam"
 	icon_state = "omnilaser"
 	damage = 30
@@ -103,17 +103,17 @@
 	muzzle_type = /obj/effect/projectile/muzzle/disabler
 	impact_type = /obj/effect/projectile/impact/disabler
 
-/obj/item/projectile/beam/disabler/bounce
+/obj/projectile/beam/disabler/bounce
 	name = "bouncing disabler ball"
 	icon_state = "omnibouncer"
 	damage = 20
 	ricochets_max = 5
 	ricochet_chance = 100
 
-/obj/item/projectile/beam/disabler/bounce/check_ricochet_flag(atom/A)
+/obj/projectile/beam/disabler/bounce/check_ricochet_flag(atom/A)
 	return TRUE //whatever it is, we bounce on it
 
-/obj/item/projectile/beam/pulse
+/obj/projectile/beam/pulse
 	name = "pulse"
 	icon_state = "u_laser"
 	damage = 50
@@ -123,7 +123,7 @@
 	muzzle_type = /obj/effect/projectile/muzzle/pulse
 	impact_type = /obj/effect/projectile/impact/pulse
 
-/obj/item/projectile/beam/pulse/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/beam/pulse/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if (!QDELETED(target) && (isturf(target) || istype(target, /obj/structure/)))
 		if(isobj(target))
@@ -134,21 +134,21 @@
 	if(istype(target_turf))
 		target_turf.IgniteTurf(rand(8, 22), "blue")
 
-/obj/item/projectile/beam/pulse/shotgun
+/obj/projectile/beam/pulse/shotgun
 	damage = 40
 
-/obj/item/projectile/beam/pulse/heavy
+/obj/projectile/beam/pulse/heavy
 	name = "heavy pulse laser"
 	icon_state = "pulse1_bl"
 	var/life = 20
 
-/obj/item/projectile/beam/pulse/heavy/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/beam/pulse/heavy/on_hit(atom/target, blocked = FALSE)
 	life -= 10
 	if(life > 0)
 		. = BULLET_ACT_FORCE_PIERCE
 	..()
 
-/obj/item/projectile/beam/emitter
+/obj/projectile/beam/emitter
 	name = "emitter beam"
 	icon_state = "emitter"
 	damage = 30
@@ -157,10 +157,10 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN
 
-/obj/item/projectile/beam/emitter/singularity_pull()
+/obj/projectile/beam/emitter/singularity_pull()
 	return //don't want the emitters to miss
 
-/obj/item/projectile/beam/emitter/pulse
+/obj/projectile/beam/emitter/pulse
 	name = "overcharged emitter beam"
 	icon_state = "u_laser"
 	damage = 50 // EVEN MORE power for the SM
@@ -171,7 +171,7 @@
 	muzzle_type = /obj/effect/projectile/muzzle/pulse
 	impact_type = /obj/effect/projectile/impact/pulse
 
-/obj/item/projectile/beam/emitter/pulse/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/beam/emitter/pulse/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if (!QDELETED(target) && (isturf(target) || istype(target, /obj/structure/)))
 		if(isobj(target))
@@ -179,7 +179,7 @@
 		else
 			SSexplosions.lowturf += target
 
-/obj/item/projectile/beam/lasertag
+/obj/projectile/beam/lasertag
 	name = "laser tag beam"
 	icon_state = "omnilaser"
 	hitsound = null
@@ -190,7 +190,7 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE
 
-/obj/item/projectile/beam/lasertag/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/beam/lasertag/on_hit(atom/target, blocked = FALSE)
 	if((blocked != 100) && ishuman(target)) //Anyone who knows the cheaters that held up objects to block their tag position knows that adding the block check to this is valid
 		var/mob/living/carbon/human/M = target
 		if(istype(M.wear_suit))
@@ -198,7 +198,7 @@
 				M.adjustStaminaLoss(34)
 	return ..()
 
-/obj/item/projectile/beam/lasertag/redtag
+/obj/projectile/beam/lasertag/redtag
 	icon_state = "laser"
 	suit_types = list(/obj/item/clothing/suit/bluetag)
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
@@ -207,20 +207,20 @@
 	muzzle_type = /obj/effect/projectile/muzzle/laser
 	impact_type = /obj/effect/projectile/impact/laser
 
-/obj/item/projectile/beam/lasertag/redtag/hitscan
+/obj/projectile/beam/lasertag/redtag/hitscan
 	hitscan = TRUE
 
-/obj/item/projectile/beam/lasertag/bluetag
+/obj/projectile/beam/lasertag/bluetag
 	icon_state = "bluelaser"
 	suit_types = list(/obj/item/clothing/suit/redtag)
 	tracer_type = /obj/effect/projectile/tracer/laser/blue
 	muzzle_type = /obj/effect/projectile/muzzle/laser/blue
 	impact_type = /obj/effect/projectile/impact/laser/blue
 
-/obj/item/projectile/beam/lasertag/bluetag/hitscan
+/obj/projectile/beam/lasertag/bluetag/hitscan
 	hitscan = TRUE
 
-/obj/item/projectile/beam/instakill
+/obj/projectile/beam/instakill
 	name = "instagib laser"
 	icon_state = "purple_laser"
 	damage = 200
@@ -228,24 +228,24 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
 	light_color = LIGHT_COLOR_PURPLE
 
-/obj/item/projectile/beam/instakill/blue
+/obj/projectile/beam/instakill/blue
 	icon_state = "blue_laser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE
 
-/obj/item/projectile/beam/instakill/red
+/obj/projectile/beam/instakill/red
 	icon_state = "red_laser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
 	light_color = LIGHT_COLOR_RED
 
-/obj/item/projectile/beam/instakill/on_hit(atom/target)
+/obj/projectile/beam/instakill/on_hit(atom/target)
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		M.visible_message(span_danger("[M] explodes into a shower of gibs!"))
 		M.gib()
 
-/obj/item/projectile/beam/grimdark
+/obj/projectile/beam/grimdark
 	pass_flags = NONE
 	light_color = LIGHT_COLOR_BLUE
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
@@ -255,7 +255,7 @@
 	wound_bonus = 0
 	speed = 1.4 // plasma ball slow
 
-/obj/item/projectile/beam/grimdark/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/beam/grimdark/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if (!QDELETED(target) && (isturf(target) || istype(target, /obj/structure/)))
 		if(isobj(target))
@@ -263,26 +263,26 @@
 		else
 			SSexplosions.medturf += target
 
-/obj/item/projectile/beam/grimdark/pistol
+/obj/projectile/beam/grimdark/pistol
 	damage = 35
 
-/obj/item/projectile/beam/laser/lasgun
+/obj/projectile/beam/laser/lasgun
 	name = "Las bolt"
 	icon_state = "las_laser"
 	speed = 0.8
 
-/obj/item/projectile/beam/laser/lasgun/longlas
+/obj/projectile/beam/laser/lasgun/longlas
 	damage = 25
 
-/obj/item/projectile/beam/laser/lasgun/laspistol
+/obj/projectile/beam/laser/lasgun/laspistol
 	damage = 15
 
-/obj/item/projectile/beam/laser/lasgun/hotshot
+/obj/projectile/beam/laser/lasgun/hotshot
 	damage = 30
 	wound_bonus = -5
 
 /// BFG
-/obj/item/projectile/beam/bfg
+/obj/projectile/beam/bfg
 	name = "searing rod"
 	icon_state = "lava"
 	damage = 35
@@ -290,7 +290,7 @@
 	light_color = "#ffff00"
 	speed = 1
 
-/obj/item/projectile/beam/bfg/Range()
+/obj/projectile/beam/bfg/Range()
 	. = ..()
 	for(var/atom/movable/passed in range(1, src))
 		if(passed == src)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -8,7 +8,7 @@
 	damage_type = BURN
 	hitsound = 'sound/weapons/sear.ogg'
 	hitsound_wall = 'sound/weapons/effects/searwall.ogg'
-	flag = LASER
+	armor_flag = LASER
 	eyeblur = 2
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
 	light_system = MOVABLE_LIGHT
@@ -94,7 +94,7 @@
 	icon_state = "omnilaser"
 	damage = 30
 	damage_type = STAMINA
-	flag = ENERGY
+	armor_flag = ENERGY
 	hitsound = 'sound/weapons/tap.ogg'
 	eyeblur = 0
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
@@ -185,7 +185,7 @@
 	hitsound = null
 	damage = 0
 	damage_type = STAMINA
-	flag = LASER
+	armor_flag = LASER
 	var/suit_types = list(/obj/item/clothing/suit/redtag, /obj/item/clothing/suit/bluetag)
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -4,7 +4,7 @@
 	damage = 60
 	damage_type = BRUTE
 	nodamage = FALSE
-	flag = BULLET
+	armor_flag = BULLET
 	hitsound_wall = "ricochet"
 	sharpness = SHARP_POINTY
 	impact_effect_type = /obj/effect/temp_visual/impact_effect

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/bullet
+/obj/projectile/bullet
 	name = "bullet"
 	icon_state = "bullet"
 	damage = 60
@@ -11,6 +11,6 @@
 	wound_falloff_tile = -5
 	speed = 0.4
 
-/obj/item/projectile/bullet/smite
+/obj/projectile/bullet/smite
 	name = "divine retribution"
 	damage = 10

--- a/code/modules/projectiles/projectile/bullets/_incendiary.dm
+++ b/code/modules/projectiles/projectile/bullets/_incendiary.dm
@@ -1,8 +1,8 @@
-/obj/item/projectile/bullet/incendiary
+/obj/projectile/bullet/incendiary
 	damage = 20
 	var/fire_stacks = 4
 
-/obj/item/projectile/bullet/incendiary/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/incendiary/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
@@ -12,7 +12,7 @@
 	if(istype(target_turf))
 		target_turf.IgniteTurf(rand(8, 22))
 
-/obj/item/projectile/bullet/incendiary/Move()
+/obj/projectile/bullet/incendiary/Move()
 	. = ..()
 	var/turf/location = get_turf(src)
 	if(location)

--- a/code/modules/projectiles/projectile/bullets/dart_syringe.dm
+++ b/code/modules/projectiles/projectile/bullets/dart_syringe.dm
@@ -1,19 +1,19 @@
-/obj/item/projectile/bullet/reusable/dart
+/obj/projectile/bullet/reusable/dart
 	name = "dart"
 	icon_state = "cbbolt"
 	damage = 6
 	var/piercing = FALSE
 
-/obj/item/projectile/bullet/reusable/dart/Initialize(mapload)
+/obj/projectile/bullet/reusable/dart/Initialize(mapload)
 	. = ..()
 
-/obj/item/projectile/bullet/reusable/dart/proc/add_dart(obj/item/reagent_containers/new_dart, syrpierce)
+/obj/projectile/bullet/reusable/dart/proc/add_dart(obj/item/reagent_containers/new_dart, syrpierce)
 	piercing = syrpierce
 	ammo_type = new_dart
 	new_dart.forceMove(src)
 	name = new_dart.name
 
-/obj/item/projectile/bullet/reusable/dart/handle_drop(mob/living/carbon/target, blocked)
+/obj/projectile/bullet/reusable/dart/handle_drop(mob/living/carbon/target, blocked)
 	if(dropped || !isitem(ammo_type) || !iscarbon(target))
 		return ..()
 
@@ -25,16 +25,16 @@
 
 	return ..() // Run further handle_drop stuff, for if the syringe doesn't embbed in the target
 
-/obj/item/projectile/bullet/reusable/dart/syringe
+/obj/projectile/bullet/reusable/dart/syringe
 	name = "syringe"
 	icon_state = "syringeproj"
 
-/obj/item/projectile/bullet/reusable/dart/syringe/blowgun
+/obj/projectile/bullet/reusable/dart/syringe/blowgun
 	name = "syringe"
 	icon_state = "syringeproj"
 	range = 2
 
-/obj/item/projectile/bullet/reusable/dart/hidden
+/obj/projectile/bullet/reusable/dart/hidden
 	name = "beanbag slug"
 	icon_state = "bullet" //So it doesn't look like a goddamned syringe
 	stamina = 5 // gotta act like we did stamina

--- a/code/modules/projectiles/projectile/bullets/dnainjector.dm
+++ b/code/modules/projectiles/projectile/bullets/dnainjector.dm
@@ -1,11 +1,11 @@
-/obj/item/projectile/bullet/dnainjector
+/obj/projectile/bullet/dnainjector
 	name = "\improper DNA injector"
 	icon_state = "syringeproj"
 	var/obj/item/dnainjector/injector
 	damage = 5
 	hitsound_wall = "shatter"
 
-/obj/item/projectile/bullet/dnainjector/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/dnainjector/on_hit(atom/target, blocked = FALSE)
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
 		if(blocked != 100)
@@ -19,6 +19,6 @@
 									   span_userdanger("You were protected against \the [src]!"))
 	return ..()
 
-/obj/item/projectile/bullet/dnainjector/Destroy()
+/obj/projectile/bullet/dnainjector/Destroy()
 	QDEL_NULL(injector)
 	return ..()

--- a/code/modules/projectiles/projectile/bullets/grenade.dm
+++ b/code/modules/projectiles/projectile/bullets/grenade.dm
@@ -1,12 +1,12 @@
 // 40mm (Grenade Launcher
 
-/obj/item/projectile/bullet/a40mm
+/obj/projectile/bullet/a40mm
 	name ="40mm grenade"
 	desc = "USE A WEEL GUN"
 	icon_state= "bolter"
 	damage = 60
 
-/obj/item/projectile/bullet/a40mm/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/a40mm/on_hit(atom/target, blocked = FALSE)
 	..()
 	explosion(target, -1, 0, 2, 1, 0, flame_range = 3)
 	return BULLET_ACT_HIT

--- a/code/modules/projectiles/projectile/bullets/lmg.dm
+++ b/code/modules/projectiles/projectile/bullets/lmg.dm
@@ -1,43 +1,43 @@
 // C3D (Borgs)
 
-/obj/item/projectile/bullet/c3d
+/obj/projectile/bullet/c3d
 	damage = 20
 
 // Mech LMG
 
-/obj/item/projectile/bullet/lmg
+/obj/projectile/bullet/lmg
 	damage = 20
 
 // Mech FNX-99
 
-/obj/item/projectile/bullet/incendiary/fnx99
+/obj/projectile/bullet/incendiary/fnx99
 	damage = 20
 
 // Turrets
 
-/obj/item/projectile/bullet/manned_turret
+/obj/projectile/bullet/manned_turret
 	damage = 20
 
-/obj/item/projectile/bullet/syndicate_turret
+/obj/projectile/bullet/syndicate_turret
 	damage = 20
 
 // 7.12x82mm (SAW)
 
-/obj/item/projectile/bullet/mm712x82
+/obj/projectile/bullet/mm712x82
 	name = "7.12x82mm bullet"
 	damage = 40
 	armour_penetration = 5
 	wound_bonus = -40				//hurt a lot but still mostly pointy
 	wound_falloff_tile = 0
 
-/obj/item/projectile/bullet/mm712x82/ap
+/obj/projectile/bullet/mm712x82/ap
 	name = "7.12x82mm armor-piercing bullet"
 	damage = 35
 	wound_bonus = -45				//they go straight through with little damage to surrounding tissue
 	armour_penetration = 45
 	bare_wound_bonus = -10			//flesh wont stop these very effectively but armor might make it tumble a bit before it enters
 
-/obj/item/projectile/bullet/mm712x82/hp
+/obj/projectile/bullet/mm712x82/hp
 	name = "7.12x82mm hollow-point bullet"
 	damage = 55
 	armour_penetration = -35		//bulletproof armor almost totally stops these, but you're still getting hit in the chest by a supersonic nugget of lead
@@ -45,7 +45,7 @@
 	wound_bonus = -35				//odds are you'll be shooting at someone with armor so you don't have a great chance for wounds
 	bare_wound_bonus = 35			//but if they aren't protected...
 
-/obj/item/projectile/bullet/incendiary/mm712x82
+/obj/projectile/bullet/incendiary/mm712x82
 	name = "7.12x82mm incendiary bullet"
 	damage = 27
 	fire_stacks = 2

--- a/code/modules/projectiles/projectile/bullets/minigun.dm
+++ b/code/modules/projectiles/projectile/bullets/minigun.dm
@@ -1,5 +1,5 @@
 //This is the bullet for the osprey
 
-/obj/item/projectile/bullet/a546
+/obj/projectile/bullet/a546
 	name = "5.46mm bullet"
 	damage = 36 // 1 more than the basic L6 bullet

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -1,38 +1,38 @@
 // 9mm (Stechkin APS)
 
-/obj/item/projectile/bullet/c9mm
+/obj/projectile/bullet/c9mm
 	name = "9mm bullet"
 	damage = 20
 	wound_bonus = -10
 
-/obj/item/projectile/bullet/c9mm/ap
+/obj/projectile/bullet/c9mm/ap
 	name = "9mm armor-piercing bullet"
 	damage = 18
 	armour_penetration = 40
 
-/obj/item/projectile/bullet/incendiary/c9mm
+/obj/projectile/bullet/incendiary/c9mm
 	name = "9mm incendiary bullet"
 	damage = 13
 	fire_stacks = 1
 
 // 10mm (Stechkin)
 
-/obj/item/projectile/bullet/c10mm
+/obj/projectile/bullet/c10mm
 	name = "10mm bullet"
 	damage = 30
 	wound_bonus = -30
 
-/obj/item/projectile/bullet/c10mm/cs
+/obj/projectile/bullet/c10mm/cs
 	name = "10mm caseless bullet"
 	damage = 27
 	speed = 0.5
 
-/obj/item/projectile/bullet/c10mm/ap
+/obj/projectile/bullet/c10mm/ap
 	name = "10mm armor-piercing bullet"
 	damage = 27
 	armour_penetration = 40
 
-/obj/item/projectile/bullet/c10mm/hp
+/obj/projectile/bullet/c10mm/hp
 	name = "10mm hollow-point bullet"
 	damage = 45
 	armour_penetration = -45
@@ -40,48 +40,48 @@
 	wound_bonus = -25 //Do you WANT a gun that can decapitate in 4 shots for traitors?
 	bare_wound_bonus = 5
 
-/obj/item/projectile/bullet/c10mm/sp
+/obj/projectile/bullet/c10mm/sp
 	name = "10mm soporific bullet"
 	damage = 30
 	damage_type = STAMINA
 	eyeblur = 20
 
-/obj/item/projectile/bullet/c10mm/sp/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/c10mm/sp/on_hit(atom/target, blocked = FALSE)
 	if((blocked != 100) && isliving(target))
 		var/mob/living/L = target
 		if(L.getStaminaLoss() >= 100)
 			L.Sleeping(400)
 	return ..()
 
-/obj/item/projectile/bullet/incendiary/c10mm
+/obj/projectile/bullet/incendiary/c10mm
 	name = "10mm incendiary bullet"
 	damage = 25
 	fire_stacks = 2
 
-/obj/item/projectile/bullet/c10mm/emp
+/obj/projectile/bullet/c10mm/emp
 	name = "10mm EMP bullet"
 	damage = 25
 
-/obj/item/projectile/bullet/c10mm/emp/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/c10mm/emp/on_hit(atom/target, blocked = FALSE)
 	..()
 	empulse(target, 0.5, 1) //Heavy EMP on target, light EMP in tiles around
 	
-/obj/item/projectile/bullet/boltpistol
+/obj/projectile/bullet/boltpistol
 	name = "Bolt round"
 	damage = 30
 	armour_penetration = 10
 	sharpness = SHARP_EDGED
 	wound_bonus = 5
 
-/obj/item/projectile/bullet/boltpistol/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/boltpistol/on_hit(atom/target, blocked = FALSE)
 	..()
 	explosion(target, -1, 0, 2)
 	return BULLET_ACT_HIT
 
-/obj/item/projectile/bullet/boltpistol/admin
+/obj/projectile/bullet/boltpistol/admin
 	damage = 100
 
-/obj/item/projectile/bullet/boltpistol/admin/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/boltpistol/admin/on_hit(atom/target, blocked = FALSE)
 	..()
 	explosion(target, -1, 0, 2)
 	if(iscarbon(target))

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -1,6 +1,6 @@
 // 7.62x38mmR (Nagant Revolver)
 
-/obj/item/projectile/bullet/n762
+/obj/projectile/bullet/n762
 	name = "7.62x38mmR bullet"
 	damage = 20
 	wound_bonus = -5
@@ -8,7 +8,7 @@
 
 // .50AE (Desert Eagle)
 
-/obj/item/projectile/bullet/a50AE
+/obj/projectile/bullet/a50AE
 	name = ".50 AE bullet"
 	damage = 45 //.357 gets armor penetration, this doesn't
 	wound_bonus = -35
@@ -16,38 +16,38 @@
 
 // .38 (Colt Detective Special + Vatra M38)
 
-/obj/item/projectile/bullet/c38
+/obj/projectile/bullet/c38
 	name = ".38 special bullet"
 	damage = 21
 	wound_bonus = -30
 	wound_falloff_tile = -2.5
 	bare_wound_bonus = 15
 
-/obj/item/projectile/bullet/c38/rubber
+/obj/projectile/bullet/c38/rubber
 	name = ".38 rubber bullet"
 	damage = 7
 	stamina = 30
 	armour_penetration = -30 //Armor hit by this is modified by x1.43.
 	sharpness = SHARP_NONE
 
-/obj/item/projectile/bullet/c38/ap
+/obj/projectile/bullet/c38/ap
 	name = ".38 armor-piercing bullet"
 	damage = 18
 	armour_penetration = 15 //Not actually all that great against armor, but not *terrible*
 
-/obj/item/projectile/bullet/c38/frost //Basically Iceblax 2
+/obj/projectile/bullet/c38/frost //Basically Iceblax 2
 	name = ".38 frost bullet"
 	armour_penetration = -45 //x1.81 vs x1.43 for how much more effective armor is
 	var/temperature = 100
 
-/obj/item/projectile/bullet/c38/frost/on_hit(atom/target, blocked = 0)
+/obj/projectile/bullet/c38/frost/on_hit(atom/target, blocked = 0)
 	if(blocked != 100)
 		if(isliving(target))
 			var/mob/living/L = target
 			L.adjust_bodytemperature(((100-blocked)/100)*(temperature - L.bodytemperature))
 	return ..()
 
-/obj/item/projectile/bullet/c38/talon
+/obj/projectile/bullet/c38/talon
 	name = ".38 talon bullet"
 	damage = 8 // 8+20 rolls 21-38 wound dmg vs no armor
 	wound_bonus = 20
@@ -55,18 +55,18 @@
 	wound_falloff_tile = -1
 	sharpness = SHARP_EDGED
 
-/obj/item/projectile/bullet/c38/bluespace
+/obj/projectile/bullet/c38/bluespace
 	name = ".38 bluespace bullet"
 	damage = 18
 	speed = 0.2 //Very, very, very fast
 
 // .32 TRAC (Caldwell Tracking Revolver)
 
-/obj/item/projectile/bullet/tra32
+/obj/projectile/bullet/tra32
 	name = ".32 TRAC bullet"
 	damage = 5
 
-/obj/item/projectile/bullet/tra32/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/tra32/on_hit(atom/target, blocked = FALSE)
 	if(blocked != 100)
 		var/mob/living/carbon/M = target
 		var/obj/item/implant/tracking/tra32/imp
@@ -80,14 +80,14 @@
 
 // .357 (Syndie Revolver)
 
-/obj/item/projectile/bullet/a357
+/obj/projectile/bullet/a357
 	name = ".357 magnum bullet"
 	damage = 40
 	armour_penetration = 15
 	wound_bonus = -45
 	wound_falloff_tile = -2.5
 
-/obj/item/projectile/bullet/pellet/a357_ironfeather
+/obj/projectile/bullet/pellet/a357_ironfeather
 	name = ".357 Ironfeather pellet"
 	damage = 8 //Total of 48 damage assuming PBS
 	armour_penetration = 10 //In between normal pellets and flechette for AP
@@ -96,39 +96,39 @@
 	tile_dropoff = 0.35 //Loses 0.05 damage less per tile than standard damaging pellets
 	wound_falloff_tile = -1.5 //Still probably won't cause wounds at range
 
-/obj/item/projectile/bullet/a357/nutcracker
+/obj/projectile/bullet/a357/nutcracker
 	name = ".357 Nutcracker bullet"
 	damage = 30
 
-/obj/item/projectile/bullet/a357/nutcracker/on_hit(atom/target) //Basically breaching slug with 1.5x damage
+/obj/projectile/bullet/a357/nutcracker/on_hit(atom/target) //Basically breaching slug with 1.5x damage
 	if(istype(target, /obj/structure/window) || istype(target, /obj/machinery/door) || istype(target, /obj/structure/door_assembly))
 		damage = 750 //One shot to break a window, two shots for a door, three if reinforced
 	..()
 
-/obj/item/projectile/bullet/a357/metalshock
+/obj/projectile/bullet/a357/metalshock
 	name = ".357 Metalshock bullet"
 	damage = 15
 	wound_bonus = -5
 
-/obj/item/projectile/bullet/a357/metalshock/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/a357/metalshock/on_hit(atom/target, blocked = FALSE)
 	..()
 	tesla_zap(target, 4, 20000, TESLA_MOB_DAMAGE) //Should do around 33 burn to the first target hit, assume no siemens coefficient (black gloves have 0.5)
 	return BULLET_ACT_HIT
 
-/obj/item/projectile/bullet/a357/heartpiercer
+/obj/projectile/bullet/a357/heartpiercer
 	name = ".357 Heartpiercer bullet"
 	damage = 35
 	armour_penetration = 45
 	penetrating = TRUE //Goes through a single mob before ending on the next target
 	penetrations = 1
 
-/obj/item/projectile/bullet/a357/wallstake
+/obj/projectile/bullet/a357/wallstake
 	name = ".357 Wallstake bullet"
 	damage = 36 //Almost entirely a meme round at this point. 36 damage barely four-shots standard armor
 	wound_bonus = -35
 	sharpness = SHARP_NONE //Blunt
 
-/obj/item/projectile/bullet/a357/wallstake/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/a357/wallstake/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(isliving(target)) //Unlike meteorslugs, these are smaller and meant to knock bodies around, not ANYTHING
 		var/atom/movable/M = target
@@ -137,7 +137,7 @@
 
 // .44 (Mateba)
 
-/obj/item/projectile/bullet/m44
+/obj/projectile/bullet/m44
 	name = ".44 magnum bullet"
 	damage = 55
 	armour_penetration = 20

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -1,21 +1,21 @@
 // 5.56mm (M-90gl Rifle + NT ARG)
 
-/obj/item/projectile/bullet/a556
+/obj/projectile/bullet/a556
 	name = "5.56mm bullet"
 	damage = 35
 	wound_bonus = -40
 
-/obj/item/projectile/bullet/a556/ap
+/obj/projectile/bullet/a556/ap
 	name = "5.56mm armor-piercing bullet"
 	damage = 31
 	armour_penetration = 50
 
-/obj/item/projectile/bullet/incendiary/a556
+/obj/projectile/bullet/incendiary/a556
 	name = "5.56mm incendiary bullet"
 	damage = 23
 	fire_stacks = 2
 
-/obj/item/projectile/bullet/a556/rubber
+/obj/projectile/bullet/a556/rubber
 	name = "5.56mm rubber bullet"
 	damage = 10
 	stamina = 47
@@ -23,14 +23,14 @@
 
 // .308 (LWT-650 DMR)
 
-/obj/item/projectile/bullet/m308
+/obj/projectile/bullet/m308
 	name = ".308 bullet"
 	speed = 0.3
 	damage = 42
 	wound_bonus = -40
 	wound_falloff_tile = 0
 
-/obj/item/projectile/bullet/m308/pen
+/obj/projectile/bullet/m308/pen
 	name = ".308 penetrator bullet"
 	damage = 35
 	armour_penetration = 35
@@ -38,25 +38,25 @@
 
 // 7.62 (Nagant Rifle + K-41s DMR)
 
-/obj/item/projectile/bullet/a762
+/obj/projectile/bullet/a762
 	name = "7.62mm bullet"
 	speed = 0.3
 	damage = 60
 	wound_bonus = -35
 	wound_falloff_tile = 0
 
-/obj/item/projectile/bullet/a762/raze
+/obj/projectile/bullet/a762/raze
 	name = "7.62mm Raze bullet"
 	damage = 40
 	irradiate = 300
 
-/obj/item/projectile/bullet/a762/raze/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/a762/raze/on_hit(atom/target, blocked = FALSE)
 	if((blocked != 100) && isliving(target))
 		var/mob/living/L = target
 		L.adjustCloneLoss(15)
 	return ..()
 
-/obj/item/projectile/bullet/a762/pen
+/obj/projectile/bullet/a762/pen
 	name = "7.62mm anti-material bullet"
 	damage = 52
 	armour_penetration = 40
@@ -64,11 +64,11 @@
 	penetrations = 2
 	penetration_type = 1
 
-/obj/item/projectile/bullet/a762/vulcan
+/obj/projectile/bullet/a762/vulcan
 	name = "7.62mm Vulcan bullet"
 	damage = 47
 
-/obj/item/projectile/bullet/a762/vulcan/on_hit(atom/target, blocked = FALSE) //God-forsaken mutant of explosion and incendiary code that makes it so it does an explosion basically without the throwing around
+/obj/projectile/bullet/a762/vulcan/on_hit(atom/target, blocked = FALSE) //God-forsaken mutant of explosion and incendiary code that makes it so it does an explosion basically without the throwing around
 	..()
 	var/turf/central_point = get_turf(target)
 	playsound(loc, 'sound/effects/explosion1.ogg', 20, TRUE)
@@ -80,12 +80,12 @@
 			warm_spot.hotspot_expose(700, 50, 1)
 	return BULLET_ACT_HIT
 
-/obj/item/projectile/bullet/a762_enchanted
+/obj/projectile/bullet/a762_enchanted
 	name = "enchanted 7.62mm bullet"
 	damage = 20
 	stamina = 80
 
-/obj/item/projectile/bullet/a762_enchanted/prehit(atom/target)
+/obj/projectile/bullet/a762_enchanted/prehit(atom/target)
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -189,7 +189,7 @@
 	name = "scattered hardlight beam"
 	icon_state = "disabler_bullet"
 	damage = 10 // Less damage than buckshot or rubbershot
-	flag = ENERGY
+	armor_flag = ENERGY
 	damage_type = STAMINA // Doesn't do "real" damage
 	sharpness = SHARP_NONE
 	armour_penetration = -40 // Energy armor is usually very low so uhh

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/bullet/shotgun/slug
+/obj/projectile/bullet/shotgun/slug
 	name = "12g shotgun slug"
 	speed = 0.5 //Shotgun = slower
 	var/tile_dropoff = 1.5
@@ -7,27 +7,27 @@
 	sharpness = SHARP_POINTY
 	wound_bonus = -30
 
-/obj/item/projectile/bullet/shotgun/slug/syndie
+/obj/projectile/bullet/shotgun/slug/syndie
 	name = "12g syndicate shotgun slug"
 	damage = 60
 	tile_dropoff = 0.5
 
-/obj/item/projectile/bullet/shotgun/slug/beanbag
+/obj/projectile/bullet/shotgun/slug/beanbag
 	name = "beanbag slug"
 	damage = 5
 	stamina = 55
 	wound_bonus = 20
 	sharpness = SHARP_NONE
 
-/obj/item/projectile/bullet/incendiary/shotgun
+/obj/projectile/bullet/incendiary/shotgun
 	name = "incendiary slug"
 	damage = 20
 
-/obj/item/projectile/bullet/incendiary/shotgun/dragonsbreath
+/obj/projectile/bullet/incendiary/shotgun/dragonsbreath
 	name = "dragonsbreath pellet"
 	damage = 7
 
-/obj/item/projectile/bullet/shotgun/slug/stun
+/obj/projectile/bullet/shotgun/slug/stun
 	name = "stunslug"
 	damage = 5
 	paralyze = 100
@@ -37,7 +37,7 @@
 	icon_state = "spark"
 	color = "#FFFF00"
 
-/obj/item/projectile/bullet/shotgun/slug/meteor
+/obj/projectile/bullet/shotgun/slug/meteor
 	name = "meteorslug"
 	icon = 'icons/obj/meteor.dmi'
 	icon_state = "dust"
@@ -47,28 +47,28 @@
 	sharpness = SHARP_NONE
 	hitsound = 'sound/effects/meteorimpact.ogg'
 
-/obj/item/projectile/bullet/shotgun/slug/meteor/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/shotgun/slug/meteor/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(ismovable(target))
 		var/atom/movable/M = target
 		var/atom/throw_target = get_edge_target_turf(M, get_dir(src, get_step_away(M, src)))
 		M.safe_throw_at(throw_target, 3, 2, force = MOVE_FORCE_OVERPOWERING)
 
-/obj/item/projectile/bullet/shotgun/slug/meteor/Initialize(mapload)
+/obj/projectile/bullet/shotgun/slug/meteor/Initialize(mapload)
 	. = ..()
 	SpinAnimation()
 
-/obj/item/projectile/bullet/shotgun/slug/frag12
+/obj/projectile/bullet/shotgun/slug/frag12
 	name = "frag12 slug"
 	damage = 25
 	wound_bonus = 0
 
-/obj/item/projectile/bullet/shotgun/slug/frag12/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/shotgun/slug/frag12/on_hit(atom/target, blocked = FALSE)
 	..()
 	explosion(target, -1, 0, 2)
 	return BULLET_ACT_HIT
 
-/obj/item/projectile/bullet/shotgun/slug/uranium
+/obj/projectile/bullet/shotgun/slug/uranium
 	name = "depleted uranium slug"
 	icon_state = "ubullet"
 	damage = 35 //Most certainly to drop below 3-shot threshold because of damage falloff
@@ -76,34 +76,34 @@
 	wound_bonus = -40
 	penetrating = TRUE //Goes through an infinite number of mobs
 
-/obj/item/projectile/bullet/shotgun/slug/Range()
+/obj/projectile/bullet/shotgun/slug/Range()
 	..()
 	if(damage > 0)
 		damage -= tile_dropoff
 	if(stamina > 0)
 		stamina -= tile_dropoff_s
 
-/obj/item/projectile/bullet/pellet
+/obj/projectile/bullet/pellet
 	speed = 0.5 //Shotgun = slower
 	var/tile_dropoff = 0.4
 	var/tile_dropoff_s = 0.3
 	armour_penetration = -20 //Armor is 25% stronger against pellets
 
-/obj/item/projectile/bullet/pellet/shotgun_buckshot
+/obj/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
 	damage = 11 //Total of 66
 	wound_bonus = 5
 	bare_wound_bonus = 5
 	wound_falloff_tile = -2.5 // low damage + additional dropoff will already curb wounding potential anything past point blank
 	
-/obj/item/projectile/bullet/pellet/shotgun_buckshot/syndie
+/obj/projectile/bullet/pellet/shotgun_buckshot/syndie
 	name = "syndicate buckshot pellet"
 	damage = 14.5 //3.5 more damage so it sucks less?
 	wound_bonus = 2
 	bare_wound_bonus = 2
 	armour_penetration = 0 //So it doesn't suffer against armor (it's for nukies only)
 
-/obj/item/projectile/bullet/pellet/shotgun_flechette
+/obj/projectile/bullet/pellet/shotgun_flechette
 	name = "flechette pellet"
 	speed = 0.4 //You're special
 	damage = 12
@@ -113,52 +113,52 @@
 	tile_dropoff = 0.35 //Ranged pellet because I guess?
 	wound_falloff_tile = -1
 
-/obj/item/projectile/bullet/pellet/shotgun_clownshot
+/obj/projectile/bullet/pellet/shotgun_clownshot
 	name = "clownshot pellet"
 	damage = 0
 	hitsound = 'sound/items/bikehorn.ogg'
 
-/obj/item/projectile/bullet/pellet/shotgun_rubbershot
+/obj/projectile/bullet/pellet/shotgun_rubbershot
 	name = "rubbershot pellet"
 	damage = 3
 	stamina = 13 //Total of 78 with less falloff (very big)
 	sharpness = SHARP_NONE
 
-/obj/item/projectile/bullet/pellet/shotgun_cryoshot
+/obj/projectile/bullet/pellet/shotgun_cryoshot
 	name = "cryoshot pellet"
 	damage = 6
 	sharpness = SHARP_NONE
 	var/temperature = 100
 
-/obj/item/projectile/bullet/pellet/shotgun_cryoshot/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/pellet/shotgun_cryoshot/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(isliving(target))
 		var/mob/living/M = target
 		M.adjust_bodytemperature((temperature - M.bodytemperature))
 
-/obj/item/projectile/bullet/pellet/shotgun_improvised
+/obj/projectile/bullet/pellet/shotgun_improvised
 	name = "improvised pellet"
 	damage = 6
 	wound_bonus = 0
 	bare_wound_bonus = 7.5
 	tile_dropoff = 0.35
 
-/obj/item/projectile/bullet/pellet/shotgun_improvised/on_range()
+/obj/projectile/bullet/pellet/shotgun_improvised/on_range()
 	do_sparks(1, TRUE, src)
 	..()
 
-/obj/item/projectile/bullet/pellet/shotgun_thundershot
+/obj/projectile/bullet/pellet/shotgun_thundershot
 	name = "thundershot pellet"
 	damage = 3
 	sharpness = SHARP_NONE
 	hitsound = 'sound/magic/lightningbolt.ogg'
 
-/obj/item/projectile/bullet/pellet/shotgun_thundershot/on_hit(atom/target)
+/obj/projectile/bullet/pellet/shotgun_thundershot/on_hit(atom/target)
 	..()
 	tesla_zap(target, rand(2, 3), 17500, TESLA_MOB_DAMAGE)
 	return BULLET_ACT_HIT
 
-/obj/item/projectile/bullet/pellet/Range()
+/obj/projectile/bullet/pellet/Range()
 	..()
 	if(damage > 0)
 		damage -= tile_dropoff
@@ -169,23 +169,23 @@
 
 // Mech Scattershot
 
-/obj/item/projectile/bullet/scattershot
+/obj/projectile/bullet/scattershot
 	damage = 16
 
 //Breaching Ammo
 
-/obj/item/projectile/bullet/shotgun/slug/breaching
+/obj/projectile/bullet/shotgun/slug/breaching
 	name = "12g breaching round"
 	desc = "A breaching round designed to destroy airlocks and windows with only a few shots, but is ineffective against other targets."
 	hitsound = 'sound/weapons/sonic_jackhammer.ogg'
 	damage = 10 //does shit damage to everything except doors and windows
 
-/obj/item/projectile/bullet/shotgun/slug/breaching/on_hit(atom/target)
+/obj/projectile/bullet/shotgun/slug/breaching/on_hit(atom/target)
 	if(istype(target, /obj/structure/window) || istype(target, /obj/machinery/door) || istype(target, /obj/structure/door_assembly))
 		damage = 500 //one shot to break a window or 3 shots to breach an airlock door
 	..()
 
-/obj/item/projectile/bullet/pellet/hardlight
+/obj/projectile/bullet/pellet/hardlight
 	name = "scattered hardlight beam"
 	icon_state = "disabler_bullet"
 	damage = 10 // Less damage than buckshot or rubbershot

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -1,16 +1,16 @@
 // .45 (M1911 & Surplus Carbine & C-20r SMG)
 
-/obj/item/projectile/bullet/c45
+/obj/projectile/bullet/c45
 	name = ".45 ACP bullet"
 	damage = 30
 	wound_bonus = -10
 
-/obj/item/projectile/bullet/c45/ap
+/obj/projectile/bullet/c45/ap
 	name = ".45 armor-piercing bullet"
 	damage = 27
 	armour_penetration = 40
 
-/obj/item/projectile/bullet/c45/hp
+/obj/projectile/bullet/c45/hp
 	name = ".45 hollow-point bullet"
 	damage = 45
 	armour_penetration = -45
@@ -18,11 +18,11 @@
 	wound_bonus = -5 //Basically L6 HP treatment on these values because it's, well, nukies
 	bare_wound_bonus = 5
 
-/obj/item/projectile/bullet/c45/venom
+/obj/projectile/bullet/c45/venom
 	name = ".45 venom bullet"
 	damage = 20
 
-/obj/item/projectile/bullet/c45/venom/on_hit(atom/target, blocked)
+/obj/projectile/bullet/c45/venom/on_hit(atom/target, blocked)
 	if((blocked != 100) && iscarbon(target))
 		var/mob/living/carbon/victim = target
 		victim.reagents.add_reagent(/datum/reagent/toxin/venom, 4)
@@ -30,56 +30,56 @@
 
 // 4.6x30mm (WT-550 Autocarbine)
 
-/obj/item/projectile/bullet/c46x30mm
+/obj/projectile/bullet/c46x30mm
 	name = "4.6x30mm bullet"
 	damage = 15
 	wound_bonus = -5
 	bare_wound_bonus = 5
 
-/obj/item/projectile/bullet/c46x30mm/ap
+/obj/projectile/bullet/c46x30mm/ap
 	name = "4.6x30mm armor-piercing bullet"
 	damage = 12
 	armour_penetration = 40
 
-/obj/item/projectile/bullet/incendiary/c46x30mm
+/obj/projectile/bullet/incendiary/c46x30mm
 	name = "4.6x30mm incendiary bullet"
 	damage = 9
 	fire_stacks = 1
 
-/obj/item/projectile/bullet/c46x30mm/rubber
+/obj/projectile/bullet/c46x30mm/rubber
 	name = "4.6x30mm rubber bullet"
 	damage = 5
 	stamina = 22
 	sharpness = SHARP_NONE
 
-/obj/item/projectile/bullet/c46x30mm/snakebite
+/obj/projectile/bullet/c46x30mm/snakebite
 	name = "4.6x30mm snakebite bullet" 
 	damage = 6
 
-/obj/item/projectile/bullet/c46x30mm/snakebite/on_hit(atom/target, blocked)
+/obj/projectile/bullet/c46x30mm/snakebite/on_hit(atom/target, blocked)
 	if((blocked != 100) && iscarbon(target))
 		var/mob/living/carbon/victim = target // Both injects toxin, and applies 6 tox damage on hit.
 		victim.reagents.add_reagent(/datum/reagent/toxin, 4)
 		victim.adjustToxLoss(6)
 
 	return ..()
-/obj/item/projectile/bullet/c46x30mm/kraken
+/obj/projectile/bullet/c46x30mm/kraken
 	name = "4.6x30mm kraken bullet"
 	damage = 22
 	armour_penetration = -60
 	wound_bonus = -30 // we arent dismembering people here
 	bare_wound_bonus = 3
 
-/obj/item/projectile/bullet/c46x30mm/airburst_pellet
+/obj/projectile/bullet/c46x30mm/airburst_pellet
 	name = "4.6x30mm airburst pellet"
 	damage = 10
 
-/obj/item/projectile/bullet/c46x30mm/airburst
+/obj/projectile/bullet/c46x30mm/airburst
 	name = "4.6x30mm airburst bullet"
 	damage = 2 // its just a casing
 	range = 5
 
-/obj/item/projectile/bullet/c46x30mm/airburst/on_range()
+/obj/projectile/bullet/c46x30mm/airburst/on_range()
 	var/obj/item/ammo_casing/c46x30mm/airburst_pellet/P = new(get_turf(src))
 	var/mob/living/L = new (get_turf(src))//it's jank, but casings can only be shot via a mob's location
 	P.fire_casing(get_edge_target_turf(firer, get_dir(firer, original)), L)

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -1,6 +1,6 @@
 // .50 (Sniper Rifle)
 
-/obj/item/projectile/bullet/p50
+/obj/projectile/bullet/p50
 	name = ".50 bullet"
 	speed = 0.3
 	damage = 70
@@ -9,13 +9,13 @@
 	armour_penetration = 50
 	var/breakthings = TRUE
 
-/obj/item/projectile/bullet/p50/on_hit(atom/target, blocked = 0)
+/obj/projectile/bullet/p50/on_hit(atom/target, blocked = 0)
 	if(isobj(target) && (blocked != 100) && breakthings)
 		var/obj/O = target
 		O.take_damage(80, BRUTE, BULLET, FALSE, null, armour_penetration)
 	return ..()
 
-/obj/item/projectile/bullet/p50/soporific
+/obj/projectile/bullet/p50/soporific
 	name = ".50 soporific bullet"
 	armour_penetration = 0
 	damage = 0
@@ -23,13 +23,13 @@
 	paralyze = 0
 	breakthings = FALSE
 
-/obj/item/projectile/bullet/p50/soporific/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/p50/soporific/on_hit(atom/target, blocked = FALSE)
 	if((blocked != 100) && isliving(target))
 		var/mob/living/L = target
 		L.Sleeping(400)
 	return ..()
 
-/obj/item/projectile/bullet/p50/penetrator
+/obj/projectile/bullet/p50/penetrator
 	name = ".50 penetrator bullet"
 	icon_state = "gauss"
 	damage = 60
@@ -38,7 +38,7 @@
 	dismemberment = 0 //It goes through you cleanly.
 	paralyze = 0
 
-/obj/item/projectile/bullet/p50/penetrator/shuttle //Nukeop Shuttle Variety
+/obj/projectile/bullet/p50/penetrator/shuttle //Nukeop Shuttle Variety
 	icon_state = "gaussstrong"
 	damage = 25
 	speed = 0.3

--- a/code/modules/projectiles/projectile/bullets/special.dm
+++ b/code/modules/projectiles/projectile/bullets/special.dm
@@ -1,6 +1,6 @@
 // Honker
 
-/obj/item/projectile/bullet/honker
+/obj/projectile/bullet/honker
 	name = "banana"
 	damage = 0
 	movement_type = FLYING | UNSTOPPABLE
@@ -10,11 +10,11 @@
 	icon_state = "banana"
 	range = 200
 
-/obj/item/projectile/bullet/honker/Initialize(mapload)
+/obj/projectile/bullet/honker/Initialize(mapload)
 	. = ..()
 	SpinAnimation()
 
-/obj/item/projectile/bullet/honker/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/honker/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	var/mob/M = target
 	if(istype(M))
@@ -22,10 +22,10 @@
 
 // Mime
 
-/obj/item/projectile/bullet/mime
+/obj/projectile/bullet/mime
 	damage = 40
 
-/obj/item/projectile/bullet/mime/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/mime/on_hit(atom/target, blocked = FALSE)
 	if((blocked != 100) && iscarbon(target))
 		var/mob/living/carbon/M = target
 		M.silent = max(M.silent, 10)

--- a/code/modules/projectiles/projectile/energy/_energy.dm
+++ b/code/modules/projectiles/projectile/energy/_energy.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/energy
+/obj/projectile/energy
 	name = "energy"
 	icon_state = "spark"
 	damage = 0

--- a/code/modules/projectiles/projectile/energy/_energy.dm
+++ b/code/modules/projectiles/projectile/energy/_energy.dm
@@ -3,5 +3,5 @@
 	icon_state = "spark"
 	damage = 0
 	damage_type = BURN
-	flag = ENERGY
+	armor_flag = ENERGY
 	reflectable = REFLECT_NORMAL

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -1,16 +1,16 @@
-/obj/item/projectile/energy/bolt //ebow bolts
+/obj/projectile/energy/bolt //ebow bolts
 	name = "bolt"
 	icon_state = "cbbolt"
 	irradiate = 200
 	pass_flags = PASSGLASS
 
-/obj/item/projectile/energy/bolt/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/energy/bolt/on_hit(atom/target, blocked = FALSE)
 	..()
 	if(ishuman(target))
 		target.reagents.add_reagent(/datum/reagent/toxin/relaxant, 6)
 		target.reagents.add_reagent(/datum/reagent/toxin/mutetoxin, 6)
 		target.reagents.add_reagent(/datum/reagent/toxin/anacea, 4)
 
-/obj/item/projectile/energy/bolt/halloween
+/obj/projectile/energy/bolt/halloween
 	name = "candy corn"
 	icon_state = "candy_corn"

--- a/code/modules/projectiles/projectile/energy/misc.dm
+++ b/code/modules/projectiles/projectile/energy/misc.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/energy/declone
+/obj/projectile/energy/declone
 	name = "radiation beam"
 	icon_state = "declone"
 	damage = 20
@@ -6,11 +6,11 @@
 	irradiate = 100
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	
-/obj/item/projectile/energy/declone/weak
+/obj/projectile/energy/declone/weak
 	damage = 9
 	irradiate = 30
 	
-/obj/item/projectile/energy/dart //ninja throwing dart
+/obj/projectile/energy/dart //ninja throwing dart
 	name = "dart"
 	icon_state = "toxin"
 	damage = 5

--- a/code/modules/projectiles/projectile/energy/net_snare.dm
+++ b/code/modules/projectiles/projectile/energy/net_snare.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/energy/net
+/obj/projectile/energy/net
 	name = "energy netting"
 	icon_state = "e_netting"
 	damage = 10
@@ -7,18 +7,18 @@
 	range = 10
 	var/obj/item/beacon/teletarget = null
 
-/obj/item/projectile/energy/net/Initialize(mapload)
+/obj/projectile/energy/net/Initialize(mapload)
 	. = ..()
 	SpinAnimation()
 
-/obj/item/projectile/energy/net/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/energy/net/on_hit(atom/target, blocked = FALSE)
 	if(isliving(target))
 		var/turf/Tloc = get_turf(target)
 		if(!locate(/obj/effect/nettingportal) in Tloc)
 			new /obj/effect/nettingportal(Tloc, destination = teletarget)
 	..()
 
-/obj/item/projectile/energy/net/on_range()
+/obj/projectile/energy/net/on_range()
 	do_sparks(1, TRUE, src)
 	..()
 
@@ -50,14 +50,14 @@
 /obj/effect/nettingportal/singularity_pull()
 	return
 
-/obj/item/projectile/energy/trap
+/obj/projectile/energy/trap
 	name = "energy snare"
 	icon_state = "e_snare"
 	nodamage = TRUE
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 4
 
-/obj/item/projectile/energy/trap/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/energy/trap/on_hit(atom/target, blocked = FALSE)
 	if(!ismob(target) || blocked >= 100) //Fully blocked by mob or collided with dense object - drop a trap
 		new/obj/item/restraints/legcuffs/beartrap/energy(get_turf(loc))
 	else if(iscarbon(target))
@@ -65,11 +65,11 @@
 		B.Crossed(target)
 	..()
 
-/obj/item/projectile/energy/trap/on_range()
+/obj/projectile/energy/trap/on_range()
 	new /obj/item/restraints/legcuffs/beartrap/energy(loc)
 	..()
 
-/obj/item/projectile/energy/trap/cyborg
+/obj/projectile/energy/trap/cyborg
 	name = "Energy Bola"
 	icon_state = "e_snare"
 	nodamage = TRUE
@@ -77,7 +77,7 @@
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 10
 
-/obj/item/projectile/energy/trap/cyborg/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/energy/trap/cyborg/on_hit(atom/target, blocked = FALSE)
 	if(!ismob(target) || blocked >= 100)
 		do_sparks(1, TRUE, src)
 		qdel(src)
@@ -87,6 +87,6 @@
 	QDEL_IN(src, 10)
 	..()
 
-/obj/item/projectile/energy/trap/cyborg/on_range()
+/obj/projectile/energy/trap/cyborg/on_range()
 	do_sparks(1, TRUE, src)
 	qdel(src)

--- a/code/modules/projectiles/projectile/energy/nuclear_particle.dm
+++ b/code/modules/projectiles/projectile/energy/nuclear_particle.dm
@@ -1,5 +1,5 @@
 //Nuclear particle projectile - a deadly side effect of fusion just kidding fuck that shit rads shouldn`t be a vomit ICBM
-/obj/item/projectile/energy/nuclear_particle
+/obj/projectile/energy/nuclear_particle
 	name = "nuclear particle"
 	icon_state = "nuclear_particle"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
@@ -18,16 +18,16 @@
 		"purple" = "#FF00FF"
 	)
 
-/obj/item/projectile/energy/nuclear_particle/Initialize(mapload)
+/obj/projectile/energy/nuclear_particle/Initialize(mapload)
 	. = ..()
 	//Random color time!
 	var/our_color = pick(particle_colors)
 	add_atom_colour(particle_colors[our_color], FIXED_COLOUR_PRIORITY)
 	set_light(4, 3, particle_colors[our_color]) //Range of 4, brightness of 3 - Same range as a flashlight
 
-/obj/item/projectile/energy/nuclear_particle/Move(atom/newloc, dir)
+/obj/projectile/energy/nuclear_particle/Move(atom/newloc, dir)
 	..()
-	for(var/obj/item/projectile/energy/nuclear_particle/P in newloc.contents)
+	for(var/obj/projectile/energy/nuclear_particle/P in newloc.contents)
 		if(istype(P) && MODULUS(Angle - P.Angle, 360) > 150 && MODULUS(Angle - P.Angle, 360) < 210 && prob(10))
 			name = "high-energy " + name
 			damage += P.damage
@@ -39,11 +39,11 @@
 			break
 
 /atom/proc/fire_nuclear_particle(angle = rand(0,360)) //used by fusion to fire random nuclear particles. Fires one particle in a random direction.
-	var/obj/item/projectile/energy/nuclear_particle/P = new /obj/item/projectile/energy/nuclear_particle(src)
+	var/obj/projectile/energy/nuclear_particle/P = new /obj/projectile/energy/nuclear_particle(src)
 	P.fire(angle)
 
 /// stronger particles
-/obj/item/projectile/energy/nuclear_particle/strong
+/obj/projectile/energy/nuclear_particle/strong
 	name = "high-energy particle"
 	damage = 10
 	irradiate = 800

--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/energy/electrode
+/obj/projectile/energy/electrode
 	name = "electrode"
 	icon_state = "spark"
 	color = "#FFFF00"
@@ -12,7 +12,7 @@
 	muzzle_type = /obj/effect/projectile/muzzle/stun
 	impact_type = /obj/effect/projectile/impact/stun
 
-/obj/item/projectile/energy/electrode/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/energy/electrode/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(!ismob(target) || blocked >= 100) //Fully blocked by mob or collided with dense object - burst into sparks!
 		do_sparks(1, TRUE, src)
@@ -30,6 +30,6 @@
 			to_chat(C,span_notice("You get charged by [src]."))
 		//yogstation edit end ---------------------------------------------
 
-/obj/item/projectile/energy/electrode/on_range() //to ensure the bolt sparks when it reaches the end of its range if it didn't hit a target yet
+/obj/projectile/energy/electrode/on_range() //to ensure the bolt sparks when it reaches the end of its range if it didn't hit a target yet
 	do_sparks(1, TRUE, src)
 	..()

--- a/code/modules/projectiles/projectile/energy/tesla.dm
+++ b/code/modules/projectiles/projectile/energy/tesla.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/energy/tesla
+/obj/projectile/energy/tesla
 	name = "tesla bolt"
 	icon_state = "tesla_projectile"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
@@ -7,23 +7,23 @@
 	var/zap_range = 3
 	var/power = 10000
 
-/obj/item/projectile/energy/tesla/fire(setAngle)
+/obj/projectile/energy/tesla/fire(setAngle)
 	if(firer)
 		chain = firer.Beam(src, icon_state = "lightning[rand(1, 12)]", time = INFINITY, maxdistance = INFINITY)
 	..()
 
-/obj/item/projectile/energy/tesla/on_hit(atom/target)
+/obj/projectile/energy/tesla/on_hit(atom/target)
 	. = ..()
 	tesla_zap(target, zap_range, power, tesla_flags)
 	qdel(src)
 
-/obj/item/projectile/energy/tesla/Destroy()
+/obj/projectile/energy/tesla/Destroy()
 	qdel(chain)
 	return ..()
 
-/obj/item/projectile/energy/tesla/revolver
+/obj/projectile/energy/tesla/revolver
 	name = "energy orb"
 
-/obj/item/projectile/energy/tesla/cannon
+/obj/projectile/energy/tesla/cannon
 	name = "tesla orb"
 	power = 20000

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/magic
+/obj/projectile/magic
 	name = "bolt of nothing"
 	icon_state = "energy"
 	damage = 0
@@ -13,7 +13,7 @@
 	/// determines the drain cost on the antimagic item
 	var/antimagic_charge_cost = 1
 
-/obj/item/projectile/magic/prehit(atom/target)
+/obj/projectile/magic/prehit(atom/target)
 	if(isliving(target))
 		var/mob/living/victim = target
 		if(victim.can_block_magic(antimagic_flags, antimagic_charge_cost))
@@ -31,17 +31,17 @@
 			return FALSE
 	return ..()
 
-/obj/item/projectile/magic/death
+/obj/projectile/magic/death
 	name = "bolt of death"
 	icon_state = "pulse1_bl"
 
-/obj/item/projectile/magic/death/on_hit(target)
+/obj/projectile/magic/death/on_hit(target)
 	. = ..()
 	if(isliving(target))
 		var/mob/living/M = target
 		M.death(0)
 
-/obj/item/projectile/magic/spellcard
+/obj/projectile/magic/spellcard
 	name = "enchanted card"
 	desc = "A piece of paper enchanted to give it extreme durability and stiffness, along with a very hot burn to anyone unfortunate enough to get hit by a charged one."
 	icon_state = "spellcard"
@@ -50,14 +50,14 @@
 	nodamage = FALSE
 	antimagic_charge_cost = 0 // since the cards gets spammed like a shotgun
 
-/obj/item/projectile/magic/resurrection
+/obj/projectile/magic/resurrection
 	name = "bolt of resurrection"
 	icon_state = "ion"
 	damage = 0
 	damage_type = OXY
 	nodamage = TRUE
 
-/obj/item/projectile/magic/resurrection/on_hit(mob/living/carbon/target)
+/obj/projectile/magic/resurrection/on_hit(mob/living/carbon/target)
 	. = ..()
 	if(isliving(target))
 		if(target.hellbound)
@@ -72,7 +72,7 @@
 		else if(target.stat != DEAD)
 			to_chat(target, span_notice("You feel great!"))
 
-/obj/item/projectile/magic/teleport
+/obj/projectile/magic/teleport
 	name = "bolt of teleportation"
 	icon_state = "bluespace"
 	damage = 0
@@ -81,7 +81,7 @@
 	var/inner_tele_radius = 0
 	var/outer_tele_radius = 6
 
-/obj/item/projectile/magic/teleport/on_hit(mob/target)
+/obj/projectile/magic/teleport/on_hit(mob/target)
 	. = ..()
 	var/teleammount = 0
 	var/teleloc = target
@@ -96,14 +96,14 @@
 				smoke.set_up(smoke_range, location = stuff.loc) //Smoke drops off if a lot of stuff is moved for the sake of sanity
 				smoke.start()
 
-/obj/item/projectile/magic/safety
+/obj/projectile/magic/safety
 	name = "bolt of safety"
 	icon_state = "bluespace"
 	damage = 0
 	damage_type = OXY
 	nodamage = TRUE
 
-/obj/item/projectile/magic/safety/on_hit(atom/target)
+/obj/projectile/magic/safety/on_hit(atom/target)
 	. = ..()
 	if(isturf(target))
 		return BULLET_ACT_HIT
@@ -117,7 +117,7 @@
 			smoke.set_up(0, location = t)
 			smoke.start()
 
-/obj/item/projectile/magic/door
+/obj/projectile/magic/door
 	name = "bolt of door creation"
 	icon_state = "energy"
 	damage = 0
@@ -125,7 +125,7 @@
 	nodamage = TRUE
 	var/list/door_types = list(/obj/structure/mineral_door/wood, /obj/structure/mineral_door/iron, /obj/structure/mineral_door/silver, /obj/structure/mineral_door/gold, /obj/structure/mineral_door/uranium, /obj/structure/mineral_door/sandstone, /obj/structure/mineral_door/transparent/plasma, /obj/structure/mineral_door/transparent/diamond)
 
-/obj/item/projectile/magic/door/on_hit(atom/target)
+/obj/projectile/magic/door/on_hit(atom/target)
 	. = ..()
 	if(istype(target, /obj/machinery/door))
 		open_door(target)
@@ -134,26 +134,26 @@
 		if(isclosedturf(T) && !isindestructiblewall(T))
 			CreateDoor(T)
 
-/obj/item/projectile/magic/door/proc/CreateDoor(turf/T)
+/obj/projectile/magic/door/proc/CreateDoor(turf/T)
 	var/door_type = pick(door_types)
 	var/obj/structure/mineral_door/D = new door_type(T)
 	T.ChangeTurf(/turf/open/floor/plating, flags = CHANGETURF_INHERIT_AIR)
 	D.Open()
 
-/obj/item/projectile/magic/door/proc/open_door(obj/machinery/door/D)
+/obj/projectile/magic/door/proc/open_door(obj/machinery/door/D)
 	if(istype(D, /obj/machinery/door/airlock))
 		var/obj/machinery/door/airlock/A = D
 		A.locked = FALSE
 	D.open()
 
-/obj/item/projectile/magic/change
+/obj/projectile/magic/change
 	name = "bolt of change"
 	icon_state = "ice_1"
 	damage = 0
 	damage_type = BURN
 	nodamage = TRUE
 
-/obj/item/projectile/magic/change/on_hit(atom/change)
+/obj/projectile/magic/change/on_hit(atom/change)
 	. = ..()
 	wabbajack(change)
 	qdel(src)
@@ -302,14 +302,14 @@
 	qdel(M)
 	return new_mob
 
-/obj/item/projectile/magic/cheese
+/obj/projectile/magic/cheese
 	name = "bolt of cheese"
 	icon_state = "cheese"
 	damage = 0
 	damage_type = BURN
 	nodamage = TRUE
 
-/obj/item/projectile/magic/cheese/on_hit(mob/living/M)
+/obj/projectile/magic/cheese/on_hit(mob/living/M)
 	. = ..()
 	cheeseify(M, FALSE)
 
@@ -344,14 +344,14 @@
 	to_chat(B, "<span class='big bold'>You are a cheesewheel!</span><b> You're a harmless wheel of parmesan that is remarkably tasty. Careful of people that want to eat you.</b>")
 	return B
 
-/obj/item/projectile/magic/animate
+/obj/projectile/magic/animate
 	name = "bolt of animation"
 	icon_state = "red_1"
 	damage = 0
 	damage_type = BURN
 	nodamage = TRUE
 
-/obj/item/projectile/magic/animate/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/magic/animate/on_hit(atom/target, blocked = FALSE)
 	target.animate_atom_living(firer)
 	..()
 
@@ -389,7 +389,7 @@
 		if(owner)
 			C.ChangeOwner(owner)
 
-/obj/item/projectile/magic/spellblade
+/obj/projectile/magic/spellblade
 	name = "blade energy"
 	icon_state = "lavastaff"
 	damage = 20
@@ -398,23 +398,23 @@
 	dismemberment = 50
 	nodamage = FALSE
 
-/obj/item/projectile/magic/spellblade/weak
+/obj/projectile/magic/spellblade/weak
 	damage = 15
 	dismemberment = 20
 	
-/obj/item/projectile/magic/spellblade/beesword
+/obj/projectile/magic/spellblade/beesword
 	name = "stinger"
 	icon_state = "bee"
 	damage = 1
 	damage_type = BRUTE
 	dismemberment = 0
 	
-/obj/item/projectile/magic/spellblade/beesword/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/magic/spellblade/beesword/on_hit(atom/target, blocked = FALSE)
 	..()
 	if(ishuman(target))
 		target.reagents.add_reagent(/datum/reagent/toxin/venom, 2)
 
-/obj/item/projectile/magic/arcane_barrage
+/obj/projectile/magic/arcane_barrage
 	name = "arcane bolt"
 	icon_state = "arcane_barrage"
 	damage = 40
@@ -424,7 +424,7 @@
 	flag = MAGIC 
 	hitsound = 'sound/weapons/barragespellhit.ogg'
 
-/obj/item/projectile/magic/locker
+/obj/projectile/magic/locker
 	name = "locker bolt"
 	icon_state = "locker"
 	nodamage = TRUE
@@ -433,7 +433,7 @@
 	var/created = FALSE //prevents creation of more then one locker if it has multiple hits
 	var/locker_suck = TRUE
 
-/obj/item/projectile/magic/locker/prehit(atom/A)
+/obj/projectile/magic/locker/prehit(atom/A)
 	if(ismob(A) && locker_suck)
 		var/mob/M = A
 		if(M.anchored)
@@ -442,7 +442,7 @@
 		return FALSE
 	return ..()
 
-/obj/item/projectile/magic/locker/on_hit(target)
+/obj/projectile/magic/locker/on_hit(target)
 	if(created)
 		return ..()
 	var/obj/structure/closet/decay/C = new(get_turf(src))
@@ -454,7 +454,7 @@
 	created = TRUE
 	return ..()
 
-/obj/item/projectile/magic/locker/Destroy()
+/obj/projectile/magic/locker/Destroy()
 	locker_suck = FALSE
 	for(var/atom/movable/AM in contents)
 		AM.forceMove(get_turf(src))
@@ -501,42 +501,42 @@
 	addtimer(CALLBACK(src, PROC_REF(decay)), 15 SECONDS)
 	icon_welded = "welded"
 
-/obj/item/projectile/magic/flying
+/obj/projectile/magic/flying
 	name = "bolt of flying"
 	icon_state = "flight"
 
-/obj/item/projectile/magic/flying/on_hit(target)
+/obj/projectile/magic/flying/on_hit(target)
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
 		var/atom/throw_target = get_edge_target_turf(L, angle2dir(Angle))
 		L.throw_at(throw_target, 200, 4)
 
-/obj/item/projectile/magic/bounty
+/obj/projectile/magic/bounty
 	name = "bolt of bounty"
 	icon_state = "bounty"
 
-/obj/item/projectile/magic/bounty/on_hit(target)
+/obj/projectile/magic/bounty/on_hit(target)
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
 		L.apply_status_effect(STATUS_EFFECT_BOUNTY, firer)
 
-/obj/item/projectile/magic/antimagic
+/obj/projectile/magic/antimagic
 	name = "bolt of antimagic"
 	icon_state = "antimagic"
 
-/obj/item/projectile/magic/antimagic/on_hit(target)
+/obj/projectile/magic/antimagic/on_hit(target)
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
 		L.apply_status_effect(STATUS_EFFECT_ANTIMAGIC)
 
-/obj/item/projectile/magic/fetch
+/obj/projectile/magic/fetch
 	name = "bolt of fetching"
 	icon_state = "fetch"
 
-/obj/item/projectile/magic/fetch/on_hit(target)
+/obj/projectile/magic/fetch/on_hit(target)
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
@@ -546,21 +546,21 @@
 		var/atom/throw_target = get_edge_target_turf(L, get_dir(L, firer))
 		L.throw_at(throw_target, 200, 4)
 
-/obj/item/projectile/magic/sapping
+/obj/projectile/magic/sapping
 	name = "bolt of sapping"
 	icon_state = "sapping"
 
-/obj/item/projectile/magic/sapping/on_hit(target)
+/obj/projectile/magic/sapping/on_hit(target)
 	. = ..()
 	if(ismob(target))
 		var/mob/M = target
 		SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, REF(src), /datum/mood_event/sapped)
 
-/obj/item/projectile/magic/necropotence
+/obj/projectile/magic/necropotence
 	name = "bolt of necropotence"
 	icon_state = "necropotence"
 
-/obj/item/projectile/magic/necropotence/on_hit(target)
+/obj/projectile/magic/necropotence/on_hit(target)
 	. = ..()
 	if(!isliving(target))
 		return
@@ -573,11 +573,11 @@
 
 	qdel(tap)
 
-/obj/item/projectile/magic/wipe
+/obj/projectile/magic/wipe
 	name = "bolt of possession"
 	icon_state = "wipe"
 
-/obj/item/projectile/magic/wipe/on_hit(target)
+/obj/projectile/magic/wipe/on_hit(target)
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/M = target
@@ -589,7 +589,7 @@
 		possession_test(M)
 		return BULLET_ACT_HIT
 
-/obj/item/projectile/magic/wipe/proc/possession_test(mob/living/carbon/target)
+/obj/projectile/magic/wipe/proc/possession_test(mob/living/carbon/target)
 	var/datum/brain_trauma/special/imaginary_friend/trapped_owner/trauma = target.gain_trauma(/datum/brain_trauma/special/imaginary_friend/trapped_owner)
 	var/poll_message = "Do you want to play as [target.real_name]?"
 	if(target.mind)
@@ -618,7 +618,7 @@
 		qdel(trauma)
 
 /// Gives magic projectiles an area of effect radius that will bump into any nearby mobs
-/obj/item/projectile/magic/aoe
+/obj/projectile/magic/aoe
 	damage = 0
 
 	/// The AOE radius that the projectile will trigger on people.
@@ -636,7 +636,7 @@
 	var/trail_icon_state = "trail"
 
 
-/obj/item/projectile/magic/aoe/Range()
+/obj/projectile/magic/aoe/Range()
 	if(trigger_range >= 1)
 		for(var/mob/living/nearby_guy in range(trigger_range, get_turf(src)))
 			if(nearby_guy.stat == DEAD)
@@ -648,18 +648,18 @@
 
 	return ..()
 
-/obj/item/projectile/magic/aoe/can_hit_target(atom/target, list/passthrough, direct_target = FALSE, ignore_loc = FALSE)
+/obj/projectile/magic/aoe/can_hit_target(atom/target, list/passthrough, direct_target = FALSE, ignore_loc = FALSE)
 	if(can_only_hit_target && target != original)
 		return FALSE
 	return ..()
 
-/obj/item/projectile/magic/aoe/Moved(atom/OldLoc, Dir)
+/obj/projectile/magic/aoe/Moved(atom/OldLoc, Dir)
 	. = ..()
 	if(trail)
 		create_trail()
 
 /// Creates and handles the trail that follows the projectile.
-/obj/item/projectile/magic/aoe/proc/create_trail()
+/obj/projectile/magic/aoe/proc/create_trail()
 	if(!trajectory)
 		return
 
@@ -674,7 +674,7 @@
 	trail.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	QDEL_IN(trail, trail_lifespan)
 
-/obj/item/projectile/magic/aoe/lightning
+/obj/projectile/magic/aoe/lightning
 	name = "lightning bolt"
 	icon_state = "tesla_projectile"	//Better sprites are REALLY needed and appreciated!~
 	damage = 25
@@ -692,21 +692,21 @@
 	/// A reference to the chain beam between the caster and the projectile
 	var/datum/beam/chain
 
-/obj/item/projectile/magic/aoe/lightning/fire(setAngle)
+/obj/projectile/magic/aoe/lightning/fire(setAngle)
 	if(firer)
 		chain = firer.Beam(src, icon_state = "lightning[rand(1, 12)]")
 	return ..()
 
-/obj/item/projectile/magic/aoe/lightning/on_hit(target)
+/obj/projectile/magic/aoe/lightning/on_hit(target)
 	. = ..()
 	tesla_zap(src, tesla_range, tesla_power, tesla_flags)
 	qdel(src)
 
-/obj/item/projectile/magic/aoe/lightning/Destroy()
+/obj/projectile/magic/aoe/lightning/Destroy()
 	QDEL_NULL(chain)
 	return ..()
 
-/obj/item/projectile/magic/aoe/lightning/eldritch
+/obj/projectile/magic/aoe/lightning/eldritch
 	name = "otherwordly power"
 	icon_state = "tesla_projectile"	
 	damage = 25
@@ -719,7 +719,7 @@
 	tesla_range = 7
 	tesla_flags = TESLA_MOB_STUN | TESLA_OBJ_DAMAGE
 
-/obj/item/projectile/magic/fireball
+/obj/projectile/magic/fireball
 	name = "bolt of fireball"
 	icon_state = "fireball"
 	damage = 10
@@ -735,7 +735,7 @@
 	/// Flash radius of the fireball
 	var/exp_flash = 3
 
-/obj/item/projectile/magic/fireball/on_hit(atom/target, blocked = FALSE, pierce_hit)
+/obj/projectile/magic/fireball/on_hit(atom/target, blocked = FALSE, pierce_hit)
 	. = ..()
 	if(isliving(target))
 		var/mob/living/mob_target = target
@@ -756,7 +756,7 @@
 	)
 
 
-/obj/item/projectile/magic/aoe/magic_missile
+/obj/projectile/magic/aoe/magic_missile
 	name = "magic missile"
 	icon_state = "magicm"
 	range = 20
@@ -771,11 +771,11 @@
 	trail_lifespan = 0.5 SECONDS
 	trail_icon_state = "magicmd"
 
-/obj/item/projectile/magic/aoe/magic_missile/lesser
+/obj/projectile/magic/aoe/magic_missile/lesser
 	color = "red" //Looks more culty this way
 	range = 10
 
-/obj/item/projectile/magic/aoe/juggernaut
+/obj/projectile/magic/aoe/juggernaut
 	name = "Gauntlet Echo"
 	icon_state = "cultfist"
 	alpha = 180
@@ -789,7 +789,7 @@
 	range = 15
 	speed = 7
 
-/obj/item/projectile/heretic_assault
+/obj/projectile/heretic_assault
 	name ="mindbolt"
 	icon_state= "chronobolt"
 	damage = 30
@@ -800,7 +800,7 @@
 	pass_flags = PASSTABLE
 	range = 5
 
-/obj/item/projectile/magic/spell/juggernaut/on_hit(atom/target, blocked)
+/obj/projectile/magic/spell/juggernaut/on_hit(atom/target, blocked)
 	. = ..()
 	var/turf/target_turf = get_turf(src)
 	playsound(target_turf, 'sound/weapons/resonator_blast.ogg', 100, FALSE)
@@ -814,14 +814,14 @@
 		adjacent_object.take_damage(90, BRUTE, MELEE, 0)
 		new /obj/effect/temp_visual/cult/turf/floor(get_turf(adjacent_object))
 
-/obj/item/projectile/magic/fireball/infernal
+/obj/projectile/magic/fireball/infernal
 	name = "infernal fireball"
 	exp_heavy = -1
 	exp_light = -1
 	exp_flash = 4
 	exp_fire= 5
 
-/obj/item/projectile/magic/fireball/infernal/on_hit(target)
+/obj/projectile/magic/fireball/infernal/on_hit(target)
 	. = ..()
 	var/turf/T = get_turf(target)
 	for(var/i=0, i<50, i+=10)
@@ -829,7 +829,7 @@
 
 //still magic related, but a different path
 
-/obj/item/projectile/temp/chill
+/obj/projectile/temp/chill
 	name = "bolt of chills"
 	icon_state = "ice_2"
 	damage = 0
@@ -840,27 +840,27 @@
 	flag = MAGIC
 
 
-/obj/item/projectile/temp/runic_icycle
+/obj/projectile/temp/runic_icycle
 	name = "Icicle"
 	icon_state = "runic_icycle"
 	damage = 6
 	flag = MAGIC
 	temperature = 80
 
-/obj/item/projectile/temp/runic_icycle/on_hit(target)
+/obj/projectile/temp/runic_icycle/on_hit(target)
 	.=..()
 	if(iscarbon(target))
 		var/mob/living/carbon/X = target
 		X.adjustBruteLoss(5)
 
-/obj/item/projectile/magic/runic_tentacle
+/obj/projectile/magic/runic_tentacle
 	name = "Tentacle"
 	icon_state = "tentacle_end"
 	damage = 6
 	flag = MAGIC
 
 
-/obj/item/projectile/magic/runic_tentacle/on_hit(target)
+/obj/projectile/magic/runic_tentacle/on_hit(target)
 	if(ismob(target))
 		new /obj/effect/temp_visual/goliath_tentacle/original(target)
 	.=..()
@@ -871,12 +871,12 @@
 		X.adjustBruteLoss(6)
 		new /obj/effect/temp_visual/goliath_tentacle/original(target)
 
-/obj/item/projectile/magic/runic_heal
+/obj/projectile/magic/runic_heal
 	name = "Runic Heal"
 	icon_state = "runic_heal"
 	flag = MAGIC
 	nodamage = TRUE
-/obj/item/projectile/magic/runic_heal/on_hit(target)
+/obj/projectile/magic/runic_heal/on_hit(target)
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/X = target
@@ -894,13 +894,13 @@
 
 
 
-/obj/item/projectile/magic/runic_fire
+/obj/projectile/magic/runic_fire
 	name = "Runic Fire"
 	icon_state = "lava"
 	flag = MAGIC
 	nodamage = FALSE
 
-/obj/item/projectile/magic/runic_fire/on_hit(target)
+/obj/projectile/magic/runic_fire/on_hit(target)
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/X = target
@@ -908,7 +908,7 @@
 		X.ignite_mob()
 
 
-/obj/item/projectile/magic/runic_honk
+/obj/projectile/magic/runic_honk
 	name = "Runic Peel"
 	icon_state = "runic_honk"
 	flag = MAGIC
@@ -918,14 +918,14 @@
 	ricochet_chance = 100
 	ricochets_max = 66
 
-/obj/item/projectile/magic/runic_honk/on_hit(target)
+/obj/projectile/magic/runic_honk/on_hit(target)
 	. = ..()
 	var/mob/X = target
 	if(istype(X))
 		X.slip(75, X.loc, GALOSHES_DONT_HELP|SLIDE, 0, FALSE)
 
 
-/obj/item/projectile/magic/runic_bomb
+/obj/projectile/magic/runic_bomb
 	name = "Runic Bomb"
 	icon_state = "runic_bomb"
 	flag = MAGIC
@@ -933,7 +933,7 @@
 	speed = 4
 	var/boom = 1
 
-/obj/item/projectile/magic/runic_bomb/on_hit(target)
+/obj/projectile/magic/runic_bomb/on_hit(target)
 	if(iscarbon(target))
 		var/mob/living/carbon/X = target
 		ADD_TRAIT(X, TRAIT_NODISMEMBER, type)
@@ -948,7 +948,7 @@
 		var/mob/M = target
 		explosion(M, -1, 0, boom, 0, 0)
 
-/obj/item/projectile/magic/runic_toxin
+/obj/projectile/magic/runic_toxin
 	name = "Runic Toxin"
 	icon_state = "syringeproj"
 	flag = MAGIC
@@ -957,7 +957,7 @@
 	nodamage = FALSE
 	eyeblur = 10
 
-/obj/item/projectile/magic/runic_toxin/on_hit(target)
+/obj/projectile/magic/runic_toxin/on_hit(target)
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/X = target
@@ -976,13 +976,13 @@
 						X.reagents.add_reagent(/datum/reagent/toxin/plasma, 10)
 
 
-/obj/item/projectile/magic/runic_death
+/obj/projectile/magic/runic_death
 	name = "Runic Death"
 	icon_state = "antimagic"
 	flag = MAGIC
 	impact_effect_type = /obj/effect/temp_visual/dir_setting/bloodsplatter
 
-/obj/item/projectile/magic/runic_death/on_hit(mob/living/target)
+/obj/projectile/magic/runic_death/on_hit(mob/living/target)
 	. = ..()
 	if(iszombie(target))
 		target.gib()
@@ -992,26 +992,26 @@
 		target.adjustBruteLoss(40)
 
 
-/obj/item/projectile/magic/shotgun/slug
+/obj/projectile/magic/shotgun/slug
 	name = "Shotgun slug"
 	icon_state = "bullet"
 	damage = 10
 	flag = MAGIC
 
-/obj/item/projectile/magic/shotgun/slug/on_hit(target)
+/obj/projectile/magic/shotgun/slug/on_hit(target)
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/X = target
 		X.adjustBruteLoss(10)
 
-/obj/item/projectile/magic/incediary_slug
+/obj/projectile/magic/incediary_slug
 	name = "Incendiary shotgun slug"
 	icon_state = "bullet"
 	damage = 5
 	flag = MAGIC
 
 
-/obj/item/projectile/magic/incediary_slug/on_hit(target)
+/obj/projectile/magic/incediary_slug/on_hit(target)
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/X = target
@@ -1019,13 +1019,13 @@
 		X.ignite_mob()
 		X.adjustBruteLoss(5)
 
-/obj/item/projectile/magic/runic_mutation
+/obj/projectile/magic/runic_mutation
 	name = "Runic Mutation"
 	icon_state = "toxin"
 	flag = MAGIC
 	irradiate = 12
 
-/obj/item/projectile/magic/runic_mutation/on_hit(target)
+/obj/projectile/magic/runic_mutation/on_hit(target)
 	. = ..()
 	if(iscarbon(target))
 		var/mob/living/carbon/X = target
@@ -1035,13 +1035,13 @@
 			X.easy_random_mutate(MINOR_NEGATIVE)
 
 
-/obj/item/projectile/magic/runic_resizement
+/obj/projectile/magic/runic_resizement
 	name = "Runic Resizement"
 	flag = MAGIC
 	icon_state = "cursehand1"
 
 
-/obj/item/projectile/magic/runic_resizement/on_hit(target)
+/obj/projectile/magic/runic_resizement/on_hit(target)
 	. = ..()
 	if(isliving(target))
 		var/mob/living/X = target
@@ -1078,7 +1078,7 @@
 							X.update_transform()
 		.=..()
 
-/obj/item/projectile/magic/ion //magic version of ion rifle bullets
+/obj/projectile/magic/ion //magic version of ion rifle bullets
 	name = "ion bolt"
 	icon_state = "ion"
 	damage = 0
@@ -1089,7 +1089,7 @@
 	var/light_emp_radius = 3
 	var/heavy_emp_radius = 0.5	//Effectively 1 but doesnt spread to adjacent tiles
 
-/obj/item/projectile/magic/ion/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/magic/ion/on_hit(atom/target, blocked = FALSE)
 	..()
 	empulse(target, heavy_emp_radius, light_emp_radius)
 	return BULLET_ACT_HIT

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -5,7 +5,7 @@
 	damage_type = OXY
 	nodamage = TRUE
 	armour_penetration = 100
-	flag = MAGIC
+	armor_flag = MAGIC
 	var/tile_dropoff = 0
 	var/tile_dropoff_s = 0
 	/// determines what type of antimagic can block the spell projectile
@@ -394,7 +394,7 @@
 	icon_state = "lavastaff"
 	damage = 20
 	damage_type = BURN
-	flag = MAGIC
+	armor_flag = MAGIC
 	dismemberment = 50
 	nodamage = FALSE
 
@@ -421,14 +421,14 @@
 	damage_type = BURN
 	nodamage = FALSE
 	armour_penetration = 20
-	flag = MAGIC 
+	armor_flag = MAGIC 
 	hitsound = 'sound/weapons/barragespellhit.ogg'
 
 /obj/projectile/magic/locker
 	name = "locker bolt"
 	icon_state = "locker"
 	nodamage = TRUE
-	flag = MAGIC
+	armor_flag = MAGIC
 	var/weld = TRUE
 	var/created = FALSE //prevents creation of more then one locker if it has multiple hits
 	var/locker_suck = TRUE
@@ -681,7 +681,7 @@
 	damage_type = BURN
 	nodamage = FALSE
 	speed = 0.3
-	flag = MAGIC
+	armor_flag = MAGIC
 
 	/// The power of the zap itself when it electrocutes someone
 	var/tesla_power = 20000
@@ -713,7 +713,7 @@
 	damage_type = BURN
 	nodamage = FALSE
 	speed = 0.3
-	flag = MAGIC
+	armor_flag = MAGIC
 
 	tesla_power = 9000
 	tesla_range = 7
@@ -837,14 +837,14 @@
 	nodamage = TRUE
 	armour_penetration = 100
 	temperature = 50
-	flag = MAGIC
+	armor_flag = MAGIC
 
 
 /obj/projectile/temp/runic_icycle
 	name = "Icicle"
 	icon_state = "runic_icycle"
 	damage = 6
-	flag = MAGIC
+	armor_flag = MAGIC
 	temperature = 80
 
 /obj/projectile/temp/runic_icycle/on_hit(target)
@@ -857,7 +857,7 @@
 	name = "Tentacle"
 	icon_state = "tentacle_end"
 	damage = 6
-	flag = MAGIC
+	armor_flag = MAGIC
 
 
 /obj/projectile/magic/runic_tentacle/on_hit(target)
@@ -874,7 +874,7 @@
 /obj/projectile/magic/runic_heal
 	name = "Runic Heal"
 	icon_state = "runic_heal"
-	flag = MAGIC
+	armor_flag = MAGIC
 	nodamage = TRUE
 /obj/projectile/magic/runic_heal/on_hit(target)
 	. = ..()
@@ -897,7 +897,7 @@
 /obj/projectile/magic/runic_fire
 	name = "Runic Fire"
 	icon_state = "lava"
-	flag = MAGIC
+	armor_flag = MAGIC
 	nodamage = FALSE
 
 /obj/projectile/magic/runic_fire/on_hit(target)
@@ -911,7 +911,7 @@
 /obj/projectile/magic/runic_honk
 	name = "Runic Peel"
 	icon_state = "runic_honk"
-	flag = MAGIC
+	armor_flag = MAGIC
 	range = 200
 	movement_type = FLYING
 	reflectable = REFLECT_NORMAL
@@ -928,7 +928,7 @@
 /obj/projectile/magic/runic_bomb
 	name = "Runic Bomb"
 	icon_state = "runic_bomb"
-	flag = MAGIC
+	armor_flag = MAGIC
 	range = 10
 	speed = 4
 	var/boom = 1
@@ -951,7 +951,7 @@
 /obj/projectile/magic/runic_toxin
 	name = "Runic Toxin"
 	icon_state = "syringeproj"
-	flag = MAGIC
+	armor_flag = MAGIC
 	damage = 1
 	damage_type = BRUTE
 	nodamage = FALSE
@@ -979,7 +979,7 @@
 /obj/projectile/magic/runic_death
 	name = "Runic Death"
 	icon_state = "antimagic"
-	flag = MAGIC
+	armor_flag = MAGIC
 	impact_effect_type = /obj/effect/temp_visual/dir_setting/bloodsplatter
 
 /obj/projectile/magic/runic_death/on_hit(mob/living/target)
@@ -996,7 +996,7 @@
 	name = "Shotgun slug"
 	icon_state = "bullet"
 	damage = 10
-	flag = MAGIC
+	armor_flag = MAGIC
 
 /obj/projectile/magic/shotgun/slug/on_hit(target)
 	. = ..()
@@ -1008,7 +1008,7 @@
 	name = "Incendiary shotgun slug"
 	icon_state = "bullet"
 	damage = 5
-	flag = MAGIC
+	armor_flag = MAGIC
 
 
 /obj/projectile/magic/incediary_slug/on_hit(target)
@@ -1022,7 +1022,7 @@
 /obj/projectile/magic/runic_mutation
 	name = "Runic Mutation"
 	icon_state = "toxin"
-	flag = MAGIC
+	armor_flag = MAGIC
 	irradiate = 12
 
 /obj/projectile/magic/runic_mutation/on_hit(target)
@@ -1037,7 +1037,7 @@
 
 /obj/projectile/magic/runic_resizement
 	name = "Runic Resizement"
-	flag = MAGIC
+	armor_flag = MAGIC
 	icon_state = "cursehand1"
 
 
@@ -1084,7 +1084,7 @@
 	damage = 0
 	damage_type = BURN
 	nodamage = TRUE
-	flag = ENERGY
+	armor_flag = ENERGY
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/ion
 	var/light_emp_radius = 3
 	var/heavy_emp_radius = 0.5	//Effectively 1 but doesnt spread to adjacent tiles

--- a/code/modules/projectiles/projectile/magic/spellcard.dm
+++ b/code/modules/projectiles/projectile/magic/spellcard.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/spellcard
+/obj/projectile/spellcard
 	name = "enchanted card"
 	desc = "A piece of paper enchanted to give it extreme durability and stiffness, along with a very hot burn to anyone unfortunate enough to get hit by a charged one."
 	icon_state = "spellcard"

--- a/code/modules/projectiles/projectile/reusable/_reusable.dm
+++ b/code/modules/projectiles/projectile/reusable/_reusable.dm
@@ -1,19 +1,19 @@
-/obj/item/projectile/bullet/reusable
+/obj/projectile/bullet/reusable
 	name = "reusable bullet"
 	desc = "How do you even reuse a bullet?"
 	var/obj/item/ammo_casing/ammo_type
 	var/dropped = FALSE
 	impact_effect_type = null
 
-/obj/item/projectile/bullet/reusable/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/reusable/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	handle_drop(target, blocked)
 
-/obj/item/projectile/bullet/reusable/on_range()
+/obj/projectile/bullet/reusable/on_range()
 	handle_drop()
 	..()
 
-/obj/item/projectile/bullet/reusable/proc/handle_drop(atom/target, blocked)
+/obj/projectile/bullet/reusable/proc/handle_drop(atom/target, blocked)
 	if(dropped || !ammo_type)
 		return
 

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -4,7 +4,7 @@
 	damage = 35
 	armour_penetration = -25 //Melee armor tends to be much higher, so this hurts
 	speed = 0.6
-	flag = MELEE
+	armor_flag = MELEE
 	icon_state = "arrow"
 	var/embed_chance = 0.4
 	var/break_chance = 0
@@ -59,7 +59,7 @@
 		var/mob/living/carbon/embede = target
 		var/obj/item/bodypart/part = embede.get_bodypart(def_zone)
 		var/obj/item/ammo_casing/reusable/arrow/arrow = ammo_type
-		if(!(istype(arrow) && arrow.explosive) && prob(embed_chance * clamp((100 - (embede.getarmor(part, flag) - armour_penetration)), 0, 100)) && embede.embed_object(ammo_type, part, TRUE))
+		if(!(istype(arrow) && arrow.explosive) && prob(embed_chance * clamp((100 - (embede.getarmor(part, armor_flag) - armour_penetration)), 0, 100)) && embede.embed_object(ammo_type, part, TRUE))
 			arrow.on_land(src)
 			dropped = TRUE
 	return ..()
@@ -232,7 +232,7 @@
 	if((blocked != 100) && iscarbon(target))
 		var/mob/living/carbon/embede = target
 		var/obj/item/bodypart/part = embede.get_bodypart(def_zone)
-		if(prob(embed_chance * clamp((100 - (embede.getarmor(part, flag) - armour_penetration)), 0, 100)))
+		if(prob(embed_chance * clamp((100 - (embede.getarmor(part, armor_flag) - armour_penetration)), 0, 100)))
 			embede.embed_object(new embed_type(), part, FALSE)
 	return ..()
 

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/bullet/reusable/arrow //Base arrow. Good against fauna, not perfect, but well-rounded.
+/obj/projectile/bullet/reusable/arrow //Base arrow. Good against fauna, not perfect, but well-rounded.
 	name = "arrow"
 	desc = "Woosh!"
 	damage = 35
@@ -10,7 +10,7 @@
 	var/break_chance = 0
 	var/fauna_damage_bonus = 10
 
-/obj/item/projectile/bullet/reusable/arrow/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/reusable/arrow/on_hit(atom/target, blocked = FALSE)
 	..()
 	var/turf/open/target_turf = get_turf(target)
 	if(istype(target_turf))
@@ -43,7 +43,7 @@
 
 	arrow.update_appearance(UPDATE_ICON)
 
-/obj/item/projectile/bullet/reusable/arrow/handle_drop(atom/target)
+/obj/projectile/bullet/reusable/arrow/handle_drop(atom/target)
 	if(dropped || !ammo_type)
 		return ..()
 
@@ -67,23 +67,23 @@
 
 // Arrow Subtypes //
 
-/obj/item/projectile/bullet/reusable/arrow/wood
+/obj/projectile/bullet/reusable/arrow/wood
 	name = "wooden arrow"
 	desc = "A wooden arrow, quickly made."
 
-/obj/item/projectile/bullet/reusable/arrow/ash //Fire-tempered head makes it tougher; more damage, but less likely to embed
+/obj/projectile/bullet/reusable/arrow/ash //Fire-tempered head makes it tougher; more damage, but less likely to embed
 	name = "ashen arrow"
 	desc = "A wooden arrow tempered by fire. It's tougher, but less likely to embed."
 	damage = 40
 	embed_chance = 0.3
 
-/obj/item/projectile/bullet/reusable/arrow/bone_tipped //A fully upgraded normal arrow; it's got the stats to show. Still less damage than a slug, resolving against melee, fired less often, slower, and with negative AP
+/obj/projectile/bullet/reusable/arrow/bone_tipped //A fully upgraded normal arrow; it's got the stats to show. Still less damage than a slug, resolving against melee, fired less often, slower, and with negative AP
 	name = "bone-tipped arrow"
 	desc = "An arrow made from bone, wood, and sinew. Sturdy and sharp."
 	damage = 45
 	armour_penetration = -10
 
-/obj/item/projectile/bullet/reusable/arrow/bone //Cheap, easy to make in bulk but mostly used for hunting fauna
+/obj/projectile/bullet/reusable/arrow/bone //Cheap, easy to make in bulk but mostly used for hunting fauna
 	name = "bone arrow"
 	desc = "An arrow made from bone and sinew. Better at hunting fauna."
 	damage = 25
@@ -91,14 +91,14 @@
 	fauna_damage_bonus = 35 //Significantly better for hunting fauna, but you don't get to instantly recharge your shots
 	embed_chance = 0.33
 
-/obj/item/projectile/bullet/reusable/arrow/chitin //Most expensive arrow time and resource-wise, simply because of ash resin. Should be good
+/obj/projectile/bullet/reusable/arrow/chitin //Most expensive arrow time and resource-wise, simply because of ash resin. Should be good
 	name = "chitin-tipped arrow"
 	desc = "An arrow made from chitin, bone, and sinew. Incredibly potent at puncturing armor and hunting fauna."
 	damage = 35
 	armour_penetration = 30 //Basically an AP arrow
 	fauna_damage_bonus = 40 //Even better, since they're that much harder to make
 
-/obj/item/projectile/bullet/reusable/arrow/bamboo //Very brittle, very fragile, but very potent at splintering into targets assuming it isn't broken on impact
+/obj/projectile/bullet/reusable/arrow/bamboo //Very brittle, very fragile, but very potent at splintering into targets assuming it isn't broken on impact
 	name = "bamboo arrow"
 	desc = "An arrow made from bamboo. Incredibly fragile and weak, but prone to shattering in unarmored targets."
 	damage = 20
@@ -106,25 +106,25 @@
 	embed_chance = 0.6 //Reminder that this resolves against melee armor
 	break_chance = 33 //Doesn't embed if it breaks
 
-/obj/item/projectile/bullet/reusable/arrow/bronze //Bronze > iron, that's why they called it the bronze age
+/obj/projectile/bullet/reusable/arrow/bronze //Bronze > iron, that's why they called it the bronze age
 	name = "bronze arrow"
 	desc = "An arrow tipped with bronze. Better against armor than iron."
 	armour_penetration = -10
 
-/obj/item/projectile/bullet/reusable/arrow/glass //Basically just a downgrade for people who can't get their hands on wood/cloth
+/obj/projectile/bullet/reusable/arrow/glass //Basically just a downgrade for people who can't get their hands on wood/cloth
 	name = "glass arrow"
 	desc = "A shoddy arrow with a broken glass shard as its tip. Can break upon impact."
 	damage = 25
 	embed_chance = 0.3
 	break_chance = 10
 
-/obj/item/projectile/bullet/reusable/arrow/glass/plasma //It's HARD to get plasmaglass shards without an axe, so this should be GOOD
+/obj/projectile/bullet/reusable/arrow/glass/plasma //It's HARD to get plasmaglass shards without an axe, so this should be GOOD
 	name = "plasmaglass arrow"
 	desc = "An arrow with a plasmaglass shard affixed to its head. Incredibly capable of puncturing armor."
 	damage = 25
 	armour_penetration = 45 //18.75 damage against elite hardsuit assuming chest shot (and that's a long reload, draw, projectile speed, etc.)
 
-/obj/item/projectile/bullet/reusable/arrow/magic
+/obj/projectile/bullet/reusable/arrow/magic
 	name = "magic arrow"
 	desc = "A magic arrow thats probably tracking you, how nice!"
 	icon_state = "arrow_magic"
@@ -134,13 +134,13 @@
 
 // Toy //
 
-/obj/item/projectile/bullet/reusable/arrow/toy //Toy arrow with velcro tip that safely embeds into target
+/obj/projectile/bullet/reusable/arrow/toy //Toy arrow with velcro tip that safely embeds into target
 	name = "toy arrow"
 	damage = 0
 	embed_chance = 0.9
 	break_chance = 0
 
-/obj/item/projectile/bullet/reusable/arrow/toy/on_hit(atom/target, blocked)
+/obj/projectile/bullet/reusable/arrow/toy/on_hit(atom/target, blocked)
 	. = ..()
 
 	if(!iscarbon(target))
@@ -163,52 +163,52 @@
 	
 	C.adjustStaminaLoss(25) // ARMOR IS CHEATING!!!
 
-/obj/item/projectile/bullet/reusable/arrow/toy/energy
+/obj/projectile/bullet/reusable/arrow/toy/energy
 	name = "toy energy bolt"
 	icon_state = "arrow_energy"
 
-/obj/item/projectile/bullet/reusable/arrow/toy/disabler
+/obj/projectile/bullet/reusable/arrow/toy/disabler
 	name = "toy disabler bolt"
 	icon_state = "arrow_disable"
 
-/obj/item/projectile/bullet/reusable/arrow/toy/pulse
+/obj/projectile/bullet/reusable/arrow/toy/pulse
 	name = "toy pulse bolt"
 	icon_state = "arrow_pulse"
 
-/obj/item/projectile/bullet/reusable/arrow/toy/xray
+/obj/projectile/bullet/reusable/arrow/toy/xray
 	name = "toy X-ray bolt"
 	icon_state = "arrow_xray"
 
-/obj/item/projectile/bullet/reusable/arrow/toy/shock
+/obj/projectile/bullet/reusable/arrow/toy/shock
 	name = "toy shock bolt"
 	icon_state = "arrow_shock"
 
-/obj/item/projectile/bullet/reusable/arrow/toy/magic
+/obj/projectile/bullet/reusable/arrow/toy/magic
 	name = "toy magic arrow"
 	icon_state = "arrow_magic"
 
 
 // Joke //
 
-/obj/item/projectile/bullet/reusable/arrow/supermatter
+/obj/projectile/bullet/reusable/arrow/supermatter
 	name = "supermatter arrow"
 
-/obj/item/projectile/bullet/reusable/arrow/supermatter/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/reusable/arrow/supermatter/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	var/obj/item/ammo_casing/reusable/arrow/supermatter/arrow = ammo_type
 	if(istype(arrow))
 		arrow.disintigrate(target)
 
-/obj/item/projectile/bullet/reusable/arrow/supermatter/on_range()
+/obj/projectile/bullet/reusable/arrow/supermatter/on_range()
 	. = ..()
 	var/obj/item/ammo_casing/reusable/arrow/supermatter/arrow = ammo_type
 	if(istype(arrow))
 		arrow.disintigrate(get_turf(src))
 
-/obj/item/projectile/bullet/reusable/arrow/singulo
+/obj/projectile/bullet/reusable/arrow/singulo
 	name = "singularity shard arrow"
 
-/obj/item/projectile/bullet/reusable/arrow/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/reusable/arrow/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	var/obj/item/ammo_casing/reusable/arrow/singulo/arrow = ammo_type
 	if(istype(arrow))
@@ -217,7 +217,7 @@
 
 // Hardlight //
 
-/obj/item/projectile/energy/arrow //Hardlight projectile. Significantly more robust than a standard laser. Capable of hardening in target's flesh
+/obj/projectile/energy/arrow //Hardlight projectile. Significantly more robust than a standard laser. Capable of hardening in target's flesh
 	name = "energy bolt"
 	icon_state = "arrow_energy"
 	damage = 40
@@ -226,7 +226,7 @@
 	var/embed_chance = 0.4
 	var/obj/item/embed_type = /obj/item/ammo_casing/reusable/arrow/energy
 	
-/obj/item/projectile/energy/arrow/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/energy/arrow/on_hit(atom/target, blocked = FALSE)
 	if(istype(target, /obj/structure/blob))
 		damage = damage / 2
 	if((blocked != 100) && iscarbon(target))
@@ -236,7 +236,7 @@
 			embede.embed_object(new embed_type(), part, FALSE)
 	return ..()
 
-/obj/item/projectile/energy/arrow/disabler //Hardlight projectile. Much more draining than a standard disabler. Needs to be competitive in DPS
+/obj/projectile/energy/arrow/disabler //Hardlight projectile. Much more draining than a standard disabler. Needs to be competitive in DPS
 	name = "disabler bolt"
 	icon_state = "arrow_disable"
 	light_color = LIGHT_COLOR_BLUE
@@ -244,14 +244,14 @@
 	damage_type = STAMINA
 	embed_type = /obj/item/ammo_casing/reusable/arrow/energy/disabler
 
-/obj/item/projectile/energy/arrow/pulse //Hardlight projectile. Woe to your enemies.
+/obj/projectile/energy/arrow/pulse //Hardlight projectile. Woe to your enemies.
 	name = "pulse bolt"
 	icon_state = "arrow_pulse"
 	light_color = LIGHT_COLOR_BLUE
 	damage = 75
 	embed_type = /obj/item/ammo_casing/reusable/arrow/energy/pulse
 
-/obj/item/projectile/energy/arrow/pulse/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/energy/arrow/pulse/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if (!QDELETED(target) && (isturf(target) || istype(target, /obj/structure/)))
 		if(isobj(target))
@@ -259,7 +259,7 @@
 		else
 			SSexplosions.medturf += target
 
-/obj/item/projectile/energy/arrow/xray //Hardlight projectile. Weakened arrow capable of passing through material. Massive irradiation on hit.
+/obj/projectile/energy/arrow/xray //Hardlight projectile. Weakened arrow capable of passing through material. Massive irradiation on hit.
 	name = "X-ray bolt"
 	icon_state = "arrow_xray"
 	light_color = LIGHT_COLOR_GREEN
@@ -270,7 +270,7 @@
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE | PASSCLOSEDTURF | PASSMACHINES | PASSSTRUCTURE | PASSDOOR
 	embed_type = /obj/item/ammo_casing/reusable/arrow/energy/xray
 
-/obj/item/projectile/energy/arrow/shock //Hardlight projectile. Replicable tasers are fair and balanced.
+/obj/projectile/energy/arrow/shock //Hardlight projectile. Replicable tasers are fair and balanced.
 	name = "shock bolt"
 	icon_state = "arrow_shock"
 	light_color = LIGHT_COLOR_YELLOW 
@@ -281,7 +281,7 @@
 	damage_type = STAMINA
 	embed_type = /obj/item/ammo_casing/reusable/arrow/energy/shock
 
-/obj/item/projectile/energy/arrow/shock/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/energy/arrow/shock/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(!ismob(target) || blocked >= 100) //Fully blocked by mob or collided with dense object - burst into sparks!
 		do_sparks(1, TRUE, src)
@@ -297,7 +297,7 @@
 			C.adjust_nutrition(40)
 			to_chat(C,span_notice("You get charged by [src]."))
 
-/obj/item/projectile/energy/arrow/clockbolt
+/obj/projectile/energy/arrow/clockbolt
 	name = "redlight bolt"
 	damage = 20
 	wound_bonus = 5

--- a/code/modules/projectiles/projectile/reusable/foam_dart.dm
+++ b/code/modules/projectiles/projectile/reusable/foam_dart.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/bullet/reusable/foam_dart
+/obj/projectile/bullet/reusable/foam_dart
 	name = "foam dart"
 	desc = "I hope you're wearing eye protection."
 	damage = 0 // It's a damn toy.
@@ -10,7 +10,7 @@
 	range = 10
 
 /// Apply stamina damage to other toy gun users
-/obj/item/projectile/bullet/reusable/foam_dart/on_hit(atom/target, blocked)
+/obj/projectile/bullet/reusable/foam_dart/on_hit(atom/target, blocked)
 	. = ..()
 
 	if(stamina > 0) // NO RIOT DARTS!!!
@@ -36,7 +36,7 @@
 	
 	C.adjustStaminaLoss(25) // ARMOR IS CHEATING!!!
 
-/obj/item/projectile/bullet/reusable/foam_dart/riot
+/obj/projectile/bullet/reusable/foam_dart/riot
 	name = "riot foam dart"
 	icon_state = "foamdart_riot_proj"
 	ammo_type = /obj/item/ammo_casing/reusable/foam_dart/riot

--- a/code/modules/projectiles/projectile/special/curse.dm
+++ b/code/modules/projectiles/projectile/special/curse.dm
@@ -2,7 +2,7 @@
 	name = "curse arm"
 	layer = LARGE_MOB_LAYER
 
-/obj/item/projectile/curse_hand
+/obj/projectile/curse_hand
 	name = "curse hand"
 	icon_state = "cursehand0"
 	hitsound = 'sound/effects/curse4.ogg'
@@ -15,25 +15,25 @@
 	var/datum/beam/arm
 	var/handedness = 0
 
-/obj/item/projectile/curse_hand/Initialize(mapload)
+/obj/projectile/curse_hand/Initialize(mapload)
 	. = ..()
 	ENABLE_BITFIELD(movement_type, UNSTOPPABLE)
 	handedness = prob(50)
 	icon_state = "cursehand[handedness]"
 
-/obj/item/projectile/curse_hand/fire(setAngle)
+/obj/projectile/curse_hand/fire(setAngle)
 	if(starting)
 		arm = starting.Beam(src, icon_state = "curse[handedness]", time = INFINITY, maxdistance = INFINITY, beam_type=/obj/effect/ebeam/curse_arm)
 	..()
 
-/obj/item/projectile/curse_hand/prehit(atom/target)
+/obj/projectile/curse_hand/prehit(atom/target)
 	if(target == original)
 		DISABLE_BITFIELD(movement_type, UNSTOPPABLE)
 	else if(!isturf(target))
 		return FALSE
 	return ..()
 
-/obj/item/projectile/curse_hand/Destroy()
+/obj/projectile/curse_hand/Destroy()
 	if(arm)
 		arm.End()
 		arm = null
@@ -50,7 +50,7 @@
 		animate(B, alpha = 0, time = 3.2 SECONDS)
 	return ..()
 
-/obj/item/projectile/curse_hand/progenitor
+/obj/projectile/curse_hand/progenitor
 	name = "psionic barrage"
 	damage_type = BRAIN
 	paralyze = 0

--- a/code/modules/projectiles/projectile/special/floral.dm
+++ b/code/modules/projectiles/projectile/special/floral.dm
@@ -4,7 +4,7 @@
 	damage = 0
 	damage_type = TOX
 	nodamage = TRUE
-	flag = ENERGY
+	armor_flag = ENERGY
 
 /obj/projectile/energy/florayield
 	name = "beta somatoray"
@@ -12,4 +12,4 @@
 	damage = 0
 	damage_type = TOX
 	nodamage = TRUE
-	flag = ENERGY
+	armor_flag = ENERGY

--- a/code/modules/projectiles/projectile/special/floral.dm
+++ b/code/modules/projectiles/projectile/special/floral.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/energy/floramut
+/obj/projectile/energy/floramut
 	name = "alpha somatoray"
 	icon_state = "energy"
 	damage = 0
@@ -6,7 +6,7 @@
 	nodamage = TRUE
 	flag = ENERGY
 
-/obj/item/projectile/energy/florayield
+/obj/projectile/energy/florayield
 	name = "beta somatoray"
 	icon_state = "energy2"
 	damage = 0

--- a/code/modules/projectiles/projectile/special/gravity.dm
+++ b/code/modules/projectiles/projectile/special/gravity.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/gravityrepulse
+/obj/projectile/gravityrepulse
 	name = "repulsion bolt"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "chronofield"
@@ -11,13 +11,13 @@
 	var/power = 4
 	var/list/thrown_items = list()
 
-/obj/item/projectile/gravityrepulse/Initialize(mapload)
+/obj/projectile/gravityrepulse/Initialize(mapload)
 	. = ..()
 	var/obj/item/ammo_casing/energy/gravity/repulse/C = loc
 	if(istype(C)) //Hard-coded maximum power so servers can't be crashed by trying to throw the entire Z level's items
 		power = min(C.gun.power, 15)
 
-/obj/item/projectile/gravityrepulse/on_hit()
+/obj/projectile/gravityrepulse/on_hit()
 	. = ..()
 	T = get_turf(src)
 	for(var/atom/movable/A in range(T, power))
@@ -33,7 +33,7 @@
 	for(var/turf/F in range(T,power))
 		new /obj/effect/temp_visual/gravpush(F)
 
-/obj/item/projectile/gravityattract
+/obj/projectile/gravityattract
 	name = "attraction bolt"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "chronofield"
@@ -46,13 +46,13 @@
 	var/power = 4
 	var/list/thrown_items = list()
 
-/obj/item/projectile/gravityattract/Initialize(mapload)
+/obj/projectile/gravityattract/Initialize(mapload)
 	. = ..()
 	var/obj/item/ammo_casing/energy/gravity/attract/C = loc
 	if(istype(C)) //Hard-coded maximum power so servers can't be crashed by trying to throw the entire Z level's items
 		power = min(C.gun.power, 15)
 
-/obj/item/projectile/gravityattract/on_hit()
+/obj/projectile/gravityattract/on_hit()
 	. = ..()
 	T = get_turf(src)
 	for(var/atom/movable/A in range(T, power))
@@ -67,7 +67,7 @@
 	for(var/turf/F in range(T,power))
 		new /obj/effect/temp_visual/gravpush(F)
 
-/obj/item/projectile/gravitychaos
+/obj/projectile/gravitychaos
 	name = "gravitational blast"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "chronofield"
@@ -80,13 +80,13 @@
 	var/power = 4
 	var/list/thrown_items = list()
 
-/obj/item/projectile/gravitychaos/Initialize(mapload)
+/obj/projectile/gravitychaos/Initialize(mapload)
 	. = ..()
 	var/obj/item/ammo_casing/energy/gravity/chaos/C = loc
 	if(istype(C)) //Hard-coded maximum power so servers can't be crashed by trying to throw the entire Z level's items
 		power = min(C.gun.power, 15)
 
-/obj/item/projectile/gravitychaos/on_hit()
+/obj/projectile/gravitychaos/on_hit()
 	. = ..()
 	T = get_turf(src)
 	for(var/atom/movable/A in range(T, power))

--- a/code/modules/projectiles/projectile/special/hallucination.dm
+++ b/code/modules/projectiles/projectile/special/hallucination.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/hallucination
+/obj/projectile/hallucination
 	name = "bullet"
 	icon = null
 	icon_state = null
@@ -8,7 +8,7 @@
 	ricochet_chance = 0
 	damage = 0
 	nodamage = TRUE
-	projectile_type = /obj/item/projectile/hallucination
+	projectile_type = /obj/projectile/hallucination
 	log_override = TRUE
 	var/hal_icon_state
 	var/image/fake_icon
@@ -21,19 +21,19 @@
 	var/hit_duration
 	var/hit_duration_wall
 
-/obj/item/projectile/hallucination/fire()
+/obj/projectile/hallucination/fire()
 	..()
 	fake_icon = image('icons/obj/projectiles.dmi', src, hal_icon_state, ABOVE_MOB_LAYER)
 	if(hal_target.client)
 		hal_target.client.images += fake_icon
 
-/obj/item/projectile/hallucination/Destroy()
+/obj/projectile/hallucination/Destroy()
 	if(hal_target.client)
 		hal_target.client.images -= fake_icon
 	QDEL_NULL(fake_icon)
 	return ..()
 
-/obj/item/projectile/hallucination/Bump(atom/A)
+/obj/projectile/hallucination/Bump(atom/A)
 	if(!ismob(A))
 		if(hal_hitsound_wall)
 			hal_target.playsound_local(loc, hal_hitsound_wall, 40, 1)
@@ -46,7 +46,7 @@
 	qdel(src)
 	return TRUE
 
-/obj/item/projectile/hallucination/proc/target_on_hit(mob/M)
+/obj/projectile/hallucination/proc/target_on_hit(mob/M)
 	if(M == hal_target)
 		to_chat(hal_target, span_userdanger("[M] is hit by \a [src] in the chest!"))
 		hal_apply_effect()
@@ -60,7 +60,7 @@
 	else if(hal_impact_effect)
 		spawn_hit(M, FALSE)
 
-/obj/item/projectile/hallucination/proc/spawn_blood(mob/M, set_dir)
+/obj/projectile/hallucination/proc/spawn_blood(mob/M, set_dir)
 	set waitfor = 0
 	if(!hal_target.client)
 		return
@@ -102,11 +102,11 @@
 	animate(blood, pixel_x = target_pixel_x, pixel_y = target_pixel_y, alpha = 0, time = 0.5 SECONDS)
 	addtimer(CALLBACK(src, PROC_REF(cleanup_blood)), 0.5 SECONDS)
 
-/obj/item/projectile/hallucination/proc/cleanup_blood(image/blood)
+/obj/projectile/hallucination/proc/cleanup_blood(image/blood)
 	hal_target.client.images -= blood
 	qdel(blood)
 
-/obj/item/projectile/hallucination/proc/spawn_hit(atom/A, is_wall)
+/obj/projectile/hallucination/proc/spawn_hit(atom/A, is_wall)
 	set waitfor = 0
 	if(!hal_target.client)
 		return
@@ -120,10 +120,10 @@
 	qdel(hit_effect)
 
 
-/obj/item/projectile/hallucination/proc/hal_apply_effect()
+/obj/projectile/hallucination/proc/hal_apply_effect()
 	return
 
-/obj/item/projectile/hallucination/bullet
+/obj/projectile/hallucination/bullet
 	name = "bullet"
 	hal_icon_state = "bullet"
 	hal_fire_sound = "gunshot"
@@ -134,10 +134,10 @@
 	hit_duration = 0.5 SECONDS
 	hit_duration_wall = 0.5 SECONDS
 
-/obj/item/projectile/hallucination/bullet/hal_apply_effect()
+/obj/projectile/hallucination/bullet/hal_apply_effect()
 	hal_target.adjustStaminaLoss(60)
 
-/obj/item/projectile/hallucination/laser
+/obj/projectile/hallucination/laser
 	name = "laser"
 	damage_type = BURN
 	hal_icon_state = "laser"
@@ -150,11 +150,11 @@
 	hit_duration_wall = 1 SECONDS
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 
-/obj/item/projectile/hallucination/laser/hal_apply_effect()
+/obj/projectile/hallucination/laser/hal_apply_effect()
 	hal_target.adjustStaminaLoss(20)
 	hal_target.blur_eyes(2)
 
-/obj/item/projectile/hallucination/taser
+/obj/projectile/hallucination/taser
 	name = "electrode"
 	damage_type = BURN
 	hal_icon_state = "spark"
@@ -165,7 +165,7 @@
 	hal_impact_effect = null
 	hal_impact_effect_wall = null
 
-/obj/item/projectile/hallucination/taser/hal_apply_effect()
+/obj/projectile/hallucination/taser/hal_apply_effect()
 	hal_target.Paralyze(100)
 	hal_target.adjust_stutter(2 SECONDS)
 	if(hal_target.dna && (hal_target.dna.check_mutation(HULK)|| hal_target.dna.check_mutation(ACTIVE_HULK)))
@@ -173,7 +173,7 @@
 	else if((hal_target.status_flags & CANKNOCKDOWN) && !HAS_TRAIT(hal_target, TRAIT_STUNIMMUNE))
 		addtimer(CALLBACK(hal_target, TYPE_PROC_REF(/mob/living/carbon, do_jitter_animation), 20), 0.5 SECONDS)
 
-/obj/item/projectile/hallucination/disabler
+/obj/projectile/hallucination/disabler
 	name = "disabler beam"
 	damage_type = STAMINA
 	hal_icon_state = "omnilaser"
@@ -185,10 +185,10 @@
 	hit_duration = 0.4 SECONDS
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 
-/obj/item/projectile/hallucination/disabler/hal_apply_effect()
+/obj/projectile/hallucination/disabler/hal_apply_effect()
 	hal_target.adjustStaminaLoss(25)
 
-/obj/item/projectile/hallucination/ebow
+/obj/projectile/hallucination/ebow
 	name = "bolt"
 	damage_type = TOX
 	hal_icon_state = "cbbolt"
@@ -198,12 +198,12 @@
 	hal_impact_effect = null
 	hal_impact_effect_wall = null
 
-/obj/item/projectile/hallucination/ebow/hal_apply_effect()
+/obj/projectile/hallucination/ebow/hal_apply_effect()
 	hal_target.Paralyze(100)
 	hal_target.adjust_stutter(5 SECONDS)
 	hal_target.adjustStaminaLoss(8)
 
-/obj/item/projectile/hallucination/change
+/obj/projectile/hallucination/change
 	name = "bolt of change"
 	damage_type = BURN
 	hal_icon_state = "ice_1"
@@ -213,10 +213,10 @@
 	hal_impact_effect = null
 	hal_impact_effect_wall = null
 
-/obj/item/projectile/hallucination/change/hal_apply_effect()
+/obj/projectile/hallucination/change/hal_apply_effect()
 	new /datum/hallucination/self_delusion(hal_target, TRUE, wabbajack = FALSE)
 
-/obj/item/projectile/hallucination/death
+/obj/projectile/hallucination/death
 	name = "bolt of death"
 	damage_type = BURN
 	hal_icon_state = "pulse1_bl"
@@ -226,5 +226,5 @@
 	hal_impact_effect = null
 	hal_impact_effect_wall = null
 
-/obj/item/projectile/hallucination/death/hal_apply_effect()
+/obj/projectile/hallucination/death/hal_apply_effect()
 	new /datum/hallucination/death(hal_target, TRUE)

--- a/code/modules/projectiles/projectile/special/ion.dm
+++ b/code/modules/projectiles/projectile/special/ion.dm
@@ -4,7 +4,7 @@
 	damage = 0
 	damage_type = BURN
 	nodamage = TRUE
-	flag = ENERGY
+	armor_flag = ENERGY
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/ion
 	var/light_emp_radius = 1
 	var/heavy_emp_radius = 0.5	//Effectively 1 but doesnt spread to adjacent tiles

--- a/code/modules/projectiles/projectile/special/ion.dm
+++ b/code/modules/projectiles/projectile/special/ion.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/ion
+/obj/projectile/ion
 	name = "ion bolt"
 	icon_state = "ion"
 	damage = 0
@@ -9,19 +9,19 @@
 	var/light_emp_radius = 1
 	var/heavy_emp_radius = 0.5	//Effectively 1 but doesnt spread to adjacent tiles
 
-/obj/item/projectile/ion/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/ion/on_hit(atom/target, blocked = FALSE)
 	..()
 	empulse(target, heavy_emp_radius, light_emp_radius)
 	return BULLET_ACT_HIT
 
-/obj/item/projectile/ion/weak
+/obj/projectile/ion/weak
 	light_emp_radius = 0
 	heavy_emp_radius = 0
 
-/obj/item/projectile/ion/light
+/obj/projectile/ion/light
 	light_emp_radius = 1
 	heavy_emp_radius = 0
 
-/obj/item/projectile/ion/heavy
+/obj/projectile/ion/heavy
 	light_emp_radius = 2
 	heavy_emp_radius = 2

--- a/code/modules/projectiles/projectile/special/meteor.dm
+++ b/code/modules/projectiles/projectile/special/meteor.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/meteor
+/obj/projectile/meteor
 	name = "meteor"
 	icon = 'icons/obj/meteor.dmi'
 	icon_state = "small1"
@@ -7,7 +7,7 @@
 	nodamage = TRUE
 	flag = BULLET
 
-/obj/item/projectile/meteor/Bump(atom/A)
+/obj/projectile/meteor/Bump(atom/A)
 	if(A == firer)
 		forceMove(A.loc)
 		return

--- a/code/modules/projectiles/projectile/special/meteor.dm
+++ b/code/modules/projectiles/projectile/special/meteor.dm
@@ -5,7 +5,7 @@
 	damage = 0
 	damage_type = BRUTE
 	nodamage = TRUE
-	flag = BULLET
+	armor_flag = BULLET
 
 /obj/projectile/meteor/Bump(atom/A)
 	if(A == firer)

--- a/code/modules/projectiles/projectile/special/mindflayer.dm
+++ b/code/modules/projectiles/projectile/special/mindflayer.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/beam/anoxia
+/obj/projectile/beam/anoxia
 	name = "anoxia ray"
 	icon_state = "flayerlaser"
 	damage = 8
@@ -9,11 +9,11 @@
 	light_color = LIGHT_COLOR_LAVENDER
 	eyeblur = 0
 
-/obj/item/projectile/beam/anoxia/mindflayer
+/obj/projectile/beam/anoxia/mindflayer
 	name = "flayer ray"
 	damage = 8
 
-/obj/item/projectile/beam/anoxia/mindflayer/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/beam/anoxia/mindflayer/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(ishuman(target))
 		var/mob/living/carbon/human/M = target
@@ -21,12 +21,12 @@
 		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, current_oxygen_damage) //the more oxygen damage you have the more brain damage you get
 		M.adjust_hallucinations_up_to(5 SECONDS, 5 SECONDS) //50 hallucination (5 seconds) when the target get hit but you can't stack it to make someone hallucinate for 5 hours because door shock hallucination exist
 
-/obj/item/projectile/beam/anoxia/bounce
+/obj/projectile/beam/anoxia/bounce
 	name = "bouncing anoxia ball"
 	icon_state = "flayerbouncer"
 	damage = 6
 	ricochets_max = 5
 	ricochet_chance = 100
 
-/obj/item/projectile/beam/anoxia/bounce/check_ricochet_flag(atom/A)
+/obj/projectile/beam/anoxia/bounce/check_ricochet_flag(atom/A)
 	return TRUE //whatever it is, we bounce on it

--- a/code/modules/projectiles/projectile/special/mindflayer.dm
+++ b/code/modules/projectiles/projectile/special/mindflayer.dm
@@ -3,7 +3,7 @@
 	icon_state = "flayerlaser"
 	damage = 8
 	damage_type = OXY //stop oxygen from being correctly processed by your cells.
-	flag = ENERGY
+	armor_flag = ENERGY
 	hitsound = 'sound/weapons/tap.ogg'
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
 	light_color = LIGHT_COLOR_LAVENDER

--- a/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -1,11 +1,11 @@
-/obj/item/projectile/bullet/neurotoxin
+/obj/projectile/bullet/neurotoxin
 	name = "neurotoxin spit"
 	icon_state = "neurotoxin"
 	damage = 5
 	damage_type = TOX
 	flag = BIO // why was this bullet protection
 
-/obj/item/projectile/bullet/neurotoxin/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/neurotoxin/on_hit(atom/target, blocked = FALSE)
 	if(isalien(target))
 		nodamage = TRUE
 	else if(iscarbon(target))

--- a/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -3,7 +3,7 @@
 	icon_state = "neurotoxin"
 	damage = 5
 	damage_type = TOX
-	flag = BIO // why was this bullet protection
+	armor_flag = BIO // why was this bullet protection
 
 /obj/projectile/bullet/neurotoxin/on_hit(atom/target, blocked = FALSE)
 	if(isalien(target))

--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/plasma
+/obj/projectile/plasma
 	name = "plasma blast"
 	icon_state = "plasmacutter"
 	damage_type = BRUTE
@@ -11,7 +11,7 @@
 	muzzle_type = /obj/effect/projectile/muzzle/plasma_cutter
 	impact_type = /obj/effect/projectile/impact/plasma_cutter
 
-/obj/item/projectile/plasma/weak
+/obj/projectile/plasma/weak
 	name = "weak plasma blast"
 	icon_state = "plasmacutter_weak"
 	damage = 3
@@ -19,7 +19,7 @@
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
 	mine_range = 0
 
-/obj/item/projectile/plasma/on_hit(atom/target)
+/obj/projectile/plasma/on_hit(atom/target)
 	. = ..()
 	if(ismineralturf(target))
 		var/turf/closed/mineral/M = target
@@ -30,35 +30,35 @@
 		if(range > 0)
 			return BULLET_ACT_FORCE_PIERCE
 
-/obj/item/projectile/plasma/scatter/adv/on_hit(atom/target)
+/obj/projectile/plasma/scatter/adv/on_hit(atom/target)
 	if(istype(target, /turf/closed/mineral/gibtonite))
 		var/turf/closed/mineral/gibtonite/gib = target
 		gib.defuse()
 	. = ..()
 
-/obj/item/projectile/plasma/adv
+/obj/projectile/plasma/adv
 	damage = 7
 	range = 5
 	mine_range = 5
 
-/obj/item/projectile/plasma/adv/malf
+/obj/projectile/plasma/adv/malf
 	damage = 20
 
-/obj/item/projectile/plasma/adv/mega
+/obj/projectile/plasma/adv/mega
 	range = 7
 	mine_range = 7
 
-/obj/item/projectile/plasma/scatter
+/obj/projectile/plasma/scatter
 	damage = 2
 	range = 5
 	mine_range = 2
 	dismemberment = 0
 
 // Same as the scatter but with automatic defusing
-/obj/item/projectile/plasma/scatter/adv
+/obj/projectile/plasma/scatter/adv
 
 // Megafauna loot, possibly best cutter?
-/obj/item/projectile/plasma/scatter/adv/stalwart
+/obj/projectile/plasma/scatter/adv/stalwart
 	name = "plasma beam"
 	icon_state = "plasmacutter_stalwart"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
@@ -73,7 +73,7 @@
 	var/fauna_damage_bonus = 10
 	var/fauna_damage_type = BRUTE
 
-/obj/item/projectile/plasma/scatter/adv/stalwart/on_hit(atom/target)
+/obj/projectile/plasma/scatter/adv/stalwart/on_hit(atom/target)
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
@@ -82,16 +82,16 @@
 			playsound(L, 'sound/weapons/resonator_blast.ogg', 100, 1)
 
 //mega plasma shotgun auto defuses
-/obj/item/projectile/plasma/scatter/adv/mega
+/obj/projectile/plasma/scatter/adv/mega
 	range = 7
 	mine_range = 3
 
-/obj/item/projectile/plasma/adv/mech
+/obj/projectile/plasma/adv/mech
 	damage = 10
 	range = 9
 	mine_range = 3
 
-/obj/item/projectile/plasma/turret
+/obj/projectile/plasma/turret
 	//Between normal and advanced for damage, made a beam so not the turret does not destroy glass
 	name = "plasma beam"
 	damage = 24

--- a/code/modules/projectiles/projectile/special/rocket.dm
+++ b/code/modules/projectiles/projectile/special/rocket.dm
@@ -1,14 +1,14 @@
-/obj/item/projectile/bullet/gyro
+/obj/projectile/bullet/gyro
 	name ="explosive bolt"
 	icon_state= "bolter"
 	damage = 50
 
-/obj/item/projectile/bullet/gyro/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/gyro/on_hit(atom/target, blocked = FALSE)
 	..()
 	explosion(target, -1, 0, 2)
 	return BULLET_ACT_HIT
 
-/obj/item/projectile/bullet/a84mm
+/obj/projectile/bullet/a84mm
 	name ="\improper HEDP rocket"
 	desc = "USE A WEEL GUN"
 	icon_state= "84mm-hedp"
@@ -17,7 +17,7 @@
 	armour_penetration = 100
 	dismemberment = 100
 
-/obj/item/projectile/bullet/a84mm/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/a84mm/on_hit(atom/target, blocked = FALSE)
 	..()
 	explosion(target, -1, 1, 3, 1, 0, flame_range = 4)
 
@@ -29,14 +29,14 @@
 		S.take_overall_damage(anti_armour_damage*0.75, anti_armour_damage*0.25)
 	return BULLET_ACT_HIT
 
-/obj/item/projectile/bullet/a84mm_he
+/obj/projectile/bullet/a84mm_he
 	name ="\improper HE missile"
 	desc = "Boom."
 	icon_state = "missile"
 	damage = 30
 	ricochets_max = 0 //it's a MISSILE
 
-/obj/item/projectile/bullet/a84mm_he/on_hit(atom/target, blocked=0)
+/obj/projectile/bullet/a84mm_he/on_hit(atom/target, blocked=0)
 	..()
 	if(!isliving(target)) //if the target isn't alive, so is a wall or something
 		explosion(target, 0, 1, 2, 4)
@@ -44,7 +44,7 @@
 		explosion(target, 0, 0, 2, 4)
 	return BULLET_ACT_HIT
 
-/obj/item/projectile/bullet/a84mm_br
+/obj/projectile/bullet/a84mm_br
 	name ="\improper HE missile"
 	desc = "Boom."
 	icon_state = "missile"
@@ -65,7 +65,7 @@
 	w_class = WEIGHT_CLASS_TINY
 
 
-/obj/item/projectile/bullet/a84mm_br/on_hit(atom/target, blocked=0)
+/obj/projectile/bullet/a84mm_br/on_hit(atom/target, blocked=0)
 	..()
 	for(var/i in sturdy)
 		if(istype(target, i))
@@ -74,13 +74,13 @@
 	//if(istype(target, /turf/closed) || ismecha(target))
 	new /obj/item/broken_missile(get_turf(src), 1)
 
-/obj/item/projectile/bullet/cball
+/obj/projectile/bullet/cball
 	name = "cannonball"
 	icon_state = "cannonball"
 	desc = "Not for bowling purposes"
 	damage = 30
 
-/obj/item/projectile/bullet/cball/on_hit(atom/target, blocked=0)
+/obj/projectile/bullet/cball/on_hit(atom/target, blocked=0)
 	var/mob/living/carbon/human/H = firer
 	var/atom/throw_target = get_edge_target_turf(target, H.dir)
 	if(istype(target, /obj/structure/window) || istype(target, /obj/machinery/door) || istype(target, /obj/structure/door_assembly))
@@ -96,7 +96,7 @@
 					C.throw_at(throw_target, 2, 4, H, 3)
 					return BULLET_ACT_HIT
 
-/obj/item/projectile/bullet/bolt
+/obj/projectile/bullet/bolt
 	name = "bolt"
 	icon_state = "bolt"
 	desc = "smaller and faster rod"

--- a/code/modules/projectiles/projectile/special/temperature.dm
+++ b/code/modules/projectiles/projectile/special/temperature.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/temp
+/obj/projectile/temp
 	name = "freeze beam"
 	icon_state = "ice_2"
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
@@ -8,30 +8,30 @@
 	flag = ENERGY
 	var/temperature = 100
 
-/obj/item/projectile/temp/on_hit(atom/target, blocked = 0)
+/obj/projectile/temp/on_hit(atom/target, blocked = 0)
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
 		L.adjust_bodytemperature(((100-blocked)/100)*(temperature - L.bodytemperature)) // the new body temperature is adjusted by 100-blocked % of the delta between body temperature and the bullet's effect temperature
 
-/obj/item/projectile/temp/bounce
+/obj/projectile/temp/bounce
 	name = "bouncing freeze ball"
 	icon_state = "pulse1" // only used by kinetic crusher
 	ricochets_max = 5
 	ricochet_chance = 100
 
-/obj/item/projectile/temp/bounce/check_ricochet_flag(atom/A)
+/obj/projectile/temp/bounce/check_ricochet_flag(atom/A)
 	return TRUE //whatever it is, we bounce on it
 
-/obj/item/projectile/temp/hot
+/obj/projectile/temp/hot
 	name = "heat beam"
 	temperature = 400
 
-/obj/item/projectile/temp/cryo
+/obj/projectile/temp/cryo
 	name = "cryo beam"
 	range = 3
 
-/obj/item/projectile/temp/cryo/on_range()
+/obj/projectile/temp/cryo/on_range()
 	var/turf/T = get_turf(src)
 	if(isopenturf(T))
 		var/turf/open/O = T

--- a/code/modules/projectiles/projectile/special/temperature.dm
+++ b/code/modules/projectiles/projectile/special/temperature.dm
@@ -5,7 +5,7 @@
 	damage = 0
 	damage_type = BURN
 	nodamage = FALSE
-	flag = ENERGY
+	armor_flag = ENERGY
 	var/temperature = 100
 
 /obj/projectile/temp/on_hit(atom/target, blocked = 0)

--- a/code/modules/projectiles/projectile/special/wormhole.dm
+++ b/code/modules/projectiles/projectile/special/wormhole.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/beam/wormhole
+/obj/projectile/beam/wormhole
 	name = "bluespace beam"
 	icon_state = "spark"
 	hitsound = "sparks"
@@ -12,24 +12,24 @@
 	muzzle_type = /obj/effect/projectile/muzzle/wormhole
 	hitscan = TRUE
 
-/obj/item/projectile/beam/wormhole/orange
+/obj/projectile/beam/wormhole/orange
 	name = "orange bluespace beam"
 	color = "#FF6600"
 
 //muh OOP, wheres my traits/implements/extends lummox 
-/obj/item/projectile/beam/wormhole/upgraded
+/obj/projectile/beam/wormhole/upgraded
 	pass_flags = PASSGLASS | PASSTABLE | PASSGRILLE | PASSMOB
 
-/obj/item/projectile/beam/wormhole/orange/upgraded
+/obj/projectile/beam/wormhole/orange/upgraded
 	pass_flags = PASSGLASS | PASSTABLE | PASSGRILLE | PASSMOB
 
-/obj/item/projectile/beam/wormhole/Initialize(mapload, obj/item/ammo_casing/energy/wormhole/casing)
+/obj/projectile/beam/wormhole/Initialize(mapload, obj/item/ammo_casing/energy/wormhole/casing)
 	. = ..()
 	if(casing)
 		gun = casing.gun
 
 
-/obj/item/projectile/beam/wormhole/on_hit(atom/target)
+/obj/projectile/beam/wormhole/on_hit(atom/target)
 	if(!gun)
 		qdel(src)
 		return 

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -81,7 +81,7 @@
 	..() //extend the zap
 	boom()
 
-/obj/structure/reagent_dispensers/fueltank/bullet_act(obj/item/projectile/P)
+/obj/structure/reagent_dispensers/fueltank/bullet_act(obj/projectile/P)
 	. = ..()
 	if(!QDELETED(src)) //wasn't deleted by the projectile's effects.
 		if(!P.nodamage && ((P.damage_type == BURN) || (P.damage_type == BRUTE)))

--- a/code/modules/recycling/disposal/bin.dm
+++ b/code/modules/recycling/disposal/bin.dm
@@ -487,7 +487,7 @@
 /atom/movable/proc/CanEnterDisposals()
 	return TRUE
 
-/obj/item/projectile/CanEnterDisposals()
+/obj/projectile/CanEnterDisposals()
 	return
 
 /obj/effect/CanEnterDisposals()

--- a/code/modules/research/experimentor.dm
+++ b/code/modules/research/experimentor.dm
@@ -394,7 +394,7 @@
 			if(MT)
 				visible_message(span_danger("[src] dangerously overheats, launching a flaming fuel orb!"))
 				investigate_log("Experimentor has launched a <font color='red'>fireball</font> at [M]!", INVESTIGATE_EXPERIMENTOR)
-				var/obj/item/projectile/magic/fireball/FB = new /obj/item/projectile/magic/fireball(start)
+				var/obj/projectile/magic/fireball/FB = new /obj/projectile/magic/fireball(start)
 				FB.preparePixelProjectile(MT, start)
 				FB.fire()
 		else if(prob(EFFECT_PROB_LOW-badThingCoeff))

--- a/code/modules/research/xenobiology/crossbreeding/_weapons.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_weapons.dm
@@ -106,9 +106,9 @@ Slimecrossing Weapons
 	return 1
 
 /obj/item/ammo_casing/magic/bloodchill
-	projectile_type = /obj/item/projectile/magic/bloodchill
+	projectile_type = /obj/projectile/magic/bloodchill
 
-/obj/item/projectile/magic/bloodchill
+/obj/projectile/magic/bloodchill
 	name = "blood ball"
 	icon_state = "pulse0_bl"
 	damage = 0
@@ -116,7 +116,7 @@ Slimecrossing Weapons
 	nodamage = TRUE
 	hitsound = 'sound/effects/splat.ogg'
 
-/obj/item/projectile/magic/bloodchill/on_hit(mob/living/target)
+/obj/projectile/magic/bloodchill/on_hit(mob/living/target)
 	. = ..()
 	if(isliving(target))
 		target.apply_status_effect(/datum/status_effect/bloodchill)

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -6,7 +6,7 @@
 /obj/machinery/power/emitter/energycannon/magical
 	name = "wabbajack statue"
 	desc = "Who am I? What is my purpose in life? What do I mean by who am I?"
-	projectile_type = /obj/item/projectile/magic/change
+	projectile_type = /obj/projectile/magic/change
 	icon = 'icons/obj/machines/magic_emitter.dmi'
 	icon_state = "wabbajack_statue"
 	icon_state_on = "wabbajack_statue_on"

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -20,7 +20,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/item/warp_cube,
 		/obj/machinery/rnd/production, //print tracking beacons, send shuttle
 		/obj/machinery/autolathe, //same
-		/obj/item/projectile/beam/wormhole,
+		/obj/projectile/beam/wormhole,
 		/obj/effect/portal,
 		/obj/item/shared_storage,
 		/obj/structure/extraction_point,

--- a/code/modules/spells/spell_types/aoe_spell/magic_missile.dm
+++ b/code/modules/spells/spell_types/aoe_spell/magic_missile.dm
@@ -14,7 +14,7 @@
 	aoe_radius = 7
 
 	/// The projectile type fired at all people around us
-	var/obj/item/projectile/projectile_type = /obj/item/projectile/magic/aoe/magic_missile
+	var/obj/projectile/projectile_type = /obj/projectile/magic/aoe/magic_missile
 
 /datum/action/cooldown/spell/aoe/magic_missile/get_things_to_cast_on(atom/center)
 	var/list/things = list()
@@ -30,7 +30,7 @@
 	fire_projectile(victim, caster)
 
 /datum/action/cooldown/spell/aoe/magic_missile/proc/fire_projectile(atom/victim, mob/caster)
-	var/obj/item/projectile/to_fire = new projectile_type()
+	var/obj/projectile/to_fire = new projectile_type()
 	to_fire.preparePixelProjectile(victim, caster)
 	to_fire.fire()
 
@@ -45,4 +45,4 @@
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC
 
 	max_targets = 6
-	projectile_type = /obj/item/projectile/magic/aoe/magic_missile/lesser
+	projectile_type = /obj/projectile/magic/aoe/magic_missile/lesser

--- a/code/modules/spells/spell_types/conjure/ed_swarm.dm
+++ b/code/modules/spells/spell_types/conjure/ed_swarm.dm
@@ -17,5 +17,5 @@
 	summoned_bot.declare_arrests = FALSE
 	summoned_bot.emag_act(owner, null)
 
-	summoned_bot.projectile = /obj/item/projectile/beam/laser
+	summoned_bot.projectile = /obj/projectile/beam/laser
 	summoned_bot.shoot_sound = 'sound/weapons/laser.ogg'

--- a/code/modules/spells/spell_types/devil.dm
+++ b/code/modules/spells/spell_types/devil.dm
@@ -95,7 +95,7 @@
 	cast_range = 2
 	spell_requirements = NONE
 
-	projectile_type = /obj/item/projectile/magic/fireball/infernal
+	projectile_type = /obj/projectile/magic/fireball/infernal
 
 /datum/action/cooldown/spell/jaunt/infernal_jaunt
 	name = "Infernal Jaunt"

--- a/code/modules/spells/spell_types/pointed/_pointed.dm
+++ b/code/modules/spells/spell_types/pointed/_pointed.dm
@@ -96,7 +96,7 @@
  */
 /datum/action/cooldown/spell/pointed/projectile
 	/// What projectile we create when we shoot our spell.
-	var/obj/item/projectile/magic/projectile_type = /obj/item/projectile/magic/teleport
+	var/obj/projectile/magic/projectile_type = /obj/projectile/magic/teleport
 	/// How many projectiles we can fire per cast. Not all at once, per click, kinda like charges
 	var/projectile_amount = 1
 	/// How many projectiles we have yet to fire, based on projectile_amount
@@ -153,20 +153,20 @@
 /datum/action/cooldown/spell/pointed/projectile/proc/fire_projectile(atom/target)
 	current_amount--
 	for(var/i in 1 to projectiles_per_fire)
-		var/obj/item/projectile/to_fire = new projectile_type()
+		var/obj/projectile/to_fire = new projectile_type()
 		ready_projectile(to_fire, target, owner, i)
 		SEND_SIGNAL(owner, COMSIG_MOB_SPELL_PROJECTILE, src, target, to_fire)
 		to_fire.fire()
 	return TRUE
 
-/datum/action/cooldown/spell/pointed/projectile/proc/ready_projectile(obj/item/projectile/to_fire, atom/target, mob/user, iteration)
+/datum/action/cooldown/spell/pointed/projectile/proc/ready_projectile(obj/projectile/to_fire, atom/target, mob/user, iteration)
 	to_fire.firer = owner
 	to_fire.fired_from = get_turf(owner)
 	to_fire.preparePixelProjectile(target, owner)
 	RegisterSignal(to_fire, COMSIG_PROJECTILE_SELF_ON_HIT, PROC_REF(on_cast_hit))
 
-	if(istype(to_fire, /obj/item/projectile/magic))
-		var/obj/item/projectile/magic/magic_to_fire = to_fire
+	if(istype(to_fire, /obj/projectile/magic))
+		var/obj/projectile/magic/magic_to_fire = to_fire
 		magic_to_fire.antimagic_flags = antimagic_flags
 
 /// Signal proc for whenever the projectile we fire hits someone.

--- a/code/modules/spells/spell_types/pointed/finger_guns.dm
+++ b/code/modules/spells/spell_types/pointed/finger_guns.dm
@@ -25,7 +25,7 @@
 	active_msg = "You draw your fingers!"
 	deactive_msg = "You put your fingers at ease. Another time."
 	cast_range = 20
-	projectile_type = /obj/item/projectile/bullet/mime
+	projectile_type = /obj/projectile/bullet/mime
 	projectile_amount = 3
 
 /datum/action/cooldown/spell/pointed/projectile/finger_guns/can_cast_spell(feedback = TRUE)

--- a/code/modules/spells/spell_types/pointed/fireball.dm
+++ b/code/modules/spells/spell_types/pointed/fireball.dm
@@ -17,8 +17,8 @@
 	active_msg = "You prepare to cast your fireball spell!"
 	deactive_msg = "You extinguish your fireball... for now."
 	cast_range = 8
-	projectile_type = /obj/item/projectile/magic/fireball
+	projectile_type = /obj/projectile/magic/fireball
 
-/datum/action/cooldown/spell/pointed/projectile/fireball/ready_projectile(obj/item/projectile/to_fire, atom/target, mob/user, iteration)
+/datum/action/cooldown/spell/pointed/projectile/fireball/ready_projectile(obj/projectile/to_fire, atom/target, mob/user, iteration)
 	. = ..()
 	to_fire.range = (6 + 2 * spell_level)

--- a/code/modules/spells/spell_types/pointed/lightning_bolt.dm
+++ b/code/modules/spells/spell_types/pointed/lightning_bolt.dm
@@ -16,7 +16,7 @@
 	base_icon_state = "lightning"
 	active_msg = "You energize your hands with arcane lightning!"
 	deactive_msg = "You let the energy flow out of your hands back into yourself..."
-	projectile_type = /obj/item/projectile/magic/aoe/lightning
+	projectile_type = /obj/projectile/magic/aoe/lightning
 
 	/// The range the bolt itself (different to the range of the projectile)
 	var/bolt_range = 15
@@ -33,12 +33,12 @@
 	REMOVE_TRAIT(remove_from, TRAIT_SHOCKIMMUNE, type) //FUCK
 	return ..()
 
-/datum/action/cooldown/spell/pointed/projectile/lightningbolt/ready_projectile(obj/item/projectile/to_fire, atom/target, mob/user, iteration)
+/datum/action/cooldown/spell/pointed/projectile/lightningbolt/ready_projectile(obj/projectile/to_fire, atom/target, mob/user, iteration)
 	. = ..()
-	if(!istype(to_fire, /obj/item/projectile/magic/aoe/lightning))
+	if(!istype(to_fire, /obj/projectile/magic/aoe/lightning))
 		return
 
-	var/obj/item/projectile/magic/aoe/lightning/bolt = to_fire
+	var/obj/projectile/magic/aoe/lightning/bolt = to_fire
 	bolt.tesla_range = bolt_range
 	bolt.tesla_power = bolt_power
 	bolt.tesla_flags = bolt_flags

--- a/code/modules/spells/spell_types/pointed/spell_cards.dm
+++ b/code/modules/spells/spell_types/pointed/spell_cards.dm
@@ -13,7 +13,7 @@
 	spell_requirements = SPELL_REQUIRES_NO_ANTIMAGIC
 
 	cast_range = 40
-	projectile_type = /obj/item/projectile/magic/spellcard
+	projectile_type = /obj/projectile/magic/spellcard
 	projectile_amount = 5
 	projectiles_per_fire = 7
 
@@ -60,7 +60,7 @@
 	. = ..()
 	QDEL_NULL(lockon_component)
 
-/datum/action/cooldown/spell/pointed/projectile/spell_cards/ready_projectile(obj/item/projectile/to_fire, atom/target, mob/user, iteration)
+/datum/action/cooldown/spell/pointed/projectile/spell_cards/ready_projectile(obj/projectile/to_fire, atom/target, mob/user, iteration)
 	. = ..()
 	if(current_target_weakref)
 		var/atom/real_target = current_target_weakref?.resolve()

--- a/code/modules/spells/spell_types/projectile/_basic_projectile.dm
+++ b/code/modules/spells/spell_types/projectile/_basic_projectile.dm
@@ -10,7 +10,7 @@
 	/// How far we try to fire the basic projectile. Blocked by dense objects.
 	var/projectile_range = 7
 	/// The projectile type fired at all people around us
-	var/obj/item/projectile/projectile_type = /obj/item/projectile/magic/aoe/magic_missile
+	var/obj/projectile/projectile_type = /obj/projectile/magic/aoe/magic_missile
 
 /datum/action/cooldown/spell/basic_projectile/cast(atom/cast_on)
 	. = ..()
@@ -24,6 +24,6 @@
 	fire_projectile(target_turf, cast_on)
 
 /datum/action/cooldown/spell/basic_projectile/proc/fire_projectile(atom/target, atom/caster)
-	var/obj/item/projectile/to_fire = new projectile_type()
+	var/obj/projectile/to_fire = new projectile_type()
 	to_fire.preparePixelProjectile(target, caster)
 	to_fire.fire()

--- a/code/modules/spells/spell_types/projectile/juggernaut.dm
+++ b/code/modules/spells/spell_types/projectile/juggernaut.dm
@@ -11,4 +11,4 @@
 	cooldown_time = 35 SECONDS
 	spell_requirements = NONE
 
-	projectile_type = /obj/item/projectile/magic/aoe/juggernaut
+	projectile_type = /obj/projectile/magic/aoe/juggernaut

--- a/code/modules/swarmers/swarmer.dm
+++ b/code/modules/swarmers/swarmer.dm
@@ -52,7 +52,7 @@
 	mob_size = MOB_SIZE_TINY
 	ventcrawler = VENTCRAWLER_ALWAYS
 	ranged = 1
-	projectiletype = /obj/item/projectile/beam/disabler/swarmer
+	projectiletype = /obj/projectile/beam/disabler/swarmer
 	ranged_cooldown_time = 20
 	projectilesound = 'sound/weapons/taser2.ogg'
 	loot = list(/obj/effect/decal/cleanable/robot_debris, /obj/item/stack/ore/bluespace_crystal)
@@ -107,7 +107,7 @@
 
 /mob/living/simple_animal/hostile/swarmer/CanAllowThrough(atom/movable/O)
 	. = ..()
-	if(istype(O, /obj/item/projectile/beam/disabler))//Allows for swarmers to fight as a group without wasting their shots hitting each other
+	if(istype(O, /obj/projectile/beam/disabler))//Allows for swarmers to fight as a group without wasting their shots hitting each other
 		return TRUE
 	if(isswarmer(O))
 		return TRUE
@@ -476,7 +476,7 @@ mob/living/simple_animal/hostile/swarmer/proc/remove_drone(mob/drone, force)
 	melee_damage_lower = 30
 	melee_damage_upper = 30
 
-/obj/item/projectile/beam/disabler/swarmer/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/beam/disabler/swarmer/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(!.)
 		return

--- a/code/modules/swarmers/swarmer_objs.dm
+++ b/code/modules/swarmers/swarmer_objs.dm
@@ -131,7 +131,7 @@
 	. = ..()
 	if(isswarmer(O))
 		return TRUE
-	if(istype(O, /obj/item/projectile/beam/disabler))
+	if(istype(O, /obj/projectile/beam/disabler))
 		return TRUE
 
 /obj/effect/temp_visual/swarmer //temporary swarmer visual feedback objects

--- a/yogstation/code/datums/mutations/extendoarm.dm
+++ b/yogstation/code/datums/mutations/extendoarm.dm
@@ -19,7 +19,7 @@
 	spell_requirements = NONE
 
 	cast_range = 50
-	projectile_type = /obj/item/projectile/bullet/arm
+	projectile_type = /obj/projectile/bullet/arm
 	active_msg = "You loosen up your arm!"
 	deactive_msg = "You relax your arm."
 	projectile_amount = 64
@@ -53,7 +53,7 @@
 
 	return TRUE
 
-/datum/action/cooldown/spell/pointed/projectile/extendoarm/ready_projectile(obj/item/projectile/bullet/arm/P, atom/target, mob/user, iteration)
+/datum/action/cooldown/spell/pointed/projectile/extendoarm/ready_projectile(obj/projectile/bullet/arm/P, atom/target, mob/user, iteration)
 	. = ..()
 	var/mob/living/carbon/C = user
 	var/new_color
@@ -67,13 +67,13 @@
 
 	var/obj/item/I = C.get_active_held_item()
 	if(I && C.dropItemToGround(I, FALSE))
-		var/obj/item/projectile/bullet/arm/ARM = P
+		var/obj/projectile/bullet/arm/ARM = P
 		ARM.grab(I)
 	P.arm = C.hand_bodyparts[C.active_hand_index]
 	P.arm.drop_limb()
 	P.arm.forceMove(P)
 
-/obj/item/projectile/bullet/arm
+/obj/projectile/bullet/arm
 	name = "arm"
 	icon = 'yogstation/icons/obj/projectiles.dmi'
 	icon_state = "arm"
@@ -89,7 +89,7 @@
 	var/returning = FALSE
 	var/datum/beam/beam
 
-/obj/item/projectile/bullet/arm/prehit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/arm/prehit(atom/target, blocked = FALSE)
 	if(returning)
 		if(target == firer)
 			var/mob/living/L = firer
@@ -110,14 +110,14 @@
 				grab(target)
 		go_home()
 
-/obj/item/projectile/bullet/arm/proc/go_home()
+/obj/projectile/bullet/arm/proc/go_home()
 	homing_target = firer
 	returning = TRUE
 	icon_state += "-reverse"
 	range = decayedRange
 	ignore_source_check = TRUE
 
-/obj/item/projectile/bullet/arm/proc/grab(obj/item/I)
+/obj/projectile/bullet/arm/proc/grab(obj/item/I)
 	if(!I)
 		return
 	I.forceMove(src)
@@ -126,7 +126,7 @@
 	grabbed = I
 	overlays += IM
 
-/obj/item/projectile/bullet/arm/proc/ungrab()
+/obj/projectile/bullet/arm/proc/ungrab()
 	if(!grabbed)
 		return
 	grabbed.forceMove(drop_location())
@@ -134,7 +134,7 @@
 	. = grabbed
 	grabbed = null
 
-/obj/item/projectile/bullet/arm/Destroy()
+/obj/projectile/bullet/arm/Destroy()
 	if(grabbed)
 		grabbed.forceMove(drop_location())
 	if(arm)

--- a/yogstation/code/game/gamemodes/shadowling/shadowling.dm
+++ b/yogstation/code/game/gamemodes/shadowling/shadowling.dm
@@ -195,7 +195,7 @@ Made by Xhuis
 		shadow_charges = min(shadow_charges + 1, 3)
 		last_charge = world.time
 
-/datum/species/shadow/ling/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/shadow/ling/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	var/turf/T = H.loc
 	if(istype(T) && shadow_charges > 0)
 		var/light_amount = T.get_lumcount()

--- a/yogstation/code/game/objects/effects/portals.dm
+++ b/yogstation/code/game/objects/effects/portals.dm
@@ -4,7 +4,7 @@
 	var/turf/real_target = get_link_target_turf()
 	if(!istype(real_target))
 		return FALSE
-	if(!force && (!ismecha(M) && !istype(M, /obj/item/projectile) && M.anchored && !allow_anchored))
+	if(!force && (!ismecha(M) && !istype(M, /obj/projectile) && M.anchored && !allow_anchored))
 		return
 	if(ismegafauna(M))
 		message_admins("[M] has used a portal at [ADMIN_VERBOSEJMP(src)] made by [usr].")
@@ -14,8 +14,8 @@
 	else
 		last_effect = world.time
 	if(do_teleport(M, real_target, innate_accuracy_penalty, no_effects = no_effect, channel = teleport_channel, forced = TRUE))
-		if(istype(M, /obj/item/projectile))
-			var/obj/item/projectile/P = M
+		if(istype(M, /obj/projectile))
+			var/obj/projectile/P = M
 			P.ignore_source_check = TRUE
 		return TRUE
 	return FALSE

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_objects/umbral_tendrils.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_objects/umbral_tendrils.dm
@@ -108,14 +108,14 @@
 	user.visible_message(span_warning("[user] draws back [src] and swings them towards [target]!"), \
 	span_velvet("<b>opehhjaoo</b><br>You swing your tendrils towards [target]!"))
 	playsound(user, 'sound/magic/tail_swing.ogg', 50, TRUE)
-	var/obj/item/projectile/umbral_tendrils/T = new(get_turf(user))
+	var/obj/projectile/umbral_tendrils/T = new(get_turf(user))
 	T.preparePixelProjectile(target, user)
 	T.twinned = twin
 	T.firer = user
 	T.fire()
 	qdel(src)
 
-/obj/item/projectile/umbral_tendrils
+/obj/projectile/umbral_tendrils
 	name = "umbral tendrils"
 	icon_state = "cursehand0"
 	hitsound = 'yogstation/sound/magic/pass_attack.ogg'
@@ -128,15 +128,15 @@
 	var/twinned = FALSE
 	var/beam
 
-/obj/item/projectile/umbral_tendrils/fire(setAngle)
+/obj/projectile/umbral_tendrils/fire(setAngle)
 	beam = firer.Beam(src, icon_state = "curse0", time = INFINITY, maxdistance = INFINITY)
 	..()
 
-/obj/item/projectile/umbral_tendrils/Destroy()
+/obj/projectile/umbral_tendrils/Destroy()
 	qdel(beam)
 	. = ..()
 
-/obj/item/projectile/umbral_tendrils/on_hit(atom/movable/target, blocked = FALSE)
+/obj/projectile/umbral_tendrils/on_hit(atom/movable/target, blocked = FALSE)
 	if(blocked >= 100)
 		return
 	. = TRUE

--- a/yogstation/code/modules/guardian/guardian.dm
+++ b/yogstation/code/modules/guardian/guardian.dm
@@ -793,6 +793,6 @@ GLOBAL_LIST_INIT(guardian_projectile_damage, list(
 	icon_state = "greyscale_bolt"
 	damage = 10
 	damage_type = BRUTE
-	flag = ENERGY
+	armor_flag = ENERGY
 	hitsound = 'sound/weapons/pierce_slow.ogg'
 	var/datum/mind/guardian_master

--- a/yogstation/code/modules/guardian/guardian.dm
+++ b/yogstation/code/modules/guardian/guardian.dm
@@ -353,7 +353,7 @@ GLOBAL_LIST_INIT(guardian_projectile_damage, list(
 	if (QDELETED(targeted_atom) || targeted_atom == targets_from.loc || targeted_atom == targets_from)
 		return
 	var/turf/startloc = get_turf(targets_from)
-	var/obj/item/projectile/guardian/emerald_splash = new(startloc)
+	var/obj/projectile/guardian/emerald_splash = new(startloc)
 	playsound(src, projectilesound, 50, TRUE)
 	if (namedatum)
 		emerald_splash.color = namedatum.color
@@ -788,7 +788,7 @@ GLOBAL_LIST_INIT(guardian_projectile_damage, list(
 						jojo.reset(TRUE, "host mind transfer")
 				to_chat(jojo, span_notice("You manifest into existence, as your master's soul appears in a new body!"))
 
-/obj/item/projectile/guardian
+/obj/projectile/guardian
 	name = "crystal bolt"
 	icon_state = "greyscale_bolt"
 	damage = 10

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/darkspawn.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/darkspawn.dm
@@ -19,7 +19,7 @@
 	COOLDOWN_DECLARE(reflect_cd_2)
 	COOLDOWN_DECLARE(reflect_cd_3)
 
-/datum/species/darkspawn/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/darkspawn/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	if(prob(50) && (COOLDOWN_FINISHED(src, reflect_cd_1) || COOLDOWN_FINISHED(src, reflect_cd_2) || COOLDOWN_FINISHED(src, reflect_cd_3)))
 		if(COOLDOWN_FINISHED(src, reflect_cd_1))
 			COOLDOWN_START(src, reflect_cd_1, DARKSPAWN_REFLECT_COOLDOWN)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -272,9 +272,9 @@
 	else
 		no_light_heal = FALSE
 
-/datum/species/pod/on_hit(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/pod/on_hit(obj/projectile/P, mob/living/carbon/human/H)
 	switch(P.type)
-		if(/obj/item/projectile/energy/floramut)
+		if(/obj/projectile/energy/floramut)
 			H.rad_act(rand(20, 30))
 			H.adjustFireLoss(5)
 			H.visible_message(span_warning("[H] writhes in pain as [H.p_their()] vacuoles boil."), span_userdanger("You writhe in pain as your vacuoles boil!"), span_italics("You hear the crunching of leaves."))
@@ -283,7 +283,7 @@
 			else
 				H.easy_random_mutate(POSITIVE)
 			H.domutcheck()
-		if(/obj/item/projectile/energy/florayield)
+		if(/obj/projectile/energy/florayield)
 			H.nutrition = min(H.nutrition+30, NUTRITION_LEVEL_FULL)
 
 /datum/species/pod/random_name(gender,unique,lastname)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -248,9 +248,9 @@
 /datum/species/preternis/has_toes()//their toes are mine, they shall never have them back
 	return FALSE
 
-/datum/species/preternis/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
+/datum/species/preternis/bullet_act(obj/projectile/P, mob/living/carbon/human/H)
 	// called before a projectile hit
-	if(istype(P, /obj/item/projectile/energy/nuclear_particle))
+	if(istype(P, /obj/projectile/energy/nuclear_particle))
 		H.fire_nuclear_particle()
 		H.visible_message(span_danger("[P] deflects off of [H]!"), span_userdanger("[P] deflects off of you!"))
 		return 1

--- a/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/friendly/goats.dm
@@ -180,14 +180,14 @@
 	var/datum/action/cooldown/spell/conjure/radiation_anomaly/radiation_anomaly
 	var/rad_emit = TRUE
 
-/mob/living/simple_animal/hostile/retaliate/goat/radioactive/bullet_act(obj/item/projectile/P)
-	if(istype(P, /obj/item/projectile/energy/nuclear_particle))
+/mob/living/simple_animal/hostile/retaliate/goat/radioactive/bullet_act(obj/projectile/P)
+	if(istype(P, /obj/projectile/energy/nuclear_particle))
 		P.damage = 0 //No damaging goat
 	return ..()
 
-/mob/living/simple_animal/hostile/retaliate/goat/radioactive/on_hit(obj/item/projectile/P)
+/mob/living/simple_animal/hostile/retaliate/goat/radioactive/on_hit(obj/projectile/P)
 	. = ..()
-	if(istype(P, /obj/item/projectile/energy/nuclear_particle))
+	if(istype(P, /obj/projectile/energy/nuclear_particle))
 		// abosrbs nuclear particle to heal
 		adjustBruteLoss(-1)
 		adjustFireLoss(-1)

--- a/yogstation/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -1,5 +1,5 @@
 #define COLOSSUS_SLEEP(X) sleep(X); if(QDELETED(src)) return;
-/obj/item/projectile/colossus
+/obj/projectile/colossus
 	name ="death bolt"
 	icon_state= "chronobolt"
 	damage = 20 //Yogs - Down from 25

--- a/yogstation/code/modules/projectiles/ammunition/caseless/misc.dm
+++ b/yogstation/code/modules/projectiles/ammunition/caseless/misc.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_casing/reusable/kineticspear
 	name = "kinetic spear"
 	desc = "A specialized spear rigged to deliver a weak kinetic blast on contact with fauna."
-	projectile_type = /obj/item/projectile/bullet/reusable/kineticspear
+	projectile_type = /obj/projectile/bullet/reusable/kineticspear
 	caliber = "speargun"
 	icon = 'yogstation/icons/obj/ammo.dmi'
 	icon_state = "kineticspear"

--- a/yogstation/code/modules/projectiles/projectile/beams.dm
+++ b/yogstation/code/modules/projectiles/projectile/beams.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/beam/emitter/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/beam/emitter/on_hit(atom/target, blocked = FALSE)
 	var/turf/T = get_turf(target)
 	if(ismineralturf(T) && prob(50))
 		var/turf/closed/mineral/M = T

--- a/yogstation/code/modules/projectiles/reusable/kineticspear.dm
+++ b/yogstation/code/modules/projectiles/reusable/kineticspear.dm
@@ -1,4 +1,4 @@
-/obj/item/projectile/bullet/reusable/kineticspear
+/obj/projectile/bullet/reusable/kineticspear
 	name = "kinetic spear"
 	desc = "A spear rigged to deliver a kinetic blast with some effect to fauna"
 	damage = 5
@@ -8,7 +8,7 @@
 	icon_state = "kineticspear"
 	hitsound = 'sound/weapons/bladeslice.ogg'
 
-/obj/item/projectile/bullet/reusable/kineticspear/on_hit(atom/target, blocked = FALSE)
+/obj/projectile/bullet/reusable/kineticspear/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target

--- a/yogstation/code/modules/spacepods/equipment.dm
+++ b/yogstation/code/modules/spacepods/equipment.dm
@@ -189,7 +189,7 @@
 	name = "disabler system"
 	desc = "A weak disabler system for space pods, fires disabler beams."
 	icon_state = "weapon_taser"
-	projectile_type = /obj/item/projectile/beam/disabler
+	projectile_type = /obj/projectile/beam/disabler
 	shot_cost = 400
 	fire_sound = 'sound/weapons/taser2.ogg'
 	overlay_icon = 'yogstation/icons/obj/spacepods/2x2.dmi'
@@ -199,7 +199,7 @@
 	name = "burst disabler system"
 	desc = "A weak disabler system for space pods, this one fires 3 at a time."
 	icon_state = "weapon_burst_taser"
-	projectile_type = /obj/item/projectile/beam/disabler
+	projectile_type = /obj/projectile/beam/disabler
 	shot_cost = 1200
 	shots_per = 3
 	fire_sound = 'sound/weapons/taser2.ogg'
@@ -211,7 +211,7 @@
 	name = "laser system"
 	desc = "A weak laser system for space pods, fires concentrated bursts of energy."
 	icon_state = "weapon_laser"
-	projectile_type = /obj/item/projectile/beam/laser
+	projectile_type = /obj/projectile/beam/laser
 	shot_cost = 600
 	fire_sound = 'sound/weapons/Laser.ogg'
 	overlay_icon = 'yogstation/icons/obj/spacepods/2x2.dmi'
@@ -223,7 +223,7 @@
 	desc = "A weak kinetic accelerator for space pods, fires bursts of energy that cut through rock."
 	icon = 'goon/icons/obj/spacepods/parts.dmi'
 	icon_state = "pod_taser"
-	projectile_type = /obj/item/projectile/kinetic/pod
+	projectile_type = /obj/projectile/kinetic/pod
 	shot_cost = 300
 	fire_delay = 14
 	fire_sound = 'sound/weapons/Kenetic_accel.ogg'
@@ -233,15 +233,15 @@
 	desc = "A kinetic accelerator system for space pods, fires bursts of energy that cut through rock."
 	icon = 'goon/icons/obj/spacepods/parts.dmi'
 	icon_state = "pod_m_laser"
-	projectile_type = /obj/item/projectile/kinetic/pod/regular
+	projectile_type = /obj/projectile/kinetic/pod/regular
 	shot_cost = 250
 	fire_delay = 10
 	fire_sound = 'sound/weapons/Kenetic_accel.ogg'
 
-/obj/item/projectile/kinetic/pod
+/obj/projectile/kinetic/pod
 	range = 4
 
-/obj/item/projectile/kinetic/pod/regular
+/obj/projectile/kinetic/pod/regular
 	damage = 50
 	pressure_decrease = 0.5
 
@@ -250,7 +250,7 @@
 	desc = "A plasma cutter system for space pods. It is capable of expelling concentrated plasma bursts to mine or cut off xeno limbs!"
 	icon = 'goon/icons/obj/spacepods/parts.dmi'
 	icon_state = "pod_p_cutter"
-	projectile_type = /obj/item/projectile/plasma
+	projectile_type = /obj/projectile/plasma
 	shot_cost = 250
 	fire_delay = 10
 	fire_sound = 'sound/weapons/plasma_cutter.ogg'
@@ -261,7 +261,7 @@
 	name = "enhanced plasma cutter system"
 	desc = "An enhanced plasma cutter system for space pods. It is capable of expelling concentrated plasma bursts to mine or cut off xeno faces!"
 	icon_state = "pod_ap_cutter"
-	projectile_type = /obj/item/projectile/plasma/adv
+	projectile_type = /obj/projectile/plasma/adv
 	shot_cost = 200
 	fire_delay = 8
 

--- a/yogstation/code/modules/spacepods/physics.dm
+++ b/yogstation/code/modules/spacepods/physics.dm
@@ -284,7 +284,7 @@
 			this_y += 32
 		if(!T)
 			continue
-		var/obj/item/projectile/proj = new proj_type(T)
+		var/obj/projectile/proj = new proj_type(T)
 		proj.starting = T
 		proj.firer = usr
 		proj.def_zone = "chest"

--- a/yogstation/code/modules/spells/spell_types/projectile/animation.dm
+++ b/yogstation/code/modules/spells/spell_types/projectile/animation.dm
@@ -12,7 +12,7 @@
 	cast_range = 20
 	cooldown_time = 6 SECONDS
 	cooldown_reduction_per_rank = 1 SECONDS
-	projectile_type = /obj/item/projectile/magic/animate
+	projectile_type = /obj/projectile/magic/animate
 	active_msg = "You prepare to cast your animation spell!"
 	deactive_msg = "You stop casting your animation spell... for now."
 	spell_requirements = NONE

--- a/yogstation/code/modules/xenoarch/loot/guns.dm
+++ b/yogstation/code/modules/xenoarch/loot/guns.dm
@@ -66,14 +66,14 @@
 //#################//
 
 /obj/item/ammo_casing/energy/polarstar
-	projectile_type = /obj/item/projectile/bullet/polarstar
+	projectile_type = /obj/projectile/bullet/polarstar
 	select_name = "polar star lens"
 	e_cost = 100
 	fire_sound = null
 	harmful = TRUE
 
 
-/obj/item/projectile/bullet/polarstar
+/obj/projectile/bullet/polarstar
 	name = "polar star bullet"
 	range = 20
 	damage = 20
@@ -82,7 +82,7 @@
 	icon_state = "spur_high"
 	var/skip = FALSE //this is the hackiest thing ive ever done but i dont know any other solution other than deparent the spur projectile
 
-/obj/item/projectile/bullet/polarstar/fire(angle, atom/direct_target)
+/obj/projectile/bullet/polarstar/fire(angle, atom/direct_target)
 	if(!fired_from || !istype(fired_from,/obj/item/gun/energy) || skip)
 		return ..()
 
@@ -104,7 +104,7 @@
 		range = 7
 	..()
 
-/obj/item/projectile/bullet/polarstar/on_range()
+/obj/projectile/bullet/polarstar/on_range()
 	if(!loc)
 		return
 	var/turf/T = loc
@@ -116,7 +116,7 @@
 	qdel(impact)
 	..()
 
-/obj/item/projectile/bullet/polarstar/on_hit(atom/target, blocked)
+/obj/projectile/bullet/polarstar/on_hit(atom/target, blocked)
 	. = ..()
 	var/impact_icon = null
 	var/impact_sound = null
@@ -139,11 +139,11 @@
 	..()
 
 /obj/item/ammo_casing/energy/polarstar/spur
-	projectile_type = /obj/item/projectile/bullet/polarstar/spur
+	projectile_type = /obj/projectile/bullet/polarstar/spur
 	select_name = "spur lens"
 
 
-/obj/item/projectile/bullet/polarstar/spur
+/obj/projectile/bullet/polarstar/spur
 	name = "spur bullet"
 	range = 20
 	damage = 40
@@ -152,7 +152,7 @@
 	icon_state = "spur_high"
 	skip = TRUE
 
-/obj/item/projectile/bullet/polarstar/spur/fire(angle, atom/direct_target)
+/obj/projectile/bullet/polarstar/spur/fire(angle, atom/direct_target)
 	if(!fired_from || !istype(fired_from,/obj/item/gun/energy))
 		return ..()
 


### PR DESCRIPTION
# Document the changes in your pull request

ports 

- https://github.com/tgstation/tgstation/pull/46692
- https://github.com/tgstation/tgstation/pull/65487

# Why is this good for the game?
Players shouldn't notice, it's just for better code control over a subtype and more closely matching tg for easier code appropriation

# Testing
Compiles, runs, and guns fire fine as well as connect with targets. The only runtime during testing had to do with scars which i don't think was related to this

# Changelog

:cl:  
tweak: projectiles are no longer an item subtype, this only matters for coders
tweak: projectiles flag var renamed to armor_flag for clarification
/:cl:
