### PR TITLE
[BUGFIX] Makes it so sharpening a weapon doesn't double the increment it's supposed to increase by

### DIFF
--- a/code/game/objects/items/sharpener.dm
+++ b/code/game/objects/items/sharpener.dm
@@ -36,7 +36,7 @@
 		to_chat(user, span_warning("[I] has already been refined before. It cannot be sharpened further!"))
 		return
 	if(!(signal_out & COMPONENT_BLOCK_SHARPEN_APPLIED)) //If the item has a relevant component and COMPONENT_BLOCK_SHARPEN_APPLIED is returned, the item only gets the throw force increase
-		I.force = clamp(I.force + increment, 0, max)
+		I.throwforce = clamp(I.throwforce + increment, 0, max)
 		I.wound_bonus = I.wound_bonus + increment //wound_bonus has no cap
 	user.visible_message(span_notice("[user] sharpens [I] with [src]!"), span_notice("You sharpen [I], making it much more deadly than before."))
 	playsound(src, 'sound/items/unsheath.ogg', 25, 1)


### PR DESCRIPTION
Special thanks to Redd for helping me figure this out

# Document the changes in your pull request

makes it so that when you sharpen a weapon using any whetstone it gets the normal amount incremented to it

I.e. if you set the increment to 4 for your whetstone, it will increase a 20 force weapon to 24, instead of 28 

rip bloodcult


# Testing

tested it live on discord yogstation public

# Changelog

:cl:  

bugfix: fixed maths for whetstones

/:cl:
