### PR TITLE
Cyborg Chameleon Projector Can Disguise as Any Crew Cyborg Module

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -358,7 +358,7 @@ GLOBAL_LIST_EMPTY(radial_menus)
 	Choices should be a list where list keys are movables or text used for element names and return value
 	and list values are movables/icons/images used for element icons
 */
-/proc/show_radial_menu(mob/user, atom/anchor, list/choices, uniqueid, radius, datum/callback/custom_check, require_near = FALSE, tooltips = FALSE, no_repeat_close = FALSE, radial_slice_icon = "radial_slice")
+/proc/show_radial_menu(mob/user, atom/anchor, list/choices, uniqueid, radius, datum/callback/custom_check, require_near = FALSE, tooltips = FALSE, no_repeat_close = FALSE, radial_slice_icon = "radial_slice", check_delay)
 	if(!user || !anchor || !length(choices))
 		return
 	if(!uniqueid)
@@ -376,6 +376,8 @@ GLOBAL_LIST_EMPTY(radial_menus)
 		menu.radius = radius
 	if(istype(custom_check))
 		menu.custom_check_callback = custom_check
+	if(check_delay)
+		menu.check_delay = check_delay
 	menu.anchor = anchor
 	menu.radial_slice_icon = radial_slice_icon
 	menu.check_screen_border(user) //Do what's needed to make it look good near borders or on hud

--- a/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
+++ b/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
@@ -13,7 +13,6 @@
 	var/active = FALSE
 	var/activationCost = 300
 	var/activationUpkeep = 50
-	var/disguise = "engineer"
 	var/mob/listeningTo
 	var/static/list/signalCache = list( // list here all signals that should break the camouflage
 			COMSIG_PARENT_ATTACKBY,

--- a/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
+++ b/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
@@ -52,43 +52,46 @@
 	else
 		to_chat(user, span_warning("You need at least [activationCost] charge in your cell to use [src]!"))
 
+/obj/item/borg_chameleon/AltClick(mob/living/silicon/robot/user)
+	friendlyName = pick(GLOB.ai_names)
+	to_chat(user, span_notice("The next disguised name will be: [friendlyName]."))
+
 /obj/item/borg_chameleon/proc/toggle(mob/living/silicon/robot/user)
 	if(active)
 		playsound(src, 'sound/effects/pop.ogg', 100, 1, -6)
 		to_chat(user, span_notice("You deactivate \the [src]."))
 		deactivate(user)
-	else
-		if(animation_playing)
-			to_chat(user, span_notice("\the [src] is recharging."))
-			return
-		animation_playing = TRUE
-		to_chat(user, span_notice("You activate \the [src]."))
-		playsound(src, 'sound/effects/seedling_chargeup.ogg', 100, 1, -6)
-		var/start = user.filters.len
-		var/X,Y,rsq,i,f
-		for(i=1, i<=7, ++i)
-			do
-				X = 60*rand() - 30
-				Y = 60*rand() - 30
-				rsq = X*X + Y*Y
-			while(rsq<100 || rsq>900)
-			user.filters += filter(type="wave", x=X, y=Y, size=rand()*2.5+0.5, offset=rand())
-		for(i=1, i<=7, ++i)
+		return
+	if(animation_playing)
+		to_chat(user, span_notice("[src] is recharging."))
+		return
+	animation_playing = TRUE
+	to_chat(user, span_notice("You activate \the [src]."))
+	playsound(src, 'sound/effects/seedling_chargeup.ogg', 100, 1, -6)
+
+	var/start = user.filters.len
+	var/X,Y,rsq,i,f
+	for(i=1, i<=7, ++i)
+		do
+			X = 60*rand() - 30
+			Y = 60*rand() - 30
+			rsq = X*X + Y*Y
+		while(rsq<100 || rsq>900)
+		user.filters += filter(type="wave", x=X, y=Y, size=rand()*2.5+0.5, offset=rand())
+	for(i=1, i<=7, ++i)
+		f = user.filters[start+i]
+		animate(f, offset=f:offset, time=0, loop=3, flags=ANIMATION_PARALLEL)
+		animate(offset=f:offset-1, time=rand()*20+(1 SECONDS))
+	if (do_after(user, 5 SECONDS, user) && user.cell.use(activationCost))
+		activate(user)
+	else	
+		to_chat(user, span_warning("The chameleon field fizzles."))
+		do_sparks(3, FALSE, user)
+		for(i=1, i<=min(7, user.filters.len), ++i) // removing filters that are animating does nothing, we gotta stop the animations first
 			f = user.filters[start+i]
-			animate(f, offset=f:offset, time=0, loop=3, flags=ANIMATION_PARALLEL)
-			animate(offset=f:offset-1, time=rand()*20+(1 SECONDS))
-		if (do_after(user, 5 SECONDS, user) && user.cell.use(activationCost))
-			playsound(src, 'sound/effects/bamf.ogg', 100, 1, -6)
-			to_chat(user, span_notice("You are now disguised as the Nanotrasen engineering borg \"[friendlyName]\"."))
-			activate(user)
-		else
-			to_chat(user, span_warning("The chameleon field fizzles."))
-			do_sparks(3, FALSE, user)
-			for(i=1, i<=min(7, user.filters.len), ++i) // removing filters that are animating does nothing, we gotta stop the animations first
-				f = user.filters[start+i]
-				animate(f)
-		user.filters = null
-		animation_playing = FALSE
+			animate(f)
+	user.filters = null
+	animation_playing = FALSE
 
 /obj/item/borg_chameleon/process()
 	if (user)
@@ -98,13 +101,42 @@
 		return PROCESS_KILL
 
 /obj/item/borg_chameleon/proc/activate(mob/living/silicon/robot/user)
+	// All selectable modules
+	var/list/modulelist = list("Standard" = /obj/item/robot_module/standard, \
+	"Engineering" = /obj/item/robot_module/engineering, \
+	"Medical" = /obj/item/robot_module/medical, \
+	"Miner" = /obj/item/robot_module/miner, \
+	"Janitor" = /obj/item/robot_module/janitor, \
+	"Service" = /obj/item/robot_module/service)
+	if(!CONFIG_GET(flag/disable_peaceborg))
+		modulelist["Peacekeeper"] = /obj/item/robot_module/peacekeeper
+	if(!CONFIG_GET(flag/disable_secborg))
+		modulelist["Security"] = /obj/item/robot_module/security
+
+	// Radical of selectable modules
+	var/list/moduleicons = list()
+	for(var/option in modulelist)
+		var/obj/item/robot_module/M = modulelist[option]
+		var/is = initial(M.cyborg_base_icon)
+		moduleicons[option] = image(icon = 'icons/mob/robots.dmi', icon_state = is)
+	var/input_module = show_radial_menu(usr, usr, moduleicons, radius = 42, custom_check = CALLBACK(src, PROC_REF(cancel_radical_on_move), usr,  user.loc), check_delay = 0.1 SECONDS)
+	
+	// Sanity
+	if(!input_module || active)
+		return
+
+	var/obj/item/robot_module/selected_module = modulelist[input_module]
+	if(!selected_module)
+		return
+
+	// Disguising
 	START_PROCESSING(SSobj, src)
 	src.user = user
 	savedName = user.name
 	user.name = friendlyName
-	user.module.cyborg_base_icon = disguise
+	user.module.cyborg_base_icon = initial(selected_module.cyborg_base_icon)
 	user.bubble_icon = "robot"
-	user.module.name = "Engineering"
+	user.module.name = input_module
 	active = TRUE
 	user.update_icons()
 	
@@ -114,6 +146,9 @@
 		UnregisterSignal(listeningTo, signalCache)
 	RegisterSignal(user, signalCache, PROC_REF(disrupt))
 	listeningTo = user
+
+	playsound(src, 'sound/effects/bamf.ogg', 100, 1, -6)
+	to_chat(user, span_notice("You are now disguised as the Nanotrasen [input_module] cyborg \"[friendlyName]\"."))
 
 /obj/item/borg_chameleon/proc/deactivate(mob/living/silicon/robot/user)
 	STOP_PROCESSING(SSobj, src)
@@ -133,3 +168,9 @@
 	if(active)
 		to_chat(user, span_danger("Your chameleon field deactivates."))
 		deactivate(user)
+
+// Checks if cyborg moved from their position and cancels the radical menu if they did.
+/obj/item/borg_chameleon/proc/cancel_radical_on_move(mob/living/silicon/robot/user, atom/last_loc)
+	if(user.loc != last_loc)
+		return FALSE
+	return TRUE


### PR DESCRIPTION
# Document the changes in your pull request
The Syndicate Saboteur Cyborg's Cyborg Chameleon Projector can now select any cyborg module that is available to normal crew cyborgs to disguise as.

Cyborg Chameleon Projector can be alt-clicked to randomize what the disguised name will be.

Moving while there is an open radical menu for the Cyborg Chameleon Projector will cause it to close.

# Why is this good for the game?
Gives more utility to the Cyborg Chameleon Projector and causes people to be more suspicious of all cyborgs of any modules during nuke ops instead of only engineering cyborgs.

# Testing
Alt-clicking:
![image](https://github.com/yogstation13/Yogstation/assets/30399783/52d313a6-e279-4815-8c94-ff751afd47dc)

Selection & Stabbing Moja while disguised:
![thing](https://github.com/yogstation13/Yogstation/assets/30399783/7c1cc9ad-b736-451d-840c-04288756dfb5)

# Wiki Documentation
Cyborg Chameleon Projector can disguise as any module that is available to normal cyborgs. Alt-clicking it will re-randomize of the name of next disguise.

# Changelog
:cl:  
rscadd: Syndicate Saboteur's Cyborg Chameleon Projector can now disguise as any cyborg module that is available to normal cyborgs.
rscadd:  Syndicate Saboteur's Cyborg Chameleon Projector can be alt-clicked to re-randomize the disguise name.
/:cl:
