### PR TITLE
Bodycams no longer disconnect when dropped

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -24,6 +24,7 @@
 	var/invuln = null
 	var/obj/item/camera_bug/bug = null
 	var/obj/item/radio/alertradio = null
+	var/obj/item/clothing/neck/bodycam/bodycam = null
 	var/obj/structure/camera_assembly/assembly = null
 	var/area/myarea = null
 

--- a/code/modules/clothing/neck/bodycamera.dm
+++ b/code/modules/clothing/neck/bodycamera.dm
@@ -91,8 +91,9 @@
 	. = ..()
 	if(prob(150/severity))
 		Disconnect()
-		bodcam.c_tag = null
-		bodcam.network[1] = null //requires a reset
+		if(!preset)
+			bodcam.c_tag = null
+			bodcam.network[1] = null //requires a reset
 		update_appearance(UPDATE_ICON)
 
 /obj/item/clothing/neck/bodycam/Destroy()
@@ -116,10 +117,14 @@
 	for (var/obj/machinery/camera/C in GLOB.cameranet.cameras)
 		if(C == bodcam)
 			continue
-		if(C.built_in == to_hook && C.status)
-			C.bodycam.attack_self(to_hook) //Disconnect other cameras that registered same mobs to prevent people abusing bodycams around the station
-			GLOB.cameranet.updatePortableCamera(C)
-			UnregisterSignal(C.bodycam.listeningTo, COMSIG_MOVABLE_MOVED)
+		if(C.built_in == to_hook)
+			if(C.status)
+				C.bodycam.attack_self(to_hook) //Disconnect other cameras that registered same mobs to prevent people abusing bodycams around the station
+				GLOB.cameranet.updatePortableCamera(C)
+				UnregisterSignal(C.bodycam.listeningTo, COMSIG_MOVABLE_MOVED)
+			if(istype(C.bodycam, /obj/item/clothing/neck/bodycam/miner))
+				C.c_tag = "Unactivated Miner Body Camera"
+
 	if(listeningTo == to_hook)//if it's already hooked, no need to do it again lol
 		return
 	if(listeningTo)

--- a/code/modules/clothing/neck/bodycamera.dm
+++ b/code/modules/clothing/neck/bodycamera.dm
@@ -22,6 +22,7 @@
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NO_STORAGE, TRAIT_GENERIC)
 	bodcam = new(src)
+	bodcam.bodycam = src
 	bodcam.c_tag = "NT_BodyCam"
 	bodcam.network = list("ss13")
 	bodcam.internal_light = FALSE
@@ -110,16 +111,15 @@
 	..()
 	getMobhook(user)
 
-/obj/item/clothing/neck/bodycam/dropped(mob/wearer)
-	if(bodcam)
-		if(bodcam.status)//if it's on
-			attack_self(wearer) //turn it off
-		GLOB.cameranet.updatePortableCamera(bodcam)
-		UnregisterSignal(listeningTo, COMSIG_MOVABLE_MOVED)
-	..()
-
 /obj/item/clothing/neck/bodycam/proc/getMobhook(mob/to_hook) //This stuff is basically copypasta from RCL.dm, look there if you are confused
 	bodcam.built_in = to_hook
+	for (var/obj/machinery/camera/C in GLOB.cameranet.cameras)
+		if(C == bodcam)
+			continue
+		if(C.built_in == to_hook && C.status)
+			C.bodycam.attack_self(to_hook) //Disconnect other cameras that registered same mobs to prevent people abusing bodycams around the station
+			GLOB.cameranet.updatePortableCamera(C)
+			UnregisterSignal(C.bodycam.listeningTo, COMSIG_MOVABLE_MOVED)
 	if(listeningTo == to_hook)//if it's already hooked, no need to do it again lol
 		return
 	if(listeningTo)


### PR DESCRIPTION
# Document the changes in your pull request
Bodycams no longer disconnect when dropped
Same bodycams registered mob will disconnect themselves to prevent abuse
Fix miner bodycams dont reset to the original tag when you get a new miner cam

# Why is this good for the game?
allows mining medic to check if a miner is gibbed, It's stupid for them to disconnect when dropped, this was made to prevent people abusing it so i have made a new check to prevent this instead.

# Testing
made two cams, picked up the first one and typed my name in and security cam registered the first one. Then i picked up the second one and typed a random name in and security cam registered the second one and disconnected the first one because it detected same mob registered in the second one



# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Bodycams no longer disconnect when dropped
tweak: Same bodycams registered mob will disconnect themselves to prevent abuse
tweak: Fix miner bodycams dont reset to the original tag when you get a new miner cam
/:cl:
