### PR TITLE
Adds shadows to gax's stairs

### DIFF
--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -2959,6 +2959,14 @@
 "byP" = (
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"bzu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/ramp_corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "bzM" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -4780,6 +4788,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"cvn" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "cvq" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole/bookmanagement,
@@ -14015,6 +14032,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
+"gHi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/ramp_middle,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "gHq" = (
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
@@ -22862,10 +22888,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"lhO" = (
-/obj/effect/turf_decal/ramp_middle,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "lia" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp/green,
@@ -24045,6 +24067,13 @@
 "lMu" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/security)
+"lMw" = (
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "lMA" = (
 /turf/closed/wall/r_wall,
 /area/hallway/secondary/entry)
@@ -27423,6 +27452,9 @@
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 9
 	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "nwr" = (
@@ -28028,14 +28060,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/aft)
-"nJc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/ramp_corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "nJe" = (
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -29037,13 +29061,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"omN" = (
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/ramp_middle,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "omU" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
@@ -39618,6 +39635,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"tuQ" = (
+/obj/effect/turf_decal/ramp_middle,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "tva" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -40869,6 +40890,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -45080,15 +45104,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"wfs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/ramp_middle,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "wfE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -46733,15 +46748,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"wVc" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/ramp_middle{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "wVo" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -92193,7 +92199,7 @@ vvd
 vmy
 vvd
 qSn
-omN
+lMw
 vvd
 atx
 pnP
@@ -92450,7 +92456,7 @@ qub
 wcy
 lzE
 jWH
-wfs
+gHi
 oAE
 atx
 pnP
@@ -92707,7 +92713,7 @@ mPt
 vvd
 vvd
 xus
-lhO
+tuQ
 rRY
 atx
 pnP
@@ -94508,7 +94514,7 @@ rrI
 faQ
 btB
 wYh
-nJc
+bzu
 aAR
 blt
 aAR
@@ -97307,12 +97313,12 @@ fnc
 aCD
 nhh
 nvT
-wVc
+cvn
 dKK
 rFX
 lEO
 hVZ
-wVc
+cvn
 jqf
 tZB
 hfQ

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -1787,6 +1787,7 @@
 	pixel_x = 11;
 	pixel_y = 8
 	},
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "aTR" = (
@@ -2323,6 +2324,7 @@
 /obj/effect/turf_decal/trimline/red/corner{
 	dir = 4
 	},
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bfj" = (
@@ -2810,6 +2812,9 @@
 /obj/effect/turf_decal/siding/wideplating/corner{
 	dir = 4
 	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 4
+	},
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
 "buE" = (
@@ -3004,6 +3009,9 @@
 	dir = 4
 	},
 /obj/machinery/seed_extractor,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 8
+	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "bBo" = (
@@ -4927,6 +4935,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/ramp_corner,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "cyB" = (
@@ -5291,6 +5300,9 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "cES" = (
+/obj/effect/turf_decal/ramp_middle{
+	dir = 8
+	},
 /turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
 	dir = 8
 	},
@@ -5982,6 +5994,9 @@
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "cWe" = (
@@ -6309,6 +6324,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
 	},
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
@@ -7574,6 +7592,9 @@
 "dKK" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -10843,6 +10864,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/ramp_corner,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "fir" = (
@@ -11091,6 +11113,9 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -28
+	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
@@ -12192,6 +12217,9 @@
 	dir = 4
 	},
 /obj/machinery/biogenerator,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 8
+	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "fOd" = (
@@ -14325,6 +14353,9 @@
 /obj/effect/turf_decal/trimline/red/arrow_ccw{
 	dir = 4
 	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
 /turf/open/floor/plasteel/stairs/goon/dark_stairs_alone,
 /area/hallway/secondary/entry)
 "gRV" = (
@@ -14687,6 +14718,9 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "hcR" = (
@@ -14925,6 +14959,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "hjs" = (
@@ -15145,6 +15182,9 @@
 /area/bridge/meeting_room)
 "hmK" = (
 /obj/effect/turf_decal/siding/wideplating,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
 "hmP" = (
@@ -15186,6 +15226,9 @@
 	pixel_x = -24
 	},
 /obj/structure/railing,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "hnx" = (
@@ -16670,6 +16713,9 @@
 /obj/item/storage/toolbox/mechanical{
 	pixel_y = -4
 	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "hWe" = (
@@ -17229,6 +17275,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "imX" = (
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/plasteel/stairs/goon/stairs2_wide{
 	dir = 1
 	},
@@ -18192,6 +18239,7 @@
 	dir = 1
 	},
 /obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "iMQ" = (
@@ -19216,6 +19264,9 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 1
+	},
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
 "jqc" = (
@@ -19237,6 +19288,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -20493,6 +20547,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
 /turf/open/floor/plasteel/stairs/goon/stairs_middle,
 /area/hallway/secondary/entry)
 "jXr" = (
@@ -20632,6 +20689,9 @@
 /obj/structure/closet/firecloset/full,
 /obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 1
+	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -20899,6 +20959,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
 	},
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
@@ -22191,6 +22254,7 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "kVA" = (
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/plasteel/stairs/goon/stairs_wide{
 	dir = 1
 	},
@@ -22454,6 +22518,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
 	},
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
@@ -22795,6 +22862,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"lhO" = (
+/obj/effect/turf_decal/ramp_middle,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "lia" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp/green,
@@ -23693,6 +23764,9 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/storage/fancy/donut_box,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "lEP" = (
@@ -23961,6 +24035,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "lMp" = (
+/obj/effect/turf_decal/ramp_middle{
+	dir = 8
+	},
 /turf/open/floor/plasteel/stairs/goon/dark_stairs_wide2{
 	dir = 8
 	},
@@ -24369,6 +24446,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "lVT" = (
@@ -26935,6 +27016,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 8
+	},
 /turf/open/floor/plasteel/stairs/goon/dark_stairs_wide2{
 	dir = 8
 	},
@@ -27944,6 +28028,14 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/aft)
+"nJc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/ramp_corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "nJe" = (
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -28945,6 +29037,13 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"omN" = (
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "omU" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
@@ -30068,6 +30167,9 @@
 "oRf" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
+	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -34028,6 +34130,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/plasteel/stairs/goon/stairs_middle,
 /area/hydroponics/garden)
 "qQn" = (
@@ -34153,6 +34256,9 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "qSn" = (
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
 /turf/open/floor/plasteel/stairs/goon/stairs_wide{
 	dir = 1
 	},
@@ -34980,6 +35086,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
 "rmC" = (
@@ -35861,6 +35968,9 @@
 /obj/item/assembly/signaler{
 	pixel_x = -8;
 	pixel_y = 5
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -37801,6 +37911,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
 "sAA" = (
@@ -39468,7 +39581,12 @@
 "trI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/stairs/goon/stairs_wide,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs_wide{
+	dir = 1
+	},
 /area/hydroponics/garden)
 "tsz" = (
 /turf/open/floor/plasteel/dark,
@@ -44501,7 +44619,12 @@
 	persistence_id = "public";
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/stairs/goon/stairs2_wide,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs2_wide{
+	dir = 1
+	},
 /area/hydroponics/garden)
 "vTP" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -44957,6 +45080,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"wfs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/ramp_middle,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "wfE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -45110,6 +45242,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 8
 	},
 /turf/open/floor/plasteel/stairs/goon/stairs_alone{
 	dir = 8
@@ -45536,6 +45671,9 @@
 /obj/structure/railing,
 /obj/effect/turf_decal/trimline/red/arrow_ccw{
 	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 4
 	},
 /turf/open/floor/plasteel/stairs/goon/dark_stairs_alone{
 	dir = 4
@@ -46210,6 +46348,9 @@
 	dir = 4
 	},
 /obj/machinery/vending/hydroseeds/weak,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 8
+	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "wKL" = (
@@ -46512,6 +46653,9 @@
 	dir = 4
 	},
 /obj/machinery/vending/hydronutrients,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 8
+	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "wTB" = (
@@ -46589,6 +46733,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
+"wVc" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "wVo" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -46700,6 +46853,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 8
+	},
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "wYp" = (
@@ -47651,6 +47811,9 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "xus" = (
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
 /turf/open/floor/plasteel/stairs/goon/stairs2_wide{
 	dir = 1
 	},
@@ -92030,7 +92193,7 @@ vvd
 vmy
 vvd
 qSn
-nPi
+omN
 vvd
 atx
 pnP
@@ -92287,7 +92450,7 @@ qub
 wcy
 lzE
 jWH
-lzE
+wfs
 oAE
 atx
 pnP
@@ -92544,7 +92707,7 @@ mPt
 vvd
 vvd
 xus
-vvd
+lhO
 rRY
 atx
 pnP
@@ -94345,7 +94508,7 @@ rrI
 faQ
 btB
 wYh
-aAR
+nJc
 aAR
 blt
 aAR
@@ -97144,12 +97307,12 @@ fnc
 aCD
 nhh
 nvT
-xJC
+wVc
 dKK
 rFX
 lEO
 hVZ
-xJC
+wVc
 jqf
 tZB
 hfQ


### PR DESCRIPTION
# Document the changes in your pull request
In line with how i've been creating stairs on other maps, looks better and more interesting with shadows on the stairs to add depth
Also adds some wideplating to showcase height.
![image](https://github.com/yogstation13/Yogstation/assets/42524344/556ad41c-6e1e-4503-8b83-21efed97a321)
![image](https://github.com/yogstation13/Yogstation/assets/42524344/b352ea67-9b96-43fd-b267-2c82aab40808)
![image](https://github.com/yogstation13/Yogstation/assets/42524344/e6a769dc-3373-4a69-b678-c1357c6f7f65)


# Why is this good for the game?
More in-line with other maps

# Testing
Doesn't need it.

# Changelog
:cl:  
mapping: Gax stairs have shadows now
/:cl:
