### PR TITLE
Bo Staff now makes you unconscious instead of sleeping you

### DIFF
--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -242,7 +242,7 @@
 			if(total_health <= HEALTH_THRESHOLD_CRIT && !H.stat)
 				H.visible_message(span_warning("[user] delivers a heavy hit to [H]'s head, knocking [H.p_them()] out cold!"), \
 									   span_userdanger("[user] knocks you unconscious!"))
-				H.SetSleeping(300)
+				H.SetUnconscious(30 SECONDS)
 				H.adjustOrganLoss(ORGAN_SLOT_BRAIN, 15, 150)
 	else
 		return ..()


### PR DESCRIPTION

# Document the changes in your pull request
bo staff now makes you unconcious instead of sleeping you

# Why is this good for the game?
Way too easy to pair with the hypno flash. Now you need to put in more effort and put a N2O tank on their back.

# Testing
probably works its a 1 line change

# Wiki Documentation
nothing

# Changelog

:cl:  
tweak: Bo Staff now makes you unconscious instead of sleeping
/:cl:
