### PR TITLE
Bugfix: Allows heretics to actually get points when sacrificing targets (sorry...)

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_transmutations.dm
@@ -195,6 +195,7 @@
 			
 			else
 				EC.charge += 2
+			LH.target = null
 			EC.total_sacrifices++
 
 		if(QDELETED(LH.target))

--- a/code/modules/antagonists/eldritch_cult/eldritch_transmutations.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_transmutations.dm
@@ -181,7 +181,6 @@
 			to_chat(carbon_user,span_danger("Your patrons accepts your offer.."))
 			var/mob/living/carbon/human/H = LH.target
 			H.apply_status_effect(STATUS_EFFECT_BRAZIL_PENANCE)
-			LH.target = null
 			var/datum/antagonist/heretic/EC = carbon_user.mind.has_antag_datum(/datum/antagonist/heretic)
 
 			if(LH.target.mind.has_antag_datum(/datum/antagonist/heretic))


### PR DESCRIPTION
# Document the changes in your pull request

ok so remember that PR I made that made it so people cost more points if they're sec/command/heretic. Well, it kinda broke gaining points by sacrificing. Whoops! It's ok though this one fixes it

# Testing
Somehow I fixed my private server and can sacrifice myself, yes this was tested with all 4 different conditions.

# Changelog

:cl:  

bugfix: fixes heretic sacrifices not giving points

/:cl:
