### PR TITLE
Lets space vines spread through firelocks that aren't welded shut

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -528,13 +528,12 @@
 							if(master)
 								master.spawn_spacevine_piece(stepturf, src)
 					else
-						if(!istype(D, /obj/machinery/door/firedoor))
-							D.open()
-							for(var/datum/spacevine_mutation/SM in mutations)
-								SM.on_spread(src, stepturf)
-								stepturf = get_step(src,direction)
-							if(master)
-								master.spawn_spacevine_piece(stepturf, src)
+						D.open()
+						for(var/datum/spacevine_mutation/SM in mutations)
+							SM.on_spread(src, stepturf)
+							stepturf = get_step(src,direction)
+						if(master)
+							master.spawn_spacevine_piece(stepturf, src)
 
 /obj/structure/spacevine/ex_act(severity, target)
 	if(istype(target, type)) //if its agressive spread vine dont do anything


### PR DESCRIPTION
# Why is this good for the game?
it's a needless restriction to the growing of space vines and there's no reason they shouldn't be able open a firelock
it just forces venus human traps to relentlessly attack firelocks because they restrict the spread of the vines

also, i couldn't make the firelocks render ontop of vines because then they'd render ontop of players
and if i shifted vines down so firelocks still rendered under, then the vines would be under players

:cl:  
tweak: space vines can spread through firelocks that aren't welded shut
/:cl:
