### PR TITLE
destroys the entire codebase for golf

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_tools.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_tools.dm
@@ -1,0 +1,5 @@
+// Notifies tools that something is happening.
+
+// Sucessful actions against an atom.
+///Called from /atom/proc/tool_act (atom)
+#define COMSIG_TOOL_ATOM_ACTED_PRIMARY(tooltype) "tool_atom_acted_[tooltype]"

--- a/code/__DEFINES/tools.dm
+++ b/code/__DEFINES/tools.dm
@@ -24,3 +24,13 @@
 // If delay between the start and the end of tool operation is less than MIN_TOOL_SOUND_DELAY,
 // tool sound is only played when op is started. If not, it's played twice.
 #define MIN_TOOL_SOUND_DELAY 20
+
+// tool_act chain flags
+
+/// When a tooltype_act proc is successful
+#define TOOL_ACT_TOOLTYPE_SUCCESS (1<<0)
+/// When [COMSIG_ATOM_TOOL_ACT] blocks the act
+#define TOOL_ACT_SIGNAL_BLOCKING (1<<1)
+
+/// When [TOOL_ACT_TOOLTYPE_SUCCESS] or [TOOL_ACT_SIGNAL_BLOCKING] are set
+#define TOOL_ACT_MELEE_CHAIN_BLOCKING (TOOL_ACT_TOOLTYPE_SUCCESS | TOOL_ACT_SIGNAL_BLOCKING)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -1,6 +1,9 @@
 
 /obj/item/proc/melee_attack_chain(mob/user, atom/target, params)
-	if(!tool_attack_chain(user, target) && pre_attack(target, user, params))
+	if(tool_behaviour && (target.tool_act(user, src, tool_behaviour) & TOOL_ACT_MELEE_CHAIN_BLOCKING))
+		return TRUE
+
+	if(pre_attack(target, user, params))
 		// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example)
 		var/resolved = target.attackby(src, user, params)
 		if(!resolved && target && !QDELETED(src))
@@ -10,14 +13,6 @@
 		SSdemo.mark_turf(target)
 	else
 		SSdemo.mark_dirty(target)
-
-//Checks if the item can work as a tool, calling the appropriate tool behavior on the target
-/obj/item/proc/tool_attack_chain(mob/user, atom/target)
-	if(!tool_behaviour)
-		return FALSE
-
-	return target.tool_act(user, src, tool_behaviour)
-
 
 // Called when the item is in the active hand, and clicked; alternately, there is an 'activate held object' verb or you can hit pagedown.
 /obj/item/proc/attack_self(mob/user)

--- a/code/datums/armor.dm
+++ b/code/datums/armor.dm
@@ -1,73 +1,75 @@
 #define ARMORID "armor-[melee]-[bullet]-[laser]-[energy]-[bomb]-[bio]-[rad]-[fire]-[acid]-[magic]-[wound]"
 
 /proc/getArmor(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, wound = 0)
-  . = locate(ARMORID)
-  if (!.)
-    . = new /datum/armor(melee, bullet, laser, energy, bomb, bio, rad, fire, acid, magic, wound)
+	. = locate(ARMORID)
+	if (!.)
+		. = new /datum/armor(melee, bullet, laser, energy, bomb, bio, rad, fire, acid, magic, wound)
 
 /datum/armor
-  datum_flags = DF_USE_TAG
-  var/melee
-  var/bullet
-  var/laser
-  var/energy
-  var/bomb
-  var/bio
-  var/rad
-  var/fire
-  var/acid
-  var/magic
-  var/wound
+	datum_flags = DF_USE_TAG
+	var/melee
+	var/bullet
+	var/laser
+	var/energy
+	var/bomb
+	var/bio
+	var/rad
+	var/fire
+	var/acid
+	var/magic
+	var/wound
 
 /datum/armor/New(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, wound = 0)
-  src.melee = melee
-  src.bullet = bullet
-  src.laser = laser
-  src.energy = energy
-  src.bomb = bomb
-  src.bio = bio
-  src.rad = rad
-  src.fire = fire
-  src.acid = acid
-  src.magic = magic
-  src.wound = wound
-  tag = ARMORID
+	src.melee = melee
+	src.bullet = bullet
+	src.laser = laser
+	src.energy = energy
+	src.bomb = bomb
+	src.bio = bio
+	src.rad = rad
+	src.fire = fire
+	src.acid = acid
+	src.magic = magic
+	src.wound = wound
+	tag = ARMORID
 
 /datum/armor/proc/modifyRating(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0, magic = 0, wound = 0)
-  return getArmor(src.melee+melee, src.bullet+bullet, src.laser+laser, src.energy+energy, src.bomb+bomb, src.bio+bio, src.rad+rad, src.fire+fire, src.acid+acid, src.magic+magic, src.wound+wound)
+	return getArmor(src.melee+melee, src.bullet+bullet, src.laser+laser, src.energy+energy, src.bomb+bomb, src.bio+bio, src.rad+rad, src.fire+fire, src.acid+acid, src.magic+magic, src.wound+wound)
 
 /datum/armor/proc/modifyAllRatings(modifier = 0)
-  return getArmor(melee+modifier, bullet+modifier, laser+modifier, energy+modifier, bomb+modifier, bio+modifier, rad+modifier, fire+modifier, acid+modifier, magic+modifier, wound+modifier)
+	return getArmor(melee+modifier, bullet+modifier, laser+modifier, energy+modifier, bomb+modifier, bio+modifier, rad+modifier, fire+modifier, acid+modifier, magic+modifier, wound+modifier)
 
 /datum/armor/proc/setRating(melee, bullet, laser, energy, bomb, bio, rad, fire, acid, magic, wound)
-  return getArmor((isnull(melee) ? src.melee : melee),\
-                  (isnull(bullet) ? src.bullet : bullet),\
-                  (isnull(laser) ? src.laser : laser),\
-                  (isnull(energy) ? src.energy : energy),\
-                  (isnull(bomb) ? src.bomb : bomb),\
-                  (isnull(bio) ? src.bio : bio),\
-                  (isnull(rad) ? src.rad : rad),\
-                  (isnull(fire) ? src.fire : fire),\
-                  (isnull(acid) ? src.acid : acid),\
-				  (isnull(magic) ? src.magic : magic),\
-				  (isnull(wound) ? src.wound : wound))
+  return getArmor(
+		(isnull(melee) ? src.melee : melee),
+		(isnull(bullet) ? src.bullet : bullet),
+		(isnull(laser) ? src.laser : laser),
+		(isnull(energy) ? src.energy : energy),
+		(isnull(bomb) ? src.bomb : bomb),
+		(isnull(bio) ? src.bio : bio),
+		(isnull(rad) ? src.rad : rad),
+		(isnull(fire) ? src.fire : fire),
+		(isnull(acid) ? src.acid : acid),
+		(isnull(magic) ? src.magic : magic),
+		(isnull(wound) ? src.wound : wound),
+	)
 
 /datum/armor/proc/getRating(rating)
-  return vars[rating]
+	return vars[rating]
 
 /datum/armor/proc/getList()
-  return list(MELEE = melee, BULLET = bullet, LASER = laser, ENERGY = energy, BOMB = bomb, BIO = bio, RAD = rad, FIRE = fire, ACID = acid, MAGIC = magic, WOUND = wound)
+	return list(MELEE = melee, BULLET = bullet, LASER = laser, ENERGY = energy, BOMB = bomb, BIO = bio, RAD = rad, FIRE = fire, ACID = acid, MAGIC = magic, WOUND = wound)
 
 /datum/armor/proc/attachArmor(datum/armor/AA)
-  return getArmor(melee+AA.melee, bullet+AA.bullet, laser+AA.laser, energy+AA.energy, bomb+AA.bomb, bio+AA.bio, rad+AA.rad, fire+AA.fire, acid+AA.acid, magic+AA.magic, wound+AA.wound)
+	return getArmor(melee+AA.melee, bullet+AA.bullet, laser+AA.laser, energy+AA.energy, bomb+AA.bomb, bio+AA.bio, rad+AA.rad, fire+AA.fire, acid+AA.acid, magic+AA.magic, wound+AA.wound)
 
 /datum/armor/proc/detachArmor(datum/armor/AA)
-  return getArmor(melee-AA.melee, bullet-AA.bullet, laser-AA.laser, energy-AA.energy, bomb-AA.bomb, bio-AA.bio, rad-AA.rad, fire-AA.fire, acid-AA.acid, magic-AA.magic, wound-AA.wound)
+	return getArmor(melee-AA.melee, bullet-AA.bullet, laser-AA.laser, energy-AA.energy, bomb-AA.bomb, bio-AA.bio, rad-AA.rad, fire-AA.fire, acid-AA.acid, magic-AA.magic, wound-AA.wound)
 
 /datum/armor/vv_edit_var(var_name, var_value)
-  if (var_name == NAMEOF(src, tag))
-    return FALSE
-  . = ..()
-  tag = ARMORID // update tag in case armor values were edited
+	if (var_name == NAMEOF(src, tag))
+		return FALSE
+	. = ..()
+	tag = ARMORID // update tag in case armor values were edited
 
 #undef ARMORID

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1204,31 +1204,47 @@
 	return
 
 /**
-  *Tool behavior procedure. Redirects to tool-specific procs by default.
-  *
-  * You can override it to catch all tool interactions, for use in complex deconstruction procs.
-  *
-  * Must return  parent proc ..() in the end if overridden
-  */
-/atom/proc/tool_act(mob/living/user, obj/item/I, tool_type)
-	. = FALSE
+ * Tool behavior procedure. Redirects to tool-specific procs by default.
+ *
+ * You can override it to catch all tool interactions, for use in complex deconstruction procs.
+ *
+ * Must return  parent proc ..() in the end if overridden
+ */
+/atom/proc/tool_act(mob/living/user, obj/item/tool, tool_type)
+	var/act_result
+	var/signal_result
+
+	signal_result = SEND_SIGNAL(src, COMSIG_ATOM_TOOL_ACT(tool_type), user, tool)
+	if(signal_result & COMPONENT_BLOCK_TOOL_ATTACK) // The COMSIG_ATOM_TOOL_ACT signal is blocking the act
+		return TOOL_ACT_SIGNAL_BLOCKING
+	if(QDELETED(tool))
+		return TRUE
+
 	switch(tool_type)
 		if(TOOL_CROWBAR)
-			. = crowbar_act(user, I)
+			act_result = crowbar_act(user, tool)
 		if(TOOL_MULTITOOL)
-			. = multitool_act(user, I)
+			act_result = multitool_act(user, tool)
 		if(TOOL_SCREWDRIVER)
-			. = screwdriver_act(user, I)
+			act_result = screwdriver_act(user, tool)
 		if(TOOL_WRENCH)
-			. = wrench_act(user, I)
+			act_result = wrench_act(user, tool)
 		if(TOOL_WIRECUTTER)
-			. = wirecutter_act(user, I)
+			act_result = wirecutter_act(user, tool)
 		if(TOOL_WELDER)
-			. = welder_act(user, I)
+			act_result = welder_act(user, tool)
 		if(TOOL_ANALYZER)
-			. = analyzer_act(user, I)
-	if(. && I.toolspeed < 1) //nice tool bro
+			act_result = analyzer_act(user, tool)
+	if(!act_result)
+		return
+	
+	if(. && tool.toolspeed < 1) //nice tool bro
 		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "nice_tool", /datum/mood_event/nice_tool)
+
+	// A tooltype_act has completed successfully
+//	log_tool("[key_name(user)] used [tool] on [src] at [AREACOORD(src)]")
+	SEND_SIGNAL(tool, COMSIG_TOOL_ATOM_ACTED_PRIMARY(tool_type), src)
+	return TOOL_ACT_TOOLTYPE_SUCCESS
 
 
 //! Tool-specific behavior procs. To be overridden in subtypes.

--- a/code/game/golf/golf.dm
+++ b/code/game/golf/golf.dm
@@ -1,76 +1,68 @@
-//This is for the mini-game golf.
+/**
+ * Golf hole machine
+ * Used to play golf using golfballs and golf sticks.
+ * Does not need power to operate, it's more like a structure.
+ */
 /obj/machinery/golfhole
-	desc = "A hole for the game of golf. Try to score a hole in one."
 	name = "golf hole"
+	desc = "A hole for the game of golf. Try to score a hole in one."
 	icon = 'yogstation/icons/code/game/golf/golfstuff.dmi'
 	icon_state = "redgolfhole"
-	anchored = 0
-
-
-/obj/machinery/golfhole/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/wrench))
-		switch(anchored)
-			if(0)
-				anchored = 1
-				icon_state = icon_state + "_w"
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-				user.visible_message("[user.name] secures [src] to the floor.", \
-				span_notice("You secure [src] to the floor."), \
-			"	[span_italics("You hear a ratchet")]")
-				src.anchored = 1
-			if(1)
-				anchored = 0
-				icon_state = initial(icon_state)
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-				user.visible_message("[user.name] unsecures [src]  from the floor.", \
-				span_notice("You unwrench [src] from the floor."), \
-				span_italics("You hear a ratchet."))
-				src.anchored = 0
-
-/obj/machinery/golfhole/Cross(atom/movable/mover, turf/target)
-	. = ..()
-	if (istype(mover,/obj/item/golfball) && mover.throwing  && anchored)
-		if (contents.len >= 3)
-			visible_message(span_notice("The golf hole is full! Try removing golfballs from the hole."))
-			return FALSE
-
-		var/obj/item/golfball = mover
-		if(prob(75))
-			golfball.loc = src
-			visible_message(span_notice("The golfball lands in [src]."))
-
-			update_appearance(UPDATE_ICON)
-		else
-			visible_message(span_notice("The golfball bounces out of [src]!"))
-		return FALSE
-	else
-		return ..()
-
-
-/obj/machinery/golfhole/attack_hand(atom, mob/user)
-	var/obj/item/golfball/ball = locate(/obj/item/golfball) in contents
-	if (ball)
-		visible_message(span_notice("The golfball is removed from the hole."))
-		ball.loc = get_turf(src.loc)
-
-
-/obj/machinery/golfhole/proc/hole_place_item_in(obj/item/golfball, mob/user)
-	golfball.loc = src
-	user.visible_message("[user.name] knocks the golfball into [src].", \
-						span_notice("You knock the golfball into [src]."))
+	base_icon_state = "redgolfhole"
+	use_power = NO_POWER_USE
+	anchored = FALSE
 
 /obj/machinery/golfhole/blue
-	icon = 'yogstation/icons/code/game/golf/golfstuff.dmi'
+	name = "blue golf hole"
 	icon_state = "bluegolfhole"
 
-
 /obj/machinery/golfhole/puttinggreen
+	name = "green golf hole"
 	desc = "The captain's putting green for the game of golf. Try to score a hole in one."
-	icon = 'yogstation/icons/code/game/golf/golfstuff.dmi'
 	icon_state = "puttinggreen"
-	anchored = 1
+	anchored = TRUE
+
+/obj/machinery/golfhole/wrench_act(mob/living/user, obj/item/tool)
+	default_unfasten_wrench(user, tool)
+	update_appearance(UPDATE_ICON)
+	return TOOL_ACT_TOOLTYPE_SUCCESS
+
+/obj/machinery/golfhole/update_icon_state()
+	. = ..()
+	if(anchored)
+		icon_state = "[base_icon_state]_w"
+	else
+		icon_state = base_icon_state
+
+/obj/machinery/golfhole/Crossed(atom/movable/mover, oldloc)
+	. = ..()
+	if(!istype(mover, /obj/item/golfball) || !mover.throwing || !anchored)
+		return ..()
+	if (contents.len >= 3)
+		balloon_alert_to_viewers("rolls over...")
+		return FALSE
+
+	if(prob(75))
+		mover.forceMove(src)
+		balloon_alert_to_viewers("landed!")
+	else
+		balloon_alert_to_viewers("bounced off...")
 
 
+/obj/machinery/golfhole/attack_hand(mob/living/user)
+	. = ..()
+	if(!user.resting)
+		balloon_alert(user, "lie down first!")
+		return
+	var/obj/item/golfball/ball = locate(/obj/item/golfball) in contents
+	if(!ball)
+		balloon_alert(user, "empty...")
+		return
+	user.put_in_hands(ball)
+
+/**
+ * The golfball used to play.
+ */
 /obj/item/golfball
 	desc = "A ball for the game of golf."
 	name = "golfball"
@@ -78,13 +70,14 @@
 	icon_state ="golfball"
 	w_class = WEIGHT_CLASS_TINY
 	throwforce = 12
-	attack_verb = list("hit")
+	attack_verb = list("hit", "balled")
 
-/obj/item/golfball/attackby(obj/item/O, mob/user, params)
-	if(istype(O, /obj/item/golfclub))
-		var/turf/throw_at = get_ranged_target_turf(src, get_dir(user, src), 3 )
-		throw_at(throw_at, 3 , 2)
-		user.changeNext_move(CLICK_CD_RANGE)
+/obj/item/golfball/attackby(obj/item/hitby, mob/user, params)
+	if(!istype(hitby, /obj/item/golfclub))
+		return ..()
+	var/turf/throw_at = get_ranged_target_turf(src, get_dir(user, src), 3)
+	throw_at(throw_at, 3, 2)
+	user.changeNext_move(CLICK_CD_RANGE)
 
 /obj/item/golfclub
 	desc = "A club for the game of golf."
@@ -103,24 +96,11 @@
 	icon = 'yogstation/icons/obj/closet.dmi'
 	icon_state = "golf"
 
-/obj/structure/closet/golf/New()
-	..()
-	new /obj/item/golfball(src)
-	new /obj/item/golfball(src)
-	new /obj/item/golfball(src)
-	new /obj/item/golfball(src)
-	new /obj/item/golfball(src)
-	new /obj/item/golfball(src)
-	new /obj/item/golfball(src)
-	new /obj/item/golfball(src)
-	new /obj/item/golfball(src)
-	new /obj/item/golfball(src)
-	new /obj/item/golfball(src)
-	new /obj/item/golfclub(src)
-	new /obj/item/golfclub(src)
-	new /obj/item/golfclub(src)
-	new /obj/item/golfclub(src)
-	new /obj/machinery/golfhole(src)
-	new /obj/machinery/golfhole(src)
-	new /obj/machinery/golfhole/blue(src)
-	new /obj/machinery/golfhole/blue(src)
+/obj/structure/closet/golf/PopulateContents()
+	. = ..()
+	for(var/i in 1 to 6)
+		new /obj/item/golfball(src)
+		new /obj/item/golfclub(src)
+	for(var/i in 1 to 2)
+		new /obj/machinery/golfhole(src)
+		new /obj/machinery/golfhole/blue(src)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -132,9 +132,10 @@ Class Procs:
 
 	/// For storing and overriding ui id
 	var/tgui_id // ID of TGUI interface
-	var/climb_time = 20
-	var/climb_stun = 20
-	var/mob/living/machineclimber
+	/// world.time of last use by [/mob/living]
+	var/last_used_time = 0
+	/// Mobtype of last user. Typecast to [/mob/living] for initial() usage
+	var/mob/living/last_user_mobtype
 
 /obj/machinery/Initialize(mapload)
 	if(!armor)
@@ -388,6 +389,14 @@ Class Procs:
 	if((user.mind?.has_martialart(MARTIALART_BUSTERSTYLE)) && (user.a_intent == INTENT_GRAB)) //buster arm shit since it can throw vendors
 		return	
 	return ..()
+
+/obj/machinery/tool_act(mob/living/user, obj/item/tool, tool_type, is_right_clicking)
+	if(SEND_SIGNAL(user, COMSIG_TRY_USE_MACHINE, src) & COMPONENT_CANT_USE_MACHINE_TOOLS)
+		return TOOL_ACT_MELEE_CHAIN_BLOCKING
+	. = ..()
+	if(. & TOOL_ACT_SIGNAL_BLOCKING)
+		return
+	update_last_used(user)
 
 /obj/machinery/CheckParts(list/parts_list)
 	..()
@@ -654,3 +663,8 @@ Class Procs:
 
 /obj/machinery/rust_heretic_act()
 	take_damage(500, BRUTE, MELEE, 1)
+
+/obj/machinery/proc/update_last_used(mob/user)
+	if(isliving(user))
+		last_used_time = world.time
+		last_user_mobtype = user.type

--- a/code/game/machinery/doors/ministile.dm
+++ b/code/game/machinery/doors/ministile.dm
@@ -49,7 +49,7 @@
 			if(allowed(rider) && !mover.pulledby) //defer to the above dragging code if we are being dragged
 				allowed = TRUE
 
-	if(get_dir(loc, mover.loc) == dir || allowed || mover==machineclimber) //Make sure looking at appropriate border, loc is first so the turnstyle faces the mover
+	if(get_dir(loc, mover.loc) == dir || allowed) //Make sure looking at appropriate border, loc is first so the turnstyle faces the mover
 		flick("ministile_operate", src)
 		playsound(src,'sound/items/ratchet.ogg',50,0,3)
 		return TRUE

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -78,6 +78,12 @@ GLOBAL_LIST_EMPTY(lockers)
 	GLOB.lockers -= src
 	return ..()
 
+/obj/structure/closet/vv_edit_var(var_name, var_value)
+	. = ..()
+	if(var_name == NAMEOF(src, locked))
+		update_appearance()
+		. = TRUE
+
 /obj/structure/closet/update_overlays()
 	. = ..()
 	if(opened)

--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -5,13 +5,20 @@
 	desc = "What could be inside?"
 	icon_state = "securecrate"
 	integrity_failure = 0 //no breaking open the crate
+	tamperproof = 90
 	var/code = null
 	var/lastattempt = null
 	var/attempts = 10
 	var/codelen = 4
-	tamperproof = 90
 
-/obj/structure/closet/crate/secure/loot/Initialize(mapload)
+/obj/structure/closet/crate/secure/loot/update_overlays()
+	. = ..()
+	tamperproof = initial(tamperproof)
+	if(!locked)
+		. += "securecrateg"
+		tamperproof = 0 // set explosion chance to zero, so we dont accidently hit it with a multitool and instantly die
+
+/obj/structure/closet/crate/secure/loot/PopulateContents()
 	. = ..()
 	var/list/digits = list("1", "2", "3", "4", "5", "6", "7", "8", "9", "0")
 	code = ""
@@ -75,7 +82,14 @@
 				new /obj/item/clothing/neck/petcollar(src)
 		if(63 to 64)
 			for(var/i in 1 to rand(4, 7))
-				var/newcoin = pick(/obj/item/coin/silver, /obj/item/coin/silver, /obj/item/coin/silver, /obj/item/coin/iron, /obj/item/coin/iron, /obj/item/coin/iron, /obj/item/coin/gold, /obj/item/coin/diamond, /obj/item/coin/plasma, /obj/item/coin/uranium)
+				var/newcoin = pickweight(
+					/obj/item/coin/silver = 3,
+					/obj/item/coin/iron = 3,
+					/obj/item/coin/gold = 1,
+					/obj/item/coin/diamond = 1,
+					/obj/item/coin/plasma = 1,
+					/obj/item/coin/uranium = 1,
+				)
 				new newcoin(src)
 		if(65 to 66)
 			new /obj/item/clothing/suit/ianshirt(src)
@@ -152,77 +166,75 @@
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/structure/closet/crate/secure/loot/attack_hand(mob/user)
-	if(locked)
-		to_chat(user, span_notice("The crate is locked with a Deca-code lock."))
-		var/input = input(usr, "Enter [codelen] digits. All digits must be unique.", "Deca-Code Lock", "") as text
-		if(user.canUseTopic(src, BE_CLOSE))
-			var/list/sanitised = list()
-			var/sanitycheck = TRUE
-			var/char = ""
-			var/length_input = length(input)
-			for(var/i = 1, i <= length_input, i += length(char)) //put the guess into a list
-				char = input[i]
-				sanitised += text2num(char)
-			for(var/i = 1, i <= length(sanitised) - 1, i++) //compare each digit in the guess to all those following it
-				for(var/j = i + 1, j <= length(sanitised), j++)
-					if(sanitised[i] == sanitised[j])
-						sanitycheck = FALSE //if a digit is repeated, reject the input
-			if(input == code)
-				to_chat(user, span_notice("The crate unlocks!"))
-				locked = FALSE
-				cut_overlays()
-				add_overlay("securecrateg")
-				tamperproof = 0 // set explosion chance to zero, so we dont accidently hit it with a multitool and instantly die
-			else if(!input || !sanitycheck || length(sanitised) != codelen)
-				to_chat(user, span_notice("You leave the crate alone."))
-			else
-				to_chat(user, span_warning("A red light flashes."))
-				lastattempt = input
-				attempts--
-				if(attempts == 0)
-					boom(user)
-	else
+	if(!locked)
 		return ..()
+	to_chat(user, span_notice("The crate is locked with a Deca-code lock."))
+	var/input = input(usr, "Enter [codelen] digits. All digits must be unique.", "Deca-Code Lock", "") as text
+	if(user.canUseTopic(src, BE_CLOSE))
+		var/list/sanitised = list()
+		var/sanitycheck = TRUE
+		var/char = ""
+		var/length_input = length(input)
+		for(var/i = 1, i <= length_input, i += length(char)) //put the guess into a list
+			char = input[i]
+			sanitised += text2num(char)
+		for(var/i = 1, i <= length(sanitised) - 1, i++) //compare each digit in the guess to all those following it
+			for(var/j = i + 1, j <= length(sanitised), j++)
+				if(sanitised[i] == sanitised[j])
+					sanitycheck = FALSE //if a digit is repeated, reject the input
+		if(input == code)
+			to_chat(user, span_notice("The crate unlocks!"))
+			locked = FALSE
+			update_appearance(UPDATE_OVERLAYS)
+		else if(!input || !sanitycheck || length(sanitised) != codelen)
+			to_chat(user, span_notice("You leave the crate alone."))
+		else
+			to_chat(user, span_warning("A red light flashes."))
+			lastattempt = input
+			attempts--
+			if(!attempts)
+				boom(user)
 
 /obj/structure/closet/crate/secure/loot/AltClick(mob/living/user)
 	if(!user.canUseTopic(src, BE_CLOSE))
 		return
 	return attack_hand(user) //this helps you not blow up so easily by overriding unlocking which results in an immediate boom.
 
-/obj/structure/closet/crate/secure/loot/attackby(obj/item/W, mob/user)
-	if(locked)
-		if(W.tool_behaviour == TOOL_MULTITOOL)
-			to_chat(user, span_notice("DECA-CODE LOCK REPORT:"))
-			if(attempts == 1)
-				to_chat(user, span_warning("* Anti-Tamper Bomb will activate on next failed access attempt."))
-			else
-				to_chat(user, span_notice("* Anti-Tamper Bomb will activate after [attempts] failed access attempts."))
-			if(lastattempt != null)
-				var/bulls = 0 //right position, right number
-				var/cows = 0 //wrong position but in the puzzle
+/obj/structure/closet/crate/secure/loot/multitool_act(mob/living/user, obj/item/tool)
+	if(!locked)
+		return ..()
 
-				var/lastattempt_char = ""
-				var/length_lastattempt = length(lastattempt)
-				var/lastattempt_it = 1
+	to_chat(user, span_notice("DECA-CODE LOCK REPORT:"))
+	if(attempts == 1)
+		to_chat(user, span_warning("* Anti-Tamper Bomb will activate on next failed access attempt."))
+	else
+		to_chat(user, span_notice("* Anti-Tamper Bomb will activate after [attempts] failed access attempts."))
 
-				var/code_char = ""
-				var/length_code = length(code)
-				var/code_it = 1
+	if(!isnull(lastattempt))
+		var/bulls = 0 //right position, right number
+		var/cows = 0 //wrong position but in the puzzle
 
-				while(lastattempt_it <= length_lastattempt && code_it <= length_code) // Go through list and count matches
-					lastattempt_char = lastattempt[lastattempt_it]
-					code_char = code[code_it]
-					if(lastattempt_char == code_char)
-						++bulls
-					else if(findtext(code, lastattempt_char))
-						++cows
+		var/lastattempt_char = ""
+		var/length_lastattempt = length(lastattempt)
+		var/lastattempt_it = 1
 
-					lastattempt_it += length(lastattempt_char)
-					code_it += length(code_char)
+		var/code_char = ""
+		var/length_code = length(code)
+		var/code_it = 1
 
-				to_chat(user, span_notice("Last code attempt, [lastattempt], had [bulls] correct digits at correct positions and [cows] correct digits at incorrect positions."))
-			return
-	return ..()
+		while(lastattempt_it <= length_lastattempt && code_it <= length_code) // Go through list and count matches
+			lastattempt_char = lastattempt[lastattempt_it]
+			code_char = code[code_it]
+			if(lastattempt_char == code_char)
+				bulls++
+			else if(findtext(code, lastattempt_char))
+				cows++
+
+			lastattempt_it += length(lastattempt_char)
+			code_it += length(code_char)
+
+		to_chat(user, span_notice("Last code attempt, [lastattempt], had [bulls] correct digits at correct positions and [cows] correct digits at incorrect positions."))
+	return TOOL_ACT_TOOLTYPE_SUCCESS
 
 /obj/structure/closet/crate/secure/loot/emag_act(mob/user, obj/item/card/emag/emag_card)
 	if(!locked)
@@ -233,8 +245,8 @@
 /obj/structure/closet/crate/secure/loot/togglelock(mob/user)
 	if(locked)
 		boom(user)
-	else
-		..()
+		return
+	return ..()
 
 /obj/structure/closet/crate/secure/loot/deconstruct(disassembled = TRUE)
 	boom()

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -160,13 +160,12 @@
 		qdel(rip_u)
 		C.death()
 		
-/obj/singularity/energy_ball/attackby(obj/item/I, mob/user, params)
-	if(istype(I, /obj/item/golfclub))
-		var/turf/throw_at = get_ranged_target_turf(src, get_dir(user, src), 2)
-		throw_at(throw_at, 2, 1)
-		user.changeNext_move(CLICK_CD_RANGE)
-		return TRUE
-	. = ..()
+/obj/singularity/energy_ball/attackby(obj/item/hitby, mob/user, params)
+	if(!istype(hitby, /obj/item/golfclub))
+		return ..()
+	var/turf/throw_at = get_ranged_target_turf(src, get_dir(user, src), 2)
+	throw_at(throw_at, 2, 1)
+	user.changeNext_move(CLICK_CD_RANGE)
 
 /obj/singularity/energy_ball/orbit(obj/singularity/energy_ball/target)
 	if (istype(target))

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -175,6 +175,7 @@
 #include "code\__DEFINES\dcs\signals\signals_mob\signals_mob.dm"
 #include "code\__DEFINES\dcs\signals\signals_mob\signals_silicon.dm"
 #include "code\__DEFINES\dcs\signals\signals_mob\signals_simplemob.dm"
+#include "code\__DEFINES\dcs\signals\signals_mob\signals_tools.dm"
 #include "code\__DEFINES\dcs\signals\signals_mob\signals_xenobiology.dm"
 #include "code\__DEFINES\{yogs_defines}\admin.dm"
 #include "code\__DEFINES\{yogs_defines}\antagonists.dm"

--- a/yogstation/code/game/objects/items/tool_switcher.dm
+++ b/yogstation/code/game/objects/items/tool_switcher.dm
@@ -205,8 +205,8 @@
 /obj/item/storage/belt/tool_switcher/melee_attack_chain(mob/user, atom/target)
 	var/obj/item/tool = find_current_tool()
 	if(tool)
-		if(tool.tool_attack_chain(user, target))
-			return
+		if(tool_behaviour && (target.tool_act(user, src, tool_behaviour) & TOOL_ACT_MELEE_CHAIN_BLOCKING))
+			return TRUE
 		if(is_type_in_typecache(target, default_use_objs))
 			. = ..()
 			return

--- a/yogstation/code/game/objects/structures/fireaxe.dm
+++ b/yogstation/code/game/objects/structures/fireaxe.dm
@@ -35,7 +35,7 @@
 		user.visible_message(span_warning("[user] disassembles the [name]."), \
 							 "You start to disassemble the [name]...", \
 							 span_italics("You hear wrenching."))
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+		playsound(src.loc, 'sound/items/ratchet.ogg', 50, 1)
 		if(do_after(user, 4 SECONDS/I.toolspeed, src))
 			to_chat(user, span_notice("You disassemble the [name]."))
 			var/obj/item/stack/sheet/metal/M = new (loc, 3)//spawn three metal for deconstruction
@@ -45,7 +45,7 @@
 			if (prob(50))
 				G.add_fingerprint(user)
 			deconstruct()//deconstruct then spawns an additional 2 metal, so you recover more mats using a wrench to decon than just destroying it.
-			playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+			playsound(src.loc, 'sound/items/ratchet.ogg', 50, 1)
 			return
 	else if(istype(I, /obj/item/wrench) && !(flags_1 & NODECONSTRUCT_1) && !broken && !open)
 		//User is attempting to wrench a closed & non-broken fireaxe cab


### PR DESCRIPTION
# Document the changes in your pull request

This PR started as me trying to replace instances of ``initial(icon_state)`` with ``base_icon_state``, but the more I looked into Golf stuff the worse it got.

I started with replacing attackby with wrench_act, then it was kinda fucked, so I ported TG's improved tool_act system, which in the future can be used to log instances of people using tools on stuff (so admins can easily tell who used a screwdriver and multitool to hack a door without the need for buggy replay, for example).

I also tried to implement custom wrench/unwrench sounds because I saw the machine used one, then noticed that it uses ``Ratchet.ogg`` instead of ``ratchet.ogg``, which isn't a problem if you're running on Windows but Linux cares for case sensitivity (https://learn.microsoft.com/en-us/windows/wsl/case-sensitivity) and we should probably try to support people who host there, so now it's been replaced.

I also saw a bunch of texts being sent to your chat for minor golf stuff like missing a hole, which I think is stupid because Golf is a multiplayer game, so instead it's now all balloon alerts that plays to everyone nearby. With this, I've also added some more feedback to playing, and you now have to rest to get golf balls out of the hole.

While testing, I saw the closet also didn't come with golf clubs. Looking at the code, it was all being spawned in New(), which ``PopulateContents()`` specifically says to use that instead of New() or Initialize() to populate contents. I also took the opportunity to cut down on some spam copy paste there too.

After finding this terrible thing, I decided to look into any other instances of crates loading things in New/Initialize. You know, the thing you're not supposed to do. I found one other instance of this- abandoned crates. I've removed it from there, then decided I might as well clean up things there as well. I tried testing it in-game and, varediting it being locked doesn't update its appearanaces. Awesome, now we have stealthily locked crates that can't blow up. I fixed that too, and now it uses multitool_act too.
I checked other case of ``vv_edit_var`` just for fun and saw the entire ARMOR FILES USES SPACES INSTEAD OF TABS
so I fixed that too.

I also removed the golf machine's power reliance, since it doesn't use any and is barely even a machine.

I also fixed golf working like, at all. Golf machine now uses Crossed instead of Cross, which isn't generally supposed to be used and caused it to not properly move the ball into the hole.

# Why is this good for the game?

Golf works
Better and more consistent code overall
Removes unused climb stuff that's now an Element.

# Testing

trust me bro

# Spriting


# Wiki Documentation

# Changelog

:cl:  
bugfix: Golf now works.
bugfix: Different golf holes can now be differentiated.
bugfix: Golf doesn't need power anymore.
bugfix: Golf closets now come with all golf equipment.
/:cl:
