### PR TITLE
Sheet snatcher can now hold tiles and rods

### DIFF
--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -293,8 +293,8 @@
 // However, making it a storage/bag allows us to reuse existing code in some places. -Sayu
 
 /obj/item/storage/bag/sheetsnatcher
-	name = "sheet snatcher"
-	desc = "A patented Nanotrasen storage system designed for any kind of mineral sheet."
+	name = "stack snatcher"
+	desc = "A patented Nanotrasen storage system designed for any kind of stacks. this is geared towards sheets, rods, and tiles."
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "sheetsnatcher"
 

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -306,7 +306,7 @@
 	. = ..()
 	var/datum/component/storage/concrete/stack/STR = GetComponent(/datum/component/storage/concrete/stack)
 	STR.allow_quick_empty = TRUE
-	STR.set_holdable(list(/obj/item/stack/sheet), list(/obj/item/stack/sheet/mineral/sandstone, /obj/item/stack/sheet/mineral/wood))
+	STR.set_holdable(list(/obj/item/stack/sheet, /obj/item/stack/tile, /obj/item/stack/rods))
 	STR.max_items = 500
 
 // -----------------------------


### PR DESCRIPTION
# Document the changes in your pull request

updates the sheet snatcher to pickup rods and tiles
updates name to stack snatcher and modifies description for this

# Why is this good for the game?
for the engineers its kinda a pain to patch a hole that a traitor blew a hole through and you get rods and tiles you cant really transport a great quantity of to a destination. helps remove tedium of carrying rods and tiles in a backpack
# Testing
tested once to see if it holds the items 


# Wiki Documentation

updates description and name if its on the wiki

# Changelog

:cl:  
tweak; renames sheet snatcher and the description. 
tweak: allows the sheet snatcher to hold rods and tiles

/:cl:
