### PR TITLE
No longer need to cut all wires to disassemble air alarm

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -731,7 +731,7 @@
 /obj/machinery/airalarm/attackby(obj/item/W, mob/user, params)
 	switch(buildstage)
 		if(2)
-			if(W.tool_behaviour == TOOL_WIRECUTTER && panel_open && wires.is_all_cut())
+			if(W.tool_behaviour == TOOL_WIRECUTTER && panel_open && wires.is_cut(WIRE_POWER))
 				W.play_tool_sound(src)
 				to_chat(user, span_notice("You cut the final wires."))
 				new /obj/item/stack/cable_coil(loc, 5)


### PR DESCRIPTION


# Document the changes in your pull request
You only need to cut power wire to disassemble air alarm

# Why is this good for the game?
Cutting all wires will trigger panic siphon and air alarm, then once you done disassembling the air alarm you have to rush to a nearby air alarm to fix the panic siphon, in the case theres no air alarm you are fucked

# Testing
whats




# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: You only need to cut power wire to disassemble air alarm
/:cl:
