### PR TITLE
Fixes Cyborgs & Drones Inability to Screwdriver Open/Close Autolathes

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -186,6 +186,10 @@
 /obj/machinery/autolathe/attackby(obj/item/O, mob/user, params)
 	if(user.a_intent == INTENT_DISARM && default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O))
 		return TRUE
+	
+	// They do not have INTENT_DISARM.
+	if((issilicon(user) || isdrone(user)) && user.a_intent == INTENT_HELP && default_deconstruction_screwdriver(user, "autolathe_t", "autolathe", O))
+		return TRUE
 
 	if(default_deconstruction_crowbar(O))
 		return TRUE


### PR DESCRIPTION
# Document the changes in your pull request
Cyborgs and drones can now properly screwdriver open/close autolathes with help intent instead of with disarm intent (note: they don't have disarm intent).

# Testing
I opened and closed an autolathe as cyborg & drone with a screwdriver.

# Changelog
:cl:  
bugfix: Cyborgs & drones can properly screwdriver open/close autolathes again.
/:cl:
