### PR TITLE
Amasec: MAKE ME PUNCHHHHHHHHHHHHHHHHHHHHHHHHHH (Effect added)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1164,7 +1164,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	name = "Amasec"
 	description = "Official drink of the Nanotrasen Gun-Club!"
 	color = "#664300" // rgb: 102, 67, 0
-	boozepwr = 35
+	boozepwr = 55
 	quality = DRINK_GOOD
 	taste_description = "dark and metallic"
 	glass_icon_state = "amasecglass"
@@ -1174,16 +1174,16 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/amasec/on_mob_metabolize(mob/living/carbon/M)
 	var/mob/living/carbon/human/guy = M
 	if(ishuman(M))
-		guy.physiology.punchdamagehigh_bonus += 1
-		guy.physiology.punchdamagelow_bonus += 1
-		guy.physiology.punchstunthreshold_bonus += 1
+		guy.physiology.punchdamagehigh_bonus += 2
+		guy.physiology.punchdamagelow_bonus += 2
+		guy.physiology.punchstunthreshold_bonus += 2
 
 /datum/reagent/consumable/ethanol/amasec/on_mob_end_metabolize(mob/living/carbon/M)
 	var/mob/living/carbon/human/guy = M
 	if(ishuman(M))
-		guy.physiology.punchdamagehigh_bonus -= 1
-		guy.physiology.punchdamagelow_bonus -= 1
-		guy.physiology.punchstunthreshold_bonus -= 1
+		guy.physiology.punchdamagehigh_bonus -= 2
+		guy.physiology.punchdamagelow_bonus -= 2
+		guy.physiology.punchstunthreshold_bonus -= 2
 	return ..()
 
 /datum/reagent/consumable/ethanol/changelingsting

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1172,15 +1172,15 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "Always handy before COMBAT!!!"
 
 /datum/reagent/consumable/ethanol/amasec/on_mob_metabolize(mob/living/carbon/M)
-	var/mob/living/carbon/human/guy = M
 	if(ishuman(M))
+		var/mob/living/carbon/human/guy = M
 		guy.physiology.punchdamagehigh_bonus += 2
 		guy.physiology.punchdamagelow_bonus += 2
 		guy.physiology.punchstunthreshold_bonus += 2
 
 /datum/reagent/consumable/ethanol/amasec/on_mob_end_metabolize(mob/living/carbon/M)
-	var/mob/living/carbon/human/guy = M
 	if(ishuman(M))
+		var/mob/living/carbon/human/guy = M
 		guy.physiology.punchdamagehigh_bonus -= 2
 		guy.physiology.punchdamagelow_bonus -= 2
 		guy.physiology.punchstunthreshold_bonus -= 2

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1171,6 +1171,21 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "Amasec"
 	glass_desc = "Always handy before COMBAT!!!"
 
+/datum/reagent/consumable/ethanol/amasec/on_mob_metabolize(mob/living/carbon/M)
+	var/mob/living/carbon/human/guy = M
+	if(ishuman(M))
+		guy.physiology.punchdamagehigh_bonus += 1
+		guy.physiology.punchdamagelow_bonus += 1
+		guy.physiology.punchstunthreshold_bonus += 1
+
+/datum/reagent/consumable/ethanol/amasec/on_mob_end_metabolize(mob/living/carbon/M)
+	var/mob/living/carbon/human/guy = M
+	if(ishuman(M))
+		guy.physiology.punchdamagehigh_bonus -= 1
+		guy.physiology.punchdamagelow_bonus -= 1
+		guy.physiology.punchstunthreshold_bonus -= 1
+	return ..()
+
 /datum/reagent/consumable/ethanol/changelingsting
 	name = "Changeling Sting"
 	description = "You take a tiny sip and feel a burning sensation..."


### PR DESCRIPTION
# Document the changes in your pull request

I have to keep up the bloat, now introducing Amasec. A W40K reference but does pretty much nothing?

No more, this gives you a bit more punch for your drink. Let the rage cages and bar fights become more entertaining. With the addition of punching, I've made the drink stronger in response. Currently it is at a +2 just because I want it to be a bit more impactful, be used alongside other things because its not usual that drinks come into play that often and in response to this I've increased the boozepower up so people can't just chug it down and keep 100u's of it in their system or something stupid.

# Why is this good for the game?
Means people will interact with the bar finally, please guys its lonely in here.

# Testing
Tested it out so it doesn't keep stacking, which it doesn't and tested to make sure the punch damage returns to normal after it leaves the body.

# Wiki Documentation

Amasec description needs an addition of "Makes you punch harder like those Space Gundams or something" or something along the lines of and its boozepwr needs changing to 55

# Changelog

:cl:  

rscadd: Gave Amasec the effect of making you punch harder (+2)
tweak: Boozepower changed from 35 to 55 

/:cl:
