### PR TITLE
Adds a variable to prevent certain chem grenades from being dismantleable once finished + minor refactor

### DIFF
--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -15,6 +15,7 @@
 	var/no_splash = FALSE //If the grenade deletes even if it has no reagents to splash with. Used for slime core reactions.
 	var/casedesc = "This basic model accepts both beakers and bottles. It heats contents by 10°K upon ignition." // Appears when examining empty casings.
 	var/obj/item/assembly/prox_sensor/landminemode = null
+	var/can_dismantle = TRUE
 
 /obj/item/grenade/chem_grenade/Initialize(mapload)
 	. = ..()
@@ -52,27 +53,7 @@
 /obj/item/grenade/chem_grenade/attackby(obj/item/I, mob/user, params)
 	if(istype(I,/obj/item/assembly) && stage == GRENADE_WIRED)
 		wires.interact(user)
-	if(I.tool_behaviour == TOOL_SCREWDRIVER)
-		if(stage == GRENADE_WIRED)
-			if(beakers.len)
-				I.play_tool_sound(src, 25)
-				to_chat(user, span_notice("You begin to secure the grenade assembly."))
-				if(do_after(user, 3 SECONDS, src))
-					embedding = initial(embedding)
-					stage_change(GRENADE_READY)
-					to_chat(user, span_notice("You lock the [initial(name)] assembly."))
-			else
-				to_chat(user, span_warning("You need to add at least one beaker before locking the [initial(name)] assembly!"))
-		else if(stage == GRENADE_READY)
-			det_time = det_time == 50 ? 30 : 50 //toggle between 30 and 50
-			if(landminemode)
-				landminemode.time = det_time * 0.1	//overwrites the proxy sensor activation timer
-
-			to_chat(user, span_notice("You modify the time delay. It's set for [DisplayTimeText(det_time)]."))
-		else
-			to_chat(user, span_warning("You need to add a wire!"))
-		return
-	else if(stage == GRENADE_WIRED && is_type_in_list(I, allowed_containers))
+	if(stage == GRENADE_WIRED && is_type_in_list(I, allowed_containers))
 		. = TRUE //no afterattack
 		if(is_type_in_list(I, banned_containers))
 			to_chat(user, span_warning("[src] is too small to fit [I]!")) // this one hits home huh anon?
@@ -101,11 +82,42 @@
 			to_chat(user, span_warning("You need one length of coil to wire the assembly!"))
 			return
 
-	else if(stage == GRENADE_READY && I.tool_behaviour == TOOL_WIRECUTTER && !active)
-		stage_change(GRENADE_WIRED)
-		to_chat(user, span_notice("You unlock the [initial(name)] assembly."))
+	else
+		return ..()
 
-	else if(stage == GRENADE_WIRED && I.tool_behaviour == TOOL_WRENCH)
+/obj/item/grenade/chem_grenade/screwdriver_act(mob/living/user, obj/item/I)
+	SEND_SIGNAL(src, COMSIG_ATOM_TOOL_ACT(TOOL_SCREWDRIVER), user, I)
+	if(stage == GRENADE_WIRED)
+		if(beakers.len)
+			I.play_tool_sound(src, 25)
+			to_chat(user, span_notice("You begin to secure the grenade assembly."))
+			if(I.use_tool(user, 3 SECONDS, src))
+				embedding = initial(embedding)
+				stage_change(GRENADE_READY)
+				to_chat(user, span_notice("You lock the [initial(name)] assembly."))
+		else
+			to_chat(user, span_warning("You need to add at least one beaker before locking the [initial(name)] assembly!"))
+	else if(stage == GRENADE_READY)
+		det_time = det_time == 50 ? 30 : 50 //toggle between 30 and 50
+		if(landminemode)
+			landminemode.time = det_time * 0.1	//overwrites the proxy sensor activation timer
+
+		to_chat(user, span_notice("You modify the time delay. It's set for [DisplayTimeText(det_time)]."))
+	else
+		to_chat(user, span_warning("You need to add a wire!"))
+
+/obj/item/grenade/chem_grenade/wirecutter_act(mob/living/user, obj/item/I)
+	. = ..()
+	if(stage == GRENADE_READY && !active)
+		if(can_dismantle)
+			stage_change(GRENADE_WIRED)
+			to_chat(user, span_notice("You unlock the [initial(name)] assembly."))
+		else
+			to_chat(user, span_notice("There's no way to open [src]'s assembly."))
+	
+/obj/item/grenade/chem_grenade/wrench_act(mob/living/user, obj/item/I)
+	. = ..()
+	if(stage == GRENADE_WIRED)
 		if(beakers.len)
 			for(var/obj/O in beakers)
 				O.forceMove(drop_location())
@@ -120,8 +132,6 @@
 		new /obj/item/stack/cable_coil(get_turf(src),1)
 		stage_change(GRENADE_EMPTY)
 		to_chat(user, span_notice("You remove the activation mechanism from the [initial(name)] assembly."))
-	else
-		return ..()
 
 /obj/item/grenade/chem_grenade/proc/stage_change(N)
 	if(N)
@@ -426,6 +436,7 @@
 	name = "cleaner grenade"
 	desc = "Waffle Co.-brand foaming space cleaner. In a special applicator for rapid cleaning of wide areas."
 	stage = GRENADE_READY
+	can_dismantle = FALSE
 
 /obj/item/grenade/chem_grenade/ez_clean/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -91,7 +91,7 @@
 		if(beakers.len)
 			I.play_tool_sound(src, 25)
 			to_chat(user, span_notice("You begin to secure the grenade assembly."))
-			if(I.use_tool(user, 3 SECONDS, src))
+			if(I.use_tool(src, user, 3 SECONDS))
 				embedding = initial(embedding)
 				stage_change(GRENADE_READY)
 				to_chat(user, span_notice("You lock the [initial(name)] assembly."))

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -85,21 +85,21 @@
 		var/mob/M = loc
 		M.dropItemToGround(src)
 
-/obj/item/grenade/attackby(obj/item/W, mob/user, params)
+/obj/item/grenade/screwdriver_act(mob/living/user, obj/item/I)
+	. = ..()
 	if(!active)
-		if(W.tool_behaviour == TOOL_MULTITOOL)
-			var/newtime = text2num(stripped_input(user, "Please enter a new detonation time", name))
-			if (newtime != null && user.canUseTopic(src, BE_CLOSE))
-				change_det_time(newtime)
-				to_chat(user, span_notice("You modify the time delay. It's set for [DisplayTimeText(det_time)]."))
-				if (round(newtime * 10) != det_time)
-					to_chat(user, span_warning("The new value is out of bounds. The lowest possible time is 3 seconds and highest is 5 seconds. Instant detonations are also possible."))
-			return
-		else if(W.tool_behaviour == TOOL_SCREWDRIVER)
-			change_det_time()
+		change_det_time()
+		to_chat(user, span_notice("You modify the time delay. It's set for [DisplayTimeText(det_time)]."))
+	
+/obj/item/grenade/multitool_act(mob/living/user, obj/item/I)
+	. = ..()
+	if(!active)
+		var/newtime = text2num(stripped_input(user, "Please enter a new detonation time", name))
+		if (newtime != null && user.canUseTopic(src, BE_CLOSE))
+			change_det_time(newtime)
 			to_chat(user, span_notice("You modify the time delay. It's set for [DisplayTimeText(det_time)]."))
-	else
-		return ..()
+			if (round(newtime * 10) != det_time)
+				to_chat(user, span_warning("The new value is out of bounds. The lowest possible time is 3 seconds and highest is 5 seconds. Instant detonations are also possible."))
 
 /obj/item/grenade/proc/change_det_time(time) //Time uses real time.
 	if(time != null)


### PR DESCRIPTION
# Why is this good for the game?
Ez clean is a REALLY strong weapon chem, especially since you only need to do touch application
it only comes from the janitor traitor uplink, but at 6tc for 180 that's more than enough to kill your targets super easily if you take the grenades apart and use the chemical in ANY other way other than grenade

Mainly so the water gun can be added without fear of janitors killing everyone with their one shot splash gun that actually has range (unlike the spray bottle)

also rewrites grenade code to use tool acts rather than attackby

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/7dd4b81f-cae5-4aaf-a134-5ef3ab3c3e5e)
(ez clean uses the same name as regular cleaner grenades)

:cl:  
tweak: EZ clean grenades can no longer be dismantled
/:cl:
