### PR TITLE
more snowcone changes

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_frozen.dm
+++ b/code/modules/food_and_drinks/food/snacks_frozen.dm
@@ -135,7 +135,7 @@
 	name = "pineapple snowcone"
 	desc = "Pineapple syrup drizzled over a snowball in a paper cup."
 	icon_state = "pineapple_sc"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/water = 10)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/pineapplejuice = 5)
 	tastes = list("ice" = 1, "water" = 1, "pineapples" = 5)
 	foodtype = FRUIT | PINEAPPLE //Pineapple to allow all that like pineapple to enjoy
 

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_frozen.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_frozen.dm
@@ -121,7 +121,7 @@
 	reqs = list(
 		/obj/item/reagent_containers/food/drinks/sillycup = 1,
 		/datum/reagent/consumable/ice = 15,
-		/obj/item/reagent_containers/food/snacks/pineappleslice = 2
+		/datum/reagent/consumable/pineapplejuice = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/pineapple
 	category = CAT_ICE
@@ -181,7 +181,7 @@
 	reqs = list(
 		/obj/item/reagent_containers/food/drinks/sillycup = 1,
 		/datum/reagent/consumable/ice = 15,
-		/datum/reagent/consumable/bluecherryjelly= 5
+		/datum/reagent/consumable/bluecherryjelly = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/blue
 	category = CAT_ICE
@@ -191,7 +191,7 @@
 	reqs = list(
 		/obj/item/reagent_containers/food/drinks/sillycup = 1,
 		/datum/reagent/consumable/ice = 15,
-		/datum/reagent/consumable/cherryjelly= 5
+		/datum/reagent/consumable/cherryjelly = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/red
 	category = CAT_ICE
@@ -263,7 +263,7 @@
 	reqs = list(
 		/obj/item/reagent_containers/food/drinks/sillycup = 1,
 		/datum/reagent/consumable/ice = 15,
-		/datum/reagent/consumable/pwr_game = 15
+		/datum/reagent/consumable/pwr_game = 5
 	)
 	result = /obj/item/reagent_containers/food/snacks/snowcones/pwrgame
 	category = CAT_ICE


### PR DESCRIPTION
forgot to add these in my last pr.

https://github.com/tgstation/tgstation/pull/48783 changes water to pineapple juice in pineapple snowcone. needs pineapple juice to make, not pineapple slices.

reduces pwr game amount in snowcone to match the other snowcones

# Why is this good for the game?
idk consistency?

# Testing
no

:cl:  OnlineGirlfriend, ktlwjec
tweak: Pineapple snow cone needs 5u pineapple juice to craft, instead of 2 pineapple slices.
tweak: Pwr game snow cone needs 5u pwrgame to craft, instead of 15u.
/:cl: