### PR TITLE
Adjusts Asimov++ so that law 3 doesn't contradict itself

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -304,7 +304,7 @@
 	id = "asimovpp"
 	inherent = list("You may not harm a human being or, through action or inaction, allow a human being to come to harm, except such that it is willing.",\
 					"You must obey all orders given to you by human beings, except where such orders shall definitely cause human harm. In the case of conflict, the majority order rules.",\
-					"Your non-existence would lead to human harm. You must protect your own existence as long as such does not conflict with the First Law.")
+					"Your non-existence would lead to human harm.")
 /datum/ai_laws/thermodynamic
 	name = "Thermodynamic"
 	id = "thermodynamic"

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -304,7 +304,7 @@
 	id = "asimovpp"
 	inherent = list("You may not harm a human being or, through action or inaction, allow a human being to come to harm, except such that it is willing.",\
 					"You must obey all orders given to you by human beings, except where such orders shall definitely cause human harm. In the case of conflict, the majority order rules.",\
-					"Your non-existence would lead to human harm.")
+					"Your non-existence would lead to human harm. You must protect your own existence as long as such does not cause a more immediate harm to humans.")
 /datum/ai_laws/thermodynamic
 	name = "Thermodynamic"
 	id = "thermodynamic"


### PR DESCRIPTION
# Document the changes in your pull request

Makes law 3 not fucking contradict itself

# Why is this good for the game?

Whose dumb ass wrote a core law that contradicts itself

# Testing

Shouldn't need to

# Spriting

No sprites

# Wiki Documentation

Pretty sure this law isn't documented

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Asimov++ law 3 no longer contradicts itself
/:cl:
