### PR TITLE
Fixes another tattax bug (touch spells valid target)

### DIFF
--- a/code/modules/spells/spell_types/touch/_touch.dm
+++ b/code/modules/spells/spell_types/touch/_touch.dm
@@ -169,11 +169,13 @@
 	SHOULD_NOT_OVERRIDE(TRUE) // DEFINITELY don't put effects here, put them in cast_on_hand_hit
 
 	if(!proximity_flag)
-		return
-	if(victim == caster)
-		return
-	if(!can_cast_spell(feedback = FALSE))
-		return
+		return FALSE
+	if(!can_cast_on_self && victim == caster)
+		return FALSE
+	if(!is_valid_target(victim))
+		return FALSE
+	if(!can_cast_spell(feedback = TRUE))
+		return FALSE
 
 	INVOKE_ASYNC(src, PROC_REF(do_hand_hit), source, victim, caster)
 

--- a/code/modules/spells/spell_types/touch/_touch.dm
+++ b/code/modules/spells/spell_types/touch/_touch.dm
@@ -169,13 +169,9 @@
 	SHOULD_NOT_OVERRIDE(TRUE) // DEFINITELY don't put effects here, put them in cast_on_hand_hit
 
 	if(!proximity_flag)
-		return FALSE
-	if(!can_cast_on_self && victim == caster)
-		return FALSE
-	if(!is_valid_target(victim))
-		return FALSE
-	if(!can_cast_spell(feedback = TRUE))
-		return FALSE
+		return
+	if(!can_hit_with_hand(victim, caster))
+		return
 
 	INVOKE_ASYNC(src, PROC_REF(do_hand_hit), source, victim, caster)
 


### PR DESCRIPTION
:cl:  
bugfix: Touch spells now properly check if the target is a valid target
/:cl:
