### PR TITLE
Ided nerfs venus human traps

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -87,8 +87,8 @@
 	ranged = TRUE
 	harm_intent_damage = 5
 	obj_damage = 60
-	melee_damage_lower = 25
-	melee_damage_upper = 25
+	melee_damage_lower = 20
+	melee_damage_upper = 20
 	a_intent = INTENT_HARM
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
@@ -110,12 +110,13 @@
 /mob/living/simple_animal/hostile/venus_human_trap/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/life_draining, damage_overtime = 5, check_damage_callback = CALLBACK(src, PROC_REF(kudzu_need)))
+	remove_verb(src, /mob/living/verb/pulled) //no dragging the poor sap into the depths of the vines never to be seen again (also no water tanks)
 
 /mob/living/simple_animal/hostile/venus_human_trap/Life(seconds_per_tick = SSMOBS_DT, times_fired)
 	. = ..()
 	pull_vines()
 	if(check_gas())
-		adjustHealth(6)
+		adjustHealth(15)
 		to_chat(src, span_danger("The gas reacts with you and starts to melt you away!"))
 	
 /mob/living/simple_animal/hostile/venus_human_trap/AttackingTarget()


### PR DESCRIPTION
# Why is this good for the game?
Vines are already degenerate enough by themselves, it's made even worse when a venus human trap can legitimately kill someone in seconds after a ranged cc grab

:cl:  
tweak: Venus human traps can no longer pull things
tweak: Venus human traps deal 5 less damage on attacks
tweak: Venus human traps take 15 damage per tick from weedkiller rather than 6 damage
/:cl:
