### PR TITLE
Buffs the improvised shotgun (maintain your shitty gun edition)

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -207,15 +207,23 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/improvised
 	sawn_desc = "I'm just here for the gasoline."
 	unique_reskin = null
-	var/slung = FALSE
 	can_bayonet = TRUE //STOP WATCHING THIS FILTH MY FELLOW CARGONIAN,WE MUST DEFEND OURSELVES
+	var/slung = FALSE
+	var/usage = 0 //how many times it's been used since last maintenance
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/improvised/afterattack()
-	if(prob(40))
+	if(prob(usage * 10))//10% chance for each shot to not fire
+		if(prob(max((usage - 5), 0) * 10))//10% chance for each shot to explode, after 6 shots
+			explosion(src, 0, 0, 1, 1)
+			playsound(src, 'sound/effects/break_stone.ogg', 30, TRUE)
+			to_chat(usr, span_warning("The round explodes in the chamber!"))
+			qdel(src)
+			return
 		playsound(src, dry_fire_sound, 30, TRUE)
 		return
 	else
 		. = ..()
+		usage++
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/improvised/attackby(obj/item/A, mob/user, params)
 	..()
@@ -231,6 +239,23 @@
 			update_appearance(UPDATE_ICON)
 		else
 			to_chat(user, span_warning("You need at least ten lengths of cable if you want to make a sling!"))
+
+/obj/item/gun/ballistic/shotgun/doublebarrel/improvised/screwdriver_act(mob/living/user, obj/item/I)
+	. = ..()
+	to_chat(user, span_notice("You start to perform maintenance on [src]."))
+	if(I.use_tool(src, user, 4 SECONDS))
+		to_chat(user, span_notice("You finish maintaining [src]."))
+		usage = 0
+
+/obj/item/gun/ballistic/shotgun/doublebarrel/improvised/examine(mob/user)
+	. = ..()
+	switch(usage)
+		if(0 to 1)
+			. += "It looks about as good as it possibly could."
+		if(2 to 5)
+			. += "It's starting to show some wear."
+		if(6 to INFINITY)
+			. += "It's not long before this thing falls apart."
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/improvised/update_icon_state()
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -209,10 +209,10 @@
 	unique_reskin = null
 	can_bayonet = TRUE //STOP WATCHING THIS FILTH MY FELLOW CARGONIAN,WE MUST DEFEND OURSELVES
 	var/slung = FALSE
-	var/usage = 1 //how many times it's been used since last maintenance
+	var/usage = 0 //how many times it's been used since last maintenance
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/improvised/afterattack()
-	if(prob(usage * 10))//10% chance for each shot to not fire
+	if(prob((usage + 1) * 10))//10% chance for each shot to not fire
 		if(prob(max((usage - 5), 0) * 10))//10% chance for each shot to explode, after 6 shots
 			explosion(src, 0, 0, 1, 1)
 			playsound(src, 'sound/effects/break_stone.ogg', 30, TRUE)
@@ -245,7 +245,7 @@
 	to_chat(user, span_notice("You start to perform maintenance on [src]."))
 	if(I.use_tool(src, user, 4 SECONDS))
 		to_chat(user, span_notice("You finish maintaining [src]."))
-		usage = 1
+		usage = 0
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/improvised/examine(mob/user)
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -212,7 +212,7 @@
 	var/usage = 0 //how many times it's been used since last maintenance
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/improvised/afterattack()
-	if(prob(max(usage * 10), 10))//10% chance for each shot to not fire with a baseline of 10%
+	if(prob((usage + 1) * 10))//10% chance for each shot to not fire with a baseline of 10%
 		if(prob(max((usage - 5), 0) * 10))//10% chance for each shot to explode, after 6 shots
 			explosion(src, 0, 0, 1, 1)
 			playsound(src, 'sound/effects/break_stone.ogg', 30, TRUE)

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -242,10 +242,14 @@
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/improvised/screwdriver_act(mob/living/user, obj/item/I)
 	. = ..()
-	to_chat(user, span_notice("You start to perform maintenance on [src]."))
+	if(usage == initial(usage))
+		to_chat(user, span_notice("[src] has no need for maintenance yet."))
+		return
+
+	to_chat(user, span_notice("You start to perform some maintenance on [src]."))
 	if(I.use_tool(src, user, 4 SECONDS))
-		to_chat(user, span_notice("You finish maintaining [src]."))
-		usage = initial(usage)
+		to_chat(user, span_notice("You fix up [src] a bit."))
+		usage = max(usage - 2, initial(usage))
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/improvised/examine(mob/user)
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -252,9 +252,9 @@
 	switch(usage)
 		if(0 to 1)
 			. += "It looks about as good as it possibly could."
-		if(2 to 5)
+		if(2 to 6)
 			. += "It's starting to show some wear."
-		if(6 to INFINITY)
+		if(7 to INFINITY)
 			. += "It's not long before this thing falls apart."
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/improvised/update_icon_state()

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -212,7 +212,7 @@
 	var/usage = 0 //how many times it's been used since last maintenance
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/improvised/afterattack()
-	if(prob((usage + 1) * 10))//10% chance for each shot to not fire with a baseline of 10%
+	if(prob(usage * 10))//10% chance for each shot to not fire
 		if(prob(max((usage - 5), 0) * 10))//10% chance for each shot to explode, after 6 shots
 			explosion(src, 0, 0, 1, 1)
 			playsound(src, 'sound/effects/break_stone.ogg', 30, TRUE)

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -209,7 +209,7 @@
 	unique_reskin = null
 	can_bayonet = TRUE //STOP WATCHING THIS FILTH MY FELLOW CARGONIAN,WE MUST DEFEND OURSELVES
 	var/slung = FALSE
-	var/usage = 0 //how many times it's been used since last maintenance
+	var/usage = 1 //how many times it's been used since last maintenance
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/improvised/afterattack()
 	if(prob(usage * 10))//10% chance for each shot to not fire
@@ -245,7 +245,7 @@
 	to_chat(user, span_notice("You start to perform maintenance on [src]."))
 	if(I.use_tool(src, user, 4 SECONDS))
 		to_chat(user, span_notice("You finish maintaining [src]."))
-		usage = 0
+		usage = 1
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/improvised/examine(mob/user)
 	. = ..()

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -245,7 +245,7 @@
 	to_chat(user, span_notice("You start to perform maintenance on [src]."))
 	if(I.use_tool(src, user, 4 SECONDS))
 		to_chat(user, span_notice("You finish maintaining [src]."))
-		usage = 0
+		usage = initial(usage)
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/improvised/examine(mob/user)
 	. = ..()
@@ -279,3 +279,4 @@
 	sawn_off = TRUE
 	slot_flags = ITEM_SLOT_BELT
 	can_bayonet = FALSE
+	usage = 1 //always slightly worse

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -212,7 +212,7 @@
 	var/usage = 0 //how many times it's been used since last maintenance
 
 /obj/item/gun/ballistic/shotgun/doublebarrel/improvised/afterattack()
-	if(prob((usage + 1) * 10))//10% chance for each shot to not fire
+	if(prob(max(usage * 10), 10))//10% chance for each shot to not fire with a baseline of 10%
 		if(prob(max((usage - 5), 0) * 10))//10% chance for each shot to explode, after 6 shots
 			explosion(src, 0, 0, 1, 1)
 			playsound(src, 'sound/effects/break_stone.ogg', 30, TRUE)


### PR DESCRIPTION
closes: #20664

# Why is this good for the game?
So people can have a reliable gun, so long as they remember to take care of it

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/73f4fca1-d719-4667-bb02-8b12c6edceea)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/3f5e12cf-3a1f-453e-b029-5c188bcf2af5)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/e654c758-2481-4674-be2f-d1728f6845f7)

:cl:  
tweak: Improvised shotgun now needs to be maintained with a screwdriver or it can explode
/:cl:
