### PR TITLE
Exploding the SM with 50% miasma and 5000 moles will spawn a Blob

### DIFF
--- a/code/modules/antagonists/blob/overmind.dm
+++ b/code/modules/antagonists/blob/overmind.dm
@@ -44,7 +44,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	var/has_announced = FALSE
 	var/basemodifier = 1
 
-/mob/camera/blob/Initialize(mapload, starting_points = 60, pointmodifier = 1)
+/mob/camera/blob/Initialize(mapload, starting_points = 60, pointmodifier = 1, announcement_delay = 6000)
 	validate_location()
 	blob_points = starting_points
 	basemodifier = pointmodifier
@@ -61,7 +61,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	if(blob_core)
 		blob_core.update_appearance(UPDATE_ICON)
 	SSshuttle.registerHostileEnvironment(src)
-	announcement_time = world.time + 6000
+	announcement_time = world.time + announcement_delay
 	. = ..()
 	START_PROCESSING(SSobj, src)
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -519,8 +519,8 @@
 	. = new_slime
 	qdel(src)
 
-/mob/proc/become_overmind(starting_points = 60, pointmodifier = 1)
-	var/mob/camera/blob/B = new /mob/camera/blob(get_turf(src), starting_points, pointmodifier)
+/mob/proc/become_overmind(starting_points = 60, pointmodifier = 1, announcement_time = 6000)
+	var/mob/camera/blob/B = new /mob/camera/blob(get_turf(src), starting_points, pointmodifier, announcement_time)
 	B.key = key
 	. = B
 	qdel(src)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -519,8 +519,8 @@
 	. = new_slime
 	qdel(src)
 
-/mob/proc/become_overmind(starting_points = 60, pointmodifier = 1, announcement_time = 6000)
-	var/mob/camera/blob/B = new /mob/camera/blob(get_turf(src), starting_points, pointmodifier, announcement_time)
+/mob/proc/become_overmind(starting_points = 60, pointmodifier = 1, announcement_delay = 6000)
+	var/mob/camera/blob/B = new /mob/camera/blob(get_turf(src), starting_points, pointmodifier, announcement_delay)
 	B.key = key
 	. = B
 	qdel(src)

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -394,7 +394,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 				var/list/candidates = pollGhostCandidates("Do you wish to be considered for the special role of Supermatter Blob?", ROLE_BLOB, null, ROLE_BLOB)
 				if(candidates.len)
 					var/mob/dead/observer/new_blob = pick(candidates)
-					var/mob/camera/blob/BC = new_blob.become_overmind(200, 1.3, 1)
+					var/mob/camera/blob/BC = new_blob.become_overmind(350, 1.5, 1)
 					BC.forceMove(T)
 					BC.place_blob_core(BLOB_FORCE_PLACEMENT)
 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -63,6 +63,8 @@
 #define DAMAGE_HARDCAP 0.002
 #define DAMAGE_INCREASE_MULTIPLIER 0.25
 
+#define MIASMA_DELAM_PERCENTAGE 50			///The percentage of miasma before it is classed as a miasma delamination, causing a blob to spawn.
+
 #define THERMAL_RELEASE_MODIFIER 5         //Higher == less heat released during reaction, not to be confused with the above values
 #define PLASMA_RELEASE_MODIFIER 750        //Higher == less plasma released by reaction
 #define OXYGEN_RELEASE_MODIFIER 325        //Higher == less oxygen released at high temperature/power
@@ -384,7 +386,23 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 			SEND_SOUND(M, 'sound/magic/charge.ogg')
 			to_chat(M, span_boldannounce("You feel reality distort for a moment..."))
 			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "delam", /datum/mood_event/delam)
+	
+	if (T)
+		var/datum/gas_mixture/air = T.return_air()
+		if (air)
+			if (((air.get_moles(/datum/gas/miasma) / air.total_moles()) * 100) > MIASMA_DELAM_PERCENTAGE && air.total_moles() > 5000)
+				var/list/candidates = pollGhostCandidates("Do you wish to be considered for the special role of Supermatter Blob?", ROLE_BLOB, null, ROLE_BLOB)
+				if(candidates.len)
+					var/mob/dead/observer/new_blob = pick(candidates)
+					var/mob/camera/blob/BC = new_blob.become_overmind(200, 1.3, 1)
+					BC.forceMove(T)
+					BC.place_blob_core(BLOB_FORCE_PLACEMENT)
 
+					message_admins("[src] has created a blob. [ADMIN_JMP(src)].")
+					investigate_log("has created a blob.", INVESTIGATE_SUPERMATTER)
+					qdel(src)
+					return
+					
 	if(resonance_cascading)
 		sound_to_playing_players('sound/magic/lightningbolt.ogg', volume = 50)
 		var/datum/round_event_control/resonance_cascade/xen = new


### PR DESCRIPTION
# Document the changes in your pull request
As title, when the SM has 50% miasma in its environment and 5000 total moles a blob will spawn, this is fairly difficult to do and i dont forsee it ever really happening but it can, and its funny.

The blob has 350 starting resource and a flat 1.5x point increase to make up for the fact it spawns in an incredibly compromising area and the crew will instantly know its location, as well as the fact it has 3 emitters pointed directly at its core

# Why is this good for the game?
Its funny, more interesting SM delams.

# Testing
Works

# Wiki Documentation
Add that SM's will spawn blobs when they have 50% miasma in them and atleast 5000 moles

# Changelog
:cl:  @Simplehorror, @azzzertyy 
rscadd: SM delams with miasma will now spawn a blob
/:cl:
