### PR TITLE
Facehuggers no longer knock you out for 3x the time it needs to + self removal delay

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -60,6 +60,9 @@
 	if((stat == CONSCIOUS && !sterile) && !isalien(user))
 		if(Leap(user))
 			return
+	if(!do_after(user, 2 SECONDS, src))
+		to_chat(user, "You fail to pry [src] off your face.")
+		return
 	. = ..()
 
 /obj/item/clothing/mask/facehugger/attack(mob/living/M, mob/user)
@@ -184,7 +187,7 @@
 
 	if(!sterile)
 		M.take_bodypart_damage(strength,0) //done here so that humans in helmets take damage
-		M.Unconscious(MAX_IMPREGNATION_TIME/0.3) //something like 25 ticks = 20 seconds with the default settings
+		M.Unconscious(MAX_IMPREGNATION_TIME) //knock them out for the longest time needed to finish the deed
 
 	GoIdle() //so it doesn't jump the people that tear it off
 

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -60,7 +60,7 @@
 	if((stat == CONSCIOUS && !sterile) && !isalien(user))
 		if(Leap(user))
 			return
-	if(!do_after(user, 2 SECONDS, src))
+	if(!sterile && !do_after(user, 2 SECONDS, src))
 		to_chat(user, "You fail to pry [src] off your face.")
 		return
 	. = ..()

--- a/code/modules/mob/living/carbon/alien/special/facehugger.dm
+++ b/code/modules/mob/living/carbon/alien/special/facehugger.dm
@@ -60,7 +60,7 @@
 	if((stat == CONSCIOUS && !sterile) && !isalien(user))
 		if(Leap(user))
 			return
-	if(!sterile && !do_after(user, 2 SECONDS, src))
+	if(!sterile && stat == CONSCIOUS && !do_after(user, 2 SECONDS, src))
 		to_chat(user, "You fail to pry [src] off your face.")
 		return
 	. = ..()


### PR DESCRIPTION
# Why is this good for the game?
Getting knocked out for close to a minute when you either can't be implanted, or you're in a group and you were careless (no real danger) is a bit annoying.
it still knocks out long enough to guarantee embryo implantation, so this won't change anything if some idiot is running off solo
it also still knocks out long enough for a xeno to fuck you up if they're nearby
it's just frustration reduction when you're effectively safe, but otherwise stuck
also, adds a delay to removal so if you're somehow stun immune then they're still a bit more dangerous since you can't just ignore them with a single click, you need to stand still for 2 seconds

same idea when i modified clock spear unbuckle time

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/c31f0ed5-2ba2-401b-af17-4f120f4a7184)

:cl:  
tweak: Facehuggers knock out for 15 seconds instead of 50 seconds
tweak: Facehuggers take 2 seconds to pry off your face
/:cl:
