### PR TITLE
Esword Quick Time Event Blocking

### DIFF
--- a/code/__HELPERS/mouse_control.dm
+++ b/code/__HELPERS/mouse_control.dm
@@ -50,3 +50,38 @@
 		p_x = text2num(screen_loc_X[2])
 		p_y = text2num(screen_loc_Y[2])
 		return new /datum/position(x, y, z, p_x, p_y)
+
+/// Accepts a string screen_loc. NORTH, WEST, CENTER, etc are not allowed
+/proc/absolute_datum_map_position_from_screen_loc(client/client, screen_loc)
+	if(!isloc(client.mob.loc))
+		return
+	var/atom/A = client.eye
+	var/turf/T = get_turf(A)
+	var/cx = T.x
+	var/cy = T.y
+	var/cz = T.z
+	var/x = 0
+	var/y = 0
+	var/z = 0
+	var/p_x = 0
+	var/p_y = 0
+	//Split screen-loc up into X+Pixel_X and Y+Pixel_Y
+	var/list/screen_loc_params = splittext(screen_loc, ",")
+	//Split X+Pixel_X up into list(X, Pixel_X)
+	var/list/screen_loc_X = splittext(screen_loc_params[1],":")
+	//Split Y+Pixel_Y up into list(Y, Pixel_Y)
+	var/list/screen_loc_Y = splittext(screen_loc_params[2],":")
+	var/sx = text2num(screen_loc_X[1])
+	var/sy = text2num(screen_loc_Y[1])
+	//Get the resolution of the client's current screen size.
+	var/list/screenview = getviewsize(client.view)
+	var/svx = screenview[1]
+	var/svy = screenview[2]
+	var/cox = round((svx - 1) / 2)
+	var/coy = round((svy - 1) / 2)
+	x = cx + (sx - 1 - cox)
+	y = cy + (sy - 1 - coy)
+	z = cz
+	p_x = text2num(screen_loc_X[2])
+	p_y = text2num(screen_loc_Y[2])
+	return new /datum/position(x, y, z, p_x, p_y)

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -78,6 +78,13 @@
 	icon_state = "power_display"
 	screen_loc = ui_lingchemdisplay
 
+/atom/movable/screen/qte
+	name = "quick time event"
+	icon_state = "selector"
+	screen_loc = "CENTER,CENTER"
+	color = COLOR_BLUE
+	mouse_opacity = 0 // Don't want to be blocking clicks on more important things (like the person you're fighting)
+
 /datum/hud/human/New(mob/living/carbon/human/owner)
 	..()
 	owner.overlay_fullscreen("see_through_darkness", /atom/movable/screen/fullscreen/see_through_darkness)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -295,6 +295,10 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /obj/item/examine(mob/user) //This might be spammy. Remove?
 	. = ..()
 
+	if(blocking_behavior == BLOCKING_QTE)
+		. += span_notice("This item utilizes quick time events to block. \
+			When you are attacked, you will have to place your mouse inside of the blue square in order to block.")
+
 	. += "[gender == PLURAL ? "They are" : "It is"] a [weightclass2text(w_class)] item."
 
 	if(HAS_TRAIT(src, TRAIT_NO_STORAGE))

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -103,6 +103,7 @@
 	embedding = list("embed_chance" = 75, "embedded_impact_pain_multiplier" = 10)
 	armour_penetration = 35
 	block_chance = 50
+	blocking_behavior = BLOCKING_QTE
 	saber_color = "green"
 
 /obj/item/melee/transforming/energy/sword/attackby(obj/item/I, mob/living/user, params)

--- a/code/game/objects/items/two_handed/dualsaber.dm
+++ b/code/game/objects/items/two_handed/dualsaber.dm
@@ -18,6 +18,7 @@
 	armour_penetration = 35
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	block_chance = 75
+	blocking_behavior = BLOCKING_QTE
 	max_integrity = 200
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 70)
 	resistance_flags = FIRE_PROOF

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -98,7 +98,7 @@
 	///How much armor this projectile pierces.
 	var/projectile_type = /obj/projectile
 	///This will de-increment every step. When 0, it will deletze the projectile.
-	var/range = 50 
+	var/range = 50
 	var/decayedRange			//stores original range
 	var/reflect_range_decrease = 5			//amount of original range that falls off when reflecting, so it doesn't go forever
 	var/reflectable = NONE // Can it be reflected or not?
@@ -119,10 +119,10 @@
 	var/stutter = 0 SECONDS
 	/// Slurring applied on projectile hit
 	var/slur = 0 SECONDS
-	
-	
+
+
 	var/irradiate = 0 //yog radiation
-	
+
 	var/dismemberment = 0 //The higher the number, the greater the bonus to dismembering. 0 will not dismember at all.
 	var/catastropic_dismemberment = FALSE //If TRUE, this projectile deals its damage to the chest if it dismembers a limb.
 
@@ -130,7 +130,7 @@
 	var/log_override = FALSE //is this type spammed enough to not log? (KAs)
 	/// We ignore mobs with these factions.
 	var/list/ignored_factions
-	
+
 	///If defined, on hit we create an item of this type then call hitby() on the hit target with this, mainly used for embedding items (bullets) in targets
 	var/shrapnel_type
 	///If we have a shrapnel_type defined, these embedding stats will be passed to the spawned shrapnel type, which will roll for embedding on the target
@@ -562,6 +562,8 @@
 	var/forcemoved = FALSE
 	for(var/i in 1 to SSprojectiles.global_iterations_per_move)
 		if(QDELETED(src))
+			return
+		if(!loc || !trajectory)
 			return
 		trajectory.increment(trajectory_multiplier)
 		var/turf/T = trajectory.return_turf()


### PR DESCRIPTION
# Document the changes in your pull request

Adds QTEs to blocking with eswords and deswords. Blocking with these items is no longer RNG

When attacked, a blue square will pop up within 64 pixels of your mouse. You will need to move your mouse into this blue square in order to block

The square will give you 0.75 seconds to react, and the size of the square scales with `block_chance`

Items with this QTE behavior will have a special examine detailing what to do when people inevitably get confused by the popping blue squares on their screen

This will need a testmerge for bug squashing that I missed as well as balance testing. Originally I was going with a .5 second window but I felt that it would be unfair with >0 server ping. I will be able to see on live how actually playable it is.

#

Most of the code is in items.dm

Take this with you ✞

# Why is this good for the game?

Skill expression > RNG; finally cool esword fights

I got this idea when listening to Duel of the Fates https://www.youtube.com/watch?v=D_2bluVPsb0

You should listen to it too

# Testing
![](https://i.imgur.com/1sXEiDr.gif)


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: Added Quick Time Event blocking to replace RNG blocking for energy swords
/:cl:
