### PR TITLE
Fixes cable colors and computer overlays

### DIFF
--- a/code/game/machinery/computer/_computer.dm
+++ b/code/game/machinery/computer/_computer.dm
@@ -55,10 +55,8 @@
 		icon_state = initial(icon_state)
 		update_appearance(UPDATE_ICON)
 
-/obj/machinery/computer/update_overlays()
+/obj/machinery/computer/update_appearance(updates)
 	. = ..()
-
-	SSvis_overlays.remove_vis_overlay(src, managed_vis_overlays)
 	//Prevents fuckery with subtypes that are meant to be pixel shifted or map shifted shit
 	if(pixel_x == 0 && pixel_y == 0)
 		// this bit of code makes the computer hug the wall its next to
@@ -84,7 +82,10 @@
 			if(istype(T, /turf/closed/wall) || W)
 				pixel_x = offet_matrix[1]
 				pixel_y = offet_matrix[2]
-		
+
+
+/obj/machinery/computer/update_overlays()
+	. = ..()
 	if(stat & NOPOWER)
 		. += "[icon_keyboard]_off"
 		return
@@ -94,8 +95,8 @@
 	var/overlay_state = icon_screen
 	if(stat & BROKEN)
 		overlay_state = "[icon_state]_broken"
-	SSvis_overlays.add_vis_overlay(src, icon, overlay_state, layer, plane, dir)
-	SSvis_overlays.add_vis_overlay(src, icon, overlay_state, layer, EMISSIVE_PLANE, dir)
+	. += mutable_appearance(icon, overlay_state)
+	. += mutable_appearance(icon, overlay_state, layer, EMISSIVE_PLANE)
 
 /obj/machinery/computer/power_change()
 	. = ..()

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -573,6 +573,8 @@ By design, d1 is the smallest direction and d2 is the highest
 		return
 	icon_state = "[initial(item_state)][amount < 3 ? amount : ""]"
 	item_state = "coil_[cable_color]"
+	color = null
+	add_atom_colour(cable_color, FIXED_COLOUR_PRIORITY)
 
 /obj/item/stack/cable_coil/update_name(updates=ALL)
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

hi

# Why is this good for the game?

# Testing

why would i test things

# Spriting

# Wiki Documentation

# Changelog

:cl:  
bugfix: Cables now properly transfer colors upon being cut
bugfix: Built computers no longer have a wacky computer screen.
/:cl:
