### PR TITLE
heretic sac spells now take into account unconscious+ people

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -57,7 +57,7 @@
 			continue
 		if(istype(atom_in_range,/mob/living))
 			var/mob/living/living_in_range = atom_in_range
-			if(living_in_range.stat != DEAD || living_in_range == user) // we only accept corpses, no living beings allowed.
+			if(!living_in_range.stat || living_in_range == user) // we only accept people in crit, no healthy beings allowed.
 				continue
 		atoms_in_range += atom_in_range
 	for(var/X in transmutations)


### PR DESCRIPTION
# Document the changes in your pull request

fixes an oversight in https://github.com/yogstation13/Yogstation/pull/20558 where non-dead people wouldn't count for sacrificing.

# Why is this good for the game?
fixes bug

# Testing


https://github.com/yogstation13/Yogstation/assets/5091394/c52ee6b0-accf-4c2b-a70c-280c728e1b33



# Changelog

:cl:  
bugfix: unconscious+ people now count towards heretic sacrifice
/:cl:
