### PR TITLE
[ROUND BREAKING BUG] Fix reactor not outputting power to correct powernet

### DIFF
--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -253,7 +253,7 @@
 
 	if(C.powernet != powernet)
 		powernet = C.powernet
-		return TRUE
+
 	return TRUE
 
 /obj/machinery/atmospherics/components/trinary/nuclear_reactor/process()

--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -651,6 +651,7 @@
 	update_parents() // double-check all the pipes are connected on startup
 	if(!powernet)
 		connect_to_network()
+	check_powernet()
 
 //Shuts off the fuel rods, ambience, etc. Keep in mind that your temperature may still go up!
 /obj/machinery/atmospherics/components/trinary/nuclear_reactor/proc/shut_down()
@@ -660,6 +661,7 @@
 	desired_k = 0
 	power = 0
 	active = FALSE
+	check_powernet()
 	update_icon()
 
 //Controlling the reactor.

--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -254,7 +254,7 @@
 	if(C.powernet != powernet)
 		powernet = C.powernet
 		return TRUE
-	return FALSE
+	return TRUE
 
 /obj/machinery/atmospherics/components/trinary/nuclear_reactor/process()
 	// Find a powernet

--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -242,13 +242,28 @@
 		var/mob/living/L = AM
 		L.adjust_bodytemperature(clamp(temperature, BODYTEMP_COOLING_MAX, BODYTEMP_HEATING_MAX)) //If you're on fire, you heat up!
 
+/obj/machinery/atmospherics/components/trinary/nuclear_reactor/proc/check_powernet() //Nuclear reactor is not using machinery/power subtype so we gotta make a new powernet check
+	var/turf/T = get_turf(src)
+	if(!T || !istype(T))
+		return FALSE
+	
+	var/obj/structure/cable/C = T.get_cable_node()
+	if(!C || !C.powernet)
+		return FALSE
+
+	if(C.powernet != powernet)
+		powernet = C.powernet
+		return TRUE
+	return FALSE
+
 /obj/machinery/atmospherics/components/trinary/nuclear_reactor/process()
 	// Find a powernet
 	if(!powernet)
 		connect_to_network()
 
 	// Make some power!
-	add_avail(last_power_produced)
+	if(check_powernet())
+		add_avail(last_power_produced)
 
 	// You're overloading the reactor. Give a more subtle warning that power is getting out of control.
 	if(power >= 100 && world.time >= next_flicker)


### PR DESCRIPTION
# Round breaking bug, as it can be easily sabotaged and fuck the reactor for the whole round, please merge asap

# Document the changes in your pull request
the reactor isnt using machinery/power subtype so it didnt have a check for when powernet reset


# Testing
I cut the cable to the first powernet and connect it to a second powernet, the reactor powered the second powernet




# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

bugfix: Fix reactor not outputting power to correct powernet
/:cl:
