### PR TITLE
Changes the description of deputy armbands and armband boxes to reflect that you can't deputize people anymore

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -810,7 +810,7 @@
 
 /obj/item/storage/box/deputy
 	name = "box of deputy armbands"
-	desc = "To be issued to those authorized to act as deputy of security."
+	desc = "A box of old Nanotrasen deputy armbands, they stopped serving a purpose ever since the deputization of crew was outlawed."
 
 /obj/item/storage/box/deputy/PopulateContents()
 	for(var/i in 1 to 7)

--- a/code/modules/clothing/under/accessories.dm
+++ b/code/modules/clothing/under/accessories.dm
@@ -261,7 +261,7 @@
 
 /obj/item/clothing/accessory/armband/deputy
 	name = "security deputy armband"
-	desc = "An armband, worn by personnel authorized to act as a deputy of station security."
+	desc = "A worn out armband, once worn by personnel authorized to act as a deputy of station security. No longer serves a purpose since Nanotrasen outlawed deputization."
 
 /obj/item/clothing/accessory/armband/cargo
 	name = "cargo bay guard armband"


### PR DESCRIPTION
# Document the changes in your pull request

I'm like half asleep from taking some benadryl, if the title wasn't self explanatory enough then you should turn your PC off and go back to grade school tbh.

# Why is this good for the game?
Something something cuncil say no deputee

# Testing
lol

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->
no

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->
Change descriptions on wiki if we got em

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Deputy armbands and boxes now say that you can't deputize people
/:cl:
