### PR TITLE
Ports "TGUI input box framework" & More

### DIFF
--- a/code/modules/client/preferences/tgui.dm
+++ b/code/modules/client/preferences/tgui.dm
@@ -8,6 +8,35 @@
 		// Force it to reload either way
 		tgui.update_static_data(client.mob)
 
+// Determines if input boxes are in tgui or old fashioned
+/datum/preference/toggle/tgui_input
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "tgui_input"
+	savefile_identifier = PREFERENCE_PLAYER
+
+/// Large button preference. Error text is in tooltip.
+/datum/preference/toggle/tgui_input_large
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "tgui_input_large"
+	savefile_identifier = PREFERENCE_PLAYER
+	default_value = FALSE
+
+/datum/preference/toggle/tgui_input_large/apply_to_client(client/client, value)
+	for (var/datum/tgui/tgui as anything in client.mob?.tgui_open_uis)
+		// Force it to reload either way
+		tgui.send_full_update(client.mob)
+
+/// Swapped button state - sets buttons to SS13 traditional SUBMIT/CANCEL
+/datum/preference/toggle/tgui_input_swapped
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "tgui_input_swapped"
+	savefile_identifier = PREFERENCE_PLAYER
+
+/datum/preference/toggle/tgui_input_swapped/apply_to_client(client/client, value)
+	for (var/datum/tgui/tgui as anything in client.mob?.tgui_open_uis)
+		// Force it to reload either way
+		tgui.send_full_update(client.mob)
+
 /datum/preference/toggle/tgui_lock
 	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
 	savefile_key = "tgui_lock"

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -70,7 +70,7 @@
 	if(mode)
 		to_chat(user, span_notice("You turn on [src]."))
 		//Now let them chose the text.
-		var/str = reject_bad_text(stripped_input(user, "Label text?", "Set label","", MAX_NAME_LEN))
+		var/str = reject_bad_text(tgui_input_text(user, "Label text?", "Set label","", MAX_NAME_LEN))
 		if(!str || !length(str))
 			to_chat(user, span_warning("Invalid text!"))
 			return

--- a/code/modules/tgui_input/number.dm
+++ b/code/modules/tgui_input/number.dm
@@ -15,7 +15,7 @@
  * * timeout - The timeout of the number input, after which the modal will close and qdel itself. Set to zero for no timeout.
  * * round_value - whether the inputted number is rounded down into an integer.
  */
-/proc/tgui_input_number(mob/user, message, title = "Number Input", default = 0, max_value = 10000, min_value = 0, timeout = 0, round_value = TRUE)
+/proc/tgui_input_number(mob/user, message = null, title = "Number Input", default = null, max_value = null, min_value = 0, timeout = 0)
 	if (!user)
 		user = usr
 	if (!istype(user))
@@ -24,19 +24,48 @@
 			user = client.mob
 		else
 			return
-	// Client does NOT have tgui_input on: Returns regular input
-	var/datum/tgui_input_number/number_input = new(user, message, title, default, max_value, min_value, timeout, round_value)
-	number_input.ui_interact(user)
-	number_input.wait()
-	if (number_input)
-		. = number_input.entry
-		qdel(number_input)
+	/// Client does NOT have tgui_fancy on: Returns regular input
+	if(!user.client.prefs.read_preference(/datum/preference/toggle/tgui_input))
+		return input(user, message, title, default) as null | num
+	var/datum/tgui_input_number/numbox = new(user, message, title, default, max_value, min_value, timeout)
+	numbox.ui_interact(user)
+	numbox.wait()
+	if (numbox)
+		. = numbox.entry
+		qdel(numbox)
+
+/**
+ * Creates an asynchronous TGUI number input window with an associated callback.
+ *
+ * This proc should be used to create numboxes that invoke a callback with the user's entry.
+ *
+ * Arguments:
+ * * user - The user to show the numbox to.
+ * * message - The content of the numbox, shown in the body of the TGUI window.
+ * * title - The title of the numbox modal, shown on the top of the TGUI window.
+ * * default - The default (or current) value, shown as a placeholder. Users can press refresh with this.
+ * * max_value - Specifies a maximum value. If none is set, any number can be entered. Pressing "max" defaults to 1000.
+ * * min_value - Specifies a minimum value. Often 0.
+ * * callback - The callback to be invoked when a choice is made.
+ * * timeout - The timeout of the numbox, after which the modal will close and qdel itself. Disabled by default, can be set to seconds otherwise.
+ */
+/proc/tgui_input_number_async(mob/user, message = null, title = "Number Input", default = null, max_value = null, min_value = 0, datum/callback/callback, timeout = 0)
+	if (!user)
+		user = usr
+	if (!istype(user))
+		if (istype(user, /client))
+			var/client/client = user
+			user = client.mob
+		else
+			return
+	var/datum/tgui_input_number/async/numbox = new(user, message, title, default, max_value, min_value, callback, timeout)
+	numbox.ui_interact(user)
 
 /**
  * # tgui_input_number
  *
- * Datum used for instantiating and using a TGUI-controlled number input that prompts the user with
- * a message and has an input for number entry.
+ * Datum used for instantiating and using a TGUI-controlled numbox that prompts the user with
+ * a message and has an input for text entry.
  */
 /datum/tgui_input_number
 	/// Boolean field describing if the tgui_input_number was closed by the user.
@@ -51,40 +80,28 @@
 	var/message
 	/// The minimum value that can be entered.
 	var/min_value
-	/// Whether the submitted number is rounded down into an integer.
-	var/round_value
-	/// The time at which the number input was created, for displaying timeout progress.
+	/// The time at which the tgui_modal was created, for displaying timeout progress.
 	var/start_time
-	/// The lifespan of the number input, after which the window will close and delete itself.
+	/// The lifespan of the tgui_input_number, after which the window will close and delete itself.
 	var/timeout
 	/// The title of the TGUI window
 	var/title
 
-/datum/tgui_input_number/New(mob/user, message, title, default, max_value, min_value, timeout, round_value)
+
+/datum/tgui_input_number/New(mob/user, message, title, default, max_value, min_value, timeout)
 	src.default = default
 	src.max_value = max_value
 	src.message = message
 	src.min_value = min_value
 	src.title = title
-	src.round_value = round_value
 	if (timeout)
 		src.timeout = timeout
 		start_time = world.time
 		QDEL_IN(src, timeout)
-	/// Checks for empty numbers - bank accounts, etc.
-	if(max_value == 0)
-		src.min_value = 0
-		if(default)
-			src.default = 0
-	/// Sanity check
-	if(default < min_value)
-		src.default = min_value
-	if(default > max_value)
-		CRASH("Default value is greater than max value.")
 
 /datum/tgui_input_number/Destroy(force, ...)
 	SStgui.close_uis(src)
-	return ..()
+	. = ..()
 
 /**
  * Waits for a user's response to the tgui_input_number's prompt before returning. Returns early if
@@ -108,20 +125,22 @@
 	return GLOB.always_state
 
 /datum/tgui_input_number/ui_static_data(mob/user)
-	var/list/data = list()
-	data["init_value"] = default // Default is a reserved keyword
-	data["max_value"] = max_value
-	data["message"] = message
-	data["min_value"] = min_value
-	data["title"] = title
-	data["round_value"] = round_value
-	return data
+	. = list(
+		"preferences" = list()
+	)
+	.["preferences"]["large_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_large)
+	.["preferences"]["swapped_buttons"] = user.client.prefs.read_preference(/datum/preference/toggle/tgui_input_swapped)
 
 /datum/tgui_input_number/ui_data(mob/user)
-	var/list/data = list()
+	. = list(
+		"max_value" = max_value,
+		"message" = message,
+		"min_value"	= min_value,
+		"placeholder" = default, /// You cannot use default as a const
+		"title" = title,
+	)
 	if(timeout)
-		data["timeout"] = CLAMP01((timeout - (world.time - start_time) - 1 SECONDS) / (timeout - 1 SECONDS))
-	return data
+		.["timeout"] = CLAMP01((timeout - (world.time - start_time) - 1 SECONDS) / (timeout - 1 SECONDS))
 
 /datum/tgui_input_number/ui_act(action, list/params)
 	. = ..()
@@ -129,21 +148,42 @@
 		return
 	switch(action)
 		if("submit")
-			if(!isnum(params["entry"]))
-				CRASH("A non number was input into tgui input number by [usr]")
-			var/choice = round_value ? round(params["entry"]) : params["entry"]
-			if(choice > max_value)
-				CRASH("A number greater than the max value was input into tgui input number by [usr]")
-			if(choice < min_value)
-				CRASH("A number less than the min value was input into tgui input number by [usr]")
-			set_entry(choice)
-			closed = TRUE
+			if(max_value && (length(params["entry"]) > max_value))
+				return FALSE
+			if(min_value && (length(params["entry"]) < min_value))
+				return FALSE
+			set_entry(params["entry"])
 			SStgui.close_uis(src)
 			return TRUE
 		if("cancel")
-			closed = TRUE
+			set_entry(null)
 			SStgui.close_uis(src)
 			return TRUE
 
 /datum/tgui_input_number/proc/set_entry(entry)
-	src.entry = entry
+		src.entry = entry
+
+/**
+ * # async tgui_input_number
+ *
+ * An asynchronous version of tgui_input_number to be used with callbacks instead of waiting on user responses.
+ */
+/datum/tgui_input_number/async
+	/// The callback to be invoked by the tgui_input_number upon having a choice made.
+	var/datum/callback/callback
+
+/datum/tgui_input_number/async/New(mob/user, message, title, default, max_value, min_value, callback, timeout)
+	..(user, message, title, default, max_value, min_value, timeout)
+	src.callback = callback
+
+/datum/tgui_input_number/async/Destroy(force, ...)
+	QDEL_NULL(callback)
+	. = ..()
+
+/datum/tgui_input_number/async/set_entry(entry)
+	. = ..()
+	if(!isnull(src.entry))
+		callback?.InvokeAsync(src.entry)
+
+/datum/tgui_input_number/async/wait()
+	return

--- a/tgui/packages/tgui/interfaces/AlertModal.js
+++ b/tgui/packages/tgui/interfaces/AlertModal.js
@@ -4,7 +4,7 @@
  * @license MIT
  */
 
-import { clamp01 } from 'common/math';
+import { Loader } from "./common/Loader";
 import { useBackend } from '../backend';
 import { Component, createRef } from 'inferno';
 import { Box, Flex, Section } from '../components';
@@ -133,15 +133,3 @@ export class AlertModal extends Component {
   }
 
 }
-
-export const Loader = props => {
-  const { value } = props;
-
-  return (
-    <div className="AlertModal__Loader">
-      <Box
-        className="AlertModal__LoaderProgress"
-        style={{ width: clamp01(value) * 100 + '%' }} />
-    </div>
-  );
-};

--- a/tgui/packages/tgui/interfaces/ListInput.js
+++ b/tgui/packages/tgui/interfaces/ListInput.js
@@ -4,9 +4,9 @@
  * @license MIT
  */
 
-import { clamp01 } from 'common/math';
+import { Loader } from "./common/Loader";
 import { useBackend, useLocalState } from '../backend';
-import { Box, Button, Flex, Section, Input } from '../components';
+import { Button, Flex, Section, Input } from '../components';
 import { Window } from '../layouts';
 
 const ARROW_KEY_UP = 38;
@@ -194,19 +194,5 @@ export const ListInput = (props, context) => {
         </Flex>
       </Window.Content>
     </Window>
-  );
-};
-
-export const Loader = props => {
-  const { value } = props;
-  return (
-    <div
-      className="ListInput__Loader">
-      <Box
-        className="ListInput__LoaderProgress"
-        style={{
-          width: clamp01(value) * 100 + '%',
-        }} />
-    </div>
   );
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/tgui.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/tgui.tsx
@@ -7,6 +7,27 @@ export const tgui_fancy: FeatureToggle = {
   component: CheckboxInput,
 };
 
+export const tgui_input: FeatureToggle = {
+  name: 'Input: Enable TGUI',
+  category: 'UI',
+  description: 'Renders input boxes in TGUI.',
+  component: CheckboxInput,
+};
+
+export const tgui_input_large: FeatureToggle = {
+  name: 'Input: Larger buttons',
+  category: 'UI',
+  description: 'Makes TGUI buttons less traditional, more functional.',
+  component: CheckboxInput,
+};
+
+export const tgui_input_swapped: FeatureToggle = {
+  name: 'Input: Swap Submit/Cancel buttons',
+  category: 'UI',
+  description: 'Makes TGUI buttons less traditional, more functional.',
+  component: CheckboxInput,
+};
+
 export const tgui_lock: FeatureToggle = {
   name: 'Lock TGUI to main monitor',
   category: 'UI',

--- a/tgui/packages/tgui/interfaces/TextInputModal.tsx
+++ b/tgui/packages/tgui/interfaces/TextInputModal.tsx
@@ -1,88 +1,64 @@
 import { Loader } from './common/Loader';
-import { InputButtons } from './common/InputButtons';
-import { useBackend, useLocalState } from '../backend';
-import { KEY_ENTER, KEY_ESCAPE } from '../../common/keycodes';
-import { Box, Section, Stack, TextArea } from '../components';
+import { InputButtons, Preferences, Validator } from './common/InputButtons';
+import { useBackend, useSharedState } from '../backend';
+import { KEY_ENTER } from 'common/keycodes';
+import { Box, Input, Section, Stack, TextArea } from '../components';
 import { Window } from '../layouts';
 
 type TextInputData = {
-  large_buttons: boolean;
   max_length: number;
   message: string;
   multiline: boolean;
   placeholder: string;
+  preferences: Preferences;
   timeout: number;
   title: string;
 };
 
-export const sanitizeMultiline = (toSanitize: string) => {
-  return toSanitize.replace(/(\n|\r\n){3,}/, '\n\n');
-};
-
-export const removeAllSkiplines = (toSanitize: string) => {
-  return toSanitize.replace(/[\r\n]+/, '');
-};
-
-export const TextInputModal = (props, context) => {
-  const { act, data } = useBackend<TextInputData>(context);
+export const TextInputModal = (_, context) => {
+  const { data } = useBackend<TextInputData>(context);
   const {
-    large_buttons,
     max_length,
-    message = '',
+    message,
     multiline,
     placeholder,
+    preferences,
     timeout,
     title,
   } = data;
-  const [input, setInput] = useLocalState<string>(
+  const { large_buttons } = preferences;
+  const [input, setInput] = useSharedState(context, 'input', placeholder);
+  const [inputIsValid, setInputIsValid] = useSharedState<Validator>(
     context,
-    'input',
-    placeholder || ''
+    'inputIsValid',
+    { isValid: false, error: null }
   );
-  const onType = (value: string) => {
-    if (value === input) {
-      return;
-    }
-    const sanitizedInput = multiline
-      ? sanitizeMultiline(value)
-      : removeAllSkiplines(value);
-    setInput(sanitizedInput);
+  const onType = (event) => {
+    event.preventDefault();
+    const target = event.target;
+    setInputIsValid(validateInput(target.value, max_length));
+    setInput(target.value);
   };
-
-  const visualMultiline = multiline || input.length >= 30;
   // Dynamically changes the window height based on the message.
-  const windowHeight =
-    135 +
-    (message.length > 30 ? Math.ceil(message.length / 4) : 0) +
-    (visualMultiline ? 75 : 0) +
-    (message.length && large_buttons ? 5 : 0);
+  const windowHeight
+    = 130 + Math.ceil(message.length / 5) + (multiline ? 75 : 0);
 
   return (
     <Window title={title} width={325} height={windowHeight}>
       {timeout && <Loader value={timeout} />}
-      <Window.Content
-        onKeyDown={(event) => {
-          const keyCode = window.event ? event.which : event.keyCode;
-          if (keyCode === KEY_ENTER && (!visualMultiline || !event.shiftKey)) {
-            act('submit', { entry: input });
-          }
-          if (keyCode === KEY_ESCAPE) {
-            act('cancel');
-          }
-        }}>
+      <Window.Content>
         <Section fill>
           <Stack fill vertical>
             <Stack.Item>
               <Box color="label">{message}</Box>
             </Stack.Item>
-            <Stack.Item grow>
-              <InputArea input={input} onType={onType} />
-            </Stack.Item>
-            <Stack.Item>
-              <InputButtons
-                input={input}
-                message={`${input.length}/${max_length}`}
-              />
+            <InputArea
+              input={input}
+              inputIsValid={inputIsValid}
+              onType={onType}
+            />
+            <Stack.Item pl={!large_buttons && 5} pr={!large_buttons && 5}>
+              <InputButtons input={input} inputIsValid={inputIsValid} />
             </Stack.Item>
           </Stack>
         </Section>
@@ -94,28 +70,55 @@ export const TextInputModal = (props, context) => {
 /** Gets the user input and invalidates if there's a constraint. */
 const InputArea = (props, context) => {
   const { act, data } = useBackend<TextInputData>(context);
-  const { max_length, multiline } = data;
-  const { input, onType } = props;
+  const { multiline } = data;
+  const { input, inputIsValid, onType } = props;
 
-  const visualMultiline = multiline || input.length >= 30;
+  if (!multiline) {
+    return (
+      <Stack.Item>
+        <Input
+          autoFocus
+          fluid
+          onInput={(event) => onType(event)}
+          onKeyDown={(event) => {
+            const keyCode = window.event ? event.which : event.keyCode;
+            if (keyCode === KEY_ENTER && inputIsValid) {
+              act('submit', { entry: input });
+            }
+          }}
+          placeholder="Type something..."
+          value={input}
+        />
+      </Stack.Item>
+    );
+  } else {
+    return (
+      <Stack.Item grow>
+        <TextArea
+          autoFocus
+          height="100%"
+          onInput={(event) => onType(event)}
+          onKeyDown={(event) => {
+            const keyCode = window.event ? event.which : event.keyCode;
+            if (keyCode === KEY_ENTER && inputIsValid) {
 
-  return (
-    <TextArea
-      autoFocus
-      autoSelect
-      height={multiline || input.length >= 30 ? '100%' : '1.8rem'}
-      maxLength={max_length}
-      onEscape={() => act('cancel')}
-      onEnter={(event) => {
-        if (visualMultiline && event.shiftKey) {
-          return;
-        }
-        event.preventDefault();
-        act('submit', { entry: input });
-      }}
-      onInput={(_, value) => onType(value)}
-      placeholder="Type something..."
-      value={input}
-    />
-  );
+              act('submit', { entry: input });
+            }
+          }}
+          placeholder="Type something..."
+          value={input}
+        />
+      </Stack.Item>
+    );
+  }
+};
+
+/** Helper functions */
+const validateInput = (input, max_length) => {
+  if (!!max_length && input.length > max_length) {
+    return { isValid: false, error: `Too long!` };
+  } else if (input.length === 0) {
+    return { isValid: false, error: null };
+  }
+  return { isValid: true, error: null };
 };

--- a/tgui/packages/tgui/interfaces/common/InputButtons.tsx
+++ b/tgui/packages/tgui/interfaces/common/InputButtons.tsx
@@ -1,32 +1,40 @@
 import { useBackend } from '../../backend';
-import { Box, Button, Flex } from '../../components';
+import { Box, Button, Stack } from '../../components';
 
 type InputButtonsData = {
+  preferences: Preferences;
+};
+
+type InputButtonsProps = {
+  input: string | number | null;
+  inputIsValid: Validator;
+};
+
+export type Validator = {
+  isValid: boolean;
+  error: string | null;
+};
+
+export type Preferences = {
   large_buttons: boolean;
   swapped_buttons: boolean;
 };
 
-type InputButtonsProps = {
-  input: string | number;
-  message?: string;
-};
-
 export const InputButtons = (props: InputButtonsProps, context) => {
   const { act, data } = useBackend<InputButtonsData>(context);
-  const { large_buttons, swapped_buttons } = data;
-  const { input, message } = props;
+  const { large_buttons = false, swapped_buttons = true } = data.preferences;
+  const { input, inputIsValid } = props;
+  const { isValid, error } = inputIsValid;
   const submitButton = (
     <Button
       color="good"
+      disabled={!isValid}
       fluid={!!large_buttons}
       height={!!large_buttons && 2}
       onClick={() => act('submit', { entry: input })}
-      m={0.5}
-      pl={2}
-      pr={2}
       pt={large_buttons ? 0.33 : 0}
       textAlign="center"
-      tooltip={large_buttons && message}
+      tooltip={!!large_buttons && error}
       width={!large_buttons && 6}>
       {large_buttons ? 'SUBMIT' : 'Submit'}
     </Button>
@@ -37,39 +45,36 @@ export const InputButtons = (props: InputButtonsProps, context) => {
       fluid={!!large_buttons}
       height={!!large_buttons && 2}
       onClick={() => act('cancel')}
-      m={0.5}
-      pl={2}
-      pr={2}
       pt={large_buttons ? 0.33 : 0}
       textAlign="center"
       width={!large_buttons && 6}>
       {large_buttons ? 'CANCEL' : 'Cancel'}
     </Button>
   );
+  const leftButton = !swapped_buttons ? cancelButton : submitButton;
+  const rightButton = !swapped_buttons ? submitButton : cancelButton;
 
   return (
-    <Flex
-      align="center"
-      direction={!swapped_buttons ? 'row' : 'row-reverse'}
-      fill
-      justify="space-around">
+    <Stack>
       {large_buttons ? (
-        <Flex.Item grow>{cancelButton}</Flex.Item>
+        <Stack.Item grow>{leftButton}</Stack.Item>
       ) : (
-        <Flex.Item>{cancelButton}</Flex.Item>
+        <Stack.Item>{leftButton}</Stack.Item>
       )}
-      {!large_buttons && message && (
-        <Flex.Item>
-          <Box color="label" textAlign="center">
-            {message}
-          </Box>
-        </Flex.Item>
+      {!large_buttons && (
+        <Stack.Item grow>
+          {!isValid && (
+            <Box color="average" nowrap textAlign="center">
+              {error}
+            </Box>
+          )}
+        </Stack.Item>
       )}
       {large_buttons ? (
-        <Flex.Item grow>{submitButton}</Flex.Item>
+        <Stack.Item grow>{rightButton}</Stack.Item>
       ) : (
-        <Flex.Item>{submitButton}</Flex.Item>
+        <Stack.Item>{rightButton}</Stack.Item>
       )}
-    </Flex>
+    </Stack>
   );
 };

--- a/tgui/packages/tgui/interfaces/common/Loader.tsx
+++ b/tgui/packages/tgui/interfaces/common/Loader.tsx
@@ -1,15 +1,14 @@
 import { Box } from '../../components';
 import { clamp01 } from 'common/math';
 
-export const Loader = (props) => {
+export const Loader = props => {
   const { value } = props;
 
   return (
     <div className="AlertModal__Loader">
       <Box
         className="AlertModal__LoaderProgress"
-        style={{ width: clamp01(value) * 100 + '%' }}
-      />
+        style={{ width: clamp01(value) * 100 + '%' }} />
     </div>
   );
 };


### PR DESCRIPTION
# Document the changes in your pull request
Ports tgstation/tgstation/pull/63190.
Also changes hand labeler's text input to use `tgui_input_text`.

Adds 3 preferences.
![image](https://github.com/yogstation13/Yogstation/assets/30399783/75936406-3676-4e98-8cdf-aeb1631fa36e)

If perferences are on, it'll makes anything that uses `tgui_input_text` show up like something this:
![image](https://github.com/yogstation13/Yogstation/assets/30399783/8e9e9814-fb42-44aa-b0ad-b24881e888b5)

Same for `tgui_input_number`.
![image](https://github.com/yogstation13/Yogstation/assets/30399783/fc17e552-aecf-4790-9db2-52e764a71f26)

Swapping submit/cancel buttons (off).
![image](https://github.com/yogstation13/Yogstation/assets/30399783/fcdbda83-89e4-452f-878e-dbfc375ea3be)

# Why is this good for the game?
Enables other ports that might need to use this. Also looks cooler than the ugly old input boxes.

# Testing
Yes. Images above. Clicking cancel/submit works fine.

# Changelog
:cl:  
rscadd: New preferences to enable TGUI and more.
tweak: Anything that uses tgui_input_text and tgui_input_number now have better looking input boxes. Can be disabled via preferences.
tweak: Hand labelers now uses tgui_input_text.
/:cl:
