### PR TITLE
Ethereals can no longer be walking voids of light

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -90,6 +90,7 @@
 	b1 = GETBLUEPART(default_color)
 	var/list/hsl = rgb2hsl(r1, g1, b1)
 	hsl[2] *= 0.6
+	hsl[3] = (1 - hsl[3]) / 2 //the light part of HSL is from 0 to 1 this increases lightness of the colour, less increase the brighter the light is
 	var/list/rgb = hsl2rgb(hsl[1], hsl[2], hsl[3]) //terrible way to do it, but it works
 	r1 = rgb[1]
 	g1 = rgb[2]

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -90,7 +90,7 @@
 	b1 = GETBLUEPART(default_color)
 	var/list/hsl = rgb2hsl(r1, g1, b1)
 	hsl[2] *= 0.6
-	hsl[3] = (1 - hsl[3]) / 2 //the light part of HSL is from 0 to 1 this increases lightness of the colour, less increase the brighter the light is
+	hsl[3] += (1 - hsl[3]) / 2 //the light part of HSL is from 0 to 1 this increases lightness of the colour, less increase the brighter the light is
 	var/list/rgb = hsl2rgb(hsl[1], hsl[2], hsl[3]) //terrible way to do it, but it works
 	r1 = rgb[1]
 	g1 = rgb[2]


### PR DESCRIPTION
# Why is this good for the game?
Regular Ethereals shouldn't be able to effectively have antiglow

# Testing
before
![image](https://github.com/yogstation13/Yogstation/assets/108117184/4a316689-d3ce-47fe-9288-5c3030d917b6)
same colour after
![image](https://github.com/yogstation13/Yogstation/assets/108117184/b2472131-8c3f-48ec-ae67-84ad451cf232)

:cl:  
tweak: Ethereals can no longer be walking voids of light
/:cl:
