### PR TITLE
flesh maul buff lets go

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -597,6 +597,7 @@
 	throw_range = 0
 	throw_speed = 0
 	wound_bonus = 30			//But your bones will be sad :(
+	armour_penetration = -20	//it having negative armor penetration is stupid but it'll balance out the wound bonus.. probably
 	hitsound = "swing_hit"
 	attack_verb = list("smashed", "slammed", "crushed", "whacked")
 	sharpness = SHARP_NONE

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -591,12 +591,11 @@
 	item_flags = NEEDS_PERMIT | ABSTRACT | DROPDEL
 	w_class = WEIGHT_CLASS_HUGE
 	tool_behaviour = TOOL_MINING
-	weapon_stats = list(SWING_SPEED = 2, ENCUMBRANCE = 1, ENCUMBRANCE_TIME = 20, REACH = 1, DAMAGE_LOW = 0, DAMAGE_HIGH = 0)	//Heavy and slow
-	force = 30					//SHATTER BONE
+	weapon_stats = list(SWING_SPEED = 1.8, ENCUMBRANCE = 1, ENCUMBRANCE_TIME = 20, REACH = 1, DAMAGE_LOW = 0, DAMAGE_HIGH = 0)	//Heavy and slow
+	force = 45					//clearly it wasnt boneshattering enough lmao
 	throwforce = 0 				//Just to be on the safe side
 	throw_range = 0
 	throw_speed = 0
-	armour_penetration = -20	//Armor will help stop some of the damage
 	wound_bonus = 30			//But your bones will be sad :(
 	hitsound = "swing_hit"
 	attack_verb = list("smashed", "slammed", "crushed", "whacked")

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -591,7 +591,7 @@
 	item_flags = NEEDS_PERMIT | ABSTRACT | DROPDEL
 	w_class = WEIGHT_CLASS_HUGE
 	tool_behaviour = TOOL_MINING
-	weapon_stats = list(SWING_SPEED = 1.4, ENCUMBRANCE = 1, ENCUMBRANCE_TIME = 20, REACH = 1, DAMAGE_LOW = 0, DAMAGE_HIGH = 0)	//Heavy and slow
+	weapon_stats = list(SWING_SPEED = 2, ENCUMBRANCE = 1, ENCUMBRANCE_TIME = 20, REACH = 1, DAMAGE_LOW = 0, DAMAGE_HIGH = 0)	//Heavy and slow
 	force = 35					//clearly it wasnt boneshattering enough lmao
 	throwforce = 0 				//Just to be on the safe side
 	throw_range = 0

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -574,7 +574,7 @@
 //	background_icon = 'icons/obj/changeling.dmi'
 	button_icon_state = "flesh_maul"
 	chemical_cost = 20
-	dna_cost = 3
+	dna_cost = 2
 	req_human = 1
 	weapon_type = /obj/item/melee/flesh_maul
 	weapon_name_simple = "maul"
@@ -591,8 +591,8 @@
 	item_flags = NEEDS_PERMIT | ABSTRACT | DROPDEL
 	w_class = WEIGHT_CLASS_HUGE
 	tool_behaviour = TOOL_MINING
-	weapon_stats = list(SWING_SPEED = 1.8, ENCUMBRANCE = 1, ENCUMBRANCE_TIME = 20, REACH = 1, DAMAGE_LOW = 0, DAMAGE_HIGH = 0)	//Heavy and slow
-	force = 45					//clearly it wasnt boneshattering enough lmao
+	weapon_stats = list(SWING_SPEED = 1.4, ENCUMBRANCE = 1, ENCUMBRANCE_TIME = 20, REACH = 1, DAMAGE_LOW = 0, DAMAGE_HIGH = 0)	//Heavy and slow
+	force = 35					//clearly it wasnt boneshattering enough lmao
 	throwforce = 0 				//Just to be on the safe side
 	throw_range = 0
 	throw_speed = 0


### PR DESCRIPTION
# Document the changes in your pull request

Buffs the flesh maul to (ideally) be an alternative to the armblade.
OLD MAUL STATS: 30 force, 2 swing speed, 3 DNA cost
NEW MAUL STATS: 35 force, 1.4 swing speed, 2 DNA cost

# Why is this good for the game?
Poor, poor flesh maul.
While it has higher damage then the arm blade, it's not by much (25 to it's 30), and the double swing speed in effect halves that. If my understanding of it is correct, it's DPS is 15, compared to the arm blade's, well.. 25.
This buffs the flesh maul to be an alternative to the arm blade, giving them both equal DPS (35/1.4 = 25, 25/1 = 25) and making them cost the same. I didn't change anything else because the flesh maul's various other upsides and downsides (30 wound chance to the arm blade's 20, bone breaking wounds, -20 armor penetration to the arm blade's 20 armor penetration, slows target on hit, slows you while active) should all make it roughly the same.
Unless I'm wrong, then feel free to let me know. Please do I want this item to be mildly useful

# Testing
It's a numbers change, shouldn't be needed.

# Wiki Documentation

Tweak it's entry on the changeling page to match up with everything new here.

# Changelog

:cl:   
tweak: Buffs the flesh maul to be on par with the arm blade.
/:cl:
