### PR TITLE
fixes kitchen vendor on one of the templates

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/bar_citadel.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/bar_citadel.dmm
@@ -322,9 +322,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "eS" = (
-/obj/machinery/vending/dinnerware{
-	contraband = list(/obj/item/kitchen/rollingpin = 2, /obj/item/kitchen/knife/butcher = 2, /obj/item/reagent_containers/food/condiment/flour = 4)
-	},
+/obj/machinery/vending/dinnerware,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "ft" = (


### PR DESCRIPTION
citadel bar had manually added contraband tweaks (gross)

# Why is this good for the game?
consistency, no reason why this bar should NOT have the large spoon and instead have a flour sack

# Testing
no

:cl:  ktlwjec
bugfix: Citadel kitchen template has the usual contraband items in the dinnerware vendor.
/:cl: