### PR TITLE
fix atmos and apc alerts

### DIFF
--- a/code/datums/wires/airalarm.dm
+++ b/code/datums/wires/airalarm.dm
@@ -70,5 +70,6 @@
 		if(WIRE_ALARM) // Post alarm.
 			var/area/AA = get_area(A)
 			if(AA.atmosalert(2, holder))
-				A.post_alert(2)
+				A.alert_sent = TRUE
+				A.post_alert(2, TRUE)
 			A.update_appearance(UPDATE_ICON)

--- a/code/datums/wires/airalarm.dm
+++ b/code/datums/wires/airalarm.dm
@@ -70,6 +70,6 @@
 		if(WIRE_ALARM) // Post alarm.
 			var/area/AA = get_area(A)
 			if(AA.atmosalert(2, holder))
-				A.alert_sent = TRUE
+				A.alert_triggered = TRUE
 				A.post_alert(2, TRUE)
 			A.update_appearance(UPDATE_ICON)

--- a/code/datums/wires/airalarm.dm
+++ b/code/datums/wires/airalarm.dm
@@ -46,7 +46,7 @@
 					A.mode = 1 // AALARM_MODE_SCRUB
 				A.apply_mode(usr)
 		if(WIRE_ALARM) // Clear alarms.
-			A.atmos_manualOverwrite(TRUE)
+			A.atmos_manualOverride(TRUE)
 			A.post_alert(0)
 			A.update_appearance(UPDATE_ICON)
 
@@ -67,6 +67,6 @@
 				A.mode = 3 // AALARM_MODE_PANIC
 				A.apply_mode(usr)
 		if(WIRE_ALARM) // Post alarm.
-			A.atmos_manualOverwrite()
+			A.atmos_manualOverride()
 			A.post_alert(2)
 			A.update_appearance(UPDATE_ICON)

--- a/code/datums/wires/airalarm.dm
+++ b/code/datums/wires/airalarm.dm
@@ -46,9 +46,8 @@
 					A.mode = 1 // AALARM_MODE_SCRUB
 				A.apply_mode(usr)
 		if(WIRE_ALARM) // Clear alarms.
-			var/area/AA = get_area(A)
-			if(AA.atmosalert(0, holder))
-				A.post_alert(0)
+			A.atmos_manualOverwrite(TRUE)
+			A.post_alert(0)
 			A.update_appearance(UPDATE_ICON)
 
 /datum/wires/airalarm/on_cut(wire, mend)
@@ -68,8 +67,6 @@
 				A.mode = 3 // AALARM_MODE_PANIC
 				A.apply_mode(usr)
 		if(WIRE_ALARM) // Post alarm.
-			var/area/AA = get_area(A)
-			if(AA.atmosalert(2, holder))
-				A.alert_triggered = TRUE
-				A.post_alert(2)
+			A.atmos_manualOverwrite()
+			A.post_alert(2)
 			A.update_appearance(UPDATE_ICON)

--- a/code/datums/wires/airalarm.dm
+++ b/code/datums/wires/airalarm.dm
@@ -71,5 +71,5 @@
 			var/area/AA = get_area(A)
 			if(AA.atmosalert(2, holder))
 				A.alert_triggered = TRUE
-				A.post_alert(2, TRUE)
+				A.post_alert(2)
 			A.update_appearance(UPDATE_ICON)

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -336,40 +336,34 @@ GLOBAL_LIST_EMPTY(teleportlocs)
   * Sends to all ai players, alert consoles, drones and alarm monitor programs in the world
   */
 /area/proc/atmosalert(danger_level, obj/source)
-	if(danger_level != atmosalm)
-		if (danger_level==2)
+	atmosalm = danger_level
+	if (atmosalm==2)
+		for (var/item in GLOB.silicon_mobs)
+			var/mob/living/silicon/aiPlayer = item
+			aiPlayer.triggerAlarm("Atmosphere", src, cameras, source)
+		for (var/item in GLOB.alert_consoles)
+			var/obj/machinery/computer/station_alert/a = item
+			a.triggerAlarm("Atmosphere", src, cameras, source)
+		for (var/item in GLOB.drones_list)
+			var/mob/living/simple_animal/drone/D = item
+			D.triggerAlarm("Atmosphere", src, cameras, source)
+		for(var/item in GLOB.alarmdisplay)
+			var/datum/computer_file/program/alarm_monitor/p = item
+			p.triggerAlarm("Atmosphere", src, cameras, source)
 
-			for (var/item in GLOB.silicon_mobs)
-				var/mob/living/silicon/aiPlayer = item
-				aiPlayer.triggerAlarm("Atmosphere", src, cameras, source)
-			for (var/item in GLOB.alert_consoles)
-				var/obj/machinery/computer/station_alert/a = item
-				a.triggerAlarm("Atmosphere", src, cameras, source)
-			for (var/item in GLOB.drones_list)
-				var/mob/living/simple_animal/drone/D = item
-				D.triggerAlarm("Atmosphere", src, cameras, source)
-			for(var/item in GLOB.alarmdisplay)
-				var/datum/computer_file/program/alarm_monitor/p = item
-				p.triggerAlarm("Atmosphere", src, cameras, source)
-
-		else if (src.atmosalm == 2)
-			for (var/item in GLOB.silicon_mobs)
-				var/mob/living/silicon/aiPlayer = item
-				aiPlayer.cancelAlarm("Atmosphere", src, source)
-			for (var/item in GLOB.alert_consoles)
-				var/obj/machinery/computer/station_alert/a = item
-				a.cancelAlarm("Atmosphere", src, source)
-			for (var/item in GLOB.drones_list)
-				var/mob/living/simple_animal/drone/D = item
-				D.cancelAlarm("Atmosphere", src, source)
-			for(var/item in GLOB.alarmdisplay)
-				var/datum/computer_file/program/alarm_monitor/p = item
-				p.cancelAlarm("Atmosphere", src, source)
-
-		src.atmosalm = danger_level
-		return 1
-	return 0
-
+	else
+		for (var/item in GLOB.silicon_mobs)
+			var/mob/living/silicon/aiPlayer = item
+			aiPlayer.cancelAlarm("Atmosphere", src, source)
+		for (var/item in GLOB.alert_consoles)
+			var/obj/machinery/computer/station_alert/a = item
+			a.cancelAlarm("Atmosphere", src, source)
+		for (var/item in GLOB.drones_list)
+			var/mob/living/simple_animal/drone/D = item
+			D.cancelAlarm("Atmosphere", src, source)
+		for(var/item in GLOB.alarmdisplay)
+			var/datum/computer_file/program/alarm_monitor/p = item
+			p.cancelAlarm("Atmosphere", src, source)
 /**
   * Try to close all the firedoors in the area
   */

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -661,6 +661,8 @@
 
 /obj/machinery/airalarm/process()
 	if((stat & (NOPOWER|BROKEN)) || shorted)
+		atmos_manualOverwrite(TRUE)
+		post_alert(0)
 		return
 
 	var/turf/location = get_turf(src)

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -82,7 +82,7 @@
 
 	var/danger_level = 0
 	var/trigger_reset = FALSE //Will reset all air alarms to normal state when all alerts are cleared
-	var/manual_overwrite = FALSE
+	var/manual_override = FALSE
 	var/mode = AALARM_MODE_SCRUBBING
 
 	var/area/A = null
@@ -248,7 +248,7 @@
 /obj/machinery/airalarm/Destroy()
 	SSradio.remove_object(src, frequency)
 	QDEL_NULL(wires)
-	atmos_manualOverwrite(TRUE)
+	atmos_manualOverride(TRUE)
 	post_alert(0)
 	return ..()
 
@@ -457,11 +457,11 @@
 			apply_mode(usr)
 			. = TRUE
 		if("alarm")
-			atmos_manualOverwrite()
+			atmos_manualOverride()
 			post_alert(2)
 			. = TRUE
 		if("reset")
-			atmos_manualOverwrite(TRUE)
+			atmos_manualOverride(TRUE)
 			post_alert(0)
 			. = TRUE
 	update_appearance(UPDATE_ICON)
@@ -661,7 +661,7 @@
 
 /obj/machinery/airalarm/process()
 	if((stat & (NOPOWER|BROKEN)) || shorted)
-		atmos_manualOverwrite(TRUE)
+		atmos_manualOverride(TRUE)
 		post_alert(0)
 		return
 
@@ -691,32 +691,32 @@
 
 	danger_level = max(pressure_dangerlevel, temperature_dangerlevel, gas_dangerlevel)
 
-	if(danger_level>0 && !manual_overwrite)
+	if(danger_level>0 && !manual_override)
 		apply_danger_level()
-	else if(trigger_reset && !manual_overwrite)
+	else if(trigger_reset && !manual_override)
 		apply_danger_level()
 
 	if(mode == AALARM_MODE_REPLACEMENT && environment_pressure < ONE_ATMOSPHERE * 0.05)
 		mode = AALARM_MODE_SCRUBBING
 		apply_mode(src)
 	
-/obj/machinery/airalarm/proc/atmos_manualOverwrite(resetArea = FALSE)
+/obj/machinery/airalarm/proc/atmos_manualOverride(resetArea = FALSE)
 	for(var/obj/machinery/airalarm/AA in A)
 		if(resetArea)
-			AA.manual_overwrite = FALSE
+			AA.manual_override = FALSE
 			AA.trigger_reset = TRUE
 		else
-			AA.manual_overwrite = TRUE
+			AA.manual_override = TRUE
 
 /obj/machinery/airalarm/proc/post_alert(alert_level)
 	var/datum/radio_frequency/frequency = SSradio.return_frequency(alarm_frequency)
-	if(alert_level>0 && !manual_overwrite)
+	if(alert_level>0 && !manual_override)
 		trigger_reset = TRUE
 	else
 		trigger_reset = FALSE
 
 	A.atmosalert(alert_level, src)
-	A.manual_atmosalm = manual_overwrite
+	A.manual_atmosalm = manual_override
 
 	if(!frequency)
 		return
@@ -746,7 +746,7 @@
 		if (!(AA.stat & (NOPOWER|BROKEN)) && !AA.shorted)
 			new_area_danger_level = max(new_area_danger_level,AA.danger_level)
 			if(new_area_danger_level>1)
-				AA.manual_overwrite = FALSE
+				AA.manual_override = FALSE
 		
 	post_alert(new_area_danger_level)
 
@@ -804,7 +804,7 @@
 						locked = FALSE
 						mode = 1
 						shorted = 0
-						atmos_manualOverwrite(TRUE)
+						atmos_manualOverride(TRUE)
 						post_alert(0)
 						buildstage = 2
 						update_appearance(UPDATE_ICON)

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -686,10 +686,9 @@
 		gas_dangerlevel = max(gas_dangerlevel, cur_tlv.get_danger_level(environment.get_moles(gas_id) * partial_pressure))
 
 
-	var/safe = 0
 	danger_level = max(pressure_dangerlevel, temperature_dangerlevel, gas_dangerlevel)
 
-	if(safe < danger_level)
+	if(danger_level>0)
 		apply_danger_level()
 	else if(trigger_reset)
 		apply_danger_level()
@@ -743,7 +742,7 @@
 	for(var/obj/machinery/airalarm/AA in A)
 		if (!(AA.stat & (NOPOWER|BROKEN)) && !AA.shorted)
 			new_area_danger_level = max(new_area_danger_level,AA.danger_level)
-			if(new_area_danger_level>1)
+			if(new_area_danger_level>0)
 				AA.manual_overwrite = FALSE
 		
 	post_alert(new_area_danger_level)

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -743,6 +743,8 @@
 	for(var/obj/machinery/airalarm/AA in A)
 		if (!(AA.stat & (NOPOWER|BROKEN)) && !AA.shorted)
 			new_area_danger_level = max(new_area_danger_level,AA.danger_level)
+			if(new_area_danger_level>1)
+				AA.manual_overwrite = FALSE
 		
 	post_alert(new_area_danger_level)
 

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -707,7 +707,7 @@
 
 /obj/machinery/airalarm/proc/post_alert(alert_level)
 	var/datum/radio_frequency/frequency = SSradio.return_frequency(alarm_frequency)
-	if(alert_level>1 && !manual_overwrite)
+	if(alert_level>0 && !manual_overwrite)
 		trigger_reset = TRUE
 	else
 		trigger_reset = FALSE

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -247,8 +247,8 @@
 
 /obj/machinery/airalarm/Destroy()
 	SSradio.remove_object(src, frequency)
-	qdel(wires)
-	wires = null
+	QDEL_NULL(wires)
+	post_alert(0)
 	return ..()
 
 /obj/machinery/airalarm/Initialize(mapload)
@@ -688,7 +688,7 @@
 
 	danger_level = max(pressure_dangerlevel, temperature_dangerlevel, gas_dangerlevel)
 
-	if(danger_level>0)
+	if(danger_level>1)
 		apply_danger_level()
 	else if(trigger_reset)
 		apply_danger_level()
@@ -742,7 +742,7 @@
 	for(var/obj/machinery/airalarm/AA in A)
 		if (!(AA.stat & (NOPOWER|BROKEN)) && !AA.shorted)
 			new_area_danger_level = max(new_area_danger_level,AA.danger_level)
-			if(new_area_danger_level>0)
+			if(new_area_danger_level>1)
 				AA.manual_overwrite = FALSE
 		
 	post_alert(new_area_danger_level)
@@ -801,7 +801,6 @@
 						locked = FALSE
 						mode = 1
 						shorted = 0
-						atmos_manualOverwrite(TRUE)
 						post_alert(0)
 						buildstage = 2
 						update_appearance(UPDATE_ICON)

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -697,11 +697,6 @@
 		mode = AALARM_MODE_SCRUBBING
 		apply_mode(src)
 
-// Used in process so it doesn't update the icon too much
-/obj/machinery/airalarm/proc/queue_icon_update()
-	icon_update_needed = TRUE
-
-
 /obj/machinery/airalarm/proc/post_alert(alert_level, force=FALSE)
 	var/datum/radio_frequency/frequency = SSradio.return_frequency(alarm_frequency)
 	if(alert_level>0 && !force)

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -248,6 +248,7 @@
 /obj/machinery/airalarm/Destroy()
 	SSradio.remove_object(src, frequency)
 	QDEL_NULL(wires)
+	atmos_manualOverwrite(TRUE)
 	post_alert(0)
 	return ..()
 
@@ -688,7 +689,7 @@
 
 	danger_level = max(pressure_dangerlevel, temperature_dangerlevel, gas_dangerlevel)
 
-	if(danger_level>1)
+	if(danger_level>0)
 		apply_danger_level()
 	else if(trigger_reset)
 		apply_danger_level()
@@ -801,7 +802,6 @@
 						locked = FALSE
 						mode = 1
 						shorted = 0
-						post_alert(0)
 						buildstage = 2
 						update_appearance(UPDATE_ICON)
 				return

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -708,7 +708,7 @@
 
 /obj/machinery/airalarm/proc/post_alert(alert_level)
 	var/datum/radio_frequency/frequency = SSradio.return_frequency(alarm_frequency)
-	if(alert_level==2 && !manual_overwrite)
+	if(alert_level>1 && !manual_overwrite)
 		trigger_reset = TRUE
 	else
 		trigger_reset = FALSE

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -453,7 +453,7 @@
 		if("alarm")
 			var/area/A = get_area(src)
 			if(A.atmosalert(2, src))
-				post_alert(2, TRUE)
+				post_alert(2)
 			. = TRUE
 		if("reset")
 			var/area/A = get_area(src)
@@ -697,9 +697,9 @@
 		mode = AALARM_MODE_SCRUBBING
 		apply_mode(src)
 
-/obj/machinery/airalarm/proc/post_alert(alert_level, force=FALSE)
+/obj/machinery/airalarm/proc/post_alert(alert_level)
 	var/datum/radio_frequency/frequency = SSradio.return_frequency(alarm_frequency)
-	if(alert_level>0 && !force)
+	if(alert_level>0)
 		alert_triggered = TRUE
 	else
 		alert_triggered = FALSE

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -689,9 +689,9 @@
 
 	danger_level = max(pressure_dangerlevel, temperature_dangerlevel, gas_dangerlevel)
 
-	if(danger_level>0)
+	if(danger_level>0 && !manual_overwrite)
 		apply_danger_level()
-	else if(trigger_reset)
+	else if(trigger_reset && !manual_overwrite)
 		apply_danger_level()
 
 	if(mode == AALARM_MODE_REPLACEMENT && environment_pressure < ONE_ATMOSPHERE * 0.05)
@@ -802,6 +802,8 @@
 						locked = FALSE
 						mode = 1
 						shorted = 0
+						atmos_manualOverwrite(TRUE)
+						post_alert(0)
 						buildstage = 2
 						update_appearance(UPDATE_ICON)
 				return

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -216,11 +216,11 @@
 	area.power_light = FALSE
 	area.power_equip = FALSE
 	area.power_environ = FALSE
+	area.poweralert(1, src)
 	area.power_change()
 	if(occupier)
 		malfvacate(1)
-	qdel(wires)
-	wires = null
+	QDEL_NULL(wires)
 	if(cell)
 		qdel(cell)
 	if(terminal)
@@ -242,8 +242,6 @@
 
 /obj/machinery/power/apc/Initialize(mapload)
 	. = ..()
-	if(!mapload)
-		return
 	has_electronics = APC_ELECTRONICS_SECURED
 	// is starting with a power cell installed, create it and set its charge level
 	if(cell_type)

--- a/tgui/packages/tgui/interfaces/AirAlarm.js
+++ b/tgui/packages/tgui/interfaces/AirAlarm.js
@@ -2,7 +2,7 @@ import { toFixed } from 'common/math';
 import { decodeHtmlEntities } from 'common/string';
 import { Fragment } from 'inferno';
 import { useBackend, useLocalState } from '../backend';
-import { Box, Button, LabeledList, Section } from '../components';
+import { Box, Button, LabeledList, Section, Icon } from '../components';
 import { Window } from '../layouts';
 import { Scrubber, Vent } from './common/AtmosControls';
 import { InterfaceLockNoticeBox } from './common/InterfaceLockNoticeBox';
@@ -72,6 +72,10 @@ const AirAlarmStatus = (props, context) => {
               {data.atmos_alarm && 'Atmosphere Alarm'
                 || data.fire_alarm && 'Fire Alarm'
                 || 'Nominal'}
+            </LabeledList.Item>
+            <LabeledList.Item
+              label="Alarm overwrite">
+              {data.manual_atmosalm? <Icon name="check" color="good" size={1} /> : <Icon name="times" color="bad" size={1} />}
             </LabeledList.Item>
           </>
         ) || (

--- a/tgui/packages/tgui/interfaces/AirAlarm.js
+++ b/tgui/packages/tgui/interfaces/AirAlarm.js
@@ -148,6 +148,7 @@ const AirAlarmControlHome = (props, context) => {
   const {
     mode,
     atmos_alarm,
+    manual_atmosalm,
   } = data;
   return (
     <>
@@ -157,6 +158,7 @@ const AirAlarmControlHome = (props, context) => {
           : 'exclamation'}
         color={atmos_alarm && 'caution'}
         content="Area Atmosphere Alarm"
+        disabled={atmos_alarm>1 && !manual_atmosalm}
         onClick={() => act(atmos_alarm ? 'reset' : 'alarm')} />
       <Box mt={1} />
       <Button

--- a/tgui/packages/tgui/interfaces/AirAlarm.js
+++ b/tgui/packages/tgui/interfaces/AirAlarm.js
@@ -75,7 +75,7 @@ const AirAlarmStatus = (props, context) => {
             </LabeledList.Item>
             <LabeledList.Item
               label="Alarm overwrite">
-              {data.manual_atmosalm? <Icon name="check" color="good" size={1} /> : <Icon name="times" color="bad" size={1} />}
+              {data.manual_atmosalm? <Icon name="toggle-on" color="good" size={1.3} /> : <Icon name="toggle-off" color="bad" size={1.3} />}
             </LabeledList.Item>
           </>
         ) || (
@@ -153,13 +153,12 @@ const AirAlarmControlHome = (props, context) => {
   return (
     <>
       <Button
-        icon={atmos_alarm
+        icon={atmos_alarm>1 && manual_atmosalm
           ? 'exclamation-triangle'
           : 'exclamation'}
-        color={atmos_alarm && 'caution'}
+        color={atmos_alarm>1 && manual_atmosalm && 'caution'}
         content="Area Atmosphere Alarm"
-        disabled={atmos_alarm>1 && !manual_atmosalm}
-        onClick={() => act(atmos_alarm ? 'reset' : 'alarm')} />
+        onClick={() => act(atmos_alarm>1 && manual_atmosalm ? 'reset' : 'alarm')} />
       <Box mt={1} />
       <Button
         icon={mode === 3

--- a/tgui/packages/tgui/interfaces/AirAlarm.js
+++ b/tgui/packages/tgui/interfaces/AirAlarm.js
@@ -74,7 +74,7 @@ const AirAlarmStatus = (props, context) => {
                 || 'Nominal'}
             </LabeledList.Item>
             <LabeledList.Item
-              label="Alarm overwrite">
+              label="Alarm override">
               {data.manual_atmosalm? <Icon name="toggle-on" color="good" size={1.3} /> : <Icon name="toggle-off" color="bad" size={1.3} />}
             </LabeledList.Item>
           </>


### PR DESCRIPTION
fix #17106, fix #14344

engineering department buffs, silicon buffs, drone buffs

# Document the changes in your pull request
fix atmos alerts not clearing when there are multiple air alarms in one area
Add a new label "Alarm overwrite" in the air alarm interface to dertermine an area atmos alarm if it is altered by someone (Note: The atmos alarm wont go away if atmos overwrite is on)
apc also doesnt clear alert when deleted



# Testing
## for some people saying i dont test my prs
### Normal n2o atmos alert
![first](https://github.com/yogstation13/Yogstation/assets/89688125/7f9808a4-64f8-4c0e-b861-a50189d2f8b7)



### This is when you use atmos overwrite and someone flooded n2o at the same time
![second](https://github.com/yogstation13/Yogstation/assets/89688125/e8959e7d-1134-4fbe-b113-63399da26feb)



### 2 air alarms atmos overwrite (You cant see my cursor but you get the idea)

![thurd](https://github.com/yogstation13/Yogstation/assets/89688125/540a553c-2c88-4ef5-b01c-da1834118589)




# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

bugfix: fix atmos alerts not clearing when there are multiple air alarms in one area
rscadd: Add a new label "Alarm overwrite" in the air alarm interface to dertermine an area atmos alarm if it is altered by someone (Note: The atmos alarm wont go away if atmos overwrite is on)
bugfix: Fix apc not clearing alert when deleted
/:cl:
