### PR TITLE
Removes Toy Sledgehammer from the Donor Item list, alternative to #20733

### DIFF
--- a/yogstation/code/modules/donor/unique_donator_items.dm
+++ b/yogstation/code/modules/donor/unique_donator_items.dm
@@ -597,9 +597,6 @@ Uncomment this and use atomproccall as necessary, then copypaste the output into
 /datum/donator_gear/sword0
 	name = "toy sword"
 	unlock_path = /obj/item/toy/sword
-/datum/donator_gear/hammer
-	name = "toy sledgehammer"
-	unlock_path = /obj/item/melee/vxtvulhammer/toy
 
 //plushies - kill me, for fuck sake
 /datum/donator_gear/plushvar


### PR DESCRIPTION
# Document the changes in your pull request

the only reason in #20733 for removing toy sledgehammers abilities was "p2w" so I see this as the far more logical solution - donors can no longer take it.  


# Why is this good for the game?
Removes a arguably "pw2" item from the donator item list instead of hugboxing a cool feature people were using to think outside the box (a major point of fun for long-time players) and that did no harm.


# Changelog

:cl:  cark
tweak: donors can no longer pick the toy sledgehammer to spawn with
/:cl:
