### PR TITLE
All lights turn red in emergency procedures

### DIFF
--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -98,6 +98,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(list(/area/engin
 		thing.change_area(old_area, newA)
 
 	newA.reg_in_areas_in_z()
+	newA.add_delta_areas()
 
 	var/list/firedoors = oldA.firedoors
 	for(var/door in firedoors)

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -98,7 +98,6 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(list(/area/engin
 		thing.change_area(old_area, newA)
 
 	newA.reg_in_areas_in_z()
-	newA.add_areas_to_nuke()
 
 	var/list/firedoors = oldA.firedoors
 	for(var/door in firedoors)

--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -98,6 +98,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(list(/area/engin
 		thing.change_area(old_area, newA)
 
 	newA.reg_in_areas_in_z()
+	newA.add_areas_to_nuke()
 
 	var/list/firedoors = oldA.firedoors
 	for(var/door in firedoors)

--- a/code/_globalvars/lists/mapping.dm
+++ b/code/_globalvars/lists/mapping.dm
@@ -41,7 +41,7 @@ GLOBAL_LIST_EMPTY(servant_spawns_scarabs) //Servants of Ratvar spawn here
 GLOBAL_LIST_EMPTY(city_of_cogs_spawns) //Anyone entering the City of Cogs spawns here
 GLOBAL_LIST_EMPTY(brazil_reception) //teleport receive spots for heretic sacrifices
 GLOBAL_LIST_EMPTY(ruin_landmarks)
-GLOBAL_LIST_EMPTY(nuke_areas)
+GLOBAL_LIST_EMPTY(delta_areas)
 GLOBAL_LIST_EMPTY(bar_areas)
 // IF YOU ARE MAKING A NEW BAR TEMPLATE AND WANT IT ROUNDSTART ADD IT TO THIS LIST!
 GLOBAL_LIST_INIT(potential_box_bars, list("Bar Trek", "Bar Spacious", "Bar Box", "Bar Casino", "Bar Citadel", "Bar Conveyor", "Bar Diner", "Bar Disco", "Bar Purple", "Bar Cheese", "Bar Grassy", "Bar Clock", "Bar Arcade"))

--- a/code/_globalvars/lists/mapping.dm
+++ b/code/_globalvars/lists/mapping.dm
@@ -41,6 +41,7 @@ GLOBAL_LIST_EMPTY(servant_spawns_scarabs) //Servants of Ratvar spawn here
 GLOBAL_LIST_EMPTY(city_of_cogs_spawns) //Anyone entering the City of Cogs spawns here
 GLOBAL_LIST_EMPTY(brazil_reception) //teleport receive spots for heretic sacrifices
 GLOBAL_LIST_EMPTY(ruin_landmarks)
+GLOBAL_LIST_EMPTY(nuke_areas)
 GLOBAL_LIST_EMPTY(bar_areas)
 // IF YOU ARE MAKING A NEW BAR TEMPLATE AND WANT IT ROUNDSTART ADD IT TO THIS LIST!
 GLOBAL_LIST_INIT(potential_box_bars, list("Bar Trek", "Bar Spacious", "Bar Box", "Bar Casino", "Bar Citadel", "Bar Conveyor", "Bar Diner", "Bar Disco", "Bar Purple", "Bar Cheese", "Bar Grassy", "Bar Clock", "Bar Arcade"))

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -7,6 +7,7 @@ SUBSYSTEM_DEF(mapping)
 
 	var/list/nuke_tiles = list()
 	var/list/nuke_threats = list()
+	var/list/area/nuke_areas = list()
 
 	var/datum/map_config/config
 	var/datum/map_config/next_map_config
@@ -208,10 +209,14 @@ SUBSYSTEM_DEF(mapping)
 /datum/controller/subsystem/mapping/proc/add_nuke_threat(datum/nuke)
 	nuke_threats[nuke] = TRUE
 	check_nuke_threats()
+	for(var/area/A in nuke_areas)
+		A.set_fire_alarm_effect(FALSE)
 
 /datum/controller/subsystem/mapping/proc/remove_nuke_threat(datum/nuke)
 	nuke_threats -= nuke
 	check_nuke_threats()
+	for(var/area/A in nuke_areas)
+		A.unset_fire_alarm_effects()
 
 /datum/controller/subsystem/mapping/proc/check_nuke_threats()
 	for(var/datum/d in nuke_threats)

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -210,13 +210,13 @@ SUBSYSTEM_DEF(mapping)
 	nuke_threats[nuke] = TRUE
 	check_nuke_threats()
 	for(var/area/A in nuke_areas)
-		A.set_fire_alarm_effect(FALSE)
+		A.set_fire_alarm_effect(TRUE)
 
 /datum/controller/subsystem/mapping/proc/remove_nuke_threat(datum/nuke)
 	nuke_threats -= nuke
 	check_nuke_threats()
 	for(var/area/A in nuke_areas)
-		A.unset_fire_alarm_effects()
+		A.unset_fire_alarm_effects(TRUE)
 
 /datum/controller/subsystem/mapping/proc/check_nuke_threats()
 	for(var/datum/d in nuke_threats)

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -7,7 +7,6 @@ SUBSYSTEM_DEF(mapping)
 
 	var/list/nuke_tiles = list()
 	var/list/nuke_threats = list()
-	var/list/area/nuke_areas = list()
 
 	var/datum/map_config/config
 	var/datum/map_config/next_map_config
@@ -209,14 +208,10 @@ SUBSYSTEM_DEF(mapping)
 /datum/controller/subsystem/mapping/proc/add_nuke_threat(datum/nuke)
 	nuke_threats[nuke] = TRUE
 	check_nuke_threats()
-	for(var/area/A in nuke_areas)
-		A.set_fire_alarm_effect(TRUE)
 
 /datum/controller/subsystem/mapping/proc/remove_nuke_threat(datum/nuke)
 	nuke_threats -= nuke
 	check_nuke_threats()
-	for(var/area/A in nuke_areas)
-		A.unset_fire_alarm_effects(TRUE)
 
 /datum/controller/subsystem/mapping/proc/check_nuke_threats()
 	for(var/datum/d in nuke_threats)

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -266,12 +266,7 @@ SUBSYSTEM_DEF(shuttle)
 
 	var/area/signal_origin = get_area(user)
 	var/emergency_reason = "\nNature of emergency:\n\n[call_reason]"
-	var/security_num = seclevel2num(get_security_level())
-	switch(security_num)
-		if(SEC_LEVEL_RED,SEC_LEVEL_GAMMA,SEC_LEVEL_EPSILON,SEC_LEVEL_DELTA)
-			emergency.request(null, signal_origin, html_decode(emergency_reason), 1) //There is a serious threat we gotta move no time to give them five minutes.
-		else
-			emergency.request(null, signal_origin, html_decode(emergency_reason), 0)
+	emergency.request(null, signal_origin, html_decode(emergency_reason))
 
 	var/datum/radio_frequency/frequency = SSradio.return_frequency(FREQ_STATUS_DISPLAYS)
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -184,6 +184,8 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	map_name = name // Save the initial (the name set in the map) name of the area.
 	canSmoothWithAreas = typecacheof(canSmoothWithAreas)
 
+	if(is_station_level(src.z))
+		SSmapping.nuke_areas += src
 
 	if(!ambientsounds && ambience_index)
 		ambientsounds = GLOB.ambience_assoc[ambience_index]
@@ -509,12 +511,12 @@ GLOBAL_LIST_EMPTY(teleportlocs)
   *
   * Updates the fire light on fire alarms in the area and sets all lights to emergency mode
   */
-/area/proc/set_fire_alarm_effect()
-	fire = TRUE
+/area/proc/set_fire_alarm_effect(active_fire=TRUE) //if active_fire = FALSE, it will only change the lights to red and not the whole fire alarm systems
+	fire = active_fire
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	for(var/alarm in firealarms)
 		var/obj/machinery/firealarm/F = alarm
-		F.update_fire_light(fire)
+		F.update_fire_light(TRUE)
 	for(var/obj/machinery/light/L in src)
 		L.update()
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -282,7 +282,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	areas_in_z["[z]"] += src
 
 /area/proc/add_delta_areas()
-	if(is_station_level(z) && !istype(src, /area/shuttle) && !istype(src, /area/ruin))
+	if(is_station_level(z) && !istype(src, /area/shuttle) && !istype(src, /area/ruin) && !istype(src, /area/space))
 		GLOB.delta_areas += src
 
 /**

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -32,7 +32,7 @@
 	var/clockwork_warp_allowed = TRUE // Can servants warp into this area from Reebe?
 	var/clockwork_warp_fail = "The structure there is too dense for warping to pierce. (This is normal in high-security areas.)"
 
-	var/fire = null
+	var/fire = FALSE
 	var/atmos = TRUE
 	var/atmosalm = FALSE
 	var/poweralm = TRUE
@@ -187,7 +187,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	canSmoothWithAreas = typecacheof(canSmoothWithAreas)
 
 	if(is_station_level(src.z))
-		SSmapping.nuke_areas += src
+		GLOB.nuke_areas += src
 
 	if(!ambientsounds && ambience_index)
 		ambientsounds = GLOB.ambience_assoc[ambience_index]
@@ -514,8 +514,9 @@ GLOBAL_LIST_EMPTY(teleportlocs)
   * Updates the fire light on fire alarms in the area and sets all lights to emergency mode
   */
 /area/proc/set_fire_alarm_effect(delta_alert=FALSE)
-	delta_light = delta_alert
-	if(!delta_alert)
+	if(delta_alert)
+		delta_light = TRUE
+	else
 		fire = TRUE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	for(var/alarm in firealarms)
@@ -530,13 +531,15 @@ GLOBAL_LIST_EMPTY(teleportlocs)
   * Updates the fire light on fire alarms in the area and sets all lights to emergency mode
   */
 /area/proc/unset_fire_alarm_effects(delta_alert=FALSE)
-	delta_light = delta_alert
-	if(!delta_alert)
+	if(delta_alert)
+		delta_light = FALSE
+	else
 		fire = FALSE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	for(var/alarm in firealarms)
 		var/obj/machinery/firealarm/F = alarm
-		F.update_fire_light(FALSE)
+		if(!delta_light)
+			F.update_fire_light(FALSE)
 	for(var/obj/machinery/light/L in src)
 		L.update()
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -73,6 +73,8 @@
 	var/unique = TRUE
 	/// If false, then this area will show up as gibberish on suit sensors.
 	var/show_on_sensors = TRUE
+	/// a simple check to determine whether the lights in an area should go red during delta alert
+	var/delta_light = FALSE
 
 	var/no_air = null
 
@@ -511,15 +513,15 @@ GLOBAL_LIST_EMPTY(teleportlocs)
   *
   * Updates the fire light on fire alarms in the area and sets all lights to emergency mode
   */
-/area/proc/set_fire_alarm_effect(delta_active=FALSE) //if active_fire = TRUE, it will only change the lights to red and not the whole fire alarm systems
-	fire = !delta_active
+/area/proc/set_fire_alarm_effect(delta_alert=FALSE)
+	delta_light = delta_alert
+	if(!delta_alert)
+		fire = TRUE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	for(var/alarm in firealarms)
 		var/obj/machinery/firealarm/F = alarm
 		F.update_fire_light(TRUE)
 	for(var/obj/machinery/light/L in src)
-		if(delta_active)
-			L.force_red = TRUE
 		L.update()
 
 /**
@@ -527,15 +529,15 @@ GLOBAL_LIST_EMPTY(teleportlocs)
   *
   * Updates the fire light on fire alarms in the area and sets all lights to emergency mode
   */
-/area/proc/unset_fire_alarm_effects(delta_inactive=FALSE)
-	fire = FALSE
+/area/proc/unset_fire_alarm_effects(delta_alert=FALSE)
+	delta_light = delta_alert
+	if(!delta_alert)
+		fire = FALSE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	for(var/alarm in firealarms)
 		var/obj/machinery/firealarm/F = alarm
 		F.update_fire_light(FALSE)
 	for(var/obj/machinery/light/L in src)
-		if(L.force_red && delta_inactive)
-			L.force_red = FALSE
 		L.update()
 
 /area/proc/set_vacuum_alarm_effect() //Just like fire alarm but blue

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -37,7 +37,6 @@
 	var/atmosalm = FALSE
 	var/poweralm = TRUE
 	var/lightswitch = TRUE
-	var/forcered = FALSE
 	var/vacuum = null //yogs- yellow vacuum lights
 	var/mining_speed = FALSE
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -282,7 +282,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	areas_in_z["[z]"] += src
 
 /area/proc/add_delta_areas()
-	if(is_station_level(z) && !istype(src, /area/shuttle))
+	if(is_station_level(z) && !istype(src, /area/shuttle) && !istype(src, /area/ruin))
 		GLOB.delta_areas += src
 
 /**

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -186,7 +186,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	map_name = name // Save the initial (the name set in the map) name of the area.
 	canSmoothWithAreas = typecacheof(canSmoothWithAreas)
 
-	add_areas_to_nuke()
+	add_delta_areas()
 
 	if(!ambientsounds && ambience_index)
 		ambientsounds = GLOB.ambience_assoc[ambience_index]

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -186,8 +186,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	map_name = name // Save the initial (the name set in the map) name of the area.
 	canSmoothWithAreas = typecacheof(canSmoothWithAreas)
 
-	if(is_station_level(src.z))
-		GLOB.nuke_areas += src
+	add_areas_to_nuke()
 
 	if(!ambientsounds && ambience_index)
 		ambientsounds = GLOB.ambience_assoc[ambience_index]
@@ -282,6 +281,10 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 		areas_in_z["[z]"] = list()
 	areas_in_z["[z]"] += src
 
+/area/proc/add_delta_areas()
+	if(is_station_level(z) && !istype(src, /area/shuttle))
+		GLOB.delta_areas += src
+
 /**
   * Destroy an area and clean it up
   *
@@ -295,6 +298,7 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 		GLOB.areas_by_type[type] = null
 	GLOB.sortedAreas -= src
 	GLOB.areas -= src
+	GLOB.delta_areas -= src
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -37,6 +37,7 @@
 	var/atmosalm = FALSE
 	var/poweralm = TRUE
 	var/lightswitch = TRUE
+	var/forcered = FALSE
 	var/vacuum = null //yogs- yellow vacuum lights
 	var/mining_speed = FALSE
 
@@ -511,13 +512,15 @@ GLOBAL_LIST_EMPTY(teleportlocs)
   *
   * Updates the fire light on fire alarms in the area and sets all lights to emergency mode
   */
-/area/proc/set_fire_alarm_effect(active_fire=TRUE) //if active_fire = FALSE, it will only change the lights to red and not the whole fire alarm systems
-	fire = active_fire
+/area/proc/set_fire_alarm_effect(delta_active=FALSE) //if active_fire = TRUE, it will only change the lights to red and not the whole fire alarm systems
+	fire = !delta_active
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	for(var/alarm in firealarms)
 		var/obj/machinery/firealarm/F = alarm
 		F.update_fire_light(TRUE)
 	for(var/obj/machinery/light/L in src)
+		if(delta_active)
+			L.force_red = TRUE
 		L.update()
 
 /**
@@ -525,13 +528,15 @@ GLOBAL_LIST_EMPTY(teleportlocs)
   *
   * Updates the fire light on fire alarms in the area and sets all lights to emergency mode
   */
-/area/proc/unset_fire_alarm_effects()
+/area/proc/unset_fire_alarm_effects(delta_inactive=FALSE)
 	fire = FALSE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	for(var/alarm in firealarms)
 		var/obj/machinery/firealarm/F = alarm
-		F.update_fire_light(fire)
+		F.update_fire_light(FALSE)
 	for(var/obj/machinery/light/L in src)
+		if(L.force_red && delta_inactive)
+			L.force_red = FALSE
 		L.update()
 
 /area/proc/set_vacuum_alarm_effect() //Just like fire alarm but blue

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -82,7 +82,7 @@
 	var/area/A = src.loc
 	A = A.loc
 
-	if(!detecting || !A.fire)
+	if(!detecting || !A.fire || !A.delta_light)
 		. += "fire_off"
 		SSvis_overlays.add_vis_overlay(src, icon, "fire_off", layer, plane, dir)
 		SSvis_overlays.add_vis_overlay(src, icon, "fire_off", layer, EMISSIVE_PLANE, dir)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -82,7 +82,7 @@
 	var/area/A = src.loc
 	A = A.loc
 
-	if(!detecting || !A.fire || !A.delta_light)
+	if(!A.fire && !A.delta_light)
 		. += "fire_off"
 		SSvis_overlays.add_vis_overlay(src, icon, "fire_off", layer, plane, dir)
 		SSvis_overlays.add_vis_overlay(src, icon, "fire_off", layer, EMISSIVE_PLANE, dir)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -235,6 +235,8 @@
 
 	var/rigged = FALSE			// true if rigged to explode
 
+	var/force_red               // force red light
+
 	var/obj/item/stock_parts/cell/cell
 	var/start_with_cell = TRUE	// if true, this fixture generates a very weak cell at roundstart
 
@@ -387,7 +389,7 @@
 		if(color)
 			CO = color
 		var/area/A = get_area(src)
-		if (A && A.fire)
+		if (A && (A.fire || force_red))
 			CO = bulb_emergency_colour
 		else if (A && A.vacuum)
 			CO = bulb_vacuum_colour

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -350,7 +350,7 @@
 				icon_state = "[base_state]"
 				return
 			var/area/A = get_area(src)
-			if(emergency_mode || (A && A.fire))
+			if(emergency_mode || (A && (A.fire || A.delta_light)))
 				icon_state = "[base_state]_emergency"
 			else if (A && A.vacuum)
 				icon_state = "[base_state]_vacuum"

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -235,8 +235,6 @@
 
 	var/rigged = FALSE			// true if rigged to explode
 
-	var/force_red               // force red light
-
 	var/obj/item/stock_parts/cell/cell
 	var/start_with_cell = TRUE	// if true, this fixture generates a very weak cell at roundstart
 
@@ -389,7 +387,7 @@
 		if(color)
 			CO = color
 		var/area/A = get_area(src)
-		if (A && (A.fire || force_red))
+		if (A && (A.fire || A.delta_light))
 			CO = bulb_emergency_colour
 		else if (A && A.vacuum)
 			CO = bulb_vacuum_colour

--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -8,6 +8,15 @@ GLOBAL_VAR_INIT(security_level, SEC_LEVEL_GREEN)
 
 //config.alert_desc_blue_downto
 
+//set all area lights on station level to red if true, do otherwise if false
+/proc/change_areas_lights_alarm(red=TRUE)
+	if(red)
+		for(var/area/A in GLOB.delta_areas)
+			A.set_fire_alarm_effect(TRUE)
+	else
+		for(var/area/A in GLOB.delta_areas)
+			A.unset_fire_alarm_effects(TRUE)
+
 /proc/set_security_level(level)
 	switch(level)
 		if("green")
@@ -95,12 +104,12 @@ GLOBAL_VAR_INIT(security_level, SEC_LEVEL_GREEN)
 					D.visible_message(span_notice("[D] whirrs as it automatically lifts access requirements!"))
 					playsound(D, 'sound/machines/boltsup.ogg', 50, TRUE)
 
-		if(level == SEC_LEVEL_DELTA)
-			for(var/area/A in GLOB.delta_areas)
-				A.set_fire_alarm_effect(TRUE)
+		if(level == SEC_LEVEL_DELTA || level == SEC_LEVEL_EPSILON)
+			change_areas_lights_alarm()
+		else if(SSshuttle.emergency.mode != SHUTTLE_IDLE && SSshuttle.emergency.mode != SHUTTLE_RECALL && level >= SEC_LEVEL_RED)
+			change_areas_lights_alarm()
 		else
-			for(var/area/A in GLOB.delta_areas)
-				A.unset_fire_alarm_effects(TRUE)
+			change_areas_lights_alarm(FALSE)
 
 		if(SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_RECALL)
 			SSshuttle.emergency.modTimer(modTimer)

--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -95,6 +95,13 @@ GLOBAL_VAR_INIT(security_level, SEC_LEVEL_GREEN)
 					D.visible_message(span_notice("[D] whirrs as it automatically lifts access requirements!"))
 					playsound(D, 'sound/machines/boltsup.ogg', 50, TRUE)
 
+		if(level == SEC_LEVEL_DELTA)
+			for(var/area/A in GLOB.nuke_areas)
+				A.set_fire_alarm_effect(TRUE)
+		else
+			for(var/area/A in GLOB.nuke_areas)
+				A.unset_fire_alarm_effects(TRUE)
+
 		if(SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_RECALL)
 			SSshuttle.emergency.modTimer(modTimer)
 

--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -104,7 +104,7 @@ GLOBAL_VAR_INIT(security_level, SEC_LEVEL_GREEN)
 					D.visible_message(span_notice("[D] whirrs as it automatically lifts access requirements!"))
 					playsound(D, 'sound/machines/boltsup.ogg', 50, TRUE)
 
-		if(level == SEC_LEVEL_DELTA || level == SEC_LEVEL_EPSILON)
+		if(level >= SEC_LEVEL_GAMMA)
 			change_areas_lights_alarm()
 		else if(SSshuttle.emergency.mode != SHUTTLE_IDLE && SSshuttle.emergency.mode != SHUTTLE_RECALL && level >= SEC_LEVEL_RED)
 			change_areas_lights_alarm()

--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -96,10 +96,10 @@ GLOBAL_VAR_INIT(security_level, SEC_LEVEL_GREEN)
 					playsound(D, 'sound/machines/boltsup.ogg', 50, TRUE)
 
 		if(level == SEC_LEVEL_DELTA)
-			for(var/area/A in GLOB.nuke_areas)
+			for(var/area/A in GLOB.delta_areas)
 				A.set_fire_alarm_effect(TRUE)
 		else
-			for(var/area/A in GLOB.nuke_areas)
+			for(var/area/A in GLOB.delta_areas)
 				A.unset_fire_alarm_effects(TRUE)
 
 		if(SSshuttle.emergency.mode == SHUTTLE_CALL || SSshuttle.emergency.mode == SHUTTLE_RECALL)

--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -106,8 +106,6 @@ GLOBAL_VAR_INIT(security_level, SEC_LEVEL_GREEN)
 
 		if(level >= SEC_LEVEL_GAMMA)
 			change_areas_lights_alarm()
-		else if(SSshuttle.emergency.mode != SHUTTLE_IDLE && SSshuttle.emergency.mode != SHUTTLE_RECALL && level >= SEC_LEVEL_RED)
-			change_areas_lights_alarm()
 		else
 			change_areas_lights_alarm(FALSE)
 

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -251,7 +251,7 @@
 	else
 		SSshuttle.emergencyLastCallLoc = null
 
-	if(SEC_LEVEL_RED <= GLOB.security_level < SEC_LEVEL_EPSILON)
+	if(GLOB.security_level >= SEC_LEVEL_RED)
 		change_areas_lights_alarm()
 
 	priority_announce("The emergency shuttle has been called. [GLOB.security_level >= SEC_LEVEL_RED ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [timeLeft(600)] minutes.[reason][SSshuttle.emergencyLastCallLoc ? "\n\nCall signal traced. Results can be viewed on any communications console." : "" ]", null, ANNOUNCER_SHUTTLECALLED, "Priority")

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -224,7 +224,7 @@
 
 	. = ..()
 
-/obj/docking_port/mobile/emergency/request(obj/docking_port/stationary/S, area/signalOrigin, reason, redAlert, set_coefficient=null)
+/obj/docking_port/mobile/emergency/request(obj/docking_port/stationary/S, area/signalOrigin, reason, set_coefficient=null)
 	if(!isnum(set_coefficient))
 		var/security_num = seclevel2num(get_security_level())
 		switch(security_num)

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -270,7 +270,7 @@
 	else
 		SSshuttle.emergencyLastCallLoc = null
 
-	if(GLOB.security_level < SEC_LEVEL_EPSILON)
+	if(GLOB.security_level < SEC_LEVEL_GAMMA)
 		change_areas_lights_alarm(FALSE)
 
 	priority_announce("The emergency shuttle has been recalled.[SSshuttle.emergencyLastCallLoc ? " Recall signal traced. Results can be viewed on any communications console." : "" ]", null, ANNOUNCER_SHUTTLERECALLED, "Priority")

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -251,7 +251,10 @@
 	else
 		SSshuttle.emergencyLastCallLoc = null
 
-	priority_announce("The emergency shuttle has been called. [redAlert ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [timeLeft(600)] minutes.[reason][SSshuttle.emergencyLastCallLoc ? "\n\nCall signal traced. Results can be viewed on any communications console." : "" ]", null, ANNOUNCER_SHUTTLECALLED, "Priority")
+	if(SEC_LEVEL_RED <= GLOB.security_level < SEC_LEVEL_EPSILON)
+		change_areas_lights_alarm()
+
+	priority_announce("The emergency shuttle has been called. [GLOB.security_level >= SEC_LEVEL_RED ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [timeLeft(600)] minutes.[reason][SSshuttle.emergencyLastCallLoc ? "\n\nCall signal traced. Results can be viewed on any communications console." : "" ]", null, ANNOUNCER_SHUTTLECALLED, "Priority")
 
 /obj/docking_port/mobile/emergency/cancel(area/signalOrigin)
 	if(mode != SHUTTLE_CALL)
@@ -266,6 +269,10 @@
 		SSshuttle.emergencyLastCallLoc = signalOrigin
 	else
 		SSshuttle.emergencyLastCallLoc = null
+
+	if(GLOB.security_level < SEC_LEVEL_EPSILON)
+		change_areas_lights_alarm(FALSE)
+
 	priority_announce("The emergency shuttle has been recalled.[SSshuttle.emergencyLastCallLoc ? " Recall signal traced. Results can be viewed on any communications console." : "" ]", null, ANNOUNCER_SHUTTLERECALLED, "Priority")
 
 /obj/docking_port/mobile/emergency/proc/is_hijacked()

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -251,9 +251,6 @@
 	else
 		SSshuttle.emergencyLastCallLoc = null
 
-	if(GLOB.security_level >= SEC_LEVEL_RED)
-		change_areas_lights_alarm()
-
 	priority_announce("The emergency shuttle has been called. [GLOB.security_level >= SEC_LEVEL_RED ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [timeLeft(600)] minutes.[reason][SSshuttle.emergencyLastCallLoc ? "\n\nCall signal traced. Results can be viewed on any communications console." : "" ]", null, ANNOUNCER_SHUTTLECALLED, "Priority")
 
 /obj/docking_port/mobile/emergency/cancel(area/signalOrigin)
@@ -269,9 +266,6 @@
 		SSshuttle.emergencyLastCallLoc = signalOrigin
 	else
 		SSshuttle.emergencyLastCallLoc = null
-
-	if(GLOB.security_level < SEC_LEVEL_GAMMA)
-		change_areas_lights_alarm(FALSE)
 
 	priority_announce("The emergency shuttle has been recalled.[SSshuttle.emergencyLastCallLoc ? " Recall signal traced. Results can be viewed on any communications console." : "" ]", null, ANNOUNCER_SHUTTLERECALLED, "Priority")
 

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn.dm
@@ -377,7 +377,7 @@
 	QDEL_IN(user, 5)
 
 /datum/antagonist/darkspawn/proc/sacrament_shuttle_call()
-	SSshuttle.emergency.request(null, 0, null, FALSE, 0.1)
+	SSshuttle.emergency.request(null, 0, null, 0.1)
 
 /datum/antagonist/darkspawn/get_preview_icon()
 	var/icon/darkspawn_icon = icon('yogstation/icons/mob/darkspawn_progenitor.dmi', "darkspawn_progenitor")


### PR DESCRIPTION
# Document the changes in your pull request
Delta, Gamma and *@&!#&EPSILON*#%@ alert now make all lights turn red

# Why is this good for the game?
For immersion and make the station seems like its on actual emergency procedure

# Testing
Tested,
switched to delta/epsilon alert level, all lights turned red
switched back to normal alert level, all lights went back to normal

Tried to use fire alarm to turn off red lights on delta, didnt do that and instead it triggered firelocks, then hit the fire alarm again It opened all the firelocks and the lights still stayed red as intended

![image](https://github.com/yogstation13/Yogstation/assets/89688125/10cec3d4-8a51-4842-b2c4-0ddd2ea65849)

Shouldnt make shuttle lights go red



# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Delta, Gamma and *@&!#&EPSILON*#%@ alert now make all lights turn red
/:cl:
