### PR TITLE
Revert "Nerfs toy sledgehammer", removes toy sledgehammer from donor list

### DIFF
--- a/yogstation/code/game/objects/items/wielded/vxtvulhammer.dm
+++ b/yogstation/code/game/objects/items/wielded/vxtvulhammer.dm
@@ -181,13 +181,8 @@
 			var/atom/throw_target = get_edge_target_turf(target, user.dir)
 			var/mob/living/victim = target
 			if(toy)
-				if(user == target)
-					victim.Paralyze(2 SECONDS)
-					victim.emote("scream")
-					to_chat(victim, span_userdanger("That was stupid."))
-				else
-					ADD_TRAIT(victim, TRAIT_IMPACTIMMUNE, "Toy Hammer")
-					victim.safe_throw_at(throw_target, rand(1,2), 3, callback = CALLBACK(src, PROC_REF(afterimpact), victim))
+				ADD_TRAIT(victim, TRAIT_IMPACTIMMUNE, "Toy Hammer")
+				victim.safe_throw_at(throw_target, rand(1,2), 3, callback = CALLBACK(src, PROC_REF(afterimpact), victim))
 			else
 				victim.throw_at(throw_target, 15, 5) //Same distance as maxed out power fist with three extra force
 				victim.Paralyze(2 SECONDS)

--- a/yogstation/code/modules/donor/unique_donator_items.dm
+++ b/yogstation/code/modules/donor/unique_donator_items.dm
@@ -597,9 +597,6 @@ Uncomment this and use atomproccall as necessary, then copypaste the output into
 /datum/donator_gear/sword0
 	name = "toy sword"
 	unlock_path = /obj/item/toy/sword
-/datum/donator_gear/hammer
-	name = "toy sledgehammer"
-	unlock_path = /obj/item/melee/vxtvulhammer/toy
 
 //plushies - kill me, for fuck sake
 /datum/donator_gear/plushvar


### PR DESCRIPTION
# Why is this good for the game?

Reverts yogstation13/Yogstation#20733

The only reason provided as to why this was 'good' was that it was p2w (arguable af).  I provided an alternative which remove the hammer from donor item list - this PR was merged and my alternative shot down as it was a 'bug fix' (it was not a bug)

:cl:  cark
tweak: Reverts #20733 and makes toy sledge a non donor item
/:cl: