### PR TITLE
Makes sol dry not almost as good as actual medicine

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -997,7 +997,7 @@
 	glass_desc = "A soothing, mellow drink made from ginger."
 
 /datum/reagent/consumable/sol_dry/on_mob_life(mob/living/carbon/M)
-	M.adjust_disgust(-5)
+	M.adjust_disgust(-1)
 	..()
 
 /datum/reagent/consumable/red_queen


### PR DESCRIPTION
Stop side-stepping my nerfs goddamnit! Disgust shouldn't be this easy to remove!

# Document the changes in your pull request

Sol dry (the soda you can buy from any soda vendor) now merely triples your disgust drain. Still good, but not where it was which was almost the same level as psicodine, an actual medicine that isn't all over the station.

# Why is this good for the game?

Helps make disgust still an annoying and potentially debilitating debuff if you're not careful with it. Also helps prevent continued abuse of certain mechanics that I was pretty sure I had already solved a while back.

# Testing

Just a number change.

# Wiki Documentation

It moderately reduces disgust levels rather than significantly.

# Changelog

:cl:  
  
tweak: Sol dry is no longer almost as good as real medicine

/:cl:
