### PR TITLE
AGCNR healium gas interaction addon

### DIFF
--- a/code/__DEFINES/reactor.dm
+++ b/code/__DEFINES/reactor.dm
@@ -55,4 +55,4 @@
 #define TRITIUM_RAD_MOD 0.2 // fuck that's a lot
 #define ANTINOBLIUM_RAD_MOD 10 // AAAAAAAAAAAAAAAAAAAA
 
-#define HEALIUM_COEFFICIENTS 0.002554 // Used for calculating the temperature requirement to restore the reactor integrity
+#define HEALIUM_COEFFICIENTS -0.000002656 // Used for calculating the temperature requirement to restore the reactor integrity

--- a/code/__DEFINES/reactor.dm
+++ b/code/__DEFINES/reactor.dm
@@ -54,3 +54,5 @@
 #define HYDROGEN_RAD_MOD 0.12 // getting a bit spicy there
 #define TRITIUM_RAD_MOD 0.2 // fuck that's a lot
 #define ANTINOBLIUM_RAD_MOD 10 // AAAAAAAAAAAAAAAAAAAA
+
+#define HEALIUM_COEFFICIENTS 0.002554 // Used for calculating the temperature requirement to restore the reactor integrity

--- a/code/__DEFINES/reactor.dm
+++ b/code/__DEFINES/reactor.dm
@@ -7,6 +7,7 @@
 #define REACTOR_TEMPERATURE_OPERATING 800 //Kelvin
 #define REACTOR_TEMPERATURE_CRITICAL 1000 //At this point the entire station is alerted to a meltdown. This may need altering
 #define REACTOR_TEMPERATURE_MELTDOWN 1200
+#define REACTOR_TEMPERATURE_GAS_FAILSAFE 1800 // Healium cant restore vessel integrity above this
 
 #define REACTOR_HEAT_CAPACITY 6000 //How much thermal energy it takes to cool the reactor
 #define REACTOR_ROD_HEAT_CAPACITY 400 //How much thermal energy it takes to cool each reactor rod

--- a/code/__DEFINES/reactor.dm
+++ b/code/__DEFINES/reactor.dm
@@ -7,7 +7,7 @@
 #define REACTOR_TEMPERATURE_OPERATING 800 //Kelvin
 #define REACTOR_TEMPERATURE_CRITICAL 1000 //At this point the entire station is alerted to a meltdown. This may need altering
 #define REACTOR_TEMPERATURE_MELTDOWN 1200
-#define REACTOR_TEMPERATURE_GAS_FAILSAFE 1800 // Healium cant restore vessel integrity above this
+
 
 #define REACTOR_HEAT_CAPACITY 6000 //How much thermal energy it takes to cool the reactor
 #define REACTOR_ROD_HEAT_CAPACITY 400 //How much thermal energy it takes to cool each reactor rod

--- a/code/__DEFINES/reactor.dm
+++ b/code/__DEFINES/reactor.dm
@@ -54,5 +54,3 @@
 #define HYDROGEN_RAD_MOD 0.12 // getting a bit spicy there
 #define TRITIUM_RAD_MOD 0.2 // fuck that's a lot
 #define ANTINOBLIUM_RAD_MOD 10 // AAAAAAAAAAAAAAAAAAAA
-
-#define HEALIUM_COEFFICIENTS -0.000002656 // Used for calculating the temperature requirement to restore the reactor integrity

--- a/code/__DEFINES/reactor.dm
+++ b/code/__DEFINES/reactor.dm
@@ -8,7 +8,6 @@
 #define REACTOR_TEMPERATURE_CRITICAL 1000 //At this point the entire station is alerted to a meltdown. This may need altering
 #define REACTOR_TEMPERATURE_MELTDOWN 1200
 
-
 #define REACTOR_HEAT_CAPACITY 6000 //How much thermal energy it takes to cool the reactor
 #define REACTOR_ROD_HEAT_CAPACITY 400 //How much thermal energy it takes to cool each reactor rod
 #define REACTOR_HEAT_EXPONENT 1.5 // The exponent used for the function for K heating

--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -1047,7 +1047,7 @@
 	- Pluonium: When you need weapons grade plutonium yesterday. Causes your fuel to deplete much, much faster. Not a huge amount of use outside of plutonium production or sabotage.<BR>\
 	- Healium: Can restore integrity if below 1800 Kelvin. The restoration rate is depended on the temperature, the lower the temperature the faster it is to restore integrity.<BR>\
 	<BR><B>Coolant effects</B><BR>\
-	- The higher heat capacity gas allows the reactor to increase coolant effciency.<BR>\
+	- High heat capacity gases like water vapor and plasma are better coolants as they can transfer more heat per mole. The inverse is true for low heat capacity gases like tritium and antinoblium.<BR>\
 	<BR><B>OH GOD IT'S SCREAMING AT ME WHAT DO I DO</B><BR>\
 	Don't panic! There's a few things you can do to prevent the station from becoming an irradiated hellscape.<BR>\
 	Scenario 1: Overheating<BR>\

--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -1044,9 +1044,9 @@
 	- Hyper-Noblium: Extremely efficient permeability increase (10x as efficient as bz)<BR>\
 	Depletion types:<BR>\
 	- Pluonium: When you need weapons grade plutonium yesterday. Causes your fuel to deplete much, much faster. Not a huge amount of use outside of plutonium production or sabotage.<BR>\
-	- Healium: Restore integrity if below 1800 Kelvin. The restoration rate is depended on the temperature, the lower the temperature the faster it is to restore integrity.<BR>\
 	<BR><B>Coolant effects</B><BR>\
 	- The higher heat capacity gas allows the reactor to increase coolant effciency.<BR>\
+	- Healium: Even tho having low heat capacity it can restore integrity if below 1800 Kelvin. The restoration rate is depended on the temperature, the lower the temperature the faster it is to restore integrity.<BR>\
 	<BR><B>OH GOD IT'S SCREAMING AT ME WHAT DO I DO</B><BR>\
 	Don't panic! There's a few things you can do to prevent the station from becoming an irradiated hellscape.<BR>\
 	Scenario 1: Overheating<BR>\

--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -499,10 +499,9 @@
 	else
 		color = null
 
-	if(vessel_integrity < initial(vessel_integrity))
-		vessel_integrity += integrity_restoration
-	else //incase it goes beyond
-		vessel_integrity = initial(vessel_integrity)
+	vessel_integrity += integrity_restoration
+	if(vessel_integrity > initial(vessel_integrity)) //hey you cant go above
+  		vessel_integrity = initial(vessel_integrity)
 	
 	//Second alert condition: Overpressurized (the more lethal one)
 	if(pressure >= REACTOR_PRESSURE_CRITICAL)

--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -499,10 +499,10 @@
 	else
 		color = null
 
-	if(vessel_integrity < 400)
+	if(vessel_integrity < initial(vessel_integrity))
 		vessel_integrity += integrity_restoration
 	else //incase it goes beyond
-		vessel_integrity = 400
+		vessel_integrity = initial(vessel_integrity)
 	
 	//Second alert condition: Overpressurized (the more lethal one)
 	if(pressure >= REACTOR_PRESSURE_CRITICAL)
@@ -1045,9 +1045,9 @@
 	- Hyper-Noblium: Extremely efficient permeability increase (10x as efficient as bz)<BR>\
 	Depletion types:<BR>\
 	- Pluonium: When you need weapons grade plutonium yesterday. Causes your fuel to deplete much, much faster. Not a huge amount of use outside of plutonium production or sabotage.<BR>\
+	- Healium: Restore integrity if below 1800 Kelvin. The restoration rate is depended on the temperature, the lower the temperature the faster it is to restore integrity.<BR>\
 	<BR><B>Coolant effects</B><BR>\
 	- The higher heat capacity gas allows the reactor to increase coolant effciency.<BR>\
-	- Healium has low heat capacity but it can restore integrity if below 1800 Kelvin.<BR>\
 	<BR><B>OH GOD IT'S SCREAMING AT ME WHAT DO I DO</B><BR>\
 	Don't panic! There's a few things you can do to prevent the station from becoming an irradiated hellscape.<BR>\
 	Scenario 1: Overheating<BR>\

--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -348,6 +348,11 @@
 		radioactivity_spice_multiplier += moderator_input.get_moles(/datum/gas/tritium) * TRITIUM_RAD_MOD
 		radioactivity_spice_multiplier += moderator_input.get_moles(/datum/gas/antinoblium) * ANTINOBLIUM_RAD_MOD
 
+		// Integrity modification
+		var/healium_moles = moderator_input.get_moles(/datum/gas/healium)
+		if(healium_moles > minimum_coolant_level)
+			integrity_restoration = max((2400-max(TCMB, temperature))/300) * delta_time //At 1800K integrity_restoration should be around 1, which then it cant keep up with the heat damage (around 1.1 maximum in temp_damage) to restore integrity
+
 		// Degradation types: degrades the fuel rods
 		var/total_degradation_moles = moderator_input.get_moles(/datum/gas/pluonium) //Because it's quite hard to get.
 		if(total_degradation_moles >= minimum_coolant_level) //I'll be nice.
@@ -412,10 +417,6 @@
 		var/coolant_heat_factor = coolant_input.heat_capacity() / (coolant_input.heat_capacity() + REACTOR_HEAT_CAPACITY + (REACTOR_ROD_HEAT_CAPACITY * has_fuel())) //What percent of the total heat capacity is in the coolant
 		last_heat_delta = heat_delta
 		temperature += heat_delta * coolant_heat_factor
-		// Integrity modification
-		var/healium_moles = coolant_input.get_moles(/datum/gas/healium)
-		if(healium_moles>1)
-			integrity_restoration = max((2400-max(TCMB, temperature))/300) * delta_time //At 1800K integrity_restoration should be around 1, which then it cant keep up with the heat damage (around 1.1 maximum in temp_damage) to restore integrity
 		coolant_input.set_temperature(last_coolant_temperature - (heat_delta * (1 - coolant_heat_factor))) //Heat the coolant output gas that we just had pass through us.
 		coolant_output.merge(coolant_input) //And now, shove the input into the output.
 		coolant_input.clear() //Clear out anything left in the input gate.
@@ -1044,9 +1045,9 @@
 	- Hyper-Noblium: Extremely efficient permeability increase (10x as efficient as bz)<BR>\
 	Depletion types:<BR>\
 	- Pluonium: When you need weapons grade plutonium yesterday. Causes your fuel to deplete much, much faster. Not a huge amount of use outside of plutonium production or sabotage.<BR>\
+	- Healium: Can restore integrity if below 1800 Kelvin. The restoration rate is depended on the temperature, the lower the temperature the faster it is to restore integrity.<BR>\
 	<BR><B>Coolant effects</B><BR>\
 	- The higher heat capacity gas allows the reactor to increase coolant effciency.<BR>\
-	- Healium: Even tho having low heat capacity it can restore integrity if below 1800 Kelvin. The restoration rate is depended on the temperature, the lower the temperature the faster it is to restore integrity.<BR>\
 	<BR><B>OH GOD IT'S SCREAMING AT ME WHAT DO I DO</B><BR>\
 	Don't panic! There's a few things you can do to prevent the station from becoming an irradiated hellscape.<BR>\
 	Scenario 1: Overheating<BR>\

--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -501,7 +501,7 @@
 
 	vessel_integrity += integrity_restoration
 	if(vessel_integrity > initial(vessel_integrity)) //hey you cant go above
-  		vessel_integrity = initial(vessel_integrity)
+		vessel_integrity = initial(vessel_integrity)
 	
 	//Second alert condition: Overpressurized (the more lethal one)
 	if(pressure >= REACTOR_PRESSURE_CRITICAL)

--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -415,7 +415,7 @@
 		// Integrity modification
 		var/healium_moles = coolant_input.get_moles(/datum/gas/healium)
 		if(healium_moles>1)
-			integrity_restoration = max(0, HEALIUM_COEFFICIENTS * temperature) * delta_time //At 1800K integrity_restoration should be around 2.23, which then it cant keep up with the heat damage to restore integrity
+			integrity_restoration = max(0, HEALIUM_COEFFICIENTS * max(TCMB, temperature)) * delta_time //At 1800K integrity_restoration should be around 2.23, which then it cant keep up with the heat damage to restore integrity
 		coolant_input.set_temperature(last_coolant_temperature - (heat_delta * (1 - coolant_heat_factor))) //Heat the coolant output gas that we just had pass through us.
 		coolant_output.merge(coolant_input) //And now, shove the input into the output.
 		coolant_input.clear() //Clear out anything left in the input gate.

--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -415,7 +415,7 @@
 		// Integrity modification
 		var/healium_moles = coolant_input.get_moles(/datum/gas/healium)
 		if(healium_moles>1)
-			integrity_restoration = min(3,log(healium_moles)/2)
+			integrity_restoration = max(0, HEALIUM_COEFFICIENTS * temperature) * delta_time
 		else
 			integrity_restoration = 0
 		coolant_input.set_temperature(last_coolant_temperature - (heat_delta * (1 - coolant_heat_factor))) //Heat the coolant output gas that we just had pass through us.
@@ -501,9 +501,9 @@
 	else
 		color = null
 
-	if(temperature <= REACTOR_TEMPERATURE_GAS_FAILSAFE && vessel_integrity <= 400)
+	if(vessel_integrity <= 400)
 		vessel_integrity += integrity_restoration
-	else if(vessel_integrity > 400) //incase it goes beyond
+	else //incase it goes beyond
 		vessel_integrity = 400
 	
 	//Second alert condition: Overpressurized (the more lethal one)

--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -416,8 +416,6 @@
 		var/healium_moles = coolant_input.get_moles(/datum/gas/healium)
 		if(healium_moles>1)
 			integrity_restoration = max(0, HEALIUM_COEFFICIENTS * temperature) * delta_time
-		else
-			integrity_restoration = 0
 		coolant_input.set_temperature(last_coolant_temperature - (heat_delta * (1 - coolant_heat_factor))) //Heat the coolant output gas that we just had pass through us.
 		coolant_output.merge(coolant_input) //And now, shove the input into the output.
 		coolant_input.clear() //Clear out anything left in the input gate.

--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -415,7 +415,7 @@
 		// Integrity modification
 		var/healium_moles = coolant_input.get_moles(/datum/gas/healium)
 		if(healium_moles>1)
-			integrity_restoration = max(0, HEALIUM_COEFFICIENTS * max(TCMB, temperature)) * delta_time //At 1800K integrity_restoration should be around 2.23, which then it cant keep up with the heat damage to restore integrity
+			integrity_restoration = max((2400-max(TCMB, temperature))/300) * delta_time //At 1800K integrity_restoration should be around 2.23, which then it cant keep up with the heat damage to restore integrity
 		coolant_input.set_temperature(last_coolant_temperature - (heat_delta * (1 - coolant_heat_factor))) //Heat the coolant output gas that we just had pass through us.
 		coolant_output.merge(coolant_input) //And now, shove the input into the output.
 		coolant_input.clear() //Clear out anything left in the input gate.

--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -1049,7 +1049,7 @@
 	- Pluonium: When you need weapons grade plutonium yesterday. Causes your fuel to deplete much, much faster. Not a huge amount of use outside of plutonium production or sabotage.<BR>\
 	<BR><B>Coolant effects</B><BR>\
 	- The higher heat capacity gas allows the reactor to increase coolant effciency.<BR>\
-	- Healium has low heat capacity but it can reduce heat damage and restore integrity below 1800 Kelvin.<BR>\
+	- Healium has low heat capacity but it can restore integrity if below 1800 Kelvin.<BR>\
 	<BR><B>OH GOD IT'S SCREAMING AT ME WHAT DO I DO</B><BR>\
 	Don't panic! There's a few things you can do to prevent the station from becoming an irradiated hellscape.<BR>\
 	Scenario 1: Overheating<BR>\

--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -415,7 +415,7 @@
 		// Integrity modification
 		var/healium_moles = coolant_input.get_moles(/datum/gas/healium)
 		if(healium_moles>1)
-			integrity_restoration = max(0, HEALIUM_COEFFICIENTS * temperature) * delta_time
+			integrity_restoration = max(0, HEALIUM_COEFFICIENTS * temperature) * delta_time //At 1800K integrity_restoration should be around 2.23
 		coolant_input.set_temperature(last_coolant_temperature - (heat_delta * (1 - coolant_heat_factor))) //Heat the coolant output gas that we just had pass through us.
 		coolant_output.merge(coolant_input) //And now, shove the input into the output.
 		coolant_input.clear() //Clear out anything left in the input gate.

--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -1047,6 +1047,9 @@
 	- Hyper-Noblium: Extremely efficient permeability increase (10x as efficient as bz)<BR>\
 	Depletion types:<BR>\
 	- Pluonium: When you need weapons grade plutonium yesterday. Causes your fuel to deplete much, much faster. Not a huge amount of use outside of plutonium production or sabotage.<BR>\
+	<BR><B>Coolant effects</B><BR>\
+	- The higher heat capacity gas allows the reactor to increase coolant effciency.<BR>\
+	- Healium has low heat capacity but it can reduce heat damage and restore integrity below 1800 Kelvin.<BR>\
 	<BR><B>OH GOD IT'S SCREAMING AT ME WHAT DO I DO</B><BR>\
 	Don't panic! There's a few things you can do to prevent the station from becoming an irradiated hellscape.<BR>\
 	Scenario 1: Overheating<BR>\

--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -415,7 +415,7 @@
 		// Integrity modification
 		var/healium_moles = coolant_input.get_moles(/datum/gas/healium)
 		if(healium_moles>1)
-			integrity_restoration = max((2400-max(TCMB, temperature))/300) * delta_time //At 1800K integrity_restoration should be around 2.23, which then it cant keep up with the heat damage to restore integrity
+			integrity_restoration = max((2400-max(TCMB, temperature))/300) * delta_time //At 1800K integrity_restoration should be around 1, which then it cant keep up with the heat damage (around 1.1 maximum in temp_damage) to restore integrity
 		coolant_input.set_temperature(last_coolant_temperature - (heat_delta * (1 - coolant_heat_factor))) //Heat the coolant output gas that we just had pass through us.
 		coolant_output.merge(coolant_input) //And now, shove the input into the output.
 		coolant_input.clear() //Clear out anything left in the input gate.

--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -499,7 +499,7 @@
 	else
 		color = null
 
-	if(vessel_integrity <= 400)
+	if(vessel_integrity < 400)
 		vessel_integrity += integrity_restoration
 	else //incase it goes beyond
 		vessel_integrity = 400

--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -415,7 +415,7 @@
 		// Integrity modification
 		var/healium_moles = coolant_input.get_moles(/datum/gas/healium)
 		if(healium_moles>1)
-			integrity_restoration = max(0, HEALIUM_COEFFICIENTS * temperature) * delta_time //At 1800K integrity_restoration should be around 2.23
+			integrity_restoration = max(0, HEALIUM_COEFFICIENTS * temperature) * delta_time //At 1800K integrity_restoration should be around 2.23, which then it cant keep up with the heat damage to restore integrity
 		coolant_input.set_temperature(last_coolant_temperature - (heat_delta * (1 - coolant_heat_factor))) //Heat the coolant output gas that we just had pass through us.
 		coolant_output.merge(coolant_input) //And now, shove the input into the output.
 		coolant_input.clear() //Clear out anything left in the input gate.


### PR DESCRIPTION
# Document the changes in your pull request

Healium inside coolant can now restore integrity of the reactor. This only work if the reactor is below 1800K

So if you have a good setup you can get the reactor stable at around 1700kelvin

Updated guide to reactor 101 paper
# Why is this good for the game?
Allow more failsafe gas to interact with the reactor, more works for atmosian. Give more crazy reactor setup ideas to atmosians

# Testing
works, also thank you @SapphicOverload for helping me with math (Im dumb at it)
![ww](https://github.com/yogstation13/Yogstation/assets/89688125/e32fed2b-579a-4b1b-902b-0169bd477a70)




# Wiki Documentation
When the reactor wiki page exists, please add this in

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

rscadd: Healium inside coolant can now restore integrity of the reactor. This only work if the reactor is below 1800K
spellcheck: Updated guide to reactor 101 paper
/:cl:
