### PR TITLE
Engineering stuff tweaks and bugfixes

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -495,3 +495,8 @@ GLOBAL_LIST_INIT(pipe_paint_colors, list(
 #define MIASMA_GIBS_MOLES 0.005
 
 #define TURF_SHARES(T) (LAZYLEN(T.atmos_adjacent_turfs))
+
+//Defines for air alarm severities in areas.
+#define ATMOS_ALARM_SEVERE "severe"
+#define ATMOS_ALARM_MINOR "minor"
+#define ATMOS_ALARM_CLEAR "clear"

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -32,7 +32,8 @@
 	var/clockwork_warp_allowed = TRUE // Can servants warp into this area from Reebe?
 	var/clockwork_warp_fail = "The structure there is too dense for warping to pierce. (This is normal in high-security areas.)"
 
-	var/fire = FALSE //If true, that means one of any fire alarms in the area is active
+	///If true, that means one of any fire alarms in the area is active
+	var/fire = FALSE
 	var/atmos = TRUE
 	var/atmosalm = FALSE
 	var/poweralm = TRUE

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -32,7 +32,6 @@
 	var/clockwork_warp_allowed = TRUE // Can servants warp into this area from Reebe?
 	var/clockwork_warp_fail = "The structure there is too dense for warping to pierce. (This is normal in high-security areas.)"
 
-	var/actual_fire = FALSE //If true, theres an actual fire detected in this area
 	var/fire = FALSE //If true, that means one of any fire alarms in the area is active
 	var/atmos = TRUE
 	var/atmosalm = FALSE

--- a/code/game/machinery/computer/atmos_alert.dm
+++ b/code/game/machinery/computer/atmos_alert.dm
@@ -62,9 +62,9 @@
 	
 	var/mob/user = usr
 	var/obj/machinery/airalarm/found_air_alarm = locate() in zone_from_tgui
-	if(priority_air_alarm)
-		priority_air_alarm.atmos_manualOverride(TRUE)
-		priority_air_alarm.post_alert(0)
+	if(found_air_alarm)
+		found_air_alarm.atmos_manualOverride(TRUE)
+		found_air_alarm.post_alert(0)
 		priority_alarms -= zone_from_tgui
 		minor_alarms -= zone_from_tgui
 		if(user)

--- a/code/game/machinery/computer/atmos_alert.dm
+++ b/code/game/machinery/computer/atmos_alert.dm
@@ -4,12 +4,17 @@
 	circuit = /obj/item/circuitboard/computer/atmos_alert
 	icon_screen = "alert:0"
 	icon_keyboard = "atmos_key"
-	var/list/priority_alarms = list()
-	var/list/minor_alarms = list()
-	var/receive_frequency = FREQ_ATMOS_ALARMS
-	var/datum/radio_frequency/radio_connection
-
 	light_color = LIGHT_COLOR_CYAN
+
+	///List of areas with a priority alarm ongoing.
+	var/list/area/priority_alarms = list()
+	///List of areas with a minor alarm ongoing.
+	var/list/area/minor_alarms = list()
+
+	///The radio connection the computer uses to receive signals.
+	var/datum/radio_frequency/radio_connection
+	///The frequency that radio_connection listens and retrieves signals from.
+	var/receive_frequency = FREQ_ATMOS_ALARMS
 
 /obj/machinery/computer/atmos_alert/Initialize(mapload)
 	. = ..()
@@ -27,39 +32,53 @@
 
 /obj/machinery/computer/atmos_alert/ui_data(mob/user)
 	var/list/data = list()
+	data["priority_alerts"] = list()
+	data["minor_alerts"] = list()
 
-	data["priority"] = list()
-	for(var/zone in priority_alarms)
-		data["priority"] += zone
-	data["minor"] = list()
-	for(var/zone in minor_alarms)
-		data["minor"] += zone
+	for(var/area/priority_alarm as anything in priority_alarms)
+		data["priority_alerts"] += list(list(
+			"name" = priority_alarm.name,
+			"ref" = REF(priority_alarm),
+		))
+
+	for(var/area/minor_alarm as anything in minor_alarms)
+		data["minor_alerts"] += list(list(
+			"name" = minor_alarm.name,
+			"ref" = REF(minor_alarm),
+		))
 
 	return data
 
 /obj/machinery/computer/atmos_alert/ui_act(action, params)
-	if(..())
-		return
-	switch(action)
-		if("clear")
-			var/zone = params["zone"]
-			for(var/area/A in priority_alarms)
-				if(A.name == zone)
-					var/obj/machinery/airalarm/AA = locate() in A
-					AA.atmos_manualOverride(TRUE)
-					AA.post_alert(0)
-					to_chat(usr, "Priority alarm for [zone] cleared.")
-					priority_alarms -= zone
-					. = TRUE
-			for(var/area/A in minor_alarms)
-				if(A.name == zone)
-					var/obj/machinery/airalarm/AA = locate() in A
-					AA.atmos_manualOverride(TRUE)
-					AA.post_alert(0)
-					to_chat(usr, "Minor alarm for [zone] cleared.")
-					minor_alarms -= zone
-					. = TRUE
-	update_appearance(UPDATE_ICON)
+	. = ..()
+	if(.)
+		return TRUE
+	if(action != "clear")
+		return TRUE
+
+	var/area/zone_from_tgui = locate(params["zone_ref"]) in priority_alarms
+	if(!zone_from_tgui || !istype(zone_from_tgui))
+		return TRUE
+	
+	var/mob/user = usr
+	var/obj/machinery/airalarm/priority_air_alarm = locate() in zone_from_tgui
+	if(priority_air_alarm)
+		priority_air_alarm.atmos_manualOverride(TRUE)
+		priority_air_alarm.post_alert(0)
+		priority_alarms -= zone_from_tgui
+		if(user)
+			user.balloon_alert("alarm cleared.")
+		update_appearance(UPDATE_ICON)
+		return TRUE
+	var/obj/machinery/airalarm/minor_air_alarm = locate() in zone_from_tgui
+	if(minor_air_alarm)
+		minor_air_alarm.atmos_manualOverride(TRUE)
+		minor_air_alarm.post_alert(0)
+		minor_alarms -= zone_from_tgui
+		if(user)
+			user.balloon_alert("alarm cleared.")
+		update_appearance(UPDATE_ICON)
+		return TRUE
 
 /obj/machinery/computer/atmos_alert/proc/set_frequency(new_frequency)
 	SSradio.remove_object(src, receive_frequency)
@@ -70,25 +89,27 @@
 	if(!signal)
 		return
 
-	var/zone = signal.data["zone"]
+	var/area/new_zone = signal.data["zone"]
 	var/severity = signal.data["alert"]
-
-	if(!zone || !severity)
+	if(!new_zone || !istype(new_zone) || !severity)
 		return
 
-	minor_alarms -= zone
-	priority_alarms -= zone
-	if(severity == "severe")
-		priority_alarms += zone
-	else if (severity == "minor")
-		minor_alarms += zone
+	//clear current references.
+	minor_alarms -= new_zone
+	priority_alarms -= new_zone
+
+	switch(severity)
+		if(ATMOS_ALARM_SEVERE)
+			priority_alarms += new_zone
+		if(ATMOS_ALARM_MINOR)
+			minor_alarms += new_zone
 	update_appearance(UPDATE_ICON)
-	return
 
 /obj/machinery/computer/atmos_alert/update_overlays()
 	. = ..()
 	if(stat & (NOPOWER|BROKEN))
 		return
+
 	if(priority_alarms.len)
 		. += "alert:2"
 	else if(minor_alarms.len)

--- a/code/game/machinery/computer/atmos_alert.dm
+++ b/code/game/machinery/computer/atmos_alert.dm
@@ -56,24 +56,16 @@
 	if(action != "clear")
 		return TRUE
 
-	var/area/zone_from_tgui = locate(params["zone_ref"]) in priority_alarms
+	var/area/zone_from_tgui = locate(params["zone_ref"]) in priority_alarms + minor_alarms
 	if(!zone_from_tgui || !istype(zone_from_tgui))
 		return TRUE
 	
 	var/mob/user = usr
-	var/obj/machinery/airalarm/priority_air_alarm = locate() in zone_from_tgui
+	var/obj/machinery/airalarm/found_air_alarm = locate() in zone_from_tgui
 	if(priority_air_alarm)
 		priority_air_alarm.atmos_manualOverride(TRUE)
 		priority_air_alarm.post_alert(0)
 		priority_alarms -= zone_from_tgui
-		if(user)
-			user.balloon_alert("alarm cleared.")
-		update_appearance(UPDATE_ICON)
-		return TRUE
-	var/obj/machinery/airalarm/minor_air_alarm = locate() in zone_from_tgui
-	if(minor_air_alarm)
-		minor_air_alarm.atmos_manualOverride(TRUE)
-		minor_air_alarm.post_alert(0)
 		minor_alarms -= zone_from_tgui
 		if(user)
 			user.balloon_alert("alarm cleared.")

--- a/code/game/machinery/computer/atmos_alert.dm
+++ b/code/game/machinery/computer/atmos_alert.dm
@@ -43,14 +43,22 @@
 	switch(action)
 		if("clear")
 			var/zone = params["zone"]
-			if(zone in priority_alarms)
-				to_chat(usr, "Priority alarm for [zone] cleared.")
-				priority_alarms -= zone
-				. = TRUE
-			if(zone in minor_alarms)
-				to_chat(usr, "Minor alarm for [zone] cleared.")
-				minor_alarms -= zone
-				. = TRUE
+			for(var/area/A in priority_alarms)
+				if(A.name == zone)
+					var/obj/machinery/airalarm/AA = locate() in A
+					AA.atmos_manualOverride(TRUE)
+					AA.post_alert(0)
+					to_chat(usr, "Priority alarm for [zone] cleared.")
+					priority_alarms -= zone
+					. = TRUE
+			for(var/area/A in minor_alarms)
+				if(A.name == zone)
+					var/obj/machinery/airalarm/AA = locate() in A
+					AA.atmos_manualOverride(TRUE)
+					AA.post_alert(0)
+					to_chat(usr, "Minor alarm for [zone] cleared.")
+					minor_alarms -= zone
+					. = TRUE
 	update_appearance(UPDATE_ICON)
 
 /obj/machinery/computer/atmos_alert/proc/set_frequency(new_frequency)

--- a/code/game/machinery/computer/atmos_alert.dm
+++ b/code/game/machinery/computer/atmos_alert.dm
@@ -60,15 +60,13 @@
 	if(!zone_from_tgui || !istype(zone_from_tgui))
 		return TRUE
 	
-	var/mob/user = usr
 	var/obj/machinery/airalarm/found_air_alarm = locate() in zone_from_tgui
 	if(found_air_alarm)
 		found_air_alarm.atmos_manualOverride(TRUE)
 		found_air_alarm.post_alert(0)
 		priority_alarms -= zone_from_tgui
 		minor_alarms -= zone_from_tgui
-		if(user)
-			user.balloon_alert("alarm cleared.")
+		balloon_alert(usr, "alarm cleared.")
 		update_appearance(UPDATE_ICON)
 		return TRUE
 

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -55,6 +55,7 @@
 	else if(O && istype(O, /obj/machinery/camera))
 		C = O
 	L[A.name] = list(A, (C ? C : O), list(source))
+	update_appearance(UPDATE_ICON)
 	return 1
 
 
@@ -72,6 +73,7 @@
 			if (srcs.len == 0)
 				cleared = 1
 				L -= I
+	update_appearance(UPDATE_ICON)
 	return !cleared
 
 /obj/machinery/computer/station_alert/update_overlays()

--- a/code/game/machinery/computer/station_alert.dm
+++ b/code/game/machinery/computer/station_alert.dm
@@ -45,6 +45,7 @@
 			var/list/sources = alarm[3]
 			if (!(source in sources))
 				sources += source
+			update_appearance(UPDATE_ICON)
 			return 1
 	var/obj/machinery/camera/C = null
 	var/list/CL = null

--- a/code/game/machinery/doors/alarmlock.dm
+++ b/code/game/machinery/doors/alarmlock.dm
@@ -35,9 +35,9 @@
 
 	if(alarm_area == get_area_name(src))
 		switch(alert)
-			if("severe")
+			if(ATMOS_ALARM_SEVERE)
 				autoclose = TRUE
 				close()
-			if("minor", "clear")
+			if(ATMOS_ALARM_MINOR, ATMOS_ALARM_CLEAR)
 				autoclose = FALSE
 				open()

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -30,14 +30,19 @@
 	light_range = 7
 	light_color = "#ff3232"
 
+	/// 1 = will auto detect fire, 0 = no auto
 	var/detecting = 1
-	var/buildstage = 2 // 2 = complete, 1 = no wires, 0 = circuit gone
+	/// 2 = complete, 1 = no wires, 0 = circuit gone
+	var/buildstage = 2
+	/// Cooldown for next alarm trigger, so it doesnt spam much
 	var/last_alarm = 0
+	/// The area of the current fire alarm
 	var/area/myarea = null
+	/// If true, then this area has a real fire and not by someone triggering it manually
 	var/real_fire = FALSE
-
-	var/bad_temp = null //Current bad temperature
-
+	/// If real_fire is true then it will show you the current hot temperature
+	var/bad_temp = null
+	/// The radio to alert engineers, atmos techs
 	var/obj/item/radio/radio
 
 /obj/machinery/firealarm/Initialize(mapload, dir, building)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -137,10 +137,11 @@
 /obj/machinery/firealarm/temperature_expose(datum/gas_mixture/air, temperature, volume)
 	var/turf/open/T = get_turf(src)
 	if((temperature >= FIRE_MINIMUM_TEMPERATURE_TO_EXIST || temperature < BODYTEMP_COLD_DAMAGE_LIMIT || (istype(T) && T.turf_fire)) && (last_alarm+FIREALARM_COOLDOWN < world.time) && !(obj_flags & EMAGGED) && detecting && !stat)
+		if(!real_fire)
+			radio.talk_into(src, "Fire detected in [myarea].", RADIO_CHANNEL_ENGINEERING)
 		real_fire = TRUE
 		bad_temp = temperature
 		alarm()
-		radio.talk_into(src, "Fire detected in [myarea].", RADIO_CHANNEL_ENGINEERING)
 		START_PROCESSING(SSmachines, src)
 	..()
 

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -136,7 +136,7 @@
 /obj/machinery/firealarm/examine(mob/user)
 	. = ..()
 	if(areafire_check())
-		. += span_danger("Fire detected in this area, current fire alarm temperature: [bad_temp+T0C]C")
+		. += span_danger("Fire detected in this area, current fire alarm temperature: [bad_temp-T0C]C")
 	else
 		. += span_notice("There's no fire detected.")
 

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -56,7 +56,7 @@
 			reset()
 		else
 			myarea.firereset(src, TRUE)
-	else if(!myarea.actual_fire && myarea.fire) //No actual fire and one of the air alarms is active
+	else if(!myarea.actual_fire && myarea.fire) //No actual fire and one of the fire alarms is active
 		reset()
 	else
 		myarea.firereset(src, TRUE)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -58,7 +58,7 @@
 	myarea = get_area(src)
 	LAZYADD(myarea.firealarms, src)
 	radio = new(src)
-	radio.keyslot = new /obj/item/encryptionkey/headset_eng
+	radio.keyslot = new /obj/item/encryptionkey/headset_eng()
 	radio.subspace_transmission = TRUE
 	radio.canhear_range = 0
 	radio.recalculateChannels()

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -38,6 +38,8 @@
 
 	var/bad_temp = null //Current bad temperature
 
+	var/obj/item/radio/radio
+
 /obj/machinery/firealarm/Initialize(mapload, dir, building)
 	. = ..()
 	if(dir)
@@ -50,6 +52,11 @@
 	update_appearance(UPDATE_ICON)
 	myarea = get_area(src)
 	LAZYADD(myarea.firealarms, src)
+	radio = new(src)
+	radio.keyslot = new /obj/item/encryptionkey/headset_eng
+	radio.subspace_transmission = TRUE
+	radio.canhear_range = 0
+	radio.recalculateChannels()
 	STOP_PROCESSING(SSmachines, src) // I will do this
 
 /obj/machinery/firealarm/Destroy()
@@ -133,6 +140,7 @@
 		real_fire = TRUE
 		bad_temp = temperature
 		alarm()
+		radio.talk_into(src, "Fire detected in [myarea].", RADIO_CHANNEL_ENGINEERING)
 		START_PROCESSING(SSmachines, src)
 	..()
 
@@ -173,10 +181,6 @@
 	add_fingerprint(user)
 	play_click_sound("button")
 	if(myarea.fire || myarea.party)
-		if(areafire_check() && !(obj_flags & EMAGGED))
-			to_chat(user, span_danger("There is a fire in this area, you cannot lift the fire doors."))
-			playsound(src, 'sound/machines/buzz-sigh.ogg', 50, FALSE)
-			return
 		reset(user)
 	else
 		alarm(user)

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -61,6 +61,7 @@
 
 /obj/machinery/firealarm/Destroy()
 	myarea.firereset(src, TRUE)
+	QDEL_NULL(radio)
 	LAZYREMOVE(myarea.firealarms, src)
 	return ..()
 

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -174,7 +174,8 @@
 	play_click_sound("button")
 	if(myarea.fire || myarea.party)
 		if(areafire_check() && !(obj_flags & EMAGGED))
-			to_chat(user, span_notice("There is a fire in this area, you cannot lift the fire doors."))
+			to_chat(user, span_danger("There is a fire in this area, you cannot lift the fire doors."))
+			playsound(src, 'sound/machines/buzz-sigh.ogg', 50, FALSE)
 			return
 		reset(user)
 	else

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -714,9 +714,13 @@
 		else
 			AA.manual_override = TRUE
 
+#define ALARM_LEVEL_CLEAR 0
+#define ALARM_LEVEL_MINOR 1
+#define ALARM_LEVEL_SEVERE 2
+
 /obj/machinery/airalarm/proc/post_alert(alert_level)
 	var/datum/radio_frequency/frequency = SSradio.return_frequency(alarm_frequency)
-	if(alert_level>0 && !manual_override)
+	if(alert_level > 0 && !manual_override)
 		trigger_reset = TRUE
 	else
 		trigger_reset = FALSE
@@ -729,21 +733,26 @@
 
 	var/datum/signal/alert_signal = new(list(
 		"zone" = A,
-		"type" = "Atmospheric"
+		"type" = "Atmospheric",
 	))
-	if(alert_level==2)
-		alert_signal.data["alert"] = "severe"
-		A.set_vacuum_alarm_effect()
-	else if (alert_level==1)
-		alert_signal.data["alert"] = "minor"
-	else if (alert_level==0)
-		alert_signal.data["alert"] = "clear"
-		A.unset_vacuum_alarm_effect()
+	switch(alert_level)
+		if(ALARM_LEVEL_CLEAR)
+			alert_signal.data["alert"] = ATMOS_ALARM_CLEAR
+			A.unset_vacuum_alarm_effect()
+		if(ALARM_LEVEL_MINOR)
+			alert_signal.data["alert"] = ATMOS_ALARM_MINOR
+		if(ALARM_LEVEL_SEVERE)
+			alert_signal.data["alert"] = ATMOS_ALARM_SEVERE
+			A.set_vacuum_alarm_effect()
 
 	frequency.post_signal(src, alert_signal, range = -1)
 
 	for(var/obj/machinery/airalarm/AA in A)
 		AA.update_appearance(UPDATE_ICON)
+
+#undef ALARM_LEVEL_CLEAR
+#undef ALARM_LEVEL_MINOR
+#undef ALARM_LEVEL_SEVERE
 
 /obj/machinery/airalarm/proc/apply_danger_level()
 

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -722,7 +722,7 @@
 		return
 
 	var/datum/signal/alert_signal = new(list(
-		"zone" = get_area_name(src),
+		"zone" = A,
 		"type" = "Atmospheric"
 	))
 	if(alert_level==2)

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -249,7 +249,7 @@
 /obj/machinery/airalarm/Destroy()
 	SSradio.remove_object(src, frequency)
 	QDEL_NULL(wires)
-	if(A.airalarms.len<2 || A.manual_atmosalm)
+	if(length(A.airalarms)<2 || A.manual_atmosalm)
 		atmos_manualOverride(TRUE)
 		post_alert(0)
 	else

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -231,6 +231,7 @@
 	..()
 	wires = new /datum/wires/airalarm(src)
 	A = get_area(src)
+	LAZYADD(A.airalarms, src)
 	if(ndir)
 		setDir(ndir)
 
@@ -248,8 +249,13 @@
 /obj/machinery/airalarm/Destroy()
 	SSradio.remove_object(src, frequency)
 	QDEL_NULL(wires)
-	atmos_manualOverride(TRUE)
-	post_alert(0)
+	if(A.airalarms.len<2 || A.manual_atmosalm)
+		atmos_manualOverride(TRUE)
+		post_alert(0)
+	else
+		atmos_manualOverride(TRUE)
+		A.atmosalert(0, src)
+	LAZYREMOVE(A.airalarms, src)
 	return ..()
 
 /obj/machinery/airalarm/Initialize(mapload)

--- a/code/modules/modular_computers/file_system/programs/engineering/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/alarm.dm
@@ -38,58 +38,16 @@
 
 	return data
 
-/datum/computer_file/program/alarm_monitor/proc/triggerAlarm(class, area/A, O, obj/source)
-	if(is_station_level(source.z))
-		if(!(A.type in GLOB.the_station_areas))
-			return
-	else if(!is_mining_level(source.z) || istype(A, /area/ruin))
-		return
-
-	var/list/L = GLOB.alarms[class]
-	for(var/I in L)
-		if (I == A.name)
-			var/list/alarm = L[I]
-			var/list/sources = alarm[3]
-			if (!(source in sources))
-				sources += source
-			return 1
-	var/obj/machinery/camera/C = null
-	var/list/CL = null
-	if(O && istype(O, /list))
-		CL = O
-		if (CL.len == 1)
-			C = CL[1]
-	else if(O && istype(O, /obj/machinery/camera))
-		C = O
-	L[A.name] = list(A, (C ? C : O), list(source))
-
-	update_alarm_display()
-
-	return 1
-
-
-/datum/computer_file/program/alarm_monitor/proc/cancelAlarm(class, area/A, obj/origin)
-	var/list/L = GLOB.alarms[class]
-	var/cleared = 0
-	for (var/I in L)
-		if (I == A.name)
-			var/list/alarm = L[I]
-			var/list/srcs  = alarm[3]
-			if (origin in srcs)
-				srcs -= origin
-			if (srcs.len == 0)
-				cleared = 1
-				L -= I
-
-	update_alarm_display()
-	return !cleared
-
 /datum/computer_file/program/alarm_monitor/proc/update_alarm_display()
 	has_alert = FALSE
 	for(var/cat in GLOB.alarms)
 		var/list/L = GLOB.alarms[cat]
 		if(L.len)
 			has_alert = TRUE
+
+/datum/computer_file/program/alarm_monitor/New()
+	..()
+	GLOB.alarmdisplay += src
 
 /datum/computer_file/program/alarm_monitor/run_program(mob/user)
 	. = ..(user)

--- a/tgui/packages/tgui/interfaces/AtmosAlertConsole.tsx
+++ b/tgui/packages/tgui/interfaces/AtmosAlertConsole.tsx
@@ -2,10 +2,19 @@ import { useBackend } from '../backend';
 import { Button, Section } from '../components';
 import { Window } from '../layouts';
 
+type Data = {
+  priority_alerts: AlertData[];
+  minor_alerts: AlertData[];
+};
+
+type AlertData = {
+  name: string;
+  ref: string;
+};
+
 export const AtmosAlertConsole = (props, context) => {
-  const { act, data } = useBackend(context);
-  const priorityAlerts = data.priority || [];
-  const minorAlerts = data.minor || [];
+  const { act, data } = useBackend<Data>(context);
+  const { priority_alerts = [], minor_alerts = [] } = data;
   return (
     <Window
       width={350}
@@ -14,32 +23,32 @@ export const AtmosAlertConsole = (props, context) => {
       <Window.Content scrollable>
         <Section title="Alarms">
           <ul>
-            {priorityAlerts.length === 0 && (
+            {priority_alerts.length === 0 && (
               <li className="color-good">
                 No Priority Alerts
               </li>
             )}
-            {priorityAlerts.map(alert => (
-              <li key={alert}>
+            {priority_alerts.map((alert) => (
+              <li key={alert.name}>
                 <Button
                   icon="times"
-                  content={alert}
+                  content={alert.name}
                   color="bad"
-                  onClick={() => act('clear', { zone: alert })} />
+                  onClick={() => act('clear', { zone_ref: alert.ref })} />
               </li>
             ))}
-            {minorAlerts.length === 0 && (
+            {minor_alerts.length === 0 && (
               <li className="color-good">
                 No Minor Alerts
               </li>
             )}
-            {minorAlerts.map(alert => (
-              <li key={alert}>
+            {minor_alerts.map((alert) => (
+              <li key={alert.name}>
                 <Button
                   icon="times"
-                  content={alert}
+                  content={alert.name}
                   color="average"
-                  onClick={() => act('clear', { zone: alert })} />
+                  onClick={() => act('clear', { zone_ref: alert.ref })} />
               </li>
             ))}
           </ul>


### PR DESCRIPTION
# Document the changes in your pull request
Atmos alert console can clear air alarm atmos alert
Fix station alert console and program not updating overlays
Fix fire alerts not clearing when there are multiple fire alarms in one area
fix destroyed airalarm clearing atmos alert if theres an actual atmos alert in an area with multiple air alarms
During an active fire nearby a firealarm, it will show you the current temperature when examined
Firealarm now notify on engineering channel when theres a fire

# Why is this good for the game?
Currently all it does is removing the alert on the console and nothing else, that is pretty lame and suck. This should help AI or atmos techs clearing atmos alerts faster

# Testing
### Atmos alert console and overlays test
![ball](https://github.com/yogstation13/Yogstation/assets/89688125/d9493b85-1b25-4695-a07d-10293aa9958e)

### Fire alerts test


![fire_test](https://github.com/yogstation13/Yogstation/assets/89688125/a444a55c-97e5-4b81-9d2c-69be9621ff35)




# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  JohnFulpWillard, warface1234455

rscadd: Atmos alert console can clear air alarm atmos alert
rscadd: During an active fire nearby a firealarm, it will show you the current temperature when examined
tweak: Firealarm now notify on engineering channel when theres a fire
bugfix: Fix station alert console and program not updating overlays
bugfix: Fix fire alerts not clearing when there are multiple fire alarms in one area
bugfix: fix destroyed airalarm clearing atmos alert if theres an actual atmos alert in an area with multiple air alarms
/:cl:
