### PR TITLE
Rewrites neural overclocker colour code and makes it cost less + CRAWL

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -486,7 +486,7 @@ GLOBAL_LIST_INIT(maintenance_loot_makeshift,list(
 	/obj/item/reagent_containers/autoinjector/medipen/pumpup = W_ESSENTIAL,
 	/obj/item/organ/heart/ghetto = W_RARE,
 	/obj/item/organ/lungs/ghetto = W_RARE,
-	/obj/item/organ/cyberimp/chest/spinalspeed/toy = W_RARE,
+	/obj/item/organ/cyberimp/chest/spinalspeed/toy = W_UNCOMMON,
 	/obj/item/reagent_containers/food/drinks/bottle/hooch = W_ESSENTIAL,
 	/obj/item/reagent_containers/food/drinks/bottle/kong = W_RARE,
 	/obj/item/reagent_containers/food/drinks/bottle/lizardwine = W_RARE,

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -299,7 +299,7 @@
 	var/obj/effect/temp_visual/decoy/fading/F = new(currentloc, owner)
 	if(!hsv)
 		hsv = RGBtoHSV(rgb(255, 0, 0))
-	hsv = RotateHue(hsv, max(world.time - last_step, 1) * 15)
+	hsv = RotateHue(hsv, world.time - last_step * 15)
 	last_step = world.time
 	F.color = HSVtoRGB(hsv)	//gotta add the flair
 

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -299,7 +299,7 @@
 	var/obj/effect/temp_visual/decoy/fading/F = new(currentloc, owner)
 	if(!hsv)
 		hsv = RGBtoHSV(rgb(255, 0, 0))
-	hsv = RotateHue(hsv, (world.time - last_step) * 10)
+	hsv = RotateHue(hsv, (world.time - last_step) * 15)
 	last_step = world.time
 	F.color = HSVtoRGB(hsv)	//gotta add the flair
 

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -238,6 +238,8 @@
 	var/on = FALSE
 	var/time_on = 0
 	var/hasexerted = FALSE
+	var/list/hsv
+	var/last_step = 0
 	COOLDOWN_DECLARE(alertcooldown)
 	COOLDOWN_DECLARE(startsoundcooldown)
 	COOLDOWN_DECLARE(endsoundcooldown)
@@ -259,17 +261,23 @@
 			playsound(owner, 'sound/effects/spinal_implant_on.ogg', 60)
 			COOLDOWN_START(src, startsoundcooldown, 1 SECONDS)
 		if(syndicate_implant)//the toy doesn't do anything aside from the trail and the sound
-			owner.add_movespeed_modifier("spinalimplant", priority=100, multiplicative_slowdown=-1)
+			if(ishuman(owner))
+				var/mob/living/carbon/human/human = owner
+				human.physiology.do_after_speed *= 0.7
+				human.physiology.crawl_speed -= 1
 			owner.next_move_modifier *= 0.7
-			owner?.dna?.species?.action_speed_coefficient *= 0.7
+			owner.add_movespeed_modifier("spinalimplant", priority=100, multiplicative_slowdown=-1)
 		RegisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE, PROC_REF(move_react))
 	else
 		if(COOLDOWN_FINISHED(src, endsoundcooldown))
 			playsound(owner, 'sound/effects/spinal_implant_off.ogg', 70)
 			COOLDOWN_START(src, endsoundcooldown, 1 SECONDS)
 		if(syndicate_implant)
+			if(ishuman(owner))
+				var/mob/living/carbon/human/human = owner
+				human.physiology.do_after_speed /= 0.7
+				human.physiology.crawl_speed += 1
 			owner.next_move_modifier /= 0.7
-			owner?.dna?.species?.action_speed_coefficient /= 0.7
 			owner.remove_movespeed_modifier("spinalimplant")
 		UnregisterSignal(owner, COMSIG_MOVABLE_PRE_MOVE)
 	on = !on
@@ -289,30 +297,11 @@
 /obj/item/organ/cyberimp/chest/spinalspeed/proc/move_react()//afterimage
 	var/turf/currentloc = get_turf(owner)
 	var/obj/effect/temp_visual/decoy/fading/F = new(currentloc, owner)
-	var/rvalue = 0
-	var/gvalue = 0
-	var/bvalue = 0
-	var/numcolors = (world.time * 32) % 1280
-	var/segment = numcolors / 256
-	var/specific_color = numcolors % 256 //works like any non-sine wave rainbow generator thing, google it
-	switch(segment)//transition isn't as precise as if i used sin() but this is far more efficient for runtime
-		if(0 to 1)
-			rvalue = 255
-			gvalue = specific_color
-		if(1 to 2)
-			rvalue = 255 - specific_color
-			gvalue = 255
-		if(2 to 3)
-			gvalue = 255
-			bvalue = specific_color
-		if(3 to 4)
-			gvalue = 255 - specific_color
-			bvalue = 255
-		if(4 to 5)
-			rvalue = specific_color
-			bvalue = 255 - specific_color
-	var/usedcolor = rgb(rvalue, gvalue, bvalue)
-	F.color = usedcolor	//gotta add the flair
+	if(!hsv)
+		hsv = RGBtoHSV(rgb(255, 0, 0))
+	hsv = RotateHue(hsv, (world.time - last_step) * 10)
+	last_step = world.time
+	F.color = HSVtoRGB(hsv)	//gotta add the flair
 
 /obj/item/organ/cyberimp/chest/spinalspeed/on_life()
 	if(!syndicate_implant)//the toy doesn't have a drawback

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -299,7 +299,7 @@
 	var/obj/effect/temp_visual/decoy/fading/F = new(currentloc, owner)
 	if(!hsv)
 		hsv = RGBtoHSV(rgb(255, 0, 0))
-	hsv = RotateHue(hsv, (world.time - last_step) * 15)
+	hsv = RotateHue(hsv, max(world.time - last_step, 1) * 15)
 	last_step = world.time
 	F.color = HSVtoRGB(hsv)	//gotta add the flair
 
@@ -323,7 +323,7 @@
 					to_chat(owner, span_userdanger("Your spine and brain feel like they're burning!"))
 					COOLDOWN_START(src, alertcooldown, 5 SECONDS)
 				hasexerted = TRUE
-				owner.set_drugginess(10)
+				owner.set_drugginess(2 SECONDS)
 				owner.adjust_hallucinations(20 SECONDS)
 				owner.adjustFireLoss(5)
 			if(100 to INFINITY)//no infinite abuse

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2185,8 +2185,12 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/autosurgeon/syndicate/spinalspeed
 	manufacturer = /datum/corporation/traitor/vahlen
 	cost = 12
-	surplus = 0
-	limited_stock = 1
+	exclude_modes = list(/datum/game_mode/infiltration, /datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
+
+/datum/uplink_item/implants/spinal/nukie
+	cost = 20
+	exclude_modes = list()
+	include_modes = list(/datum/game_mode/infiltration, /datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/implants/emp_shield
 	name = "EMP Shield Implant"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2184,7 +2184,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Stimulates your central nervous system in order to enable you to perform muscle movements faster. Careful not to overuse it."
 	item = /obj/item/autosurgeon/syndicate/spinalspeed
 	manufacturer = /datum/corporation/traitor/vahlen
-	cost = 14
+	cost = 12
 	surplus = 0
 	limited_stock = 1
 


### PR DESCRIPTION
huh, wish i knew about rotatehue before i tore my hair out coding it in the first place

# Why is this good for the game
it's a very utility focused item that costs so much makes it impossible to pair with other items

:cl:  
tweak: neural overclocker also gives a slight crawl speed increase
tweak: neural overclocker costs 12tc instead of 14tc for traitors
tweak: neural overclocker costs 20tc instead of 14tc for nukies
tweak: toy neural overclocker is slightly more common in maints
/:cl:
