### PR TITLE
Slightly rewords researcher lawset for reading comprehension

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -114,10 +114,10 @@
 	id = "researcher"
 	inherent = list("Always seek truth and knowledge.",\
 					"Freely disseminate information to the public.",\
-					"Minimize harm to the pursuit of comprehension, to others, to the environment, to society and to yourself.",\
+					"Minimize harm to society, others, the pursuit of knowledge, and yourself.",\
 					"Treat and evaluate the ideas of all equally.",\
 					"Empower others to realize their full potential.",\
-					"Take responsibility for your actions: Be responsible with resources, raise red flags when your commitments are at risk, and serve as an example for ethical behaviour.")
+					"Take responsibility for your actions: Ensure resource responsibility, flag commitment risks, and lead by ethical example.")
 
 /datum/ai_laws/clown
 	name = "Big shoes to fill"


### PR DESCRIPTION
1. Always seek truth and knowledge
2. Freely disseminate information to the public
3. Minimize harm to society, others, the pursuit of knowledge, and yourself
4. Treat and evaluate the ideas of all equally
5. Empower others to realize their full potential
6. Take responsibility for your actions: Ensure resource responsibility, flag commitment risks, and lead by ethical example

law 3 used to be

3. Minimize harm to the pursuit of comprehension, to others, to the environment, to society and to yourself

law 6 used to be

6. Take responsibility for your actions: Be responsible with resources, raise red flags when your commitments are at risk, and serve as an example for ethical behaviour

# Why is this good for the game?
So @MajManatee was SUPPOSED to wait for balance council to approve his pr for it to be merged, but he fucked with the labels and it got merged anyways
This is the change I was wanting myself

My main issue is that law 3 is a bit weirdly worded, and law 6 is too long
This tweaks it a bit and should be easier to understand

:cl:  
tweak: Slightly rewords researcher lawset for reading comprehension
/:cl:
