### PR TITLE
Give crystallization cooldown timer on status panel for etheral heart

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -94,11 +94,16 @@
 			. += "Chemical Storage: [changeling.chem_charges]/[changeling.chem_storage]"
 			. += "Absorbed DNA: [changeling.absorbedcount]"
 
-		//WS Begin - Display Ethereal Charge
+		//WS Begin - Display Ethereal Charge and Crystallization Cooldown
 		if(istype(src))
 			var/datum/species/ethereal/eth_species = src.dna?.species
+			var/obj/item/organ/heart/ethereal/eth_heart = getorganslot(ORGAN_SLOT_HEART)
 			if(istype(eth_species))
 				. += "Crystal Charge: [round((nutrition / NUTRITION_LEVEL_MOSTLY_FULL) * 100, 0.1)]%"
+			if(eth_heart)
+				var/crystallization_timer = round(COOLDOWN_TIMELEFT(eth_heart, crystalize_cooldown) / 600)
+				var/cooldown_finished = COOLDOWN_FINISHED(eth_heart, crystalize_cooldown)
+				. += "Crystallization Process Cooldown: [cooldown_finished ? "Ready" : "[crystallization_timer] minutes left"]"
 
 		var/datum/antagonist/zombie/zombie = mind.has_antag_datum(/datum/antagonist/zombie)
 		if(zombie)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -101,7 +101,7 @@
 			if(istype(eth_species))
 				. += "Crystal Charge: [round((nutrition / NUTRITION_LEVEL_MOSTLY_FULL) * 100, 0.1)]%"
 			if(eth_heart)
-				var/crystallization_timer = round(COOLDOWN_TIMELEFT(eth_heart, crystalize_cooldown) / 60)
+				var/crystallization_timer = round(COOLDOWN_TIMELEFT(eth_heart, crystalize_cooldown) / 10)
 				var/cooldown_finished = COOLDOWN_FINISHED(eth_heart, crystalize_cooldown)
 				. += "Crystallization Process Cooldown: [cooldown_finished ? "Ready" : "[crystallization_timer] seconds left"]"
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -101,9 +101,9 @@
 			if(istype(eth_species))
 				. += "Crystal Charge: [round((nutrition / NUTRITION_LEVEL_MOSTLY_FULL) * 100, 0.1)]%"
 			if(eth_heart)
-				var/crystallization_timer = round(COOLDOWN_TIMELEFT(eth_heart, crystalize_cooldown) / 600)
+				var/crystallization_timer = round(COOLDOWN_TIMELEFT(eth_heart, crystalize_cooldown) / 60)
 				var/cooldown_finished = COOLDOWN_FINISHED(eth_heart, crystalize_cooldown)
-				. += "Crystallization Process Cooldown: [cooldown_finished ? "Ready" : "[crystallization_timer] minutes left"]"
+				. += "Crystallization Process Cooldown: [cooldown_finished ? "Ready" : "[crystallization_timer] seconds left"]"
 
 		var/datum/antagonist/zombie/zombie = mind.has_antag_datum(/datum/antagonist/zombie)
 		if(zombie)


### PR DESCRIPTION

# Document the changes in your pull request
Ethereal heart now gives a crystallization cooldown timer on status panel

# Why is this good for the game?
Allow ethereals to know when the crystallization is ready

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/89688125/7d6783f9-232d-4921-96b5-b5e06459d803)




# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: Ethereal heart now gives a crystallization cooldown timer on status panel
/:cl:
