### PR TITLE
Nerfs toy sledgehammer

### DIFF
--- a/yogstation/code/game/objects/items/wielded/vxtvulhammer.dm
+++ b/yogstation/code/game/objects/items/wielded/vxtvulhammer.dm
@@ -181,8 +181,13 @@
 			var/atom/throw_target = get_edge_target_turf(target, user.dir)
 			var/mob/living/victim = target
 			if(toy)
-				ADD_TRAIT(victim, TRAIT_IMPACTIMMUNE, "Toy Hammer")
-				victim.safe_throw_at(throw_target, rand(1,2), 3, callback = CALLBACK(src, PROC_REF(afterimpact), victim))
+				if(user == target)
+					victim.Paralyze(2 SECONDS)
+					victim.emote("scream")
+					to_chat(victim, span_userdanger("That was stupid."))
+				else
+					ADD_TRAIT(victim, TRAIT_IMPACTIMMUNE, "Toy Hammer")
+					victim.safe_throw_at(throw_target, rand(1,2), 3, callback = CALLBACK(src, PROC_REF(afterimpact), victim))
 			else
 				victim.throw_at(throw_target, 15, 5) //Same distance as maxed out power fist with three extra force
 				victim.Paralyze(2 SECONDS)


### PR DESCRIPTION
# Document the changes in your pull request

Toy sledgehammer can no longer be used to throw yourself forward 1 tile (or several, in space)

It instead stuns you and calls you stupid

# Why is this good for the game?
p2w etc etc

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/28408322/bcd9a259-59c3-48f1-9a2e-972cebae0b6d)


# Changelog

:cl:  
tweak: Toy sledgehammer can no longer be used to propel yourself forward in space or over tables
/:cl:
