### PR TITLE
Deputy

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -77649,7 +77649,6 @@
 /area/medical/medbay/aft)
 "xBV" = (
 /obj/structure/table/wood,
-/obj/item/storage/box/deputy,
 /obj/item/storage/pencil_holder/crew/fancy{
 	pixel_x = -8;
 	pixel_y = 12

--- a/_maps/map_files/DonutStation/DonutStation.dmm
+++ b/_maps/map_files/DonutStation/DonutStation.dmm
@@ -55735,7 +55735,6 @@
 	pixel_x = 3;
 	pixel_y = 2
 	},
-/obj/item/storage/box/deputy,
 /obj/item/storage/secure/safe/HoS{
 	pixel_x = 35
 	},

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -25528,7 +25528,6 @@
 	pixel_x = -6;
 	pixel_y = 8
 	},
-/obj/item/storage/box/deputy,
 /obj/machinery/requests_console{
 	announcementConsole = 1;
 	department = "Head of Security's Desk";

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -17072,7 +17072,6 @@
 	pixel_x = -31
 	},
 /obj/structure/table/wood,
-/obj/item/storage/box/deputy,
 /obj/machinery/button/door{
 	id = "hosspace";
 	name = "Space Shutters Control";


### PR DESCRIPTION
# Document the changes in your pull request

Removes the deputy armband box from all maps (except Ice) 'cause council said no deputies

# Why is this good for the game?
Council ruled no deputies, remove armbands so people aren't mistaken

# Testing
What do you think?

# Spriting
Nada

# Wiki Documentation

Remove mentions of deputies 

# Changelog
:cl:  
mapping: Deputy armband boxes have been removed, as council has ruled that you are not allowed to deputize people
/:cl:
