### PR TITLE
Refactors process_flags to use mob biotypes

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -79,6 +79,9 @@
 #define MOB_REPTILE		(1<<8)
 #define MOB_SPIRIT		(1<<9)
 
+/// All the biotypes that matter
+#define ALL_BIOTYPES (MOB_ORGANIC|MOB_INORGANIC|MOB_ROBOTIC|MOB_UNDEAD)
+
 //Organ defines for carbon mobs
 #define ORGAN_ORGANIC   1
 #define ORGAN_ROBOTIC   2

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -80,6 +80,7 @@
 #define MOB_SPIRIT		(1<<9)
 
 /// All the biotypes that matter
+#define ALL_NON_ROBOTIC (MOB_ORGANIC|MOB_INORGANIC|MOB_UNDEAD)
 #define ALL_BIOTYPES (MOB_ORGANIC|MOB_INORGANIC|MOB_ROBOTIC|MOB_UNDEAD)
 
 //Organ defines for carbon mobs

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -104,10 +104,6 @@
 #define DEVIL_BODYPART "devil"
 /*see __DEFINES/inventory.dm for bodypart bitflag defines*/
 
-// Processing flags, defines the types of mobs are compatible with certain reagents, organs, and symptoms
-#define ORGANIC (1<<0)
-#define SYNTHETIC (1<<1)
-
 // Health/damage defines for carbon mobs
 #define HUMAN_MAX_OXYLOSS 3
 #define HUMAN_CRIT_MAX_OXYLOSS (SSmobs.wait/30)

--- a/code/datums/diseases/advance/symptoms/deafness.dm
+++ b/code/datums/diseases/advance/symptoms/deafness.dm
@@ -32,7 +32,6 @@ Bonus
 		"Resistance 9" = "Causes permanent deafness, instead of intermittent.",
 		"Stealth 4" = "The symptom remains hidden until active.",
 	)
-	process_flags = ORGANIC | SYNTHETIC
 
 /datum/symptom/deafness/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/deafness.dm
+++ b/code/datums/diseases/advance/symptoms/deafness.dm
@@ -32,6 +32,7 @@ Bonus
 		"Resistance 9" = "Causes permanent deafness, instead of intermittent.",
 		"Stealth 4" = "The symptom remains hidden until active.",
 	)
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/symptom/deafness/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -121,7 +121,7 @@ Bonus
 		"Stage Speed 8" = "Increases explosion radius and explosion damage to the host when the host is wet.",
 		"Transmission 8" = "Additionally synthesizes chlorine trifluoride and napalm inside the host. More chemicals are synthesized if the resistance 9 threshold has been met."
 	)
-	process_flags = ORGANIC | SYNTHETIC //is funny
+	compatible_biotypes = ALL_BIOTYPES //is funny
 
 /datum/symptom/alkali/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/hallucigen.dm
+++ b/code/datums/diseases/advance/symptoms/hallucigen.dm
@@ -32,7 +32,7 @@ Bonus
 		"Stage Speed 7" = "Increases the amount of hallucinations.",
 		"Stealth 4" = "The virus mimics positive symptoms.",
 	)
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/symptom/hallucigen/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -380,7 +380,7 @@
 		"Transmission 6" = "Increases temperature adjustment rate.",
 		"Stage Speed 7" = "Increases healing speed.",
 	)
-	process_flags = ORGANIC | SYNTHETIC //only really for temp stabilize
+	compatible_biotypes = ALL_BIOTYPES //only really for temp stabilize
 
 /datum/symptom/heal/plasma/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/nanites.dm
+++ b/code/datums/diseases/advance/symptoms/nanites.dm
@@ -14,7 +14,7 @@
 		"Transmission 5" = "Increases the virus' growth rate while nanites are present.",
 		"Stage Speed 7" = "Increases the replication boost."
 	)
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/symptom/nano_boost/Start(datum/disease/advance/A)
 	. = ..()
@@ -51,7 +51,7 @@
 		"Stage Speed 5" = "Increases the virus' growth rate while nanites are present.",
 		"Resistance 7" = "Severely increases the rate at which the nanites are destroyed."
 	)
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/symptom/nano_destroy/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/necropolis.dm
+++ b/code/datums/diseases/advance/symptoms/necropolis.dm
@@ -21,7 +21,7 @@
 	var/list/cached_tentacle_turfs
 	var/turf/last_location
 	var/tentacle_recheck_cooldown = 100
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/symptom/necroseed/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/radiation.dm
+++ b/code/datums/diseases/advance/symptoms/radiation.dm
@@ -15,7 +15,7 @@
 		"Transmission 12" = "Makes the host irradiate others around them as well.",
 		"Stage Speed 8" = "Host takes radiation damage faster."
 	)
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/symptom/radiation/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/species.dm
+++ b/code/datums/diseases/advance/symptoms/species.dm
@@ -24,7 +24,7 @@
 	transmittable = 3
 	level = 5
 	severity = 0
-	process_flags = ORGANIC | SYNTHETIC //i don't think this needs to be here, but just in case
+	compatible_biotypes = ALL_BIOTYPES //i don't think this needs to be here, but just in case
 
 /datum/symptom/inorganic_adaptation/Start(datum/disease/advance/A)
 	. = ..()

--- a/code/datums/diseases/advance/symptoms/symptoms.dm
+++ b/code/datums/diseases/advance/symptoms/symptoms.dm
@@ -29,7 +29,7 @@
 	var/neutered = FALSE
 	var/list/thresholds
 	var/naturally_occuring = TRUE //if this symptom can appear from /datum/disease/advance/GenerateSymptoms()
-	var/process_flags = ORGANIC //some symptoms don't affect robotic mobs
+	var/compatible_biotypes = MOB_ORGANIC //most symptoms only affect organic mobs
 
 /datum/symptom/New()
 	var/list/S = SSdisease.list_symptoms
@@ -57,7 +57,7 @@
 		return FALSE
 	if(world.time < next_activation)
 		return FALSE
-	if(process_flags & A.affected_mob.get_process_flags())
+	if(compatible_biotypes & A.affected_mob.mob_biotypes)
 		next_activation = world.time + rand(symptom_delay_min * 10, symptom_delay_max * 10)
 		return TRUE
 

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -1426,3 +1426,4 @@
 	id = "lasting_void_chill"
 	duration = -1
 
+

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -1426,5 +1426,3 @@
 	id = "lasting_void_chill"
 	duration = -1
 
-/datum/status_effect/magnet
-	

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -1426,4 +1426,5 @@
 	id = "lasting_void_chill"
 	duration = -1
 
-
+/datum/status_effect/magnet
+	

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -157,7 +157,7 @@
 	var/species_type = prefs.read_preference(/datum/preference/choiced/species)
 	var/datum/species/species = new species_type
 
-	var/disallowed_trait = (NOMOUTH in species.species_traits) || !(species.process_flags & ORGANIC)// Cant drink or process alcohol
+	var/disallowed_trait = (NOMOUTH in species.species_traits) || !(species.inherent_biotypes & MOB_ORGANIC)// Cant drink or process alcohol
 	qdel(species)
 
 	if(disallowed_trait)
@@ -572,7 +572,7 @@
 	var/species_type = prefs.read_preference(/datum/preference/choiced/species)
 	var/datum/species/species = new species_type
 
-	var/disallowed_trait = !(species.process_flags & ORGANIC) //if you can't process organic chems you couldn't get addicted in the first place
+	var/disallowed_trait = !(species.inherent_biotypes & MOB_ORGANIC) //if you can't process organic chems you couldn't get addicted in the first place
 	qdel(species)
 
 	if(disallowed_trait)
@@ -641,7 +641,7 @@
 	var/species_type = prefs.read_preference(/datum/preference/choiced/species)
 	var/datum/species/species = new species_type
 
-	var/disallowed_trait = !(species.process_flags & ORGANIC)
+	var/disallowed_trait = !(species.inherent_biotypes & MOB_ORGANIC)
 	qdel(species)
 
 	if(disallowed_trait)
@@ -734,7 +734,7 @@
 	var/species_type = prefs.read_preference(/datum/preference/choiced/species)
 	var/datum/species/species = new species_type
 
-	var/disallowed_trait = !(species.process_flags & ORGANIC) // why would robots be allergic to things
+	var/disallowed_trait = !(species.inherent_biotypes & MOB_ORGANIC) // why would robots be allergic to things
 	qdel(species)
 
 	if(disallowed_trait)

--- a/code/modules/antagonists/abductor/equipment/gland.dm
+++ b/code/modules/antagonists/abductor/equipment/gland.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "gland"
 	status = ORGAN_ROBOTIC
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 	beating = TRUE
 	var/true_name = "baseline placebo referencer"
 	var/cooldown_low = 30 SECONDS

--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -24,7 +24,7 @@
 	icon_state = "roro core 2"
 	visual = FALSE
 	item_flags = NOBLUDGEON
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 	slot = "hivecore"
 	force = 0
 	actions_types = list(/datum/action/item_action/organ_action/use)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -703,7 +703,7 @@ GLOBAL_LIST_EMPTY(aide_list)
 	name = "Flight Potion"
 	description = "Strange mutagenic compound of unknown origins."
 	reagent_state = LIQUID
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 	color = "#FFEBEB"
 
 /datum/reagent/flightpotion/reaction_mob(mob/living/M, methods = TOUCH, reac_volume, show_message = 1)

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -191,7 +191,7 @@
 		return
 
 	// This should be a better check but this covers 99.9% of cases
-	if(!(process_flags & C.get_process_flags()))
+	if(!(compatible_biotypes & C.mob_biotypes))
 		to_chat(user, span_warner("This brain is incompatiable with this beings biology!"))
 		return
 
@@ -278,7 +278,7 @@
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "posibrain-ipc"
 	organ_flags = ORGAN_SYNTHETIC
-	process_flags = SYNTHETIC
+	compatible_biotypes = MOB_ROBOTIC
 
 /obj/item/organ/brain/positron/emp_act(severity)
 	if(prob(25))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1176,10 +1176,6 @@
 		return FALSE
 	return ..()
 
-/// Returns the type of organs, reagents, and symptoms this mob is compatible with
-/mob/living/carbon/human/get_process_flags()
-	return dna?.species?.process_flags // uses the process flags of whichever species we are
-
 /mob/living/carbon/human/species
 	var/race = null
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -138,8 +138,6 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	///the icon used for the wings + details icon of a different source colour
 	var/wings_icon = "Angel"
 	var/wings_detail
-	/// Used for reagents, organs, and virus symptoms. We're going to assume you're a meatbag unless you say otherwise.
-	var/process_flags = ORGANIC
 	/// What kind of gibs to spawn
 	var/species_gibs = "human"
 	/// Can this species use numbers in its name?
@@ -1315,7 +1313,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		H.reagents.del_reagent(chem.type)
 		return TRUE
 	//This handles dumping unprocessable reagents.
-	if(!(chem.process_flags & H.get_process_flags()))
+	if(!(chem.compatible_biotypes & H.mob_biotypes))
 		chem.holder.remove_reagent(chem.type, chem.metabolization_rate)
 		return TRUE
 	return FALSE

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -37,7 +37,6 @@
 	staminamod = 0.8
 	siemens_coeff = 1.75
 	action_speed_coefficient = 0.9 // designed for labor, they should be good at it
-	process_flags = SYNTHETIC
 	species_gibs = "robotic"
 	attack_sound = 'sound/items/trayhit1.ogg'
 	screamsound = 'goon/sound/robot_scream.ogg'

--- a/code/modules/mob/living/carbon/human/species_types/android.dm
+++ b/code/modules/mob/living/carbon/human/species_types/android.dm
@@ -19,7 +19,6 @@
 	limbs_id = "synth"
 	toxmod = 0
 	clonemod = 0
-	process_flags = SYNTHETIC
 	species_gibs = "robotic"
 	attack_sound = 'sound/items/trayhit1.ogg'
 	screamsound = 'goon/sound/robot_scream.ogg'

--- a/code/modules/mob/living/carbon/human/species_types/synths.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synths.dm
@@ -17,7 +17,6 @@
 	mutantstomach = /obj/item/organ/stomach/cell
 	mutantears = /obj/item/organ/ears/robot
 	mutantlungs = /obj/item/organ/lungs/ipc
-	process_flags = SYNTHETIC //can now process chems that a robot would be able to process, because they're robots
 	var/disguise_fail_health = 75 //When their health gets to this level their synthflesh partially falls off
 	var/datum/species/fake_species //a species to do most of our work for us, unless we're damaged
 	var/list/initial_species_traits //for getting these values back for assume_disguise()

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -347,7 +347,7 @@
 /mob/living/carbon/proc/handle_organs()
 	for(var/V in internal_organs)
 		var/obj/item/organ/O = V
-		if(O.process_flags & get_process_flags()) // assume carbons are organic by default
+		if(O.compatible_biotypes & mob_biotypes) // assume carbons are organic by default
 			O.on_life()
 
 /mob/living/carbon/handle_diseases()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1036,10 +1036,6 @@
 /mob/living/proc/get_permeability(def_zone, linear = FALSE)
 	return 1
 
-/// Returns the type of organs, reagents, and symptoms this mob is compatible with
-/mob/living/proc/get_process_flags()
-	return (mob_biotypes & MOB_ROBOTIC) ? SYNTHETIC : ORGANIC // makes assumptions, override if you want something specific
-
 /mob/living/proc/harvest(mob/living/user) //used for extra objects etc. in butchering
 	return
 

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -601,7 +601,7 @@
 	return 0
 
 /datum/reagents/proc/reaction_check(mob/living/M, datum/reagent/R)
-	return (R.process_flags & M.get_process_flags())
+	return (R.compatible_biotypes & M.mob_biotypes)
 
 /**
   * Applies the relevant reaction_ proc for every reagent in this holder

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -60,8 +60,8 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/addiction_stage = 0
 	/// Alternative names used for the drug
 	var/addiction_name = null
-	/// What can process this? ORGANIC, SYNTHETIC, or ORGANIC | SYNTHETIC?. We'll assume by default that it affects organics.
-	var/process_flags = ORGANIC
+	/// What biotypes can process this? We'll assume by default that it affects organics and undead (for plasmemes).
+	var/compatible_biotypes = MOB_ORGANIC|MOB_UNDEAD
 	/// How flammable is this material?
 	var/accelerant_quality = 0
 	/// You fucked up and this is now triggering its overdose effects, purge that shit quick.

--- a/code/modules/reagents/chemistry/reagents.dm
+++ b/code/modules/reagents/chemistry/reagents.dm
@@ -60,8 +60,8 @@ GLOBAL_LIST_INIT(name2reagent, build_name2reagent())
 	var/addiction_stage = 0
 	/// Alternative names used for the drug
 	var/addiction_name = null
-	/// What biotypes can process this? We'll assume by default that it affects organics and undead (for plasmemes).
-	var/compatible_biotypes = MOB_ORGANIC|MOB_UNDEAD
+	/// What biotypes can process this? We'll assume by default that it affects organics (and undead, for plasmemes)
+	var/compatible_biotypes = ALL_NON_ROBOTIC
 	/// How flammable is this material?
 	var/accelerant_quality = 0
 	/// You fucked up and this is now triggering its overdose effects, purge that shit quick.

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -754,7 +754,7 @@
 	nutriment_factor = 5 * REAGENTS_METABOLISM
 	color = "#97ee63"
 	taste_description = "pure electricity"
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/reagent/consumable/liquidelectricity/reaction_turf(turf/T, reac_volume)//splash the electric "blood" all over the place
 	if(!istype(T))

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -442,10 +442,10 @@
 	reagent_state = LIQUID
 	color = "#F1C40F"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
-	process_flags = SYNTHETIC
+	compatible_biotypes = MOB_ROBOTIC
 
 /datum/reagent/medicine/system_cleaner/reaction_mob(mob/living/L, methods=TOUCH, reac_volume)
-	if(!(L.get_process_flags() & ORGANIC))
+	if(!(L.mob_biotypes & MOB_ORGANIC))
 		for(var/thing in L.diseases) // can clean viruses from fully synthetic hosts
 			var/datum/disease/D = thing
 			D.cure()
@@ -463,7 +463,7 @@
 	description = "Repairs brain damage in synthetics."
 	color = "#727272"
 	taste_description = "metallic"
-	process_flags = SYNTHETIC
+	compatible_biotypes = MOB_ROBOTIC
 
 /datum/reagent/medicine/liquid_solder/on_mob_life(mob/living/M)
 	var/obj/item/organ/O = M.getorganslot(ORGAN_SLOT_BRAIN)
@@ -486,7 +486,7 @@
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 	var/healing = 0.5
 	overdose_threshold = 30
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/reagent/medicine/omnizine/on_mob_life(mob/living/carbon/M)
 	M.adjustToxLoss(-healing*REM, 0)
@@ -1895,7 +1895,7 @@
 	color = "#ff00d4"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	taste_description = "acidic oil"
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 	var/nanite_reduction = -50
 
 /datum/reagent/medicine/naniteremover/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -128,7 +128,7 @@
 	glass_name = "glass of water"
 	glass_desc = "The father of all refreshments."
 	shot_glass_icon_state = "shotglassclear"
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 	default_container = /obj/item/reagent_containers/glass/beaker/waterbottle/large
 
 /*
@@ -345,7 +345,7 @@
 	description = "YOUR FLESH! IT BURNS!"
 	taste_description = "burning"
 	accelerant_quality = 20
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/reagent/hellwater/on_mob_life(mob/living/carbon/M)
 	M.fire_stacks = min(5,M.fire_stacks + 3)
@@ -360,7 +360,7 @@
 	description = "Strange liquid that defies the laws of physics"
 	taste_description = "glass"
 	color = "#1f8016"
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/reagent/eldritch/on_mob_life(mob/living/carbon/M)
 	if(IS_HERETIC(M) || IS_HERETIC_MONSTER(M))
@@ -392,7 +392,7 @@
 	description = "Lubricant is a substance introduced between two moving surfaces to reduce the friction and wear between them. giggity."
 	color = "#009CA8" // rgb: 0, 156, 168
 	taste_description = "cherry" // by popular demand
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 	metabolization_rate = 2 * REAGENTS_METABOLISM // Double speed
 
 
@@ -1053,7 +1053,7 @@
 	color = "#B8B8C0" // rgb: 184, 184, 192
 	taste_description = "the inside of a reactor"
 	var/irradiation_level = 1
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/reagent/uranium/on_mob_life(mob/living/carbon/M)
 	M.apply_effect(irradiation_level/M.metabolism_efficiency,EFFECT_IRRADIATE,0)
@@ -1074,7 +1074,7 @@
 	color = "#C7C7C7" // rgb: 199,199,199
 	taste_description = "the colour blue and regret"
 	irradiation_level = 2*REM
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/reagent/bluespace
 	name = "Bluespace Dust"
@@ -1082,7 +1082,7 @@
 	reagent_state = SOLID
 	color = "#0000CC"
 	taste_description = "fizzling blue"
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/reagent/bluespace/reaction_mob(mob/living/M, methods=TOUCH, reac_volume)
 	if((methods & (TOUCH|VAPOR)) && (reac_volume > 5))
@@ -1108,7 +1108,7 @@
 	reagent_state = SOLID
 	color = "#db0735"
 	taste_description = "bitter evil"
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 	metabolization_rate = 0.2 * REAGENTS_METABOLISM
 	can_synth = FALSE
 
@@ -1153,7 +1153,7 @@
 	glass_name = "glass of Dr. Gibb"
 	glass_desc = "Dr. Gibb. Not as dangerous as the glass_name might imply."
 	accelerant_quality = 10
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/reagent/fuel/reaction_mob(mob/living/M, methods=TOUCH, reac_volume)//Splashing people with welding fuel to make them easy to ignite!
 	if(methods & (TOUCH|VAPOR))
@@ -1470,7 +1470,7 @@
 	metabolization_rate = REAGENTS_METABOLISM * 0.5 // Because nitrium/freon/hyper-nob are handled through gas breathing, metabolism must be lower for breathcode to keep up
 	color = "90560B"
 	can_synth = FALSE
-	process_flags = ORGANIC | SYNTHETIC // works in open air, don't think it cares what kind of body it's in
+	compatible_biotypes = ALL_BIOTYPES // works in open air, don't think it cares what kind of body it's in
 	taste_description = "searingly cold"
 
 /datum/reagent/hypernoblium/on_mob_add(mob/living/L)
@@ -1495,7 +1495,7 @@
 	metabolization_rate = REAGENTS_METABOLISM * 0.5 // handled through gas breathing, metabolism must be lower for breathcode to keep up
 	color = "000000"
 	can_synth = FALSE
-	process_flags = ORGANIC | SYNTHETIC // BURN IT ALLLLLL
+	compatible_biotypes = ALL_BIOTYPES // BURN IT ALLLLLL
 	taste_description = "searingly hot"
 	self_consuming = TRUE
 	var/flame_timer = 0
@@ -1740,7 +1740,7 @@
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	taste_description = "oil"
-	process_flags = SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/reagent/oil/on_mob_life(mob/living/carbon/M)
 	M.adjustFireLoss(-2*REM, FALSE, FALSE, BODYPART_ROBOTIC)
@@ -1753,7 +1753,7 @@
 	color = "#C8A5DC"
 	taste_description = "bitterness"
 	taste_mult = 1.5
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/reagent/stable_plasma/on_mob_life(mob/living/carbon/C)
 	C.adjustPlasma(10)

--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -5,7 +5,7 @@
 	reagent_state = SOLID
 	color = "#550000"
 	taste_description = "sweet tasting metal"
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/reagent/thermite/reaction_turf(turf/T, reac_volume)
 	if(reac_volume >= 1)
@@ -37,7 +37,7 @@
 	metabolization_rate = 4
 	taste_description = "burning"
 	accelerant_quality = 20
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/reagent/clf3/on_mob_life(mob/living/carbon/M)
 	M.adjust_fire_stacks(2)
@@ -139,7 +139,7 @@
 	taste_description = "burning"
 	self_consuming = TRUE
 	accelerant_quality = 20
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/reagent/phlogiston/reaction_mob(mob/living/M, methods=TOUCH, reac_volume)
 	M.adjust_fire_stacks(1)
@@ -163,7 +163,7 @@
 	taste_description = "burning"
 	self_consuming = TRUE
 	accelerant_quality = 20
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/reagent/napalm/on_mob_life(mob/living/carbon/M)
 	M.adjust_fire_stacks(1)
@@ -181,7 +181,7 @@
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	taste_description = "bitterness"
 	self_consuming = TRUE
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 
 /datum/reagent/cryostylane/on_mob_life(mob/living/carbon/M) //TODO: code freezing into an ice cube
@@ -217,7 +217,7 @@
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	taste_description = "charged metal"
 	self_consuming = TRUE
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 	var/shock_timer = 0
 
 /datum/reagent/teslium/on_mob_metabolize(mob/living/L)
@@ -302,7 +302,7 @@ datum/reagent/frigorific_mixture
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	taste_description = "bitterness"
 	self_consuming = TRUE
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 
 /datum/reagent/frigorific_mixture/on_mob_life(mob/living/carbon/M) //TODO: code freezing into an ice cube

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -60,7 +60,7 @@
 	color = "#8228A0"
 	toxpwr = 3
 	accelerant_quality = 10
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/reagent/toxin/plasma/on_mob_life(mob/living/carbon/C)
 	if(holder.has_reagent(/datum/reagent/medicine/epinephrine))
@@ -445,7 +445,7 @@
 	color = "#787878"
 	metabolization_rate = 0.125 * REAGENTS_METABOLISM
 	toxpwr = 0
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 	var/radpower = 40
 
 /datum/reagent/toxin/polonium/on_mob_life(mob/living/carbon/M)
@@ -797,7 +797,7 @@
 	metabolization_rate = 1.2 * REAGENTS_METABOLISM
 	toxpwr = 0.5
 	taste_description = "spinning"
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/reagent/toxin/rotatium/on_mob_life(mob/living/carbon/M)
 	return ..() //dont forget to reenable this
@@ -848,7 +848,7 @@
 	var/acidpwr = 10 //the amount of protection removed from the armour
 	taste_description = "acid"
 	self_consuming = TRUE
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /datum/reagent/toxin/acid/reaction_mob(mob/living/carbon/C, methods=TOUCH, reac_volume, show_message = 1, permeability = 1)
 	if(!istype(C))

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -105,7 +105,7 @@
 			return -1
 
 		var/obj/item/organ/O = tool
-		if(!(O.process_flags & target.get_process_flags()))
+		if(!(O.compatible_biotypes & target.mob_biotypes))
 			to_chat(user, span_notice("[target] is not compatible with [O]!"))
 			return -1
 

--- a/code/modules/surgery/organs/appendix.dm
+++ b/code/modules/surgery/organs/appendix.dm
@@ -58,7 +58,7 @@
 	desc = "One of the most advanced cybernetic organs ever created."
 	icon_state = "implant-filter"
 	organ_flags = ORGAN_SYNTHETIC
-	process_flags = ORGANIC | SYNTHETIC // THE GREATEST INVENTION IN THE HISTORY OF CYBERNETICS
+	compatible_biotypes = ALL_BIOTYPES // THE GREATEST INVENTION IN THE HISTORY OF CYBERNETICS
 	now_failing = span_warning("NOT AGAIN!")
 	now_fixed = span_info("Thank god that's over.")
 

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -424,7 +424,7 @@
 	desc = "An internal power cord hooked up to a battery. Useful if you run on volts."
 	contents = newlist(/obj/item/apc_powercord)
 	slot = ORGAN_SLOT_STOMACH_AID //so ipcs don't get shafted for nothing
-	process_flags = SYNTHETIC
+	compatible_biotypes = MOB_ROBOTIC
 	zone = BODY_ZONE_CHEST
 
 /obj/item/organ/cyberimp/arm/power_cord/SetSlotFromZone() // don't swap the zone

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -5,7 +5,7 @@
 	visual = FALSE
 	status = ORGAN_ROBOTIC
 	organ_flags = ORGAN_SYNTHETIC
-	process_flags = ORGANIC | SYNTHETIC // everyone can use cybernetic implants
+	compatible_biotypes = ALL_BIOTYPES // everyone can use cybernetic implants
 	var/implant_color = "#FFFFFF"
 	var/implant_overlay
 	var/syndicate_implant = FALSE //Makes the implant invisible to health analyzers and medical HUDs.

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -94,7 +94,7 @@
 	icon = 'icons/obj/clothing/hats.dmi'
 	icon_state = "kitty"
 	visual = TRUE
-	process_flags = ORGANIC | SYNTHETIC // meowchine... turn back now
+	compatible_biotypes = ALL_BIOTYPES // meowchine... turn back now
 	damage_multiplier = 2
 
 /obj/item/organ/ears/cat/Insert(mob/living/carbon/human/H, special = 0, drop_if_replaced = TRUE)
@@ -120,7 +120,7 @@
 	damage_multiplier = 0.8
 	status = ORGAN_ROBOTIC
 	organ_flags = ORGAN_SYNTHETIC
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /obj/item/organ/ears/penguin
 	name = "penguin ears"
@@ -154,7 +154,7 @@
 	gender = PLURAL
 	status = ORGAN_ROBOTIC
 	organ_flags = ORGAN_SYNTHETIC
-	process_flags = SYNTHETIC // for IPCs
+	compatible_biotypes = MOB_ROBOTIC // for IPCs
 
 /obj/item/organ/ears/robot/emp_act(severity)
 	switch(severity)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -165,7 +165,7 @@
 	desc = "Your vision is augmented."
 	status = ORGAN_ROBOTIC
 	organ_flags = ORGAN_SYNTHETIC
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /obj/item/organ/eyes/robotic/emp_act(severity)
 	. = ..()

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -129,7 +129,7 @@
 	toxTolerance = -1
 	toxLethality = 0
 	status = ORGAN_ROBOTIC
-	process_flags = SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 /obj/item/organ/liver/cybernetic/upgraded/ipc/emp_act(severity)
 	if(prob(10))

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -503,7 +503,7 @@
 	desc = "A radiator in the shape of a lung used to exchange heat to cool down"
 	icon_state = "lungs-c"
 	organ_flags = ORGAN_SYNTHETIC
-	process_flags = SYNTHETIC // no more humans with IPC lungs, that's just silly
+	compatible_biotypes = MOB_ROBOTIC // no more humans with IPC lungs, that's just silly
 	status = ORGAN_ROBOTIC
 	COOLDOWN_DECLARE(last_message)
 

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -7,8 +7,8 @@
 	throwforce = 0
 	var/zone = BODY_ZONE_CHEST
 	var/slot
-	// Does this organ work in organics, synthetics, or both? Assume it's a flesh-compatible organ by default.
-	var/process_flags = ORGANIC
+	// What biotypes is this organ compatible with? Assume it's a flesh-compatible organ by default.
+	var/compatible_biotypes = MOB_ORGANIC|MOB_INORGANIC|MOB_UNDEAD
 	// DO NOT add slots with matching names to different zones - it will break internal_organs_slot list!
 	var/organ_flags = 0
 	var/maxHealth = STANDARD_ORGAN_THRESHOLD
@@ -90,7 +90,7 @@
 		if(!C)
 			return
 		life_tick++
-		if((C.stat == DEAD || !(process_flags & owner.get_process_flags())) && !HAS_TRAIT(C, TRAIT_PRESERVED_ORGANS)) // organic organs decompose inside incompatible bodies
+		if((C.stat == DEAD || !(compatible_biotypes & owner.mob_biotypes)) && !HAS_TRAIT(C, TRAIT_PRESERVED_ORGANS)) // organic organs decompose inside incompatible bodies
 			if(damage >= maxHealth)
 				organ_flags |= ORGAN_FAILING
 				damage = maxHealth

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -172,7 +172,7 @@
 	desc = "A crystal-like organ that stores the electric charge of ethereals."
 	status = ORGAN_ORGANIC
 	organ_flags = NONE
-	compatible_biotypes = MOB_ROBOTIC
+	compatible_biotypes = ALL_NON_ROBOTIC
 
 /obj/item/organ/stomach/cell/ethereal/Insert(mob/living/carbon/M, special = 0)
 	..()

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -139,7 +139,7 @@
 	desc = "A micro-cell, for IPC use only. Do not swallow."
 	status = ORGAN_ROBOTIC
 	organ_flags = ORGAN_SYNTHETIC
-	process_flags = SYNTHETIC
+	compatible_biotypes = MOB_ROBOTIC
 	var/stored_charge = NUTRITION_LEVEL_WELL_FED
 	var/emp_message = span_warning("Alert: EMP Detected. Cycling battery.")
 
@@ -172,7 +172,7 @@
 	desc = "A crystal-like organ that stores the electric charge of ethereals."
 	status = ORGAN_ORGANIC
 	organ_flags = NONE
-	process_flags = ORGANIC
+	compatible_biotypes = MOB_ROBOTIC
 
 /obj/item/organ/stomach/cell/ethereal/Insert(mob/living/carbon/M, special = 0)
 	..()

--- a/code/modules/surgery/organs/tails.dm
+++ b/code/modules/surgery/organs/tails.dm
@@ -7,7 +7,7 @@
 	visual = TRUE
 	zone = BODY_ZONE_PRECISE_GROIN
 	slot = ORGAN_SLOT_TAIL
-	process_flags = ORGANIC | SYNTHETIC // pretty much entirely cosmetic, if someone wants to make crimes against nature then sure
+	compatible_biotypes = ALL_BIOTYPES // pretty much entirely cosmetic, if someone wants to make crimes against nature then sure
 	/// The sprite accessory this tail gives to the human it's attached to. If null, it will inherit its value from the human's DNA once attached.
 	var/tail_type = "None"
 

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -123,7 +123,7 @@
 	desc = "A mysterious structure that allows for instant communication between users. Pretty impressive until you need to eat something."
 	icon_state = "tongueayylmao"
 	say_mod = "gibbers"
-	process_flags = ORGANIC | SYNTHETIC // fuck it, alien technology
+	compatible_biotypes = ALL_BIOTYPES // fuck it, alien technology
 	taste_sensitivity = NO_TASTE_SENSITIVITY // ayys cannot taste anything.
 	modifies_speech = TRUE
 	var/mothership
@@ -255,7 +255,7 @@
 	name = "robotic voicebox"
 	desc = "A voice synthesizer that can interface with organic lifeforms."
 	status = ORGAN_ROBOTIC
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 	organ_flags = ORGAN_SYNTHETIC
 	icon_state = "tonguerobot"
 	say_mod = "states"

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -7,7 +7,7 @@
 	name = "vocal cords"
 	icon_state = "appendix"
 	visual = FALSE
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 	zone = BODY_ZONE_PRECISE_MOUTH
 	slot = ORGAN_SLOT_VOICE
 	gender = PLURAL
@@ -32,7 +32,7 @@
 	desc = "Fragments of adamantine exist in all golems, stemming from their origins as purely magical constructs. These are used to \"hear\" messages from their leaders."
 	zone = BODY_ZONE_HEAD
 	slot = ORGAN_SLOT_ADAMANTINE_RESONATOR
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 	icon_state = "adamantine_resonator"
 	visual = FALSE
 

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
@@ -6,7 +6,7 @@
 	//preternis eyes need to be powered by a preternis to function, in a non preternis they slowly power down to blindness
 	status = ORGAN_ROBOTIC
 	organ_flags = ORGAN_SYNTHETIC
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 
 	low_threshold_passed = span_info("Your Preternis eyes switch to battery saver mode.")
 	high_threshold_passed = span_info("Your Preternis eyes only show a sliver of battery life left!")
@@ -39,10 +39,10 @@
 	. = ..()
 	if(!owner)
 		return
-	if((owner.get_process_flags() & SYNTHETIC) && !powered)
+	if((owner.mob_biotypes & MOB_ROBOTIC) && !powered)
 		powered = TRUE
 		to_chat(owner, span_notice("A battery icon disappears from your vision as your [src] switch to external power."))
-	if(!(owner.get_process_flags() & SYNTHETIC) && powered) //these eyes depend on being inside a preternis for power
+	if(!(owner.mob_biotypes & MOB_ROBOTIC) && powered) //these eyes depend on being inside a preternis for power
 		powered = FALSE
 		to_chat(owner, span_boldwarning("Your [src] flash warnings that they've lost their power source, and are running on emergency power!"))
 	if(powered)
@@ -105,7 +105,7 @@
 	name = "preternis cell-stomach"
 	desc = "Calling it a stomach is perhaps a bit generous. It's better at grinding rocks than dissolving food. Also works as a power cell."
 	icon_state = "stomach-c"
-	process_flags = ORGANIC | SYNTHETIC // also works as a stomach, so organics can use it too
+	compatible_biotypes = ALL_BIOTYPES // also works as a stomach, so organics can use it too
 
 /obj/item/organ/stomach/cell/preternis/on_life()
 	. = ..()

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -16,7 +16,6 @@
 	toxic_food = NONE
 	liked_food = FRIED | SUGAR | JUNKFOOD
 	disliked_food = GROSS | VEGETABLES
-	process_flags = ORGANIC | SYNTHETIC
 	burnmod = 1.2 //The plasteel has a really high heat capacity, however, it's not great at dispersing the heat to concentrated heat is gonna burn
 	coldmod = 3 //The plasteel around them saps their body heat quickly if it gets cold
 	heatmod = 2 //Once the heat gets through it's gonna BURN

--- a/yogstation/code/modules/surgery/organs/heart.dm
+++ b/yogstation/code/modules/surgery/organs/heart.dm
@@ -3,7 +3,7 @@
 	desc = "A specialized heart constructed from nanites that helps coordinate nanites allowing them to regenerate quicker inside the body without any ill effects. Caution this organ will fall apart without nanites to sustain itself!"
 	icon_state = "heart-nanites"
 	organ_flags = ORGAN_SYNTHETIC
-	process_flags = ORGANIC | SYNTHETIC
+	compatible_biotypes = ALL_BIOTYPES
 	var/nanite_boost = 1
 
 /obj/item/organ/heart/nanite/emp_act()


### PR DESCRIPTION
Refactors process checks to use mob biotypes instead of being its own thing, because it's easier to understand this way and will let me do cool stuff with it in future projects.

No gameplay effects except being maybe a bit better at catching certain edge cases with reagent/organ/disease processing.

:cl:   
experimental: report any bugs with reagent processing, disease symptoms, or organs
/:cl:
