### PR TITLE
Hearty Punch is no longer limited stock!!! (Output changed)

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -556,7 +556,7 @@
 /datum/chemical_reaction/hearty_punch
 	name = "Hearty Punch"
 	id = /datum/reagent/consumable/ethanol/hearty_punch
-	results = list(/datum/reagent/consumable/ethanol/hearty_punch = 1)  //Very little, for balance reasons
+	results = list(/datum/reagent/consumable/ethanol/hearty_punch = 6)  //Very little, for balance reasons
 	required_reagents = list(/datum/reagent/consumable/ethanol/brave_bull = 5, /datum/reagent/consumable/ethanol/syndicatebomb = 5, /datum/reagent/consumable/ethanol/absinthe = 5)
 	mix_message = "The mixture darkens to a healthy crimson."
 	required_temp = 315 //Piping hot!


### PR DESCRIPTION
# Document the changes in your pull request

Hearty punch is a really decent get out of crit drink, the downside to it is. It is barely made and even when made it takes an extreme amount of units. You need 5 of three ingredients to make 1 unit of hearty punch. 150 units of ingredients will make 10 units of hearty punch. So to make a full bottle you'll need 1500 units. It is a lot, and so I've tweaked it so its not so bad.
Now it will give 6 units which is lesser than half the ingredients combined.
So it will go like this now:
15 = 6 units
30 = 12 units
45 = 18 units
60 = 24 units
75 = 30 units
90 = 36 units
105 = 42 units 

It still takes longer but at least now it isn't CBT to do so. Plus it still requires Berry juice which is a T2 upgrade or botanists need to care enough so this shouldn't heavily break the game.

# Why is this good for the game?
Means Hearty Punch can be churned out a little bit easier, so if barkeeps really want to they can save the critted mime that got beaten in his bar because of their "pranks"

# Testing
Its a number change

# Wiki Documentation

Needs to say 6 units instead of 15. Instead of 1 unit instead of 15

# Changelog

:cl:  

tweak: Hearty punch output gone from 1 to 6

/:cl:
