### PR TITLE
Replaces exploit with gamebreaking exploit in PR request template

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -118,6 +118,8 @@ There is no strict process when it comes to merging pull requests. Pull requests
 
 * We ask that you use the changelog system to document your player facing changes, which prevents our players from being caught unaware by said changes - you can find more information about this [on this wiki page](http://tgstation13.org/wiki/Guide_to_Changelogs).
 
+* If you are fixing a game-breaking bug, it's advised to use the [s] tag to not bring unwanted attention to your pull request. Very rarely is it acceptable to use this label outside of these situations, due to it hiding information from many sources.
+
 * If you are proposing multiple changes, which change many different aspects of the code, you are expected to section them off into different pull requests in order to make it easier to review them and to deny/accept the changes that are deemed acceptable.
 
 * If your pull request is accepted, the code you add no longer belongs exclusively to you but to everyone; everyone is free to work on it, but you are also free to support or object to any changes being made, which will likely hold more weight, as you're the one who added the feature. It is a shame this has to be explicitly said, but there have been cases where this would've saved some trouble.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ Mention if you have tested your changes. If you changed a map, make sure you use
 If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.
 
 Prefix the PR title with [admin] if it involves something admin related. 
-Prefix the PR title with [s] if you are fixing an exploit, so that it is not announced on the Yogstation Discord and the server.
+Prefix the PR title with [s] if you are fixing a game-breaking exploit, so that it is not announced on the Yogstation Discord and the server. This hides it from anyone who isn't watching the Github page, which means it will be your responsibility to bring its attention to Maintainers.
 
 Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ Mention if you have tested your changes. If you changed a map, make sure you use
 If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.
 
 Prefix the PR title with [admin] if it involves something admin related. 
-Prefix the PR title with [s] if you are fixing a game-breaking exploit, so that it is not announced on the Yogstation Discord and the server. This hides it from anyone who isn't watching the Github page, which means it will be your responsibility to bring its attention to Maintainers.
+Prefix the PR title with [s] if you are fixing a game-breaking exploit, so that it is not announced on the Yogstation Discord and the server.
 
 Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->
 


### PR DESCRIPTION
# Document the changes in your pull request

The PR template says what ``[s]`` should be used for, but just about any bug in the game can be classified as an exploit. I really don't want to have to stalk the github page to see these random PRs that fix issues that aren't breaking the game, and I think abusing it would also be bad.
~~I also mentioned that maintainers aren't aware of PRs with [s] so they can bring it up themselves to someone available.~~ They do actually, I just haven't noticed it.

I've noticed a lot that ``[s]`` is abused frequently here, it's really stupid. Usually it's just to avoid commenters, which I do not agree with at all- stop trying to hide stuff from people god damn.

Not mentioning any PRs here because I don't want witch-hunts I just want this label to stop being used so liberally.