### PR TITLE
Green Alert Shuttle arrival now only takes 15 minutes

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -229,7 +229,7 @@
 		var/security_num = seclevel2num(get_security_level())
 		switch(security_num)
 			if(SEC_LEVEL_GREEN)
-				set_coefficient = 2
+				set_coefficient = 1.5
 			if(SEC_LEVEL_BLUE)
 				set_coefficient = 1
 			else


### PR DESCRIPTION
# Document the changes in your pull request

As the title says. Instead of 20m it's 15m.

# Why is this good for the game?

As now there is a possibility (albeit rare) for a shift to come to an end at green alert, 20 minutes just seems... a long time.

I thought about just making it 10m like blue, but that can be decided on in the comments here and I can change it.

# Testing

Tested. Functional.

# Changelog

:cl:  
tweak: Evac shuttle now only takes 15 minutes to get to station during green alert
/:cl:
