### PR TITLE
Makes sleeping carp human only

### DIFF
--- a/code/game/objects/items/granters/martial_arts/sleeping_carp.dm
+++ b/code/game/objects/items/granters/martial_arts/sleeping_carp.dm
@@ -19,6 +19,12 @@
 		"Glub...",
 	)
 
+/obj/item/book/granter/martial/carp/can_learn(mob/user)
+	if(!ishumanbasic(user))
+		to_chat(user, span_warning("You fail to decipher the meaning of the strange markings."))
+		return FALSE
+	return ..()
+
 /obj/item/book/granter/martial/carp/on_reading_finished(mob/living/carbon/user)
 	. = ..()
 	update_appearance()

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -689,15 +689,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	manufacturer = /datum/corporation/traitor/donkco
 	surplus = 0
 
-/datum/uplink_item/stealthy_weapons/martialarts
-	name = "Martial Arts Scroll"
-	desc = "This scroll contains the secrets of an ancient martial arts technique known as Sleeping Carp. You will master unarmed combat, \
-			deflecting all ranged weapon fire when throwmode is enabled, but you also refuse to use dishonorable ranged weaponry."
-	item = /obj/item/book/granter/martial/carp
-	cost = 14
-	surplus = 0
-	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops, /datum/game_mode/infiltration) // yogs: infiltration
-
 /datum/uplink_item/stealthy_weapons/crossbow
 	name = "Miniature Energy Crossbow"
 	desc = "A short bow mounted across a tiller in miniature. \
@@ -2307,6 +2298,15 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 12
 	manufacturer = /datum/corporation/traitor/vahlen
 	item = /obj/item/dnainjector/hulkmut
+	restricted_species = list("human")
+
+/datum/uplink_item/race_restricted/martialarts
+	name = "Martial Arts Scroll"
+	desc = "This scroll contains the secrets of an ancient martial arts technique known as Sleeping Carp. You will master unarmed combat, \
+			deflecting all ranged weapon fire when throwmode is enabled, but you also refuse to use dishonorable ranged weaponry."
+	item = /obj/item/book/granter/martial/carp
+	cost = 14
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops, /datum/game_mode/infiltration) // yogs: infiltration
 	restricted_species = list("human")
 
 // Role-specific items


### PR DESCRIPTION
# Why is this good for the game?
Sleeping carp always sorta felt more "specialized" thematically than the other general martial arts
Now that the other species have their own martial arts or species specific items, this gives a reason to play human still

and yes biome, this also includes felinids

:cl:  
tweak: Makes sleeping carp human only
/:cl:
