### PR TITLE
Botanist lockers now spawn with a scythe and weedkiller grenade in them

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
@@ -11,3 +11,4 @@
 	new /obj/item/cultivator(src)
 	new /obj/item/hatchet(src)
 	new /obj/item/storage/box/disks_plantgene(src)
+	new /obj/item/scythe(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/hydroponics.dm
@@ -12,3 +12,4 @@
 	new /obj/item/hatchet(src)
 	new /obj/item/storage/box/disks_plantgene(src)
 	new /obj/item/scythe(src)
+	new /obj/item/grenade/chem_grenade/antiweed(src)


### PR DESCRIPTION
# Why is this good for the game?
So botany can be expected to fight space vines if they come up
They're worse weapons that toolboxes, so it'll be fine

:cl:  
tweak: Botanist lockers now spawn with a scythe and a weedkiller grenade in them
/:cl:
