### PR TITLE
[ASTEROID] moves evac up, removes petting zoo

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -40,6 +40,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"aam" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "aao" = (
 /turf/closed/wall,
 /area/maintenance/port/fore)
@@ -83,11 +95,6 @@
 /obj/item/statuebust,
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
-"aaN" = (
-/mob/living/simple_animal/hostile/retaliate/frog,
-/obj/structure/sink/puddle,
-/turf/open/floor/grass,
-/area/maintenance/starboard/fore)
 "aaQ" = (
 /turf/closed/wall,
 /area/quartermaster/miningdock)
@@ -235,10 +242,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/fore)
-"abX" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/grass,
-/area/maintenance/starboard/fore)
 "abZ" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/satellite)
@@ -335,11 +338,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
-"acX" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/mob/living/simple_animal/butterfly,
-/turf/open/floor/grass,
-/area/maintenance/starboard/fore)
 "acY" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -873,11 +871,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
-"ahx" = (
-/mob/living/simple_animal/hostile/retaliate/frog,
-/obj/structure/flora/grass/jungle,
-/turf/open/floor/grass,
-/area/maintenance/starboard/fore)
 "ahy" = (
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
@@ -1874,10 +1867,6 @@
 "aqy" = (
 /turf/template_noop,
 /area/maintenance/port/fore)
-"aqz" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/grass,
-/area/maintenance/starboard/fore)
 "aqC" = (
 /obj/machinery/recharge_station,
 /obj/effect/decal/cleanable/dirt,
@@ -1889,10 +1878,6 @@
 "aqF" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hos)
-"aqG" = (
-/mob/living/simple_animal/hostile/retaliate/dolphin/manatee,
-/turf/open/floor/fakespace,
-/area/maintenance/starboard/fore)
 "aqH" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/cmo)
@@ -2514,10 +2499,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"avX" = (
-/obj/structure/flora/rock/jungle,
-/turf/open/floor/grass,
-/area/maintenance/starboard/fore)
 "avZ" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot_red,
@@ -2549,6 +2530,11 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/fore)
+"awp" = (
+/turf/open/floor/plasteel/stairs/goon/stairs_middle{
+	dir = 8
+	},
+/area/hallway/secondary/exit)
 "awr" = (
 /obj/structure/table/wood,
 /obj/item/camera_film,
@@ -3221,16 +3207,9 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"aCa" = (
-/mob/living/simple_animal/hostile/retaliate/dolphin,
-/turf/open/floor/fakespace,
-/area/maintenance/starboard/fore)
 "aCb" = (
 /turf/closed/wall/r_wall,
 /area/science/server)
-"aCe" = (
-/turf/open/floor/fakespace,
-/area/maintenance/starboard/fore)
 "aCf" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -3425,11 +3404,6 @@
 /obj/item/surgical_drapes,
 /turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
-"aCZ" = (
-/mob/living/simple_animal/hostile/retaliate/frog,
-/obj/structure/flora/rock/jungle,
-/turf/open/floor/grass,
-/area/maintenance/starboard/fore)
 "aDd" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -4404,11 +4378,6 @@
 "aLR" = (
 /turf/closed/wall,
 /area/security/checkpoint/auxiliary)
-"aLW" = (
-/mob/living/simple_animal/opossum,
-/obj/structure/flora/ausbushes/sparsegrass,
-/turf/open/floor/grass,
-/area/maintenance/starboard/fore)
 "aMc" = (
 /obj/machinery/door/poddoor{
 	id = "toxinsdriver";
@@ -5825,9 +5794,6 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
-"aZN" = (
-/turf/open/floor/grass,
-/area/maintenance/starboard/fore)
 "aZO" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -6684,6 +6650,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"bnG" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "bnM" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 5
@@ -8819,16 +8798,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"cbv" = (
-/obj/structure/sign/painting{
-	persistence_id = "public";
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "cbx" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Tanks and Filtration";
@@ -8978,6 +8947,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/storage)
+"cdf" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit)
 "cdi" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/atmospherics/miner/toxins,
@@ -9703,6 +9676,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"clL" = (
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "cma" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -9978,18 +9958,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"csn" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "csp" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -10844,15 +10812,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/genetics/cloning)
-"cFH" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/mob/living/simple_animal/butterfly,
-/mob/living/simple_animal/hostile/lizard{
-	name = "Utot";
-	real_name = "Wags-His-Tail"
-	},
-/turf/open/floor/grass,
-/area/maintenance/starboard/fore)
 "cFI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -10877,6 +10836,12 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
+"cGk" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "cGo" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -11040,18 +11005,6 @@
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"cIO" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "cJm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -12184,10 +12137,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"dbF" = (
-/obj/item/chair/stool,
-/turf/open/floor/wood/broken/two,
-/area/maintenance/starboard/fore)
 "dbM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -12422,6 +12371,10 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"dfi" = (
+/obj/machinery/light,
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "dft" = (
 /obj/structure/displaycase/labcage,
 /obj/effect/turf_decal/stripes/line{
@@ -13500,11 +13453,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"dzR" = (
-/obj/structure/flora/junglebush/b,
-/obj/item/reagent_containers/food/snacks/egg,
-/turf/open/floor/grass,
-/area/maintenance/starboard/fore)
 "dAa" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -13986,6 +13934,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"dIN" = (
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "dJi" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
@@ -14755,6 +14707,23 @@
 /mob/living/simple_animal/hostile/russian,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation)
+"dST" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/exit";
+	dir = 8;
+	name = "Escape Hallway APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "dSW" = (
 /obj/effect/turf_decal/bot_red,
 /obj/machinery/rnd/production/techfab/department/armory,
@@ -14972,16 +14941,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"dVT" = (
-/obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/exit";
-	name = "Escape Hallway APC";
-	pixel_y = -23
-	},
-/obj/structure/cable,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "dVX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -16401,10 +16360,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"eqA" = (
-/obj/machinery/vending/snack/random,
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "eqP" = (
 /obj/structure/table/glass,
 /turf/open/floor/white{
@@ -17150,12 +17105,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"eDu" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "eDE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -17469,10 +17418,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"eIg" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "eIi" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -17484,6 +17429,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"eIj" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/sign/departments/evac{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "eIC" = (
 /mob/living/simple_animal/cow/betsy,
 /turf/open/floor/grass,
@@ -17510,6 +17465,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"eIN" = (
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "eJa" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
@@ -17777,6 +17735,15 @@
 	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"eME" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
 "eMF" = (
 /obj/structure/cable{
@@ -18247,16 +18214,6 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
-"eTf" = (
-/obj/structure/chair,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/landmark/start/assistant,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "eTm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
@@ -18565,12 +18522,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
-"eYm" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "eYn" = (
 /obj/machinery/button/door{
 	id = "rnd";
@@ -19030,6 +18981,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
+"feP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "ffp" = (
 /obj/machinery/light{
 	dir = 4
@@ -20200,9 +20162,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
-"fAo" = (
-/turf/closed/wall/mineral/wood,
-/area/maintenance/starboard/fore)
 "fAy" = (
 /obj/effect/landmark/start/librarian,
 /turf/open/floor/carpet,
@@ -21096,10 +21055,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/genetics)
-"fQU" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "fQX" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -22167,6 +22122,10 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/hallway/secondary/entry)
+"gjQ" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "gkb" = (
 /turf/open/floor/plasteel/stairs/left{
 	dir = 8
@@ -22385,15 +22344,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"gnD" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/dark,
-/area/escapepodbay)
 "gnS" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -22517,10 +22467,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"gqt" = (
-/obj/structure/rack,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "gqG" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -22771,10 +22717,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"gvk" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "gvC" = (
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/structure/closet/crate,
@@ -24069,12 +24011,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"gNT" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "gNV" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/machinery/light/small{
@@ -25103,10 +25039,6 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
-"hfW" = (
-/obj/item/chair/stool,
-/turf/open/floor/fakespace,
-/area/maintenance/starboard/fore)
 "hgg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -27253,6 +27185,13 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/science/server)
+"hNR" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "hNT" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Hydroponics";
@@ -27592,10 +27531,6 @@
 "hTw" = (
 /turf/open/space/basic,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"hTy" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "hTE" = (
 /obj/structure/table/wood,
 /turf/open/floor/grass,
@@ -28458,17 +28393,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
-"ijb" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "ijd" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -28603,6 +28527,21 @@
 	},
 /turf/open/floor/engine/co2,
 /area/engine/atmos/distro)
+"iln" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/sign/departments/evac{
+	pixel_x = -32
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "ilt" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -30325,6 +30264,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"iOz" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/crowbar/red,
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit)
 "iOH" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -32085,13 +32030,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"jmH" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "jmM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -33064,6 +33002,13 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
+"jDk" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "jDl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -33689,11 +33634,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"jOv" = (
-/obj/structure/flora/ausbushes/brflowers,
-/mob/living/simple_animal/sheep,
-/turf/open/floor/grass,
-/area/maintenance/starboard/fore)
 "jOx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -34940,10 +34880,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"kiq" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plasteel/dark,
-/area/escapepodbay)
 "kit" = (
 /turf/open/floor/plasteel/burnt,
 /area/maintenance/port/fore)
@@ -36544,6 +36480,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"kLh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/yellow/warning/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "kLl" = (
 /obj/machinery/atmospherics/pipe/manifold/supplymain/hidden{
 	dir = 1
@@ -37086,16 +37033,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"kVp" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "kVJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -37158,6 +37095,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"kWF" = (
+/obj/structure/railing,
+/turf/open/floor/plasteel/stairs/goon/stairs2_wide{
+	dir = 8
+	},
+/area/hallway/secondary/exit)
 "kWI" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
@@ -38405,6 +38348,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"luD" = (
+/obj/structure/flora/ausbushes/palebush,
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "luS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible/layer2{
 	dir = 8
@@ -38512,12 +38459,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"lxy" = (
-/obj/machinery/camera{
-	c_tag = "Petting Zoo"
-	},
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "lxC" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey{
@@ -38828,6 +38769,21 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"lDo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/warning/lower{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "lDs" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -38986,6 +38942,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"lGF" = (
+/obj/machinery/holopad,
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "lGG" = (
 /obj/machinery/door/window/northleft{
 	dir = 8;
@@ -39058,11 +39018,6 @@
 "lIG" = (
 /turf/closed/wall/mineral/silver,
 /area/space/nearstation)
-"lIH" = (
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/starboard/fore)
 "lIL" = (
 /obj/machinery/light,
 /obj/structure/cable{
@@ -40999,12 +40954,6 @@
 /obj/item/toy/dummy,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"mlN" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/crowbar/red,
-/turf/open/floor/plasteel/dark,
-/area/escapepodbay)
 "mlS" = (
 /obj/machinery/camera{
 	c_tag = "Engineering East";
@@ -41122,6 +41071,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/execution/transfer)
+"mnq" = (
+/obj/structure/flora/ausbushes/reedbush,
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "mnt" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/execution/transfer";
@@ -41619,10 +41572,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"mui" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "muj" = (
 /obj/machinery/computer/prisoner{
 	dir = 1
@@ -42164,10 +42113,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/morgue)
-"mDi" = (
-/mob/living/simple_animal/chicken,
-/turf/open/floor/grass,
-/area/maintenance/starboard/fore)
 "mDt" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -42472,14 +42417,6 @@
 /obj/item/clothing/head/beanie/waldo,
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"mHG" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/mob/living/simple_animal/butterfly,
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/grass,
-/area/maintenance/starboard/fore)
 "mHH" = (
 /obj/machinery/processor/slime,
 /obj/effect/turf_decal/stripes{
@@ -43204,6 +43141,10 @@
 /obj/structure/sign/poster/contraband/have_a_puff,
 /turf/closed/wall,
 /area/hydroponics)
+"mRK" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "mRR" = (
 /obj/effect/turf_decal/tile/dark/half/contrasted{
 	dir = 4
@@ -43853,6 +43794,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"nbb" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "nbC" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
@@ -48126,12 +48071,6 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"oua" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "ous" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Storage";
@@ -49079,17 +49018,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage/backroom)
-"oIL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "oIN" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 1
@@ -49525,14 +49453,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"oOE" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Petting Zoo Door";
-	req_access_txt = "12"
-	},
-/turf/open/floor/grass,
-/area/maintenance/starboard/fore)
 "oPc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -50247,6 +50167,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"pbM" = (
+/obj/structure/sign/painting{
+	persistence_id = "public";
+	pixel_y = -32
+	},
+/turf/closed/wall,
+/area/hallway/secondary/exit)
 "pbR" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/red,
@@ -50662,6 +50589,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"piD" = (
+/obj/effect/turf_decal/siding/wideplating,
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "piI" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -50797,11 +50728,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"pkH" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/mob/living/simple_animal/sheep,
-/turf/open/floor/grass,
-/area/maintenance/starboard/fore)
 "pkP" = (
 /obj/machinery/light{
 	dir = 1
@@ -51192,17 +51118,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"ppP" = (
-/obj/structure/closet/crate,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/coin/iron{
-	icon_state = "coin_bananium_heads";
-	name = "arcade coin";
-	pixel_x = 1;
-	pixel_y = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "ppQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -51486,11 +51401,6 @@
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"ptZ" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/item/chair/stool,
-/turf/open/floor/grass,
-/area/maintenance/starboard/fore)
 "puc" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/eastright,
@@ -51593,6 +51503,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"pvL" = (
+/turf/open/space/basic,
+/area/hallway/secondary/exit)
 "pvM" = (
 /obj/machinery/light{
 	dir = 1
@@ -52691,13 +52604,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"pOc" = (
-/mob/living/simple_animal/hostile/retaliate/dolphin/manatee{
-	desc = "An older looking Space Manatee with a coating of what looks like ash. It looks at you with warm, old eyes";
-	name = "Boris"
-	},
-/turf/open/floor/fakespace,
-/area/maintenance/starboard/fore)
 "pOe" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -52876,6 +52782,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"pRa" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "pRf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -53002,12 +52912,6 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"pUg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "pUh" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
@@ -53637,24 +53541,6 @@
 /obj/effect/spawner/structure/solars/solar_96,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/aft)
-"qbv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/trimline/neutral/warning/lower{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "qbz" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/stripes/line{
@@ -54026,6 +53912,18 @@
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"qjd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "qjj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -55298,6 +55196,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"qGc" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs_wide{
+	dir = 8
+	},
+/area/hallway/secondary/exit)
 "qGm" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -56330,13 +56236,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/closed/wall/r_wall,
 /area/tcommsat/computer)
-"qYl" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/grass,
-/area/maintenance/starboard/fore)
 "qYm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -56910,6 +56809,12 @@
 	},
 /turf/open/floor/grass,
 /area/maintenance/starboard/aft)
+"rgk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "rgl" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -57950,10 +57855,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"ruK" = (
-/obj/machinery/light,
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "ruM" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/grille/broken,
@@ -58592,6 +58493,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"rFs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "rFu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable/yellow{
@@ -58616,6 +58531,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"rFM" = (
+/obj/structure/table/wood,
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "rGc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -60497,6 +60416,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"sgM" = (
+/obj/effect/turf_decal/siding/wideplating/corner{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "shd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -60571,9 +60496,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
-"siy" = (
-/turf/open/floor/wood/broken/seven,
-/area/maintenance/starboard/fore)
 "siH" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner/lower,
 /obj/effect/turf_decal/trimline/darkblue/filled/corner/lower{
@@ -60754,12 +60676,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"smn" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/fakespace,
-/area/maintenance/starboard/fore)
 "smv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -63912,14 +63828,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /turf/closed/wall,
 /area/science/robotics/lab)
-"tic" = (
-/obj/machinery/door/window/northleft{
-	dir = 4;
-	name = "Petting Zoo Door";
-	req_access_txt = "12"
-	},
-/turf/open/floor/fakespace,
-/area/maintenance/starboard/fore)
 "tij" = (
 /obj/machinery/light_switch{
 	pixel_y = -24
@@ -64189,12 +64097,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"tmA" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "tmL" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -64278,12 +64180,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"toi" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "tom" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/airalarm{
@@ -64306,6 +64202,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
+"toV" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "tpz" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -65694,11 +65596,6 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"tMj" = (
-/mob/living/simple_animal/chick,
-/obj/item/reagent_containers/food/snacks/egg,
-/turf/open/floor/grass,
-/area/maintenance/starboard/fore)
 "tMo" = (
 /obj/structure/plasticflaps{
 	opacity = 1
@@ -67286,10 +67183,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"ukw" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "ulb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -67483,6 +67376,20 @@
 /obj/structure/girder/displaced,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"unB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "unH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -67610,14 +67517,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
-"upz" = (
-/obj/machinery/door/window/northleft{
-	dir = 8;
-	name = "Petting Zoo Door";
-	req_access_txt = "12"
-	},
-/turf/open/floor/fakespace,
-/area/maintenance/starboard/fore)
 "upC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2
@@ -68891,6 +68790,12 @@
 /obj/structure/sign/poster/contraband/rebels_unite,
 /turf/closed/wall/r_wall,
 /area/ruin/space/has_grav/listeningstation)
+"uOb" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "uOl" = (
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -69130,6 +69035,17 @@
 /obj/machinery/papershredder,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"uRX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "uRZ" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
@@ -69226,6 +69142,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"uVe" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "uVk" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
@@ -70891,12 +70814,6 @@
 /obj/effect/turf_decal/trimline/green/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"vwT" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "vxa" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Chapel"
@@ -70972,14 +70889,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"vya" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "vyc" = (
 /obj/effect/turf_decal/sand,
 /obj/machinery/holopad,
@@ -72025,6 +71934,12 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/janitor)
+"vSA" = (
+/obj/effect/turf_decal/siding/wideplating/corner{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "vSE" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -73040,9 +72955,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"wji" = (
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "wjp" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/disposalpipe/trunk{
@@ -73161,6 +73073,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
+"wkz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "wkK" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -75042,15 +74966,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/fitness)
-"wKD" = (
-/obj/item/coin/iron{
-	icon_state = "coin_bananium_heads";
-	name = "arcade coin";
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "wKL" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable,
@@ -75731,6 +75646,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"wUF" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "wUJ" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -76201,14 +76128,6 @@
 "xcB" = (
 /turf/template_noop,
 /area/space)
-"xcN" = (
-/obj/machinery/door/window/northleft{
-	dir = 8;
-	name = "Petting Zoo Door";
-	req_access_txt = "12"
-	},
-/turf/open/floor/grass,
-/area/maintenance/starboard/fore)
 "xcT" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/russian,
@@ -77044,15 +76963,6 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"xto" = (
-/obj/item/coin/iron{
-	icon_state = "coin_bananium_heads";
-	name = "arcade coin";
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/turf/open/floor/wood,
-/area/maintenance/starboard/fore)
 "xtT" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -119490,8 +119400,8 @@ msb
 msb
 msb
 msb
-lrc
-lrc
+msb
+msb
 msb
 msb
 msb
@@ -119516,8 +119426,8 @@ tdR
 tdR
 ePU
 aaS
-aZH
-aZH
+aeK
+thx
 aZH
 axP
 axP
@@ -119747,14 +119657,17 @@ msb
 msb
 msb
 msb
-lrc
-lrc
 msb
 msb
 msb
 msb
 msb
 msb
+axP
+axP
+axP
+axP
+axP
 msb
 msb
 msb
@@ -119772,10 +119685,7 @@ axP
 axP
 axP
 axP
-aaS
-aeK
-thx
-aZH
+kyZ
 axP
 kgy
 ckQ
@@ -120004,35 +119914,35 @@ msb
 msb
 msb
 msb
-lrc
-lrc
-lrc
 msb
 msb
 msb
 msb
 msb
-msb
-msb
-msb
-fAo
-fAo
-fAo
-fAo
-fAo
-ukw
-mui
-gvk
-eqA
-fAo
-fAo
-fAo
-fAo
-fAo
-fAo
-ajI
-ajI
-kyZ
+axP
+axP
+vFD
+vFD
+vFD
+axP
+axP
+axP
+axP
+axP
+axP
+axP
+axP
+axP
+aZH
+kvc
+aZH
+wuh
+aZH
+aZH
+aZH
+aZH
+aZH
+aZH
 axP
 axP
 jgk
@@ -120259,12 +120169,6 @@ msb
 msb
 msb
 msb
-lrc
-msb
-lrc
-aET
-slm
-lrc
 msb
 msb
 msb
@@ -120272,23 +120176,29 @@ msb
 msb
 msb
 msb
-fAo
-wji
-vwT
-oua
-wji
-wji
-wji
-wji
-wji
-wji
-wji
-oua
-wji
-wji
-fAo
-ajI
+axP
+hgE
+xds
+xds
+xds
+gEj
+rSp
+rSp
+rSp
+rSp
+rSp
+rSp
+rSp
+pxO
 aZH
+lYd
+axP
+axP
+axP
+nQg
+axP
+axP
+axP
 aZH
 aZH
 aZH
@@ -120516,36 +120426,36 @@ msb
 msb
 msb
 msb
-lrc
-lrc
-xsF
-aET
-aET
-xsF
-lrc
-lrc
 msb
 msb
 msb
 msb
 msb
-fAo
-wji
-wji
-wji
-tmA
-wji
-wji
-wji
-wji
-wji
-tmA
-tmA
-wji
-wji
-fAo
+msb
+axP
+axP
+kgo
+rSp
+rSp
+rSp
+rSp
+rSp
+rSp
+rSp
+rSp
+rSp
+xds
+ivJ
 axP
 aZH
+aZH
+axP
+aXS
+aXS
+aXS
+aXS
+aOf
+axP
 aZH
 gzW
 lYd
@@ -120773,38 +120683,38 @@ msb
 msb
 msb
 msb
-lrc
-qWO
-xuO
-xuO
-xuO
-xuO
-lAf
-lrc
 msb
 msb
 msb
 msb
 msb
-fAo
-wji
-aio
-xcN
-aio
-aio
-xcN
-aio
-aio
-upz
-aio
-aio
-aio
-wji
-fAo
+msb
 axP
-aZH
+mfW
+xds
+rSp
+rSp
+rSp
+ssc
+ssc
+ssc
+rSp
+rSp
+rSp
+aio
+aio
 axP
-aZH
+axP
+odu
+axP
+aXS
+aXS
+aXS
+aXS
+aXS
+axP
+wBL
+wBL
 aZH
 aZH
 aZH
@@ -121030,36 +120940,36 @@ msb
 msb
 msb
 msb
-lrc
-lAf
-kAi
-xfJ
-fXs
-jgt
-qWO
-lrc
 msb
 msb
 msb
 msb
 msb
-fAo
-wji
-aio
-abX
-jOv
-aio
-ahx
-mHG
-aio
-pOc
-aCe
-aCe
-aio
-ruK
-fAo
-siy
-fQU
+msb
+axP
+nJL
+xds
+rSp
+rSp
+jdT
+jga
+qdR
+giR
+qvj
+rSp
+rSp
+ija
+ija
+ija
+axP
+axP
+axP
+aXS
+aXS
+aXS
+aXS
+aXS
+axP
 axP
 axP
 axP
@@ -121286,37 +121196,37 @@ msb
 msb
 msb
 msb
-lrc
-lrc
-lAf
-thQ
-mfY
-lrS
-qlH
-lAf
-lrc
 msb
 msb
 msb
 msb
 msb
-fAo
-wji
-aio
-acX
-abX
-aio
-cFH
-aCZ
-aio
-aCe
-smn
-aqG
-aio
-wji
-kVp
-wji
-xto
+msb
+msb
+axP
+mfW
+xds
+rSp
+rSp
+jdT
+tSG
+bkD
+bkD
+knE
+rSp
+rSp
+pXG
+ija
+hGo
+axP
+msb
+axP
+aXS
+aXS
+aXS
+aXS
+aXS
+axP
 axP
 oYi
 aZH
@@ -121543,37 +121453,37 @@ msb
 msb
 msb
 msb
-lrc
-lrc
-lAf
-lAf
-kvF
-veU
-lAf
-lAf
-lrc
-lrc
 msb
 msb
 msb
 msb
-fAo
-lxy
-aio
-pkH
-ptZ
-aio
-avX
-aaN
-aio
-aCe
-aqG
-aCe
-aio
-wji
-fAo
-aZH
-wji
+msb
+msb
+msb
+axP
+axP
+wVQ
+rSp
+rSp
+jdT
+nyv
+oIa
+wbq
+qvj
+rSp
+rSp
+iTs
+vau
+stF
+axP
+msb
+axP
+aXS
+aXS
+aXS
+aXS
+aXS
+axP
 aWe
 aZH
 ckQ
@@ -121797,41 +121707,41 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-lrc
-lrc
-lAf
-rZG
-vDQ
-jdN
-eLh
-lAf
 lrc
 lrc
 msb
 msb
 msb
 msb
-fAo
-eYm
-aio
-aio
-aio
-aio
-aio
-aio
-aio
-aio
-aio
-aio
-aio
-wji
-fAo
-eDu
-wji
-aZH
+msb
+msb
+msb
+msb
+msb
+axP
+axP
+usg
+mmj
+rSp
+kud
+kud
+kud
+rSp
+rSp
+rSp
+lYP
+bcH
+uAH
+axP
+msb
+axP
+aXS
+aXS
+aXS
+aXS
+aXS
+axP
+odu
 aZH
 axP
 axP
@@ -122054,40 +121964,40 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-lrc
-lrc
-map
-iUz
-lQh
-cqc
-uwB
-ygU
 lrc
 lrc
 msb
 msb
 msb
 msb
-fAo
-wji
-aio
-aLW
-abX
-aio
-aZN
-aqz
-aio
-aCa
-aCe
-aCa
-aio
-wji
-fAo
-dbF
-wji
+msb
+msb
+msb
+msb
+msb
+msb
+axP
+eHx
+rSp
+rSp
+uPI
+sKu
+rSp
+rSp
+jLj
+axP
+axP
+axP
+axP
+axP
+msb
+axP
+aXS
+aXS
+aXS
+aXS
+aXS
+axP
 axP
 jgk
 axP
@@ -122311,41 +122221,41 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
 lrc
-lrc
-map
-fUA
-dNW
-tdD
-oRn
-ygU
 lrc
 lrc
 msb
 msb
 msb
 msb
-fAo
-wji
-aio
-qYl
-aLW
-aio
-mDi
-tMj
-aio
-aCe
-aCa
-hfW
-aio
-wji
-kVp
-xto
-aZH
+msb
+msb
+msb
+msb
+msb
 axP
+axP
+axP
+axP
+ajI
+gfQ
+axP
+axP
+axP
+axP
+msb
+msb
+msb
+msb
+msb
+axP
+aXS
+aXS
+aXS
+aXS
+aXS
+axP
+aZH
 eZW
 aZH
 aZH
@@ -122566,43 +122476,43 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
+lrc
 msb
 lrc
-lrc
-kGw
-lAm
-rfO
-itc
-npM
-kfl
-qWO
+aET
+slm
 lrc
 msb
 msb
 msb
 msb
 msb
-fAo
-wji
-aio
-abX
-abX
-aio
-dzR
-mDi
-aio
-aCe
-aCe
-aCe
-aio
-ruK
-fAo
-fQU
-hTy
+msb
+msb
+msb
+msb
+msb
+lrc
+lrc
+mcH
+fyT
 axP
+axP
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+axP
+aXS
+aXS
+aXS
+aXS
+aXS
+axP
+aZH
 aZH
 vyi
 aZH
@@ -122622,9 +122532,9 @@ cva
 cVp
 uaE
 lRU
-qbv
-toi
-dVT
+lDo
+ajX
+kMh
 akh
 akh
 nAr
@@ -122823,43 +122733,43 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
 lrc
 lrc
-lAf
-uAm
-gkb
-bgo
-qWO
-qWO
+xsF
+aET
+aET
+xsF
 lrc
-fBT
+lrc
 msb
 msb
 msb
 msb
-fAo
-wji
-aio
-oOE
-aio
-aio
-oOE
-aio
-aio
-tic
-aio
-aio
-aio
-wji
-fAo
-ajI
-aZH
+msb
+msb
+msb
+msb
+vbH
 axP
+axP
+aZH
+aAP
+axP
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+axP
+aXS
+aXS
+aXS
+aXS
+aXS
+axP
+aZH
 jgk
 axP
 aZH
@@ -123080,47 +122990,47 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
 lrc
-lrc
-lrc
-lrc
-mre
-oaC
-lqb
-gzr
-sDD
-mre
-lrc
+qWO
+xuO
+xuO
+xuO
+xuO
+lAf
 lrc
 msb
 msb
 msb
 msb
-fAo
-wji
-wji
-wji
-tmA
-wji
-wji
-tmA
-wji
-wji
-tmA
-tmA
-wji
-wji
-fAo
-uAn
-lYd
-aZH
-aZH
+msb
+msb
+msb
+msb
+msb
 axP
-msM
-wgX
+qVZ
+aZH
+kRA
+axP
+msb
+msb
+msb
+msb
+aNY
+aNY
+aNY
+aNY
+aNY
+aNY
+aNY
+aNY
+aNY
+aNY
+aNY
+aNY
+aNY
+aNY
+aam
 aJn
 aJn
 aJn
@@ -123337,63 +123247,63 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
 lrc
-lrc
-lrc
-lrc
-qWO
-axy
-nzM
-ley
-oLK
 lAf
+kAi
+xfJ
+fXs
+jgt
+qWO
 lrc
-fBT
 msb
 msb
 msb
 msb
-fAo
-wji
-wji
-gNT
-wji
-wji
-wji
-wji
-wji
-wji
-wji
-gNT
-wji
-wji
-fAo
-gqt
+msb
+msb
+msb
+msb
+msb
+axP
+qVZ
 aZH
-aZH
+ano
 axP
-axP
-axP
-wgX
-kiq
+msb
+msb
+msb
+msb
+aNY
+cdf
 aXI
 sVl
 msW
 iKH
 shY
 shY
-oIL
+rFs
 rez
 nGH
 joj
+dST
+feP
+kLh
+unB
+wUF
 shY
 shY
-ijb
-eTf
-vya
+wkz
+shY
+shY
+shY
+uRX
+iln
+shY
+shY
+shY
+shY
+shY
+qjd
 ajX
 uZz
 anj
@@ -123593,50 +123503,36 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
 lrc
-kGw
 lrc
-qWO
-jVs
-ygU
-jsp
-lsu
+lAf
+thQ
+mfY
+lrS
+qlH
 lAf
 lrc
-lrc
 msb
 msb
 msb
+msb
+msb
+msb
+msb
+msb
+msb
+ajI
+ajI
+ajI
 axP
-fAo
-fAo
-fAo
-fAo
-fAo
-fAo
-fAo
-cIO
-fAo
-fAo
-fAo
-fAo
-fAo
-fAo
-fAo
-qVZ
-lIH
-aZH
 axP
-aZH
-aAP
-wgX
-mlN
-pUg
+msb
+msb
+msb
+msb
+aNY
+iOz
+rgk
 srH
 eMp
 aNY
@@ -123648,9 +123544,23 @@ ajX
 ajX
 ajX
 ajX
-aKE
-ajr
+ajX
+ajX
 pVj
+ajX
+ajX
+hNR
+ajX
+ajX
+ajX
+ajX
+hNR
+ajX
+ajX
+ajX
+ajX
+ajX
+ajX
 ajX
 cjo
 anj
@@ -123850,18 +123760,18 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
 lrc
 lrc
+lAf
+lAf
+kvF
+veU
+lAf
+lAf
+lrc
 lrc
 msb
 msb
-lrc
-fBT
 msb
 msb
 msb
@@ -123869,31 +123779,17 @@ msb
 msb
 msb
 msb
-axP
-hgE
-vFD
-vFD
-vFD
-gEj
-rSp
-rSp
-rSp
-rSp
-rSp
-rSp
-rSp
-pxO
-aZH
-wKD
-aZH
-aZH
-aZH
-gzW
-aZH
-wBL
-wgX
-gnD
-pUg
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+aNY
+eME
+rgk
 srH
 arR
 aNY
@@ -123905,9 +123801,23 @@ njm
 ajX
 ajX
 hNV
-aKE
-ajr
+ajX
+ajX
 pVj
+ajX
+ajX
+hNR
+ajX
+ajX
+ajX
+ajX
+eIj
+ajX
+ajX
+ajX
+ajX
+ajX
+ajX
 ajX
 abM
 npb
@@ -124107,48 +124017,34 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
+lrc
+lrc
+lAf
+rZG
+vDQ
+jdN
+eLh
+lAf
 lrc
 lrc
 msb
-fBT
-lrc
-lrc
-kGw
 msb
 msb
 msb
 msb
 msb
-axP
-axP
-kgo
-xds
-xds
-xds
-rSp
-rSp
-rSp
-rSp
-rSp
-rSp
-xds
-ivJ
-axP
-odu
-jmH
-aZH
-aZH
-aZH
-aZH
-aWe
-ppP
-wgX
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+aNY
 wWP
 oWp
 srH
@@ -124166,10 +124062,24 @@ bsp
 xCS
 oyK
 ajX
-cbv
+ajX
 aNY
+aNY
+aNY
+aNY
+aNY
+aNY
+nbb
+nbb
+qGc
+awp
+kWF
+nbb
+nbb
+pbM
 aNY
 mAH
+dtk
 dtk
 oWe
 aOl
@@ -124364,17 +124274,14 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
 lrc
-ntc
+lrc
+map
+iUz
+lQh
+cqc
+uwB
+ygU
 lrc
 lrc
 msb
@@ -124382,30 +124289,19 @@ msb
 msb
 msb
 msb
-axP
-mfW
-xds
-rSp
-rSp
-rSp
-ssc
-ssc
-ssc
-rSp
-rSp
-rSp
-aio
-aio
-axP
-axP
-axP
-axP
-nQg
-axP
-axP
-axP
-axP
-wgX
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+aNY
 vuM
 ozN
 ozN
@@ -124421,14 +124317,28 @@ apC
 apC
 apC
 apC
-csn
+bnG
 apC
 ajX
 cfs
 aNY
+pvL
+acb
+aNY
+jDk
+eIN
+piD
+ajX
+ajX
+ajX
+uVe
+eIN
+dfi
+aNY
+anj
 wlI
 wlI
-wlI
+anj
 aOl
 jEq
 vRc
@@ -124621,48 +124531,34 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
+lrc
+lrc
+map
+fUA
+dNW
+tdD
+oRn
+ygU
+lrc
 lrc
 msb
-lrc
-fBT
 msb
 msb
 msb
 msb
 msb
-axP
-nJL
-xds
-rSp
-rSp
-jdT
-jga
-qdR
-giR
-qvj
-rSp
-rSp
-ija
-ija
-ija
-axP
-aXS
-aXS
-aXS
-aXS
-aOf
-axP
 msb
-wgX
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+aNY
 aOQ
 uam
 uam
@@ -124683,6 +124579,20 @@ aAE
 ajX
 uqF
 aNY
+pvL
+acb
+iSn
+eIN
+clL
+vSA
+toV
+toV
+toV
+sgM
+mnq
+eIN
+iSn
+acb
 acb
 acb
 acb
@@ -124877,18 +124787,15 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
+lrc
+lrc
+kGw
+lAm
+rfO
+itc
+npM
+kfl
+qWO
 lrc
 msb
 msb
@@ -124896,28 +124803,17 @@ msb
 msb
 msb
 msb
-axP
-mfW
-xds
-rSp
-rSp
-jdT
-tSG
-bkD
-bkD
-knE
-rSp
-rSp
-pXG
-ija
-hGo
-axP
-aXS
-aXS
-aXS
-aXS
-aXS
-axP
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+msb
+msb
 msb
 wgX
 jxK
@@ -124940,6 +124836,20 @@ ajX
 ajX
 stY
 aNY
+pvL
+acb
+iSn
+mRK
+rFM
+rFM
+dIN
+eIN
+eIN
+eIN
+eIN
+cGk
+iSn
+acb
 acb
 wKR
 acb
@@ -125135,6 +125045,16 @@ msb
 msb
 msb
 msb
+lrc
+lrc
+lAf
+uAm
+gkb
+bgo
+qWO
+qWO
+lrc
+fBT
 msb
 msb
 msb
@@ -125151,30 +125071,6 @@ msb
 msb
 msb
 msb
-msb
-msb
-axP
-axP
-wVQ
-rSp
-rSp
-jdT
-nyv
-oIa
-wbq
-qvj
-rSp
-rSp
-iTs
-vau
-stF
-axP
-aXS
-aXS
-aXS
-aXS
-aXS
-axP
 msb
 wgX
 uam
@@ -125197,6 +125093,20 @@ oEN
 kYZ
 cfs
 aNY
+pvL
+acb
+iSn
+eIN
+rFM
+rFM
+eIN
+lGF
+mRK
+eIN
+eIN
+rFM
+iSn
+acb
 acb
 acb
 acb
@@ -125390,6 +125300,18 @@ acb
 msb
 msb
 msb
+lrc
+lrc
+lrc
+lrc
+mre
+oaC
+lqb
+gzr
+sDD
+mre
+lrc
+lrc
 msb
 msb
 msb
@@ -125400,38 +125322,12 @@ msb
 msb
 msb
 msb
+acb
 msb
 msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-axP
-axP
-usg
-mmj
-rSp
-kud
-kud
-kud
-rSp
-rSp
-rSp
-lYP
-bcH
-uAH
-axP
-aXS
-aXS
-aXS
-aXS
-aXS
-axP
 msb
 dKd
 mgZ
@@ -125454,6 +125350,20 @@ iSn
 ejM
 iSn
 aNY
+pvL
+acb
+iSn
+eIN
+gjQ
+cGk
+luD
+eIN
+eIN
+pRa
+eIN
+cGk
+iSn
+acb
 acb
 acb
 acb
@@ -125647,6 +125557,18 @@ acb
 msb
 msb
 msb
+lrc
+lrc
+lrc
+lrc
+qWO
+axy
+nzM
+ley
+oLK
+lAf
+lrc
+fBT
 msb
 msb
 msb
@@ -125657,38 +125579,12 @@ msb
 msb
 msb
 msb
+acb
 msb
 msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-axP
-eHx
-rSp
-rSp
-uPI
-sKu
-rSp
-rSp
-jLj
-axP
-axP
-axP
-axP
-axP
-aXS
-aXS
-aXS
-aXS
-aXS
-axP
 msb
 dKd
 rUZ
@@ -125709,6 +125605,20 @@ iSn
 iFH
 iSn
 iFH
+iSn
+acb
+acb
+acb
+iSn
+iSn
+eIN
+eIN
+eIN
+uOb
+eIN
+eIN
+eIN
+iSn
 iSn
 acb
 acb
@@ -125905,6 +125815,17 @@ msb
 msb
 msb
 msb
+lrc
+kGw
+lrc
+qWO
+jVs
+ygU
+jsp
+lsu
+lAf
+lrc
+lrc
 msb
 msb
 msb
@@ -125914,40 +125835,15 @@ msb
 msb
 msb
 msb
+acb
+acb
+acb
 msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-axP
-axP
-axP
-axP
-ajI
-gfQ
-axP
-axP
-axP
-axP
-msb
-msb
-msb
-axP
-aXS
-aXS
-aXS
-aXS
-aXS
-axP
-msb
-msb
+acb
+acb
 acb
 acb
 acb
@@ -125967,6 +125863,20 @@ xGv
 iSn
 utD
 aNY
+acb
+acb
+acb
+acb
+iSn
+iSn
+iSn
+iSn
+aNY
+iSn
+iSn
+iSn
+iSn
+acb
 acb
 acb
 acb
@@ -126162,48 +126072,34 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
+lrc
+lrc
+lrc
 msb
 msb
 lrc
-lrc
-mcH
-fyT
-axP
-ajI
+fBT
 msb
 msb
 msb
 msb
 msb
-axP
-aXS
-aXS
-aXS
-aXS
-aXS
-axP
 msb
+msb
+msb
+msb
+msb
+msb
+msb
+acb
+acb
+acb
+acb
+acb
+acb
+msb
+acb
+acb
 acb
 acb
 acb
@@ -126224,6 +126120,20 @@ ruT
 iSn
 byQ
 iSn
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -126420,6 +126330,13 @@ msb
 msb
 msb
 msb
+lrc
+lrc
+msb
+fBT
+lrc
+lrc
+kGw
 msb
 msb
 msb
@@ -126432,35 +126349,14 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-vbH
-axP
-axP
-aZH
-aAP
-ajI
-msb
-msb
-msb
-msb
-msb
-axP
-aXS
-aXS
-aXS
-aXS
-aXS
-axP
-msb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -126481,6 +126377,20 @@ iMZ
 iSn
 iMZ
 iSn
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -126680,6 +126590,10 @@ msb
 msb
 msb
 msb
+lrc
+ntc
+lrc
+lrc
 msb
 msb
 msb
@@ -126692,33 +126606,15 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-axP
-qVZ
-aZH
-kRA
-ajI
-msb
-msb
-msb
-msb
-msb
-axP
-aXS
-aXS
-aXS
-aXS
-aXS
-axP
-msb
-msb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -126738,6 +126634,20 @@ keN
 iSn
 keN
 iSn
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -126937,6 +126847,10 @@ msb
 msb
 msb
 msb
+lrc
+msb
+lrc
+fBT
 msb
 msb
 msb
@@ -126950,32 +126864,14 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-axP
-qVZ
-aZH
-ano
-ajI
-msb
-msb
-msb
-msb
-msb
-axP
-aXS
-aXS
-aXS
-aXS
-aXS
-axP
-msb
-msb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -126986,6 +126882,20 @@ acb
 acb
 acb
 aEa
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -127196,6 +127106,7 @@ msb
 msb
 msb
 msb
+lrc
 msb
 msb
 msb
@@ -127210,29 +127121,28 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-ajI
-ajI
-ajI
-ajI
-ajI
-msb
-msb
-msb
-msb
-msb
-axP
-axP
-eIg
-eIg
-eIg
-axP
-axP
-msb
-msb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -127469,26 +127379,26 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
 acb
 acb
 acb
 acb
-msb
-msb
-msb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -127726,18 +127636,18 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
 acb
-msb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -127982,15 +127892,15 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -128239,15 +128149,15 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -128496,14 +128406,14 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -128752,14 +128662,14 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -129009,15 +128919,15 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -129266,14 +129176,14 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -129524,13 +129434,13 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -129781,14 +129691,14 @@ acb
 acb
 msb
 acb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -130039,13 +129949,13 @@ acb
 acb
 acb
 acb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -130297,13 +130207,13 @@ acb
 acb
 acb
 acb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
+acb
+acb
+acb
+acb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -130555,12 +130465,12 @@ acb
 acb
 acb
 acb
-msb
-msb
-msb
-msb
-msb
-msb
+acb
+acb
+acb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -130813,12 +130723,12 @@ acb
 acb
 acb
 acb
-msb
-msb
-msb
-msb
-msb
-msb
+acb
+acb
+acb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -131073,9 +130983,9 @@ acb
 acb
 acb
 acb
-msb
-msb
-msb
+acb
+acb
+acb
 acb
 acb
 acb
@@ -131332,7 +131242,7 @@ acb
 acb
 acb
 acb
-msb
+acb
 acb
 acb
 acb
@@ -131589,7 +131499,7 @@ acb
 acb
 acb
 acb
-msb
+acb
 acb
 acb
 acb

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -8942,10 +8942,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/storage)
-"cdf" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit)
 "cdi" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/atmospherics/miner/toxins,
@@ -17758,15 +17754,6 @@
 	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"eME" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit)
 "eMF" = (
 /obj/structure/cable{
@@ -29001,6 +28988,16 @@
 "iss" = (
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/tcoms)
+"isA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "isE" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Auxillary Art Storage"
@@ -30293,12 +30290,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"iOz" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/crowbar/red,
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit)
 "iOH" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -35056,6 +35047,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"kmi" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "kmo" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -56487,6 +56491,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"rce" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/crowbar/red,
+/turf/open/floor/plasteel/dark,
+/area/escapepodbay)
 "rcg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -56839,12 +56849,6 @@
 	},
 /turf/open/floor/grass,
 /area/maintenance/starboard/aft)
-"rgk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "rgl" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -61981,6 +61985,10 @@
 	},
 /turf/open/floor/plating,
 /area/clerk)
+"sFM" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel/dark,
+/area/escapepodbay)
 "sFQ" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 4
@@ -66545,6 +66553,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"tZU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "uac" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = -32
@@ -68302,6 +68316,12 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"uDJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "uDZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -68311,6 +68331,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"uEl" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high/plus,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/escapepodbay)
 "uEH" = (
 /obj/structure/sign/poster/official/love_ian,
 /turf/closed/wall/r_wall,
@@ -69070,17 +69099,6 @@
 /obj/machinery/papershredder,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"uRX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "uRZ" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/bot,
@@ -123073,11 +123091,11 @@ msb
 msb
 msb
 msb
-aNY
-aNY
-aNY
-aNY
-aNY
+wgX
+wgX
+wgX
+wgX
+wgX
 aNY
 aNY
 aNY
@@ -123330,8 +123348,8 @@ msb
 msb
 msb
 msb
-aNY
-cdf
+wgX
+sFM
 aXI
 sVl
 msW
@@ -123350,10 +123368,10 @@ wUF
 shY
 shY
 wkz
+isA
 shY
 shY
-shY
-uRX
+kmi
 iln
 shY
 shY
@@ -123587,9 +123605,9 @@ msb
 msb
 msb
 msb
-aNY
-iOz
-rgk
+wgX
+rce
+tZU
 srH
 eMp
 aNY
@@ -123607,10 +123625,10 @@ pVj
 ajX
 ajX
 hNR
+huV
 ajX
 ajX
-ajX
-ajX
+uDJ
 hNR
 ajX
 ajX
@@ -123844,9 +123862,9 @@ msb
 msb
 msb
 msb
-aNY
-eME
-rgk
+wgX
+uEl
+tZU
 srH
 arR
 aNY
@@ -124101,7 +124119,7 @@ msb
 msb
 msb
 msb
-aNY
+wgX
 wWP
 oWp
 srH
@@ -124358,7 +124376,7 @@ msb
 msb
 msb
 msb
-aNY
+wgX
 vuM
 ozN
 ozN
@@ -124615,7 +124633,7 @@ msb
 msb
 msb
 msb
-aNY
+wgX
 aOQ
 uam
 uam

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -2530,11 +2530,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/port/fore)
-"awp" = (
-/turf/open/floor/plasteel/stairs/goon/stairs_middle{
-	dir = 8
-	},
-/area/hallway/secondary/exit)
 "awr" = (
 /obj/structure/table/wood,
 /obj/item/camera_film,
@@ -4289,6 +4284,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"aJX" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "aKc" = (
 /turf/template_noop,
 /area/maintenance/port/aft)
@@ -15046,6 +15053,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"dXz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "dXL" = (
 /obj/item/cigbutt,
 /turf/open/floor/plasteel/dark,
@@ -16395,6 +16411,11 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
+"ers" = (
+/obj/machinery/vending/snack/random,
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit)
 "ert" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -17230,6 +17251,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
+"eFH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "eFP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
@@ -17786,6 +17813,13 @@
 /obj/effect/turf_decal/trimline/yellow/warning/lower,
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
+"eMN" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "eNk" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -22122,10 +22156,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/hallway/secondary/entry)
-"gjQ" = (
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass,
-/area/hallway/secondary/exit)
 "gkb" = (
 /turf/open/floor/plasteel/stairs/left{
 	dir = 8
@@ -22993,6 +23023,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"gzl" = (
+/obj/structure/flora/ausbushes/palebush,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "gzr" = (
 /obj/item/reagent_containers/food/drinks/beer,
 /obj/machinery/button/door{
@@ -26272,14 +26307,6 @@
 /mob/living/simple_animal/butterfly,
 /turf/open/floor/grass,
 /area/medical/medbay/aft)
-"hzN" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/vacant_room)
 "hzX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -28628,16 +28655,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"imH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/exit)
 "imL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -34236,6 +34253,10 @@
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"jXh" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/vacant_room)
 "jXi" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -37095,12 +37116,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"kWF" = (
-/obj/structure/railing,
-/turf/open/floor/plasteel/stairs/goon/stairs2_wide{
-	dir = 8
-	},
-/area/hallway/secondary/exit)
 "kWI" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
@@ -38348,10 +38363,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"luD" = (
-/obj/structure/flora/ausbushes/palebush,
-/turf/open/floor/grass,
-/area/hallway/secondary/exit)
 "luS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible/layer2{
 	dir = 8
@@ -38942,10 +38953,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"lGF" = (
-/obj/machinery/holopad,
-/turf/open/floor/grass,
-/area/hallway/secondary/exit)
 "lGG" = (
 /obj/machinery/door/window/northleft{
 	dir = 8;
@@ -50961,6 +50968,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"pnM" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs_wide{
+	dir = 8
+	},
+/area/hallway/secondary/exit)
 "pnO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -51503,9 +51524,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"pvL" = (
-/turf/open/space/basic,
-/area/hallway/secondary/exit)
 "pvM" = (
 /obj/machinery/light{
 	dir = 1
@@ -53948,6 +53966,10 @@
 "qjw" = (
 /turf/template_noop,
 /area/space/nearstation)
+"qjL" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "qke" = (
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -55196,14 +55218,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"qGc" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/turf/open/floor/plasteel/stairs/goon/stairs_wide{
-	dir = 8
-	},
-/area/hallway/secondary/exit)
 "qGm" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -60609,6 +60623,13 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"sll" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "slm" = (
 /obj/structure/shuttle/engine/large{
 	dir = 8
@@ -64714,6 +64735,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"txs" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "txt" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -66735,6 +66761,18 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/solar/port/aft)
+"uem" = (
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs2_wide{
+	dir = 8
+	},
+/area/hallway/secondary/exit)
 "uen" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
@@ -67581,10 +67619,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/genetics)
-"uqF" = (
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit)
 "uqG" = (
 /obj/structure/window/reinforced{
 	pixel_y = 2
@@ -71326,6 +71360,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"vHq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
 "vHx" = (
 /obj/machinery/computer/atmos_alert,
 /obj/effect/turf_decal/stripes/line{
@@ -73320,6 +73363,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
+"wnd" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "wnf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -73409,14 +73458,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"wpI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/exit)
 "wpS" = (
 /obj/structure/railing{
 	dir = 1
@@ -74898,6 +74939,23 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"wJf" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs_middle{
+	dir = 8
+	},
+/area/hallway/secondary/exit)
 "wJk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -76357,6 +76415,10 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/cmo)
+"xgu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "xgC" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 5
@@ -119190,7 +119252,7 @@ nHl
 aQk
 qrP
 ayK
-hzN
+jXh
 qzh
 aiZ
 xrm
@@ -119447,7 +119509,7 @@ nHl
 apm
 aNo
 apm
-hzN
+jXh
 dOd
 vCI
 sPZ
@@ -119704,7 +119766,7 @@ mKk
 bSf
 rjp
 apm
-hzN
+jXh
 gho
 sGE
 jDM
@@ -119961,7 +120023,7 @@ uqo
 adL
 vfv
 apm
-hzN
+jXh
 qzh
 aiZ
 hwl
@@ -123301,7 +123363,7 @@ iln
 shY
 shY
 shY
-shY
+wUF
 shY
 qjd
 ajX
@@ -123558,7 +123620,7 @@ hNR
 ajX
 ajX
 ajX
-ajX
+vHq
 ajX
 ajX
 ajX
@@ -123794,8 +123856,8 @@ srH
 arR
 aNY
 aNY
-imH
-imH
+nbb
+nbb
 aNY
 njm
 ajX
@@ -123815,7 +123877,7 @@ eIj
 ajX
 ajX
 ajX
-ajX
+vHq
 ajX
 ajX
 ajX
@@ -124053,7 +124115,7 @@ aNY
 eky
 ajX
 aKE
-wpI
+nbb
 aYB
 cyV
 dvT
@@ -124069,13 +124131,13 @@ aNY
 aNY
 aNY
 aNY
-nbb
-nbb
-qGc
-awp
-kWF
-nbb
-nbb
+qjL
+qjL
+pnM
+wJf
+uem
+qjL
+qjL
 pbM
 aNY
 mAH
@@ -124310,7 +124372,7 @@ aNY
 ajr
 ajX
 aKE
-wpI
+nbb
 opy
 huV
 apC
@@ -124322,14 +124384,14 @@ apC
 ajX
 cfs
 aNY
-pvL
+acb
 acb
 aNY
 jDk
 eIN
 piD
 ajX
-ajX
+vHq
 ajX
 uVe
 eIN
@@ -124567,7 +124629,7 @@ aNY
 ajr
 ajX
 gGd
-wpI
+nbb
 ajX
 ajX
 aAE
@@ -124577,16 +124639,16 @@ aAE
 fiE
 aAE
 ajX
-uqF
+ers
 aNY
-pvL
+acb
 acb
 iSn
 eIN
 clL
 vSA
 toV
-toV
+aJX
 toV
 sgM
 mnq
@@ -124836,16 +124898,16 @@ ajX
 ajX
 stY
 aNY
-pvL
+acb
 acb
 iSn
 mRK
 rFM
 rFM
 dIN
-eIN
-eIN
-eIN
+dXz
+xgu
+wnd
 eIN
 cGk
 iSn
@@ -125081,7 +125143,7 @@ aNY
 iwc
 jjp
 wsp
-wpI
+nbb
 pvX
 oEN
 oEN
@@ -125093,14 +125155,14 @@ oEN
 kYZ
 cfs
 aNY
-pvL
+acb
 acb
 iSn
 eIN
 rFM
 rFM
 eIN
-lGF
+eMN
 mRK
 eIN
 eIN
@@ -125350,14 +125412,14 @@ iSn
 ejM
 iSn
 aNY
-pvL
+acb
 acb
 iSn
 eIN
-gjQ
-cGk
-luD
-eIN
+txs
+sll
+gzl
+eFH
 eIN
 pRa
 eIN

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -4284,18 +4284,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"aJX" = (
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/hallway/secondary/exit)
 "aKc" = (
 /turf/template_noop,
 /area/maintenance/port/aft)
@@ -11577,6 +11565,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"cSm" = (
+/obj/structure/railing,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs2_wide{
+	dir = 8
+	},
+/area/hallway/secondary/exit)
 "cSt" = (
 /obj/effect/turf_decal/bot_red,
 /obj/effect/turf_decal/caution/stand_clear/white,
@@ -11793,6 +11793,18 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/science/research)
+"cWD" = (
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "cWE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -14042,6 +14054,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/pumproom)
+"dKS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "dLf" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15053,15 +15069,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
-"dXz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/grass,
-/area/hallway/secondary/exit)
 "dXL" = (
 /obj/item/cigbutt,
 /turf/open/floor/plasteel/dark,
@@ -16411,11 +16418,6 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/space/has_grav/listeningstation)
-"ers" = (
-/obj/machinery/vending/snack/random,
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
-/area/hallway/secondary/exit)
 "ert" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -17251,12 +17253,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
-"eFH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/grass,
-/area/hallway/secondary/exit)
 "eFP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
@@ -17813,13 +17809,6 @@
 /obj/effect/turf_decal/trimline/yellow/warning/lower,
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
-"eMN" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/grass,
-/area/hallway/secondary/exit)
 "eNk" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -21803,6 +21792,13 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"gdD" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "gdF" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -22156,6 +22152,10 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/hallway/secondary/entry)
+"gjQ" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "gkb" = (
 /turf/open/floor/plasteel/stairs/left{
 	dir = 8
@@ -23023,11 +23023,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"gzl" = (
-/obj/structure/flora/ausbushes/palebush,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/grass,
-/area/hallway/secondary/exit)
 "gzr" = (
 /obj/item/reagent_containers/food/drinks/beer,
 /obj/machinery/button/door{
@@ -26080,6 +26075,23 @@
 	},
 /turf/open/floor/plating,
 /area/science/robotics/lab)
+"hvG" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs_middle{
+	dir = 8
+	},
+/area/hallway/secondary/exit)
 "hvN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -34253,10 +34265,6 @@
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"jXh" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/vacant_room)
 "jXi" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -38363,6 +38371,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"luD" = (
+/obj/structure/flora/ausbushes/palebush,
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "luS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible/layer2{
 	dir = 8
@@ -39135,6 +39147,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"lKJ" = (
+/obj/machinery/vending/snack/random,
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/exit)
 "lKL" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -41018,6 +41035,10 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"mmu" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/hallway/secondary/exit)
 "mmC" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -50968,20 +50989,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"pnM" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/stairs/goon/stairs_wide{
-	dir = 8
-	},
-/area/hallway/secondary/exit)
 "pnO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -53966,10 +53973,6 @@
 "qjw" = (
 /turf/template_noop,
 /area/space/nearstation)
-"qjL" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/hallway/secondary/exit)
 "qke" = (
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -54211,6 +54214,15 @@
 "qnI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"qnO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -55860,6 +55872,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"qRk" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/vacant_room)
 "qRp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -60623,13 +60639,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"sll" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/grass,
-/area/hallway/secondary/exit)
 "slm" = (
 /obj/structure/shuttle/engine/large{
 	dir = 8
@@ -64735,11 +64744,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"txs" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/grass,
-/area/hallway/secondary/exit)
 "txt" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -65431,6 +65435,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"tIK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "tIM" = (
 /mob/living/simple_animal/pet/dog/corgi/borgi,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -66761,18 +66774,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/solar/port/aft)
-"uem" = (
-/obj/structure/railing,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/stairs/goon/stairs2_wide{
-	dir = 8
-	},
-/area/hallway/secondary/exit)
 "uen" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
@@ -71360,15 +71361,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"vHq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "vHx" = (
 /obj/machinery/computer/atmos_alert,
 /obj/effect/turf_decal/stripes/line{
@@ -71539,6 +71531,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"vLh" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs_wide{
+	dir = 8
+	},
+/area/hallway/secondary/exit)
 "vLv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -72456,6 +72462,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"waU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "wba" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp{
@@ -73363,12 +73375,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
-"wnd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/hallway/secondary/exit)
 "wnf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -74925,6 +74931,10 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"wIL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "wIN" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the ai satellite.";
@@ -74939,23 +74949,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"wJf" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/stairs/goon/stairs_middle{
-	dir = 8
-	},
-/area/hallway/secondary/exit)
 "wJk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -76415,10 +76408,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/cmo)
-"xgu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/grass,
-/area/hallway/secondary/exit)
 "xgC" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 5
@@ -79372,6 +79361,12 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet,
 /area/medical/psych)
+"yeK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/grass,
+/area/hallway/secondary/exit)
 "yeO" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/warden,
@@ -119252,7 +119247,7 @@ nHl
 aQk
 qrP
 ayK
-jXh
+qRk
 qzh
 aiZ
 xrm
@@ -119509,7 +119504,7 @@ nHl
 apm
 aNo
 apm
-jXh
+qRk
 dOd
 vCI
 sPZ
@@ -119766,7 +119761,7 @@ mKk
 bSf
 rjp
 apm
-jXh
+qRk
 gho
 sGE
 jDM
@@ -120023,7 +120018,7 @@ uqo
 adL
 vfv
 apm
-jXh
+qRk
 qzh
 aiZ
 hwl
@@ -123620,7 +123615,7 @@ hNR
 ajX
 ajX
 ajX
-vHq
+qnO
 ajX
 ajX
 ajX
@@ -123877,7 +123872,7 @@ eIj
 ajX
 ajX
 ajX
-vHq
+qnO
 ajX
 ajX
 ajX
@@ -124131,13 +124126,13 @@ aNY
 aNY
 aNY
 aNY
-qjL
-qjL
-pnM
-wJf
-uem
-qjL
-qjL
+mmu
+mmu
+vLh
+hvG
+cSm
+mmu
+mmu
 pbM
 aNY
 mAH
@@ -124391,7 +124386,7 @@ jDk
 eIN
 piD
 ajX
-vHq
+qnO
 ajX
 uVe
 eIN
@@ -124639,7 +124634,7 @@ aAE
 fiE
 aAE
 ajX
-ers
+lKJ
 aNY
 acb
 acb
@@ -124648,7 +124643,7 @@ eIN
 clL
 vSA
 toV
-aJX
+cWD
 toV
 sgM
 mnq
@@ -124905,9 +124900,9 @@ mRK
 rFM
 rFM
 dIN
-dXz
-xgu
-wnd
+tIK
+wIL
+waU
 eIN
 cGk
 iSn
@@ -125162,7 +125157,7 @@ eIN
 rFM
 rFM
 eIN
-eMN
+gdD
 mRK
 eIN
 eIN
@@ -125416,11 +125411,11 @@ acb
 acb
 iSn
 eIN
-txs
-sll
-gzl
-eFH
-eIN
+gjQ
+cGk
+dKS
+yeK
+luD
 pRa
 eIN
 cGk


### PR DESCRIPTION
# Document the changes in your pull request

Moves evac up, and gives a little garden area.

![image](https://github.com/yogstation13/Yogstation/assets/5091394/ed75fb81-fc87-4de8-acb4-b5a4d4cc38ef)

Maint is redone and arcade is moved.
![image](https://github.com/yogstation13/Yogstation/assets/5091394/d46e084d-f1f5-426d-b0f8-feb06fbce5f4)

Petting zoo is unfortunately gone, because it was way too big for it's usage (nobody used it)

This will prevent the big ass shuttles from destroying atmos, killing everyone

# Changelog

:cl:  
mapping: Moves evac up on AsteroidStation, removes petting zoo and adds small garden where evac used to be.
/:cl:
