### PR TITLE
NEW OBJECTIVE: Targetted organ harvesting

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1767,7 +1767,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 /datum/objective/steal_organ/update_explanation_text()
 	if(target && target_organ)
 		var/mob/living/carbon/human/H = target.current
-		explanation_text = "Steal the original [target_organ] of [target.name], the [isipc(H) ? H.dna.species.name : lowertext(H.dna.species.name)] [target.assigned_role]."
+		explanation_text = "Steal \the original [target_organ] of [target.name], the [isipc(H) ? H.dna.species.name : lowertext(H.dna.species.name)] [target.assigned_role]."
 	else
 		explanation_text = "Free Objective"
 	. = ..()

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1749,11 +1749,11 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 
 /datum/objective/steal_organ/is_valid_target(datum/mind/possible_target)
 	if(iscarbon(possible_target?.current))
-		var/mob/living/carbon/possible_carbon_target = possible_target
+		var/mob/living/carbon/possible_carbon_target = possible_target.current
 		return LAZYLEN(possible_carbon_target.internal_organs)
 
 /datum/objective/steal_organ/finalize()
-	var/datum/mind/mind_target = find_target()
+	var/datum/mind/mind_target = find_target() // Also sets target
 	if(!mind_target)
 		return FALSE
 

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -194,11 +194,16 @@
 			destroy_objective.owner = owner
 			destroy_objective.find_target()
 			add_objective(destroy_objective)
-		else if(prob(30))
+		else if(prob(20))
 			var/datum/objective/maroon/maroon_objective = new
 			maroon_objective.owner = owner
 			maroon_objective.find_target()
 			add_objective(maroon_objective)
+		else if(prob(20))
+			var/datum/objective/steal_organ/organ_objective = new
+			organ_objective.owner = owner
+			organ_objective.finalize()
+			add_objective(organ_objective)
 		else
 			var/N = pick(/datum/objective/assassinate, /datum/objective/assassinate/cloned, /datum/objective/assassinate/once)
 			var/datum/objective/assassinate/kill_objective = new N

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -204,6 +204,13 @@
 			organ_objective.owner = owner
 			organ_objective.finalize()
 			add_objective(organ_objective)
+			// perform with "surgical" precision, you must keep them alive to not arouse too much suspicion
+			if(prob(50) && !istype(organ_objective, /obj/item/organ/brain)) // you COULD do this with pod cloning but meh
+				var/datum/objective/protect/keep_them_alive = new
+				keep_them_alive.owner = owner
+				keep_them_alive.target = organ_objective.target
+				keep_them_alive.update_explanation_text()
+				add_objective(keep_them_alive)
 		else
 			var/N = pick(/datum/objective/assassinate, /datum/objective/assassinate/cloned, /datum/objective/assassinate/once)
 			var/datum/objective/assassinate/kill_objective = new N


### PR DESCRIPTION
# Document the changes in your pull request

New assassinate-adjacent objective: Steal organ

You are tasked with stealing a random organ from a specific person. It has to be the original organ that they start with, not a replacement. This means that you can steal someone's lungs and then have them replaced so that they aren't round removed.

If this organ is not their brain, then you have a 50% chance of also getting a protect objective on this person, which means you can't just esword open their stomach/head contents for an easy greentext, you will have to employ "surgical" precision.

# Why is this good for the game?
<img width=100 height=100 src='https://github.com/yogstation13/Yogstation/assets/28408322/00b46ffa-61c0-49e2-b84c-c28375671e34'>

Ghetto surgery, syndicate surgery kit, not necessarily lethal interactions, especially with the protect objective tacked on

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/28408322/72acd5af-a16a-495c-8a1f-d2bf398222c1)

# Wiki Documentation
See above for exact text

# Changelog

:cl:  
rscadd: Added a new "steal organ" objective which tasks you with stealing an internal organ from someone specific. Be careful though, as you may have to replace it to keep them alive!
/:cl:
