### PR TITLE
Nerfs blazing oil (again)

### DIFF
--- a/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
+++ b/code/modules/antagonists/blob/blobstrains/blazing_oil.dm
@@ -14,7 +14,7 @@
 	reagent = /datum/reagent/blob/blazing_oil
 
 /datum/blobstrain/reagent/blazing_oil/extinguish_reaction(obj/structure/blob/B)
-	B.take_damage(1.3, BURN, ENERGY)
+	B.take_damage(2.5, BURN, ENERGY)
 
 /datum/blobstrain/reagent/blazing_oil/damage_reaction(obj/structure/blob/B, damage, damage_type, damage_flag)
 	if(damage_type == BRUTE) 


### PR DESCRIPTION
#19629 

I wasn't wrong. This time though I'm merely doubling extinguisher damage and leaving the brute mod as is because apparently people were mad about that.


# Why is this good for the game?

Blazing oil is still blatantly op


# Changelog

:cl:  

tweak: (Nearly) doubles extinguisher damage against blazing oil blobs
experimental: it's like I was right the whole time
/:cl:
