### PR TITLE
Taking damage resets Worldbreaker plate growth timer

### DIFF
--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -153,6 +153,9 @@
 	if(plates <= 0)//no plate to lose
 		return
 
+	deltimer(plate_timer)//reset the plate timer
+	plate_timer = addtimer(CALLBACK(src, PROC_REF(grow_plate), H), PLATE_INTERVAL, TIMER_LOOP|TIMER_UNIQUE|TIMER_STOPPABLE)
+
 	if(damagetype != BRUTE && damagetype != BURN)
 		damage /= 4 //brute and burn are most effective
 

--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -154,7 +154,7 @@
 		return
 
 	deltimer(plate_timer)//reset the plate timer
-	plate_timer = addtimer(CALLBACK(src, PROC_REF(grow_plate), H), PLATE_INTERVAL, TIMER_LOOP|TIMER_UNIQUE|TIMER_STOPPABLE)
+	plate_timer = addtimer(CALLBACK(src, PROC_REF(grow_plate), user), PLATE_INTERVAL, TIMER_LOOP|TIMER_UNIQUE|TIMER_STOPPABLE)
 
 	if(damagetype != BRUTE && damagetype != BURN)
 		damage /= 4 //brute and burn are most effective


### PR DESCRIPTION
# Why is this good for the game?
I had intended to make plates be sort of a two phase thing
build up > fight (break off) > build up
but since they can regenerate during the fight it sorta just ended up with them constantly regenerating, making them really strong in battles of attrition, they'd also suddenly get more tanky, even between hits

this should allow for those attacking a worldbreaker user to keep the pressure on, never letting the user regen plates and whittle them down

:cl:  
tweak: Taking damage resets Worldbreaker plate growth timer
/:cl:
