### PR TITLE
Adds an incapacitated check to ash jaunt + speedboost status

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -72,6 +72,8 @@
 
 #define STATUS_EFFECT_HOLYLIGHT_HEALBOOST /datum/status_effect/holylight_healboost //short-term heal boost that grants the chaplain favor
 
+#define STATUS_EFFECT_SPEEDBOOST /datum/status_effect/speedboost //applies a speed boost
+
 /////////////
 // DEBUFFS //
 /////////////

--- a/code/datums/status_effects/buffs/buffs.dm
+++ b/code/datums/status_effects/buffs/buffs.dm
@@ -747,7 +747,7 @@
 	status_type = STATUS_EFFECT_MULTIPLE
 	alert_type = /atom/movable/screen/alert/status_effect/speedboost
 	var/speedstrength
-	var/id //id for the speed boost
+	var/identifier //id for the speed boost
 
 /atom/movable/screen/alert/status_effect/speedboost
 	name = "Speedboost"
@@ -757,13 +757,13 @@
 /datum/status_effect/speedboost/on_creation(mob/living/new_owner, strength, length, identifier)
 	duration = length
 	speedstrength = strength
-	id = id
+	src.identifier = identifier
 	. = ..()
 
 /datum/status_effect/speedboost/on_apply()
 	. = ..()
-	if(. && speedstrength && id)
-		owner.add_movespeed_modifier(id, multiplicative_slowdown = speedstrength)
+	if(. && speedstrength && identifier)
+		owner.add_movespeed_modifier(identifier, multiplicative_slowdown = speedstrength)
 
 /datum/status_effect/speedboost/on_remove()
-	owner.remove_movespeed_modifier(id)
+	owner.remove_movespeed_modifier(identifier)

--- a/code/datums/status_effects/buffs/buffs.dm
+++ b/code/datums/status_effects/buffs/buffs.dm
@@ -738,3 +738,32 @@
 /datum/status_effect/holylight_healboost/on_remove()
 	var/datum/component/heal_react/boost/holylight/healing = owner.GetComponent(/datum/component/heal_react/boost/holylight)
 	healing?.RemoveComponent()
+
+
+/datum/status_effect/speedboost
+	id = "speedboost"
+	duration = 30 SECONDS
+	tick_interval = -1
+	status_type = STATUS_EFFECT_MULTIPLE
+	alert_type = /atom/movable/screen/alert/status_effect/speedboost
+	var/speedstrength
+	var/id //id for the speed boost
+
+/atom/movable/screen/alert/status_effect/speedboost
+	name = "Speedboost"
+	desc = "Move fast."
+	icon_state = "evading" //again, i'm a coder, not a spriter
+
+/datum/status_effect/speedboost/on_creation(mob/living/new_owner, strength, length, identifier)
+	duration = length
+	speedstrength = strength
+	id = id
+	. = ..()
+
+/datum/status_effect/speedboost/on_apply()
+	. = ..()
+	if(. && speedstrength && id)
+		owner.add_movespeed_modifier(id, multiplicative_slowdown = speedstrength)
+
+/datum/status_effect/speedboost/on_remove()
+	owner.remove_movespeed_modifier(id)

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -13,6 +13,7 @@
 	spell_requirements = SPELL_CASTABLE_WITHOUT_INVOCATION
 
 	exit_jaunt_sound = null
+	check_flags = AB_CHECK_CONSCIOUS | AB_CHECK_INCAPACITATED
 	jaunt_duration = 1.1 SECONDS
 	jaunt_in_time = 1.3 SECONDS
 	jaunt_out_time = 0.6 SECONDS
@@ -22,6 +23,10 @@
 
 /datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash/do_steam_effects()
 	return
+
+/datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash/end_jaunt(mob/living/cast_on, obj/effect/dummy/phased_mob/spell_jaunt/holder, turf/final_point)
+	. = ..()
+	cast_on.apply_status_effect(STATUS_EFFECT_SPEEDBOOST, -0.5, 1 SECONDS, "ash jaunt")
 
 /datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash/long
 	name = "Ashen Walk"

--- a/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_magic.dm
@@ -24,10 +24,6 @@
 /datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash/do_steam_effects()
 	return
 
-/datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash/end_jaunt(mob/living/cast_on, obj/effect/dummy/phased_mob/spell_jaunt/holder, turf/final_point)
-	. = ..()
-	cast_on.apply_status_effect(STATUS_EFFECT_SPEEDBOOST, -0.5, 1 SECONDS, "ash jaunt")
-
 /datum/action/cooldown/spell/jaunt/ethereal_jaunt/ash/long
 	name = "Ashen Walk"
 	desc = "A long range spell that allows you pass unimpeded through multiple walls."


### PR DESCRIPTION
# Why is this good for the game?
Currently you can waste ash jaunt by using it while cced, since most ccs last long enough to outlast the 1.1 seconds of the jaunt
Also, i was going to add the speedboost status effect to ash jaunt, but because of balance changes i've removed it, but i still want the status effect in

# Testing for the status effect
https://github.com/yogstation13/Yogstation/assets/108117184/e9f37107-c0c4-444e-976e-9bb3de64f7a3


:cl:  
tweak: can no longer use ash jaunt while stunned (wasting it)
/:cl:
