### PR TITLE
Gambling Hall Clerk Template

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/clerk_gamble.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/clerk_gamble.dmm
@@ -6,6 +6,16 @@
 	},
 /turf/open/floor/carpet/black,
 /area/clerk)
+"c" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/wood,
+/area/clerk)
 "d" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -96,10 +106,6 @@
 	},
 /turf/open/floor/wood,
 /area/clerk)
-"r" = (
-/obj/structure/chair/stool,
-/turf/open/floor/wood,
-/area/clerk)
 "s" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
@@ -107,6 +113,14 @@
 "t" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
+	},
+/turf/open/floor/wood,
+/area/clerk)
+"u" = (
+/obj/structure/chair/stool,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/open/floor/wood,
 /area/clerk)
@@ -306,12 +320,6 @@
 "V" = (
 /turf/open/floor/carpet/black,
 /area/clerk)
-"W" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/turf/open/floor/wood,
-/area/clerk)
 "X" = (
 /obj/structure/chair/stool,
 /obj/machinery/light{
@@ -433,12 +441,12 @@ G
 (9,1,1) = {"
 G
 F
-r
+u
 f
 G
 w
 A
-W
+c
 G
 "}
 (10,1,1) = {"

--- a/_maps/RandomRuins/StationRuins/BoxStation/clerk_gamble.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/clerk_gamble.dmm
@@ -1,9 +1,87 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/obj/machinery/vending/cola/random,
+"b" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/carpet/black,
+/area/clerk)
+"d" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/clerk)
-"b" = (
+"e" = (
+/obj/machinery/camera{
+	c_tag = "Clerk's Gambling Hall"
+	},
+/turf/open/floor/wood,
+/area/clerk)
+"f" = (
+/obj/structure/table/wood,
+/obj/item/coinstack,
+/obj/item/coin/gold,
+/obj/item/coin/gold,
+/obj/item/coin/gold,
+/obj/item/coin/plasma,
+/obj/item/coin/uranium,
+/obj/item/coin/diamond,
+/obj/item/coin/iron,
+/obj/item/coin/iron,
+/turf/open/floor/carpet/black,
+/area/clerk)
+"g" = (
+/obj/structure/table/wood/poker,
+/obj/machinery/door/poddoor/shutters{
+	id = "gamblinghall"
+	},
+/turf/open/floor/carpet/black,
+/area/clerk)
+"h" = (
+/obj/machinery/vending/gifts,
+/turf/open/floor/wood,
+/area/clerk)
+"i" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "gamblinghall_ext"
+	},
+/turf/open/floor/plating,
+/area/clerk)
+"j" = (
+/turf/template_noop,
+/area/template_noop)
+"k" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/wood,
+/area/clerk)
+"l" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/clerk)
+"m" = (
+/obj/structure/chair,
+/turf/open/floor/carpet/black,
+/area/clerk)
+"n" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/wood,
+/area/clerk)
+"p" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/open/floor/wood,
+/area/clerk)
+"q" = (
 /obj/machinery/power/apc{
 	areastring = "/area/clerk";
 	dir = 1;
@@ -18,204 +96,82 @@
 	},
 /turf/open/floor/wood,
 /area/clerk)
-"d" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/clerk)
-"e" = (
-/obj/structure/table/wood/poker,
-/obj/machinery/door/poddoor/shutters{
-	id = "gamblinghall"
-	},
-/obj/item/toy/cards/deck,
-/turf/open/floor/carpet/black,
-/area/clerk)
-"f" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
-/area/clerk)
-"g" = (
-/turf/open/floor/carpet/black,
-/area/clerk)
-"h" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/wood,
-/area/clerk)
-"i" = (
-/obj/item/storage/secure/safe{
-	pixel_x = 5;
-	pixel_y = -25
-	},
-/turf/open/floor/carpet/black,
-/area/clerk)
-"l" = (
-/obj/structure/table/wood,
-/obj/machinery/paystand/register{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/clerk)
-"m" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = 32
-	},
-/turf/open/floor/wood,
-/area/clerk)
-"n" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "gamblinghall_ext"
-	},
-/turf/open/floor/plating,
-/area/clerk)
-"p" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "gamblinghall_ext"
-	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/clerk)
-"q" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/clerk)
 "r" = (
 /obj/structure/chair/stool,
 /turf/open/floor/wood,
 /area/clerk)
 "s" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/carpet/black,
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood,
 /area/clerk)
 "t" = (
-/obj/structure/chair/stool,
-/obj/machinery/light{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
-	},
-/turf/open/floor/carpet/black,
-/area/clerk)
-"u" = (
-/obj/structure/table/wood,
-/obj/item/coinstack,
-/obj/item/coin/gold,
-/obj/item/coin/gold,
-/obj/item/coin/gold,
-/obj/item/coin/plasma,
-/obj/item/coin/uranium,
-/obj/item/coin/diamond,
-/obj/item/coin/iron,
-/obj/item/coin/iron,
-/turf/open/floor/carpet/black,
-/area/clerk)
-"v" = (
-/obj/structure/table/wood,
-/obj/item/a_gift{
-	pixel_x = -5;
-	pixel_y = -2
-	},
-/obj/item/a_gift{
-	pixel_x = 7;
-	pixel_y = 4
 	},
 /turf/open/floor/wood,
 /area/clerk)
 "w" = (
 /obj/structure/chair/stool,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
 /turf/open/floor/carpet/black,
 /area/clerk)
-"y" = (
-/obj/machinery/vending/autodrobe,
-/turf/open/floor/wood,
-/area/clerk)
-"z" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/wood,
-/area/clerk)
-"A" = (
-/obj/machinery/camera{
-	c_tag = "Clerk's Gambling Hall"
-	},
-/turf/open/floor/wood,
-/area/clerk)
-"B" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/wood,
-/area/clerk)
-"C" = (
-/turf/template_noop,
-/area/template_noop)
-"D" = (
-/turf/closed/wall,
-/area/clerk)
-"E" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock{
-	name = "Gambling Hall";
-	req_access_txt = "36"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/wood,
-/area/clerk)
-"F" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/clerk)
-"G" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/wood,
-/area/clerk)
-"H" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/open/floor/wood,
-/area/clerk)
-"I" = (
+"x" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/clerk)
-"J" = (
+"y" = (
+/mob/living/simple_animal/spiffles,
 /turf/open/floor/wood,
 /area/clerk)
-"L" = (
+"z" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock{
+	name = "Gambling Hall"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "gamblinghall_ext"
+	},
+/turf/open/floor/wood,
+/area/clerk)
+"A" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/clerk)
+"B" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock{
+	name = "Gambling Hall"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "gamblinghall_ext"
+	},
+/turf/open/floor/wood,
+/area/clerk)
+"C" = (
+/obj/structure/chair/stool,
+/turf/open/floor/carpet/black,
+/area/clerk)
+"D" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "gamblinghall_ext"
+	},
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/clerk)
+"E" = (
 /obj/machinery/firealarm{
 	pixel_y = 28
 	},
@@ -227,26 +183,83 @@
 	},
 /turf/open/floor/wood,
 /area/clerk)
-"M" = (
-/obj/machinery/vending/gifts,
+"F" = (
+/obj/machinery/vending/autodrobe,
 /turf/open/floor/wood,
 /area/clerk)
-"N" = (
-/mob/living/simple_animal/spiffles,
+"G" = (
+/turf/closed/wall,
+/area/clerk)
+"H" = (
 /turf/open/floor/wood,
 /area/clerk)
-"O" = (
-/obj/structure/chair,
-/turf/open/floor/carpet/black,
+"I" = (
+/obj/machinery/vending/games,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood,
 /area/clerk)
-"P" = (
-/obj/structure/table/wood/poker,
-/obj/machinery/door/poddoor/shutters{
-	id = "gamblinghall"
+"J" = (
+/obj/machinery/vending/cola/random,
+/turf/open/floor/wood,
+/area/clerk)
+"K" = (
+/obj/item/storage/secure/safe{
+	pixel_x = 5;
+	pixel_y = -25
 	},
 /turf/open/floor/carpet/black,
 /area/clerk)
+"L" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/clerk)
+"N" = (
+/obj/structure/table/wood,
+/obj/machinery/paystand/register{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/clerk)
+"O" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/wood,
+/area/clerk)
+"P" = (
+/obj/structure/table/wood,
+/obj/item/a_gift{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/item/a_gift{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/turf/open/floor/wood,
+/area/clerk)
 "Q" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/clerk)
+"R" = (
 /obj/machinery/door/airlock{
 	name = "Gambling Hall";
 	req_access_txt = "36"
@@ -262,20 +275,55 @@
 	},
 /turf/open/floor/wood,
 /area/clerk)
-"R" = (
+"S" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/clerk)
+"T" = (
+/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock{
-	name = "Gambling Hall"
+	name = "Gambling Hall";
+	req_access_txt = "36"
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "gamblinghall_ext"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/wood,
+/area/clerk)
+"U" = (
+/obj/structure/table/wood/poker,
+/obj/machinery/door/poddoor/shutters{
+	id = "gamblinghall"
+	},
+/obj/item/toy/cards/deck,
+/turf/open/floor/carpet/black,
+/area/clerk)
+"V" = (
+/turf/open/floor/carpet/black,
+/area/clerk)
+"W" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
 	},
 /turf/open/floor/wood,
 /area/clerk)
-"S" = (
+"X" = (
+/obj/structure/chair/stool,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/clerk)
+"Y" = (
+/obj/effect/landmark/start/yogs/clerk,
+/turf/open/floor/carpet/black,
+/area/clerk)
+"Z" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
@@ -293,158 +341,114 @@
 	},
 /turf/open/floor/wood,
 /area/clerk)
-"T" = (
-/obj/structure/chair/stool,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/carpet/black,
-/area/clerk)
-"U" = (
-/obj/machinery/vending/games,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/clerk)
-"V" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood,
-/area/clerk)
-"W" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/carpet/black,
-/area/clerk)
-"Y" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock{
-	name = "Gambling Hall"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "gamblinghall_ext"
-	},
-/turf/open/floor/wood,
-/area/clerk)
-"Z" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/clerk)
 
 (1,1,1) = {"
-C
-D
-D
-D
-D
-D
-D
-D
-D
+j
+G
+G
+G
+G
+G
+G
+G
+G
 "}
 (2,1,1) = {"
-C
-D
-v
-l
-D
-a
-I
-V
-D
+j
+G
+P
+N
+G
+J
+x
+s
+G
 "}
 (3,1,1) = {"
-C
-D
-J
-S
-D
-A
-F
-J
-p
-"}
-(4,1,1) = {"
-C
-Q
-h
-B
-E
+j
 G
-z
-J
-R
-"}
-(5,1,1) = {"
-C
-D
-L
-i
-D
-t
-s
-J
-n
-"}
-(6,1,1) = {"
-D
-D
-b
-g
-e
-P
-d
-J
-Y
-"}
-(7,1,1) = {"
-D
-M
-q
-g
-O
-P
-W
+H
 Z
-n
-"}
-(8,1,1) = {"
-D
-U
-N
-g
-P
-P
-w
+G
+e
+d
 H
 D
 "}
-(9,1,1) = {"
-D
-y
-r
-u
-D
+(4,1,1) = {"
+j
+R
+O
+k
 T
-f
+n
+L
+H
+z
+"}
+(5,1,1) = {"
+j
+G
+E
+K
+G
+X
+Q
+H
+i
+"}
+(6,1,1) = {"
+G
+G
+q
+V
+U
+g
+S
+H
+B
+"}
+(7,1,1) = {"
+G
+h
+l
+Y
 m
-D
+g
+b
+t
+i
+"}
+(8,1,1) = {"
+G
+I
+y
+V
+g
+g
+C
+p
+G
+"}
+(9,1,1) = {"
+G
+F
+r
+f
+G
+w
+A
+W
+G
 "}
 (10,1,1) = {"
-D
-D
-D
-D
-D
-D
-D
-D
-D
+G
+G
+G
+G
+G
+G
+G
+G
+G
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/clerk_gamble.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/clerk_gamble.dmm
@@ -1,56 +1,119 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/mob/living/simple_animal/spiffles,
+/obj/machinery/vending/cola/random,
 /turf/open/floor/wood,
-/area/space)
+/area/clerk)
 "b" = (
-/obj/machinery/light{
+/obj/machinery/power/apc{
+	areastring = "/area/clerk";
+	dir = 1;
+	name = "Gift Shop APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/space)
-"c" = (
+/area/clerk)
+"d" = (
+/obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/clerk)
+"e" = (
+/obj/structure/table/wood/poker,
+/obj/machinery/door/poddoor/shutters{
+	id = "gamblinghall"
+	},
+/obj/item/toy/cards/deck,
+/turf/open/floor/carpet/black,
+/area/clerk)
+"f" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/carpet/black,
+/area/clerk)
+"g" = (
+/turf/open/floor/carpet/black,
+/area/clerk)
+"h" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/wood,
+/area/clerk)
+"i" = (
+/obj/item/storage/secure/safe{
+	pixel_x = 5;
+	pixel_y = -25
+	},
+/turf/open/floor/carpet/black,
+/area/clerk)
+"l" = (
+/obj/structure/table/wood,
+/obj/machinery/paystand/register{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/wood,
-/area/space)
-"d" = (
-/obj/machinery/vending/autodrobe,
-/turf/open/floor/wood,
-/area/space)
-"e" = (
+/area/clerk)
+"m" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
 /turf/open/floor/wood,
-/area/space)
-"f" = (
+/area/clerk)
+"n" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "gamblinghall_ext"
+	},
+/turf/open/floor/plating,
+/area/clerk)
+"p" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "gamblinghall_ext"
 	},
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/clerk)
-"g" = (
+"q" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/clerk)
+"r" = (
 /obj/structure/chair/stool,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
 /turf/open/floor/wood,
-/area/space)
-"h" = (
-/obj/structure/table/wood/poker,
-/obj/machinery/door/poddoor/shutters{
-	id = "gamblinghall"
+/area/clerk)
+"s" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/item/toy/cards/deck,
-/turf/open/floor/wood,
-/area/space)
-"i" = (
+/turf/open/floor/carpet/black,
+/area/clerk)
+"t" = (
+/obj/structure/chair/stool,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/clerk)
+"u" = (
 /obj/structure/table/wood,
 /obj/item/coinstack,
 /obj/item/coin/gold,
@@ -61,9 +124,158 @@
 /obj/item/coin/diamond,
 /obj/item/coin/iron,
 /obj/item/coin/iron,
+/turf/open/floor/carpet/black,
+/area/clerk)
+"v" = (
+/obj/structure/table/wood,
+/obj/item/a_gift{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/item/a_gift{
+	pixel_x = 7;
+	pixel_y = 4
+	},
 /turf/open/floor/wood,
-/area/space)
-"k" = (
+/area/clerk)
+"w" = (
+/obj/structure/chair/stool,
+/turf/open/floor/carpet/black,
+/area/clerk)
+"y" = (
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/wood,
+/area/clerk)
+"z" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/clerk)
+"A" = (
+/obj/machinery/camera{
+	c_tag = "Clerk's Gambling Hall"
+	},
+/turf/open/floor/wood,
+/area/clerk)
+"B" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/wood,
+/area/clerk)
+"C" = (
+/turf/template_noop,
+/area/template_noop)
+"D" = (
+/turf/closed/wall,
+/area/clerk)
+"E" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock{
+	name = "Gambling Hall";
+	req_access_txt = "36"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/wood,
+/area/clerk)
+"F" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/clerk)
+"G" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/wood,
+/area/clerk)
+"H" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/open/floor/wood,
+/area/clerk)
+"I" = (
+/obj/machinery/vending/coffee,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/clerk)
+"J" = (
+/turf/open/floor/wood,
+/area/clerk)
+"L" = (
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/clerk)
+"M" = (
+/obj/machinery/vending/gifts,
+/turf/open/floor/wood,
+/area/clerk)
+"N" = (
+/mob/living/simple_animal/spiffles,
+/turf/open/floor/wood,
+/area/clerk)
+"O" = (
+/obj/structure/chair,
+/turf/open/floor/carpet/black,
+/area/clerk)
+"P" = (
+/obj/structure/table/wood/poker,
+/obj/machinery/door/poddoor/shutters{
+	id = "gamblinghall"
+	},
+/turf/open/floor/carpet/black,
+/area/clerk)
+"Q" = (
+/obj/machinery/door/airlock{
+	name = "Gambling Hall";
+	req_access_txt = "36"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/clerk)
+"R" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock{
+	name = "Gambling Hall"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "gamblinghall_ext"
+	},
+/turf/open/floor/wood,
+/area/clerk)
+"S" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
@@ -80,209 +292,33 @@
 	pixel_y = -24
 	},
 /turf/open/floor/wood,
-/area/space)
-"l" = (
-/turf/open/floor/wood,
-/area/space)
-"m" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock{
-	name = "Gambling Hall"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "gamblinghall_ext"
-	},
-/turf/open/floor/wood,
 /area/clerk)
-"n" = (
-/obj/machinery/camera{
-	c_tag = "Clerk's Gambling Hall"
+"T" = (
+/obj/structure/chair/stool,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
-/turf/open/floor/wood,
-/area/space)
-"o" = (
-/obj/structure/table/wood,
-/obj/item/a_gift{
-	pixel_x = -5;
-	pixel_y = -2
-	},
-/obj/item/a_gift{
-	pixel_x = 7;
-	pixel_y = 4
-	},
-/turf/open/floor/wood,
-/area/space)
-"q" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/wood,
-/area/space)
-"r" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/open/floor/wood,
-/area/space)
-"s" = (
-/obj/structure/chair,
-/turf/open/floor/wood,
-/area/space)
-"t" = (
-/obj/structure/table/wood,
-/obj/machinery/paystand/register{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/space)
-"u" = (
-/obj/structure/table/wood/poker,
-/obj/machinery/door/poddoor/shutters{
-	id = "gamblinghall"
-	},
-/turf/open/floor/wood,
-/area/space)
-"v" = (
-/turf/template_noop,
-/area/template_noop)
-"w" = (
+/turf/open/floor/carpet/black,
+/area/clerk)
+"U" = (
 /obj/machinery/vending/games,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/space)
-"x" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/space)
-"y" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/wood,
-/area/space)
-"z" = (
+/area/clerk)
+"V" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
-/area/space)
-"A" = (
-/obj/machinery/vending/gifts,
-/turf/open/floor/wood,
-/area/space)
-"B" = (
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/space)
-"C" = (
-/obj/structure/chair/stool,
-/turf/open/floor/wood,
-/area/space)
-"E" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/space)
-"F" = (
-/obj/machinery/door/airlock{
-	name = "Gambling Hall";
-	req_access_txt = "36"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
 /area/clerk)
-"G" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "gamblinghall_ext"
-	},
-/turf/open/floor/plating,
-/area/clerk)
-"H" = (
-/obj/item/storage/secure/safe{
-	pixel_x = 5;
-	pixel_y = -25
-	},
-/turf/open/floor/wood,
-/area/space)
-"J" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock{
-	name = "Gambling Hall";
-	req_access_txt = "36"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/wood,
-/area/space)
-"L" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/wood,
-/area/space)
-"N" = (
-/obj/structure/chair/stool,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/space)
-"O" = (
-/turf/closed/wall,
-/area/clerk)
-"P" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/space)
-"R" = (
+"W" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
-/turf/open/floor/wood,
-/area/space)
-"S" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/space)
-"U" = (
+/turf/open/floor/carpet/black,
+/area/clerk)
+"Y" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -295,152 +331,120 @@
 	},
 /turf/open/floor/wood,
 /area/clerk)
-"V" = (
-/turf/closed/wall,
-/area/space)
-"W" = (
+"Z" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/wood,
-/area/space)
-"X" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/space)
-"Y" = (
-/obj/machinery/power/apc{
-	areastring = "/area/clerk";
-	dir = 1;
-	name = "Gift Shop APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/space)
-"Z" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/wood,
-/area/space)
+/area/clerk)
 
 (1,1,1) = {"
-v
-O
-O
-O
-O
-O
-O
-O
-O
+C
+D
+D
+D
+D
+D
+D
+D
+D
 "}
 (2,1,1) = {"
+C
+D
 v
-O
-o
-t
+l
+D
+a
+I
 V
-L
-x
-z
-O
+D
 "}
 (3,1,1) = {"
-v
-O
-l
-k
-V
-n
-P
-l
-f
+C
+D
+J
+S
+D
+A
+F
+J
+p
 "}
 (4,1,1) = {"
-v
-F
-q
-Z
+C
+Q
+h
+B
+E
+G
+z
 J
-y
-c
-l
-m
+R
 "}
 (5,1,1) = {"
-v
-O
-B
-H
-V
-N
-E
-l
-G
+C
+D
+L
+i
+D
+t
+s
+J
+n
 "}
 (6,1,1) = {"
-O
-O
+D
+D
+b
+g
+e
+P
+d
+J
 Y
-l
-h
-u
-X
-l
-U
 "}
 (7,1,1) = {"
+D
+M
+q
+g
 O
-A
-S
-l
-s
-u
-R
+P
 W
-G
+Z
+n
 "}
 (8,1,1) = {"
-O
+D
+U
+N
+g
+P
+P
 w
-a
-l
-u
-u
-C
-r
-O
+H
+D
 "}
 (9,1,1) = {"
-O
-d
-C
-i
-V
-g
-b
-e
-O
+D
+y
+r
+u
+D
+T
+f
+m
+D
 "}
 (10,1,1) = {"
-O
-O
-O
-O
-O
-O
-O
-O
-O
+D
+D
+D
+D
+D
+D
+D
+D
+D
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/clerk_gamble.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/clerk_gamble.dmm
@@ -1,0 +1,431 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/open/floor/wood,
+/area/space)
+"d" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/space)
+"e" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/wood,
+/area/space)
+"f" = (
+/obj/machinery/camera{
+	c_tag = "Clerk's Gambling Hall"
+	},
+/turf/open/floor/wood,
+/area/space)
+"g" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop_ext"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock{
+	name = "Gambling Hall"
+	},
+/turf/open/floor/wood,
+/area/clerk)
+"h" = (
+/obj/item/storage/secure/safe{
+	pixel_x = 5;
+	pixel_y = -25
+	},
+/turf/open/floor/wood,
+/area/space)
+"i" = (
+/obj/machinery/vending/coffee,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/space)
+"j" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood,
+/area/space)
+"k" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/space)
+"l" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/wood,
+/area/space)
+"m" = (
+/obj/structure/chair,
+/turf/open/floor/wood,
+/area/space)
+"n" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/space)
+"o" = (
+/obj/machinery/power/apc{
+	areastring = "/area/clerk";
+	dir = 1;
+	name = "Gift Shop APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/space)
+"p" = (
+/obj/structure/table/wood/poker,
+/obj/machinery/door/poddoor/shutters{
+	id = "giftshop"
+	},
+/turf/open/floor/wood,
+/area/space)
+"q" = (
+/obj/machinery/vending/cola/random,
+/turf/open/floor/wood,
+/area/space)
+"s" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/space)
+"t" = (
+/turf/template_noop,
+/area/template_noop)
+"w" = (
+/turf/closed/wall,
+/area/space)
+"x" = (
+/obj/structure/table/wood,
+/obj/item/coinstack,
+/obj/item/coin/gold,
+/obj/item/coin/gold,
+/obj/item/coin/gold,
+/obj/item/coin/plasma,
+/obj/item/coin/uranium,
+/obj/item/coin/diamond,
+/obj/item/coin/iron,
+/obj/item/coin/iron,
+/turf/open/floor/wood,
+/area/space)
+"y" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/wood,
+/area/space)
+"z" = (
+/obj/structure/table/wood,
+/obj/item/a_gift{
+	pixel_x = -5;
+	pixel_y = -2
+	},
+/obj/item/a_gift{
+	pixel_x = 7;
+	pixel_y = 4
+	},
+/turf/open/floor/wood,
+/area/space)
+"A" = (
+/obj/machinery/vending/gifts,
+/turf/open/floor/wood,
+/area/space)
+"B" = (
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/space)
+"C" = (
+/obj/machinery/door/airlock{
+	name = "Gambling Hall";
+	req_access_txt = "36"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/clerk)
+"D" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/space)
+"E" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop_ext"
+	},
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/clerk)
+"F" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock{
+	name = "Gambling Hall";
+	req_access_txt = "36"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/wood,
+/area/space)
+"G" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/space)
+"H" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop_ext"
+	},
+/turf/open/floor/plating,
+/area/clerk)
+"I" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "giftshop_ext"
+	},
+/obj/machinery/door/airlock{
+	name = "Gambling Hall"
+	},
+/turf/open/floor/wood,
+/area/clerk)
+"J" = (
+/obj/machinery/vending/games,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/space)
+"K" = (
+/obj/structure/chair/stool,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/wood,
+/area/space)
+"L" = (
+/mob/living/simple_animal/spiffles,
+/turf/open/floor/wood,
+/area/space)
+"N" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/space)
+"P" = (
+/obj/structure/chair/stool,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/space)
+"Q" = (
+/obj/machinery/vending/autodrobe,
+/turf/open/floor/wood,
+/area/space)
+"R" = (
+/turf/closed/wall,
+/area/clerk)
+"S" = (
+/obj/structure/table/wood/poker,
+/obj/machinery/door/poddoor/shutters{
+	id = "giftshop"
+	},
+/obj/item/toy/cards/deck,
+/turf/open/floor/wood,
+/area/space)
+"T" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/wood,
+/area/space)
+"U" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/space)
+"V" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/space)
+"W" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/open/floor/wood,
+/area/space)
+"Y" = (
+/obj/structure/table/wood,
+/obj/machinery/paystand/register{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/space)
+"Z" = (
+/obj/structure/chair/stool,
+/turf/open/floor/wood,
+/area/space)
+
+(1,1,1) = {"
+t
+R
+R
+R
+R
+R
+R
+R
+R
+"}
+(2,1,1) = {"
+t
+R
+z
+Y
+w
+q
+i
+j
+R
+"}
+(3,1,1) = {"
+t
+R
+a
+s
+w
+f
+D
+a
+E
+"}
+(4,1,1) = {"
+t
+C
+l
+T
+F
+y
+V
+a
+g
+"}
+(5,1,1) = {"
+t
+R
+B
+h
+w
+P
+k
+a
+E
+"}
+(6,1,1) = {"
+R
+R
+o
+a
+S
+p
+G
+a
+I
+"}
+(7,1,1) = {"
+R
+A
+n
+a
+m
+p
+N
+d
+H
+"}
+(8,1,1) = {"
+R
+J
+L
+a
+p
+p
+Z
+W
+R
+"}
+(9,1,1) = {"
+R
+Q
+Z
+x
+w
+K
+U
+e
+R
+"}
+(10,1,1) = {"
+R
+R
+R
+R
+R
+R
+R
+R
+R
+"}

--- a/_maps/RandomRuins/StationRuins/BoxStation/clerk_gamble.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/clerk_gamble.dmm
@@ -1,11 +1,25 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
+/mob/living/simple_animal/spiffles,
+/turf/open/floor/wood,
+/area/space)
+"b" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/space)
+"c" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
 /turf/open/floor/wood,
 /area/space)
 "d" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
+/obj/machinery/vending/autodrobe,
 /turf/open/floor/wood,
 /area/space)
 "e" = (
@@ -15,108 +29,28 @@
 /turf/open/floor/wood,
 /area/space)
 "f" = (
-/obj/machinery/camera{
-	c_tag = "Clerk's Gambling Hall"
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "gamblinghall_ext"
+	},
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/clerk)
+"g" = (
+/obj/structure/chair/stool,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
 /turf/open/floor/wood,
 /area/space)
-"g" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop_ext"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock{
-	name = "Gambling Hall"
-	},
-/turf/open/floor/wood,
-/area/clerk)
 "h" = (
-/obj/item/storage/secure/safe{
-	pixel_x = 5;
-	pixel_y = -25
+/obj/structure/table/wood/poker,
+/obj/machinery/door/poddoor/shutters{
+	id = "gamblinghall"
 	},
+/obj/item/toy/cards/deck,
 /turf/open/floor/wood,
 /area/space)
 "i" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/space)
-"j" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood,
-/area/space)
-"k" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/space)
-"l" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/wood,
-/area/space)
-"m" = (
-/obj/structure/chair,
-/turf/open/floor/wood,
-/area/space)
-"n" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/space)
-"o" = (
-/obj/machinery/power/apc{
-	areastring = "/area/clerk";
-	dir = 1;
-	name = "Gift Shop APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/space)
-"p" = (
-/obj/structure/table/wood/poker,
-/obj/machinery/door/poddoor/shutters{
-	id = "giftshop"
-	},
-/turf/open/floor/wood,
-/area/space)
-"q" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/wood,
-/area/space)
-"s" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/space)
-"t" = (
-/turf/template_noop,
-/area/template_noop)
-"w" = (
-/turf/closed/wall,
-/area/space)
-"x" = (
 /obj/structure/table/wood,
 /obj/item/coinstack,
 /obj/item/coin/gold,
@@ -129,12 +63,47 @@
 /obj/item/coin/iron,
 /turf/open/floor/wood,
 /area/space)
-"y" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+"k" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "gamblinghall";
+	name = "Gift Shop Internal Shutters";
+	pixel_x = -6;
+	pixel_y = -24
+	},
+/obj/machinery/button/door{
+	id = "gamblinghall_ext";
+	name = "Gift Shop External Shutters";
+	pixel_x = 6;
+	pixel_y = -24
+	},
 /turf/open/floor/wood,
 /area/space)
-"z" = (
+"l" = (
+/turf/open/floor/wood,
+/area/space)
+"m" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock{
+	name = "Gambling Hall"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "gamblinghall_ext"
+	},
+/turf/open/floor/wood,
+/area/clerk)
+"n" = (
+/obj/machinery/camera{
+	c_tag = "Clerk's Gambling Hall"
+	},
+/turf/open/floor/wood,
+/area/space)
+"o" = (
 /obj/structure/table/wood,
 /obj/item/a_gift{
 	pixel_x = -5;
@@ -144,6 +113,71 @@
 	pixel_x = 7;
 	pixel_y = 4
 	},
+/turf/open/floor/wood,
+/area/space)
+"q" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/wood,
+/area/space)
+"r" = (
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -28
+	},
+/turf/open/floor/wood,
+/area/space)
+"s" = (
+/obj/structure/chair,
+/turf/open/floor/wood,
+/area/space)
+"t" = (
+/obj/structure/table/wood,
+/obj/machinery/paystand/register{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/space)
+"u" = (
+/obj/structure/table/wood/poker,
+/obj/machinery/door/poddoor/shutters{
+	id = "gamblinghall"
+	},
+/turf/open/floor/wood,
+/area/space)
+"v" = (
+/turf/template_noop,
+/area/template_noop)
+"w" = (
+/obj/machinery/vending/games,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/space)
+"x" = (
+/obj/machinery/vending/coffee,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/space)
+"y" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/wood,
+/area/space)
+"z" = (
+/obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
 /area/space)
 "A" = (
@@ -163,6 +197,16 @@
 /turf/open/floor/wood,
 /area/space)
 "C" = (
+/obj/structure/chair/stool,
+/turf/open/floor/wood,
+/area/space)
+"E" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/space)
+"F" = (
 /obj/machinery/door/airlock{
 	name = "Gambling Hall";
 	req_access_txt = "36"
@@ -178,20 +222,21 @@
 	},
 /turf/open/floor/wood,
 /area/clerk)
-"D" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
+"G" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "gamblinghall_ext"
+	},
+/turf/open/floor/plating,
+/area/clerk)
+"H" = (
+/obj/item/storage/secure/safe{
+	pixel_x = 5;
+	pixel_y = -25
 	},
 /turf/open/floor/wood,
 /area/space)
-"E" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop_ext"
-	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/clerk)
-"F" = (
+"J" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -204,228 +249,198 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/space)
-"G" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
+"L" = (
+/obj/machinery/vending/cola/random,
 /turf/open/floor/wood,
 /area/space)
-"H" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop_ext"
-	},
-/turf/open/floor/plating,
-/area/clerk)
-"I" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "giftshop_ext"
-	},
-/obj/machinery/door/airlock{
-	name = "Gambling Hall"
-	},
-/turf/open/floor/wood,
-/area/clerk)
-"J" = (
-/obj/machinery/vending/games,
+"N" = (
+/obj/structure/chair/stool,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/wood,
 /area/space)
-"K" = (
-/obj/structure/chair/stool,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+"O" = (
+/turf/closed/wall,
+/area/clerk)
+"P" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/space)
-"L" = (
-/mob/living/simple_animal/spiffles,
-/turf/open/floor/wood,
-/area/space)
-"N" = (
+"R" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
 /turf/open/floor/wood,
 /area/space)
-"P" = (
-/obj/structure/chair/stool,
-/obj/machinery/light{
+"S" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/space)
+"U" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock{
+	name = "Gambling Hall"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "gamblinghall_ext"
+	},
+/turf/open/floor/wood,
+/area/clerk)
+"V" = (
+/turf/closed/wall,
+/area/space)
+"W" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
 /turf/open/floor/wood,
 /area/space)
-"Q" = (
-/obj/machinery/vending/autodrobe,
-/turf/open/floor/wood,
-/area/space)
-"R" = (
-/turf/closed/wall,
-/area/clerk)
-"S" = (
-/obj/structure/table/wood/poker,
-/obj/machinery/door/poddoor/shutters{
-	id = "giftshop"
+"X" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/item/toy/cards/deck,
 /turf/open/floor/wood,
 /area/space)
-"T" = (
+"Y" = (
+/obj/machinery/power/apc{
+	areastring = "/area/clerk";
+	dir = 1;
+	name = "Gift Shop APC";
+	pixel_y = 23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/space)
+"Z" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/space)
-"U" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/space)
-"V" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/wood,
-/area/space)
-"W" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -28
-	},
-/turf/open/floor/wood,
-/area/space)
-"Y" = (
-/obj/structure/table/wood,
-/obj/machinery/paystand/register{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/space)
-"Z" = (
-/obj/structure/chair/stool,
-/turf/open/floor/wood,
-/area/space)
 
 (1,1,1) = {"
-t
-R
-R
-R
-R
-R
-R
-R
-R
+v
+O
+O
+O
+O
+O
+O
+O
+O
 "}
 (2,1,1) = {"
+v
+O
+o
 t
-R
+V
+L
+x
 z
-Y
-w
-q
-i
-j
-R
+O
 "}
 (3,1,1) = {"
-t
-R
-a
-s
-w
+v
+O
+l
+k
+V
+n
+P
+l
 f
-D
-a
-E
 "}
 (4,1,1) = {"
-t
-C
-l
-T
+v
 F
+q
+Z
+J
 y
-V
-a
-g
+c
+l
+m
 "}
 (5,1,1) = {"
-t
-R
+v
+O
 B
-h
-w
-P
-k
-a
+H
+V
+N
 E
+l
+G
 "}
 (6,1,1) = {"
-R
-R
-o
-a
-S
-p
-G
-a
-I
+O
+O
+Y
+l
+h
+u
+X
+l
+U
 "}
 (7,1,1) = {"
-R
+O
 A
-n
-a
-m
-p
-N
-d
-H
+S
+l
+s
+u
+R
+W
+G
 "}
 (8,1,1) = {"
-R
-J
-L
+O
+w
 a
-p
-p
-Z
-W
-R
+l
+u
+u
+C
+r
+O
 "}
 (9,1,1) = {"
-R
-Q
-Z
-x
-w
-K
-U
+O
+d
+C
+i
+V
+g
+b
 e
-R
+O
 "}
 (10,1,1) = {"
-R
-R
-R
-R
-R
-R
-R
-R
-R
+O
+O
+O
+O
+O
+O
+O
+O
+O
 "}

--- a/_maps/RandomRuins/StationRuins/BoxStation/clerk_meta.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/clerk_meta.dmm
@@ -36,6 +36,19 @@
 	},
 /turf/open/indestructible/carpet/black,
 /area/clerk)
+"f" = (
+/obj/effect/turf_decal/tile/yellow/opposingcorners,
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/clerk";
+	dir = 1;
+	name = "Gift Shop APC";
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/dark,
+/area/clerk)
 "g" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /turf/open/floor/plasteel/dark,
@@ -251,19 +264,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/clerk)
-"F" = (
-/obj/effect/turf_decal/tile/yellow/opposingcorners,
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/clerk";
-	dir = 4;
-	name = "Gift Shop APC";
-	pixel_y = 27
 	},
 /turf/open/floor/plasteel/dark,
 /area/clerk)
@@ -491,7 +491,7 @@ a
 "}
 (7,1,1) = {"
 a
-F
+f
 r
 Y
 h

--- a/code/_globalvars/lists/mapping.dm
+++ b/code/_globalvars/lists/mapping.dm
@@ -44,7 +44,7 @@ GLOBAL_LIST_EMPTY(ruin_landmarks)
 GLOBAL_LIST_EMPTY(bar_areas)
 // IF YOU ARE MAKING A NEW BAR TEMPLATE AND WANT IT ROUNDSTART ADD IT TO THIS LIST!
 GLOBAL_LIST_INIT(potential_box_bars, list("Bar Trek", "Bar Spacious", "Bar Box", "Bar Casino", "Bar Citadel", "Bar Conveyor", "Bar Diner", "Bar Disco", "Bar Purple", "Bar Cheese", "Bar Grassy", "Bar Clock", "Bar Arcade"))
-GLOBAL_LIST_INIT(potential_box_clerk, list("Clerk Box", "Clerk Pod", "Clerk Meta"))
+GLOBAL_LIST_INIT(potential_box_clerk, list("Clerk Box", "Clerk Pod", "Clerk Meta", "Clerk Gambling Hall"))
 
 /// Away missions
 GLOBAL_LIST_EMPTY(awaydestinations)	//a list of landmarks that the warpgate can take you to

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -680,6 +680,10 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 /obj/item/coinstack/Initialize(mapload)
 	. = ..()
 	coins = list()
+	var/turf/T = get_turf()
+	if(T)
+		for(var/obj/item/coin/C in T.contents)
+			add_to_stack(C, null, FALSE)
 	update_appearance(UPDATE_ICON)
 
 /obj/item/coinstack/examine(mob/user)
@@ -721,8 +725,9 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	C.forceMove(src)
 	C.pixel_x = 0
 	C.pixel_y = 0
-	src.add_fingerprint(user)
-	to_chat(user,span_notice("You add [C] to the stack of coins."))
+	if(user)
+		src.add_fingerprint(user)
+		to_chat(user,span_notice("You add [C] to the stack of coins."))
 	update_appearance(UPDATE_ICON)
 	return TRUE
 

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -680,7 +680,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 /obj/item/coinstack/Initialize(mapload)
 	. = ..()
 	coins = list()
-	var/turf/T = get_turf()
+	var/turf/T = get_turf(src)
 	if(T)
 		for(var/obj/item/coin/C in T.contents)
 			add_to_stack(C, null, FALSE)

--- a/yogstation/code/datums/ruins/station.dm
+++ b/yogstation/code/datums/ruins/station.dm
@@ -290,6 +290,11 @@
 	suffix = "clerk_meta.dmm"
 	name = "Clerk Meta"
 
+/datum/map_template/ruin/station/box/clerk/gamble
+	id = "clerk_gamble"
+	suffix = "clerk_gamble.dmm"
+	name = "Clerk Gambling Hall"
+
 /datum/map_template/ruin/station/meta
 	prefix = "_maps/RandomRuins/StationRuins/MetaStation/"
 

--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -102,7 +102,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	return TRUE
 
 /obj/effect/landmark/stationroom/box/clerk
-	template_names = list("Clerk Box", "Clerk Pod", "Clerk Meta")
+	template_names = list("Clerk Box", "Clerk Pod", "Clerk Meta", "Clerk Gambling Hall")
 
 /obj/effect/landmark/stationroom/box/clerk/load(template_name)
 	GLOB.stationroom_landmarks -= src


### PR DESCRIPTION
# Document the changes in your pull request

Adds a new clerk template that's a gambling hall. Deck of cards under the shutters, Poker table under that. Some coins spawn on the table in a stack for you to use as a little boost for gambling money.

Excludes any slot machines as the interaction within should be with the Clerk, but there are some places to add some.

![image](https://github.com/yogstation13/Yogstation/assets/5091394/1fa8d8fc-0bd0-424d-bb7c-8c85b116c18c)


# Why is this good for the game?
Some more gameplay for Clerk, I've seen this transformation done multiple times to instead make Clerk a job that takes other's money through gambling (the house always wins) compared to greytiding into various places, stealing stuff, and then trying to sell it.

# Changelog

:cl:  
mapping: Gives Clerk a new template where instead of a giftshop it's a gambling hall.
rscadd: Gives coinstacks the ability to be maploaded in. 
/:cl:
