### PR TITLE
You can smash plates on heads

### DIFF
--- a/code/modules/food_and_drinks/plate.dm
+++ b/code/modules/food_and_drinks/plate.dm
@@ -12,6 +12,7 @@
 	var/max_height_offset = 5
 	///Offset of where the click is calculated from, due to how food is positioned in their DMIs.
 	var/placement_offset = -12
+	var/smash_force = 10 //damage for head smashing
 
 
 /obj/item/plate/attackby(obj/item/I, mob/user, params)
@@ -104,6 +105,44 @@
 	playsound(scatter_turf, 'sound/items/ceramic_break.ogg', 60, TRUE)
 	qdel(src)
 
+//head smashing (funny)
+/obj/item/plate/attack(mob/living/target, mob/living/user)
+	var/obj/item/bodypart/affecting = user.zone_selected
+
+	if(!target)
+		return
+	if(user.a_intent != INTENT_HARM || affecting != BODY_ZONE_HEAD)
+		return ..()
+	if(HAS_TRAIT(user, TRAIT_PACIFISM))
+		to_chat(user, span_warning("You don't want to harm [target]!"))
+		return
+
+	var/armor_block = 0
+
+	if(ishuman(target))
+
+		var/mob/living/carbon/human/H = target
+		armor_block = H.run_armor_check(affecting, MELEE,"","",armour_penetration)
+	else
+		armor_block = target.run_armor_check(affecting, MELEE)
+
+	armor_block = min(90,armor_block)
+	target.apply_damage(smash_force, BRUTE, affecting, armor_block)
+
+	//attack message
+	if(target != user)
+		target.visible_message(span_danger("[user] has smashed [target] on the head with a [src.name]!"), \
+				span_userdanger("[user] has smashed [target] on the head with a [src.name]!"))
+	else
+		user.visible_message(span_danger("[target] hits [target.p_them()]self with a [src.name] on the head!"), \
+				span_userdanger("[target] hits [target.p_them()]self with a [src.name] on the head!"))
+
+	log_combat(user, target, "attacked", src)
+
+	throw_impact(target, user) //plate smash
+
+	return
+
 /obj/item/plate/large
 	name = "buffet plate"
 	desc = "A large plate made for the professional catering industry but also appreciated by mukbangers and other persons of considerable size and heft."
@@ -111,6 +150,7 @@
 	max_items = 12
 	max_x_offset = 8
 	max_height_offset = 12
+	smash_force = 12
 
 /obj/item/plate/small
 	name = "appetizer plate"
@@ -119,6 +159,7 @@
 	max_items = 2
 	max_x_offset = 3
 	max_height_offset = 4
+	smash_force = 5
 
 /obj/item/plate_shard
 	name = "ceramic shard"

--- a/code/modules/food_and_drinks/plate.dm
+++ b/code/modules/food_and_drinks/plate.dm
@@ -13,6 +13,7 @@
 	///Offset of where the click is calculated from, due to how food is positioned in their DMIs.
 	var/placement_offset = -12
 	var/smash_force = 10 //damage for head smashing
+	var/const/duration = 13 // Directly relates to the 'knockdown' duration. Lowered by armor (i.e. helmets)
 
 
 /obj/item/plate/attackby(obj/item/I, mob/user, params)
@@ -118,16 +119,28 @@
 		return
 
 	var/armor_block = 0
+	var/armor_duration = 0 //The more force the plate has, the longer the duration.
 
 	if(ishuman(target))
 
 		var/mob/living/carbon/human/H = target
+		var/headarmor = 0 // Target's head armor
 		armor_block = H.run_armor_check(affecting, MELEE,"","",armour_penetration)
+
+		if(istype(H.head, /obj/item/clothing/head))
+			headarmor = H.head.armor.melee
+		else
+			headarmor = 0
+
+		armor_duration = (duration - headarmor) + force //knockdown duration
+
 	else
 		armor_block = target.run_armor_check(affecting, MELEE)
+		armor_duration = duration + force
 
 	armor_block = min(90,armor_block)
 	target.apply_damage(smash_force, BRUTE, affecting, armor_block)
+	target.apply_effect(min(armor_duration, 200) , EFFECT_KNOCKDOWN)
 
 	//attack message
 	if(target != user)


### PR DESCRIPTION
You can smash plates on people's heads (harm intent, target head), causes a small knockdown. Same knockdown as a beer bottle. Plates have varying force depending on plate size, for damage applied during this. Still do no damage when attacking normally, as I like to imagine the damage is applied due to the smashing.

# Why is this good for the game?
A fun little thing for cook fighting, it makes sense, and also I've had multiple people ask for this.

# Testing
Made sure it works on head only. Made sure knockdown+damage are reduced with armor.
Probably needs someone to check this over to make sure the code can't be cleaned up a bit but it definitely works.

:cl:  ktlwjec
rscadd: Plates smash and apply a short knockdown (same as beer bottles) when attacked on the head.
/:cl: