### PR TITLE
Put rad scrub plus smoke machine in engineering and cargo pack

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -19450,6 +19450,25 @@
 	},
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai_upload)
+"fmi" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
+	},
+/obj/machinery/smoke_machine,
+/obj/item/reagent_containers/glass/beaker/large/radscrub,
+/obj/item/reagent_containers/glass/beaker/large/radscrub,
+/obj/item/reagent_containers/glass/beaker/large/radscrub,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "fmn" = (
 /obj/machinery/light{
 	dir = 4
@@ -63327,18 +63346,6 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"tac" = (
-/obj/machinery/power/terminal{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "taw" = (
 /obj/machinery/turnstile/brig{
 	dir = 1
@@ -122629,7 +122636,7 @@ aYF
 pRm
 hHG
 aPn
-tac
+fmi
 rHy
 xeC
 die

--- a/_maps/map_files/DonutStation/DonutStation.dmm
+++ b/_maps/map_files/DonutStation/DonutStation.dmm
@@ -12744,12 +12744,6 @@
 "fpH" = (
 /turf/closed/wall/r_wall,
 /area/teleporter)
-"fpL" = (
-/obj/structure/cable/orange{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fpS" = (
 /obj/machinery/air_sensor/atmos/carbon_tank,
 /turf/open/floor/engine/co2{
@@ -39168,6 +39162,19 @@
 	initial_gas_mix = "n2=1000;TEMP=293.15"
 	},
 /area/engine/atmos)
+"rab" = (
+/obj/structure/cable/orange{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/machinery/smoke_machine,
+/obj/item/reagent_containers/glass/beaker/large/radscrub,
+/obj/item/reagent_containers/glass/beaker/large/radscrub,
+/obj/item/reagent_containers/glass/beaker/large/radscrub,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rai" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -96155,7 +96162,7 @@ ylr
 ylr
 ylr
 ocR
-fpL
+rab
 xsv
 efb
 tua

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -7973,6 +7973,17 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"dVx" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/smoke_machine,
+/obj/item/reagent_containers/glass/beaker/large/radscrub,
+/obj/item/reagent_containers/glass/beaker/large/radscrub,
+/obj/item/reagent_containers/glass/beaker/large/radscrub,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "dVz" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/machinery/firealarm{
@@ -30194,13 +30205,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"oXp" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "oXr" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
@@ -74527,7 +74531,7 @@ rCR
 eKF
 qmZ
 kFU
-oXp
+dVx
 oyB
 geh
 wfm

--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -15063,6 +15063,19 @@
 "eAN" = (
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"eAP" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/machinery/smoke_machine,
+/obj/item/reagent_containers/glass/beaker/large/radscrub,
+/obj/item/reagent_containers/glass/beaker/large/radscrub,
+/obj/item/reagent_containers/glass/beaker/large/radscrub,
+/turf/open/floor/plasteel{
+	dir = 1
+	},
+/area/engine/engineering)
 "eBh" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -56488,19 +56501,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"qwT" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/item/kirbyplants{
-	icon_state = "plant-20";
-	pixel_y = 3
-	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/turf/open/floor/plasteel{
-	dir = 1
-	},
-/area/engine/engineering)
 "qxh" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 31
@@ -123223,7 +123223,7 @@ jXO
 tDb
 kXH
 ept
-qwT
+eAP
 fZl
 scl
 jAk

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -24976,18 +24976,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"ghP" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
-	},
-/obj/item/stack/cable_coil,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "giq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -32269,6 +32257,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"iUF" = (
+/obj/machinery/camera{
+	c_tag = "Engineering Storage";
+	dir = 4
+	},
+/obj/structure/sign/departments/minsky/command/charge{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/smoke_machine,
+/obj/item/reagent_containers/glass/beaker/large/radscrub,
+/obj/item/reagent_containers/glass/beaker/large/radscrub,
+/obj/item/reagent_containers/glass/beaker/large/radscrub,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "iUI" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel,
@@ -42605,6 +42610,19 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"mXY" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/item/stack/cable_coil,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/obj/item/electronics/airlock,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mYN" = (
 /obj/structure/table,
 /obj/item/clipboard,
@@ -64873,21 +64891,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
-"vza" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Storage";
-	dir = 4
-	},
-/obj/structure/table,
-/obj/item/electronics/airlock,
-/obj/structure/sign/departments/minsky/command/charge{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vzb" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -5;
@@ -97262,9 +97265,9 @@ aiw
 xey
 bvV
 hDa
-vza
+iUF
 xbs
-ghP
+mXY
 crp
 qQV
 qQV

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -932,6 +932,18 @@
 					/obj/item/extinguisher/advanced)
 	crate_name = "advanced firefighting crate"
 
+/datum/supply_pack/engineering/antirad
+	name = "Anti Radiation Smoke Machine Crate"
+	desc = "Station is full of radiation? Worry no more! Introducing to you a smoke machine with radiation-cleaning chemicals that can make rad disappear quicker than your ex can ghost you!"
+	cost = 2000
+	contains = list(/obj/machinery/smoke_machine,
+					/obj/item/reagent_containers/glass/beaker/large/radscrub,
+					/obj/item/reagent_containers/glass/beaker/large/radscrub,
+					/obj/item/reagent_containers/glass/beaker/large/radscrub
+					)
+	crate_name = "anti radiation smoke machine crate"
+	crate_type = /obj/structure/closet/crate/radiation
+
 /datum/supply_pack/engineering/engiequipment
 	name = "Engineering Gear Crate"
 	desc = "Gear up with three toolbelts, high-visibility vests, welding goggles, hardhats, and two pairs of meson goggles!"

--- a/code/modules/reagents/chemistry/machinery/smoke_machine.dm
+++ b/code/modules/reagents/chemistry/machinery/smoke_machine.dm
@@ -36,6 +36,14 @@
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
 		reagents.maximum_volume += REAGENTS_BASE_VOLUME * B.rating
 
+/obj/machinery/smoke_machine/radbgone
+	name = "anti radiation smoke machine"
+	desc = "A machine with a centrifuge installed into it. It produces a cloud of radscrub chemical that can remove any radiation contamination."
+
+/obj/machinery/smoke_machine/radbgone/Initialize(mapload)
+	. = ..()
+	reagents.add_reagent(/datum/reagent/medicine/radscrub = 300)
+
 /obj/machinery/smoke_machine/update_icon_state()
 	. = ..()
 	if((!is_operational()) || (!on) || (reagents.total_volume == 0))

--- a/code/modules/reagents/chemistry/machinery/smoke_machine.dm
+++ b/code/modules/reagents/chemistry/machinery/smoke_machine.dm
@@ -36,14 +36,6 @@
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
 		reagents.maximum_volume += REAGENTS_BASE_VOLUME * B.rating
 
-/obj/machinery/smoke_machine/radbgone
-	name = "anti radiation smoke machine"
-	desc = "A machine with a centrifuge installed into it. It produces a cloud of radscrub chemical that can remove any radiation contamination."
-
-/obj/machinery/smoke_machine/radbgone/Initialize(mapload)
-	. = ..()
-	reagents.add_reagent(/datum/reagent/medicine/radscrub = 300)
-
 /obj/machinery/smoke_machine/update_icon_state()
 	. = ..()
 	if((!is_operational()) || (!on) || (reagents.total_volume == 0))

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -217,6 +217,10 @@
 /obj/item/reagent_containers/glass/beaker/slime
 	list_reagents = list(/datum/reagent/toxin/slimejelly = 50)
 
+/obj/item/reagent_containers/glass/beaker/large/radscrub
+	name = "Rad Scrub Plus beaker"
+	list_reagents = list(/datum/reagent/medicine/radscrub= 100)
+
 /obj/item/reagent_containers/glass/beaker/large/styptic
 	name = "styptic reserve tank"
 	list_reagents = list(/datum/reagent/medicine/styptic_powder = 50)


### PR DESCRIPTION


# Document the changes in your pull request
Put rad scrub plus smoke machine in engineering
You can now order rad scrub plus smoke machine in cargo

# Why is this good for the game?
AAAAAAAAAAAAAAAAAAAAAAAAA
![image](https://github.com/yogstation13/Yogstation/assets/89688125/8e6da6cd-a9f6-467b-b408-7a98c75f0506)

Engineering doesnt have proper equipment to clear radiation when rad anomaly spawn on the station, a rad b gone sprayer isnt enough to clear an entire area

# Testing
It works


# Wiki Documentation
New cargo pack rad scrub plus smoke machine and maybe something about smoke machine existence in engineering

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
mapping: Put rad scrub plus smoke machine in engineering
tweak: You can now order rad scrub plus smoke machine in cargo
/:cl:
