### PR TITLE
Removes the 8 seconds of confusion from stun baton hits.

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -221,11 +221,9 @@
 		else
 			L.Paralyze(stunforce)
 		L.adjust_jitter(20 SECONDS)
-		L.adjust_confusion(8 SECONDS)
 		L.apply_effect(EFFECT_STUTTER, stunforce)
 	else if(current_stamina_damage > 70)
 		L.adjust_jitter(10 SECONDS)
-		L.adjust_confusion(8 SECONDS)
 		L.apply_effect(EFFECT_STUTTER, stunforce)
 	else if(current_stamina_damage >= 20)
 		L.adjust_jitter(5 SECONDS)


### PR DESCRIPTION
# Document the changes in your pull request

The eight seconds of confusion victims face when struck by a stun baton is removed.

# Why is this good for the game?

The baton is a two hit stun weapon, having an eight second confusion attached to the first hit makes it nearly impossible to avoid the second.

# Changelog

:cl:   
tweak: Stun batons no longer confuse their victims.
/:cl:
