### PR TITLE
Revert "Makes ghost beacons able to be used more generally for mapping"

### DIFF
--- a/yogstation/code/game/objects/structures/ghostbeacon.dm
+++ b/yogstation/code/game/objects/structures/ghostbeacon.dm
@@ -7,13 +7,10 @@
 	anchored = TRUE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	var/list/mob/living/carbon/ghosts = list()
-	var/area/spawnArea
 
 /obj/structure/ghostbeacon/Initialize(mapload)
 	. = ..()
 	GLOB.poi_list |= src
-	var/area/A = get_area(loc)
-	spawnArea = A
 	START_PROCESSING(SSprocessing, src)
 
 /obj/structure/ghostbeacon/Destroy()
@@ -33,15 +30,6 @@
 			qdel(M)
 		if(QDELETED(M)) // Admin fuckery check
 			ghosts.Remove(M) // -= doesnt work with qdeled objects
-
-		// Get your ass back here
-		// Only problem is a admin sending someone to the admin gulag
-		// Unsure what to do. Detect if the zlevel is centcom?
-		// Is it even a problem?
-		var/area/A = get_area(M)
-		if(spawnArea != A)
-			to_chat(M, span_warner("Your corporeal form gets ripped back!"))
-			M.loc = loc
 
 /obj/structure/ghostbeacon/attack_ghost(mob/user)
 	. = ..()
@@ -95,3 +83,6 @@
 	r_hand = /obj/item/tank/internals/plasmaman/belt/full
 	mask = /obj/item/clothing/mask/breath
 	uniform = /obj/item/clothing/under/plasmaman/enviroslacks
+	shoes = /obj/item/clothing/shoes/sneakers/brown
+	glasses = /obj/item/clothing/glasses/sunglasses
+	back = /obj/item/storage/backpack


### PR DESCRIPTION
Reverts yogstation13/Yogstation#20629

The beacon is way way way too restricting where they cant even go half way across a ship, and cant even reach the bar in the space ninja zone. This is not needed and fixes a problem that doesnt exist. If you wanna make spawn points that restrict people, use something else and not this which worked fine as is instead of butchering something niche and making it useless.

Oh I also need the version as it was for events lol