### PR TITLE
[DONUT] Fits ATMOS maints with an auxiliary shuttle dock, and moves an escape pod.  Also replaces old consoles with new ones.

### DIFF
--- a/_maps/map_files/DonutStation/DonutStation.dmm
+++ b/_maps/map_files/DonutStation/DonutStation.dmm
@@ -68,18 +68,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"abC" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "ace" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -1599,10 +1587,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aHR" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "aIA" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -2141,15 +2125,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aUo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "aUq" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 8;
@@ -2657,6 +2632,10 @@
 /obj/effect/spawner/structure/solars/solar_96,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
+"bga" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "bgb" = (
 /obj/structure/table/glass,
 /obj/machinery/power/apc{
@@ -3298,6 +3277,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/storage/tech)
+"bsD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "bsI" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -4898,6 +4888,11 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/storage/tools)
+"bZz" = (
+/obj/machinery/light/small,
+/obj/effect/turf_decal/trimline/yellow/arrow_cw,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "bZL" = (
 /obj/item/clothing/mask/gas{
 	pixel_x = -3;
@@ -5751,6 +5746,10 @@
 /obj/effect/spawner/lootdrop/techstorage/engineering,
 /turf/open/floor/plating,
 /area/storage/tech)
+"crg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "crq" = (
 /turf/closed/wall/rust,
 /area/quartermaster/warehouse)
@@ -5998,6 +5997,21 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"cwn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "cww" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -6391,18 +6405,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
-"cDI" = (
-/obj/structure/sign/warning/pods{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "cDY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -7007,10 +7009,6 @@
 /obj/structure/sign/poster/contraband/random,
 /turf/closed/wall/rust,
 /area/quartermaster/warehouse)
-"cQm" = (
-/obj/effect/turf_decal/trimline/yellow/arrow_cw,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "cQq" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 10
@@ -7792,6 +7790,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"diJ" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "diN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -8796,6 +8798,24 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"dGL" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "dGO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -9028,6 +9048,18 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
+"dLW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "dMg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
@@ -9049,11 +9081,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
-"dMJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "dMR" = (
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
@@ -9730,17 +9757,6 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
-"eay" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 11;
-	height = 22;
-	id = "whiteship_home";
-	name = "SS13: Auxiliary Dock, Station-Port";
-	width = 35
-	},
-/turf/open/space/basic,
-/area/space)
 "eaz" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -10854,12 +10870,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"eBt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/yellow/arrow_cw,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "eBz" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -11235,12 +11245,6 @@
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
-"eJh" = (
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "eJG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -12001,15 +12005,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
-"eYp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "eYy" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Biohazard";
@@ -12331,6 +12326,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"fgg" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 11;
+	height = 22;
+	id = "whiteship_home";
+	name = "SS13: Auxiliary Dock, Station-Port";
+	width = 35
+	},
+/turf/open/space/basic,
+/area/space)
 "fgr" = (
 /obj/structure/altar_of_gods,
 /turf/open/floor/plasteel/chapel{
@@ -12634,6 +12640,17 @@
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
+"flF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "fml" = (
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/plasteel,
@@ -13035,6 +13052,18 @@
 	},
 /turf/open/floor/wood,
 /area/tcommsat/computer)
+"fun" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "fuA" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -13658,21 +13687,6 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"fJM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/trimline/yellow/corner{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "fJT" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecomms Control Room";
@@ -14091,6 +14105,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"fTd" = (
+/obj/effect/turf_decal/trimline/yellow/arrow_cw,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "fTe" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -14526,17 +14544,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"gel" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "geq" = (
 /obj/structure/frame/computer{
 	anchored = 1;
@@ -15012,6 +15019,15 @@
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"gpj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "gpL" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -15355,12 +15371,6 @@
 	initial_gas_mix = "co2=1000;TEMP=293.15"
 	},
 /area/engine/atmos)
-"gxc" = (
-/obj/effect/turf_decal/trimline/yellow/corner{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "gxd" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medical Maintenance Access";
@@ -15792,6 +15802,17 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"gKn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "gKs" = (
 /obj/structure/tank_dispenser,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -16164,6 +16185,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"gUe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "gUj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -16359,6 +16391,15 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
+"gYX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "gZc" = (
 /obj/structure/railing{
 	dir = 1
@@ -16972,17 +17013,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"hpE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "hpI" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
@@ -17074,6 +17104,16 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"hrg" = (
+/obj/structure/sign/warning/vacuum{
+	name = "EXTERNAL AIRLOCK";
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "hrh" = (
 /obj/machinery/camera{
 	c_tag = "Research - Surgery";
@@ -17179,15 +17219,6 @@
 "hub" = (
 /turf/closed/wall/r_wall,
 /area/security/prison)
-"huh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "hui" = (
 /obj/structure/lattice/catwalk,
 /obj/item/stack/cable_coil/random/five,
@@ -17826,21 +17857,6 @@
 /obj/machinery/porta_turret/ai,
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
-"hHT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "hIt" = (
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
@@ -19676,6 +19692,22 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/science/storage)
+"iDf" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "iDm" = (
 /obj/structure/table/glass,
 /obj/item/crowbar,
@@ -20414,6 +20446,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"iVj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "0"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "iVo" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -20569,6 +20622,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
+"iZk" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/airlock/external{
+	name = "Auxiliary Docking Port"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "iZp" = (
 /obj/structure/rack,
 /obj/item/tank/internals/emergency_oxygen,
@@ -20720,12 +20783,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"jeq" = (
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "jes" = (
 /obj/structure/chair/stool,
 /obj/structure/disposalpipe/segment{
@@ -21611,24 +21668,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"jwS" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "jxw" = (
 /obj/machinery/light,
 /obj/structure/chair/office/light{
@@ -23342,10 +23381,6 @@
 /obj/machinery/door/poddoor/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
-"kds" = (
-/obj/structure/barricade/wooden,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "kdx" = (
 /obj/machinery/nanite_program_hub,
 /turf/open/floor/plasteel/dark,
@@ -24027,15 +24062,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"ktw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "ktA" = (
 /obj/machinery/atmospherics/components/binary/valve/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -24054,6 +24080,11 @@
 /obj/machinery/computer/arcade,
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
+"kuG" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "kuL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -24064,17 +24095,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"kuW" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 11;
-	height = 22;
-	id = "whiteship_home";
-	name = "SS13: Auxiliary Dock, Station-Port";
-	width = 35
-	},
-/turf/open/space/basic,
-/area/space)
 "kvm" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger{
@@ -24450,15 +24470,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"kII" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "kIX" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/metal/fifty,
@@ -25571,6 +25582,19 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
+"lgZ" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Two"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "lhd" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -26224,6 +26248,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
+"lwp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "lwC" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/effect/turf_decal/tile/green/opposingcorners{
@@ -26473,6 +26506,15 @@
 	dir = 8
 	},
 /area/chapel/main)
+"lDG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "lDH" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -26593,13 +26635,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"lFF" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "lFL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
@@ -27106,15 +27141,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"lQA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+"lQG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/aft";
+	dir = 8;
+	name = "Aft Maintenance APC";
+	pixel_x = -25
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/aft)
 "lQO" = (
 /obj/machinery/button/door{
 	id = "cargowarehouse";
@@ -27345,18 +27386,6 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
-"lTT" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "lUc" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -28114,21 +28143,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
-"mnp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "mnt" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
@@ -28187,6 +28201,21 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"mov" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/sign/warning/docking{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "moA" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -28396,6 +28425,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
+"msP" = (
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "msR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -29276,13 +29311,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"mMT" = (
-/obj/machinery/advanced_airlock_controller{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "mNb" = (
 /obj/machinery/field/generator,
 /obj/machinery/camera/emp_proof{
@@ -29472,27 +29500,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mQH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "0"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "mQR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -30387,6 +30394,21 @@
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
+"nif" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "nio" = (
 /obj/structure/table,
 /obj/item/storage/box/lights/mixed,
@@ -31093,6 +31115,16 @@
 "nzl" = (
 /turf/open/floor/circuit/green/telecomms,
 /area/ai_monitored/turret_protected/ai)
+"nzq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "nzv" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel/dark,
@@ -31548,17 +31580,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"nIj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "nIq" = (
 /obj/machinery/newscaster{
 	pixel_x = -32
@@ -31612,6 +31633,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/warehouse)
+"nJl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Auxiliary Docking Port"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "nJo" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering - Engine Containment East";
@@ -32326,6 +32356,18 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
+"nYK" = (
+/obj/structure/sign/warning/pods{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "nZb" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -32521,6 +32563,13 @@
 /obj/item/seeds/random,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"obK" = (
+/obj/machinery/advanced_airlock_controller{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "obM" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -32772,6 +32821,20 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/main)
+"ogw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "ogN" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -33494,10 +33557,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"oxD" = (
-/obj/effect/turf_decal/trimline/yellow/corner,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "oxG" = (
 /obj/item/grenade/barrier{
 	pixel_x = 4
@@ -36377,6 +36436,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"pNE" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "pNI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
@@ -37018,27 +37089,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"pZV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper"
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "qaj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/trimline/white/filled/corner/lower{
@@ -37206,6 +37256,27 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/fore)
+"qdY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	icon_state = "airlock_unres_helper"
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "qej" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -37788,16 +37859,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"qpA" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/door/airlock/external{
-	name = "Auxiliary Docking Port"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "qpH" = (
 /obj/machinery/conveyor{
 	dir = 0;
@@ -38870,21 +38931,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"qQw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/sign/warning/docking{
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/trimline/yellow/corner{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "qQQ" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -39007,6 +39053,21 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
+"qSK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "qTz" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -39036,19 +39097,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"qUm" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod Two"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "qUw" = (
 /obj/structure/rack,
 /obj/item/storage/bag/plants/portaseeder,
@@ -39566,11 +39614,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"rgf" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "rgj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -40009,15 +40052,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"rqQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "rrg" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -40672,15 +40706,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"rFE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "rFJ" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/purple/visible{
@@ -41148,6 +41173,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"rPb" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Two"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "rPg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -41435,6 +41470,21 @@
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
+"rYY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "rZJ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -41678,6 +41728,11 @@
 	},
 /turf/open/floor/wood,
 /area/hallway/primary/central)
+"sgY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "shb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -44388,6 +44443,15 @@
 /obj/machinery/computer/arcade,
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
+"tnX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "tnY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -44513,6 +44577,12 @@
 	},
 /turf/open/floor/wood,
 /area/tcommsat/computer)
+"tqd" = (
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "tqq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -44575,18 +44645,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"tqV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "tqW" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -45185,15 +45243,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"tBc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Auxiliary Docking Port"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "tBD" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
@@ -45244,21 +45293,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"tDu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/aft";
-	dir = 8;
-	name = "Aft Maintenance APC";
-	pixel_x = -25
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "tDD" = (
 /obj/machinery/air_sensor/atmos/nitrous_tank,
 /turf/open/floor/engine/n2o{
@@ -45312,6 +45346,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"tEY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "tFf" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 10
@@ -45933,21 +45976,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"tRU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "tRV" = (
 /obj/machinery/door/airlock/external{
 	name = "External Freight Airlock"
@@ -46260,16 +46288,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"tYV" = (
-/obj/structure/sign/warning/vacuum{
-	name = "EXTERNAL AIRLOCK";
-	pixel_y = -32
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "tYZ" = (
 /obj/item/target/alien/anchored,
 /obj/effect/turf_decal/stripes/line{
@@ -46674,6 +46692,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"ugL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "uhl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -47196,10 +47227,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"utW" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "uua" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47529,16 +47556,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"uDG" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod Two"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "uDW" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -49434,37 +49451,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
-"vtW" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "vus" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/rods,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"vuy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "vuQ" = (
 /obj/machinery/telecomms/server/presets/common,
 /obj/machinery/light{
@@ -49553,6 +49544,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
+"vwN" = (
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "vxr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
@@ -49689,6 +49686,15 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"vyP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "vzN" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -51176,6 +51182,15 @@
 "whA" = (
 /turf/closed/wall/r_wall,
 /area/medical/virology)
+"whJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "whY" = (
 /obj/machinery/light{
 	dir = 1
@@ -51316,20 +51331,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"wlj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "wlo" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
@@ -51371,19 +51372,6 @@
 "wmD" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
-"wmQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "wnn" = (
 /obj/structure/displaycase/trophy,
 /turf/open/floor/carpet,
@@ -52686,15 +52674,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"wNQ" = (
-/obj/machinery/light/small,
-/obj/effect/turf_decal/trimline/yellow/arrow_cw,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "wNV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/medbay/central)
+"wNZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "wOb" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -53890,6 +53882,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"xlB" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "xlH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -54134,6 +54133,12 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
+"xqf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/arrow_cw,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "xqF" = (
 /obj/machinery/conveyor{
 	id = "garbage"
@@ -54503,6 +54508,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"xxP" = (
+/obj/effect/turf_decal/trimline/yellow/corner,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "xye" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -54827,15 +54836,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"xFy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "xFF" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/surgery,
@@ -55596,17 +55596,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"xTP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/yellow/corner{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "xUh" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/satellite)
@@ -62586,7 +62575,7 @@ ylr
 ylr
 ylr
 ylr
-eay
+ylr
 ylr
 ylr
 ylr
@@ -75671,10 +75660,10 @@ vgR
 jyB
 jyB
 lJE
-xFy
-qUm
-rgf
-uDG
+lwp
+lgZ
+kuG
+rPb
 spx
 ylr
 ylr
@@ -75928,9 +75917,9 @@ vgR
 vgR
 vgR
 vgR
-cDI
+nYK
 jyB
-mMT
+obK
 jyB
 ylr
 ylr
@@ -76185,7 +76174,7 @@ jyB
 jyB
 vgR
 jyB
-aUo
+tnX
 jyB
 jyB
 jyB
@@ -76441,8 +76430,8 @@ fDZ
 oLF
 jyB
 vgR
-xFy
-rFE
+lwp
+vyP
 jyB
 jyB
 jyB
@@ -76698,7 +76687,7 @@ fDZ
 fDZ
 hAx
 vgR
-aUo
+tnX
 jyB
 jyB
 fDZ
@@ -76955,7 +76944,7 @@ fDZ
 fDZ
 jyB
 vgR
-lQA
+whJ
 vgR
 hAx
 fDZ
@@ -77212,7 +77201,7 @@ vDp
 vDp
 vDp
 vDp
-vtW
+iDf
 vDp
 jyB
 fDZ
@@ -77469,7 +77458,7 @@ clM
 clM
 lBV
 vDp
-rqQ
+gYX
 gIJ
 jyB
 jyB
@@ -77726,7 +77715,7 @@ clM
 clM
 clM
 vDp
-rqQ
+gYX
 gIJ
 gIJ
 vQX
@@ -77983,7 +77972,7 @@ clM
 clM
 clM
 vDp
-rqQ
+gYX
 vDp
 vDp
 gIJ
@@ -78240,7 +78229,7 @@ vDp
 lKc
 vDp
 vDp
-rqQ
+gYX
 gIJ
 vDp
 vDp
@@ -78494,10 +78483,10 @@ jyB
 rai
 jyB
 gIJ
-kII
-dMJ
-dMJ
-huh
+gpj
+sgY
+sgY
+wNZ
 gIJ
 gIJ
 gIJ
@@ -78751,7 +78740,7 @@ gIJ
 arm
 vDp
 vDp
-eYp
+lDG
 vDp
 vDp
 vDp
@@ -79008,7 +78997,7 @@ gIJ
 arm
 gIJ
 vDp
-eYp
+lDG
 gIJ
 gIJ
 gIJ
@@ -79263,9 +79252,9 @@ iSE
 xQL
 gIJ
 frf
-abC
-lTT
-ktw
+fun
+pNE
+tEY
 vDp
 vDp
 gIJ
@@ -89043,7 +89032,7 @@ rSz
 rSz
 rSz
 rSz
-mQH
+iVj
 akr
 myW
 ylr
@@ -89558,7 +89547,7 @@ mPL
 jWl
 pwz
 tpZ
-oxD
+xxP
 vDp
 ylr
 ylr
@@ -89815,7 +89804,7 @@ mvx
 jQt
 mew
 lEP
-cQm
+fTd
 vDp
 ylr
 ylr
@@ -90072,7 +90061,7 @@ mvc
 xnb
 mew
 jTD
-cQm
+fTd
 vDp
 ylr
 ylr
@@ -90329,7 +90318,7 @@ mvc
 fSn
 mew
 jTD
-wNQ
+bZz
 vDp
 vDp
 vDp
@@ -90586,9 +90575,9 @@ mvc
 mvc
 mew
 jvO
-gxc
-jeq
-tYV
+vwN
+tqd
+hrg
 vDp
 vxU
 vDp
@@ -90845,7 +90834,7 @@ mew
 kSE
 fEn
 fEn
-eBt
+xqf
 jhB
 sxy
 qrg
@@ -91102,7 +91091,7 @@ mew
 jTD
 gIJ
 gIJ
-cQm
+fTd
 vDp
 eMS
 vDp
@@ -91359,7 +91348,7 @@ dyp
 arm
 gIJ
 gIJ
-cQm
+fTd
 vDp
 vDp
 vDp
@@ -91616,11 +91605,11 @@ nfI
 arm
 gIJ
 gIJ
-gxc
-jeq
-jeq
-jeq
-eJh
+vwN
+tqd
+tqd
+tqd
+msP
 xbB
 xbB
 xbB
@@ -91877,22 +91866,22 @@ gOO
 gOO
 gOO
 gOO
-xTP
-pZV
-hpE
-hpE
-hpE
-tqV
-hpE
-wlj
-hpE
-hpE
-mnp
-gel
-gel
-gel
-hHT
-tRU
+bsD
+qdY
+flF
+flF
+flF
+dLW
+flF
+ogw
+flF
+flF
+qSK
+gUe
+gUe
+gUe
+rYY
+nif
 xbB
 xbB
 mMC
@@ -92149,14 +92138,14 @@ oLK
 oLK
 oLK
 uix
-fJM
-hpE
-jwS
-hpE
-hpE
-hpE
-tDu
-wmQ
+cwn
+flF
+dGL
+flF
+flF
+flF
+lQG
+ugL
 xbB
 ylr
 ylr
@@ -92410,10 +92399,10 @@ uJr
 uJr
 iKZ
 uJr
-aHR
-aHR
-aHR
-vuy
+crg
+crg
+crg
+nzq
 xbB
 ylr
 ylr
@@ -92668,9 +92657,9 @@ uix
 iGK
 sAg
 xbB
-aHR
-kds
-qQw
+crg
+diJ
+mov
 xbB
 xbB
 xbB
@@ -92925,13 +92914,13 @@ oLK
 iKZ
 uJr
 xbB
-aHR
-kds
-nIj
-tBc
+crg
+diJ
+gKn
+nJl
 mtF
-qpA
-kuW
+iZk
+fgg
 ylr
 ylr
 ylr
@@ -95494,7 +95483,7 @@ xSu
 oLK
 iKZ
 uJr
-lFF
+xlB
 uJr
 uJr
 uJr
@@ -95751,7 +95740,7 @@ uix
 uix
 iKZ
 uJr
-lFF
+xlB
 tTS
 uJr
 uJr
@@ -98319,7 +98308,7 @@ aGn
 aGn
 aGn
 xbB
-utW
+bga
 vfk
 xbB
 aGn

--- a/_maps/map_files/DonutStation/DonutStation.dmm
+++ b/_maps/map_files/DonutStation/DonutStation.dmm
@@ -9482,6 +9482,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"dUj" = (
+/obj/machinery/modular_computer/console/preset/command/cmo{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/heads/cmo)
 "dUG" = (
 /turf/open/floor/plasteel,
 /area/janitor)
@@ -16585,12 +16591,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
-"hec" = (
-/obj/machinery/computer/crew{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/heads/cmo)
 "hef" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -50670,6 +50670,22 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"vVw" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Engineer's Desk";
+	departmentType = 3;
+	name = "Chief Engineer RC";
+	pixel_x = -32
+	},
+/obj/machinery/modular_computer/console/preset/command/ce{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/heads/chief)
 "vVz" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/airless{
@@ -51466,23 +51482,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"woW" = (
-/obj/machinery/computer/card/minor/ce{
-	dir = 4;
-	icon_state = "computer"
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Engineer's Desk";
-	departmentType = 3;
-	name = "Chief Engineer RC";
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "wpc" = (
 /obj/structure/table,
 /obj/machinery/button/massdriver{
@@ -82070,7 +82069,7 @@ qSt
 tpK
 ykb
 wNV
-hec
+dUj
 aCH
 nUw
 eKL
@@ -91580,7 +91579,7 @@ ogQ
 mVN
 jvn
 eXN
-woW
+vVw
 pjL
 jvn
 jvn

--- a/_maps/map_files/DonutStation/DonutStation.dmm
+++ b/_maps/map_files/DonutStation/DonutStation.dmm
@@ -68,6 +68,18 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"abC" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "ace" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -1587,6 +1599,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"aHR" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "aIA" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -2125,6 +2141,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aUo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "aUq" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 8;
@@ -5859,19 +5884,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cui" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/external{
-	name = "AISat External Access";
-	req_one_access_txt = "32;19"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "cuq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -5951,16 +5963,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"cvK" = (
-/obj/machinery/door/airlock/maintenance_hatch,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "cvV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6389,6 +6391,18 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
+"cDI" = (
+/obj/structure/sign/warning/pods{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "cDY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -6993,6 +7007,10 @@
 /obj/structure/sign/poster/contraband/random,
 /turf/closed/wall/rust,
 /area/quartermaster/warehouse)
+"cQm" = (
+/obj/effect/turf_decal/trimline/yellow/arrow_cw,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cQq" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 10
@@ -9031,6 +9049,11 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
+"dMJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "dMR" = (
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
@@ -9688,13 +9711,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
-"eae" = (
-/obj/structure/sign/warning/vacuum{
-	name = "EXTERNAL AIRLOCK";
-	pixel_y = -32
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "ear" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -10838,6 +10854,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"eBt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/yellow/arrow_cw,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "eBz" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -11213,6 +11235,12 @@
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
+"eJh" = (
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "eJG" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -11973,6 +12001,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"eYp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "eYy" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Biohazard";
@@ -13621,6 +13658,21 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"fJM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "fJT" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecomms Control Room";
@@ -14474,6 +14526,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"gel" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "geq" = (
 /obj/structure/frame/computer{
 	anchored = 1;
@@ -15140,19 +15203,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"gtg" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod Two"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "gtI" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -15305,18 +15355,12 @@
 	initial_gas_mix = "co2=1000;TEMP=293.15"
 	},
 /area/engine/atmos)
-"gwF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+"gxc" = (
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/aft)
+/area/maintenance/port/aft)
 "gxd" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Medical Maintenance Access";
@@ -16928,6 +16972,17 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"hpE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "hpI" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
@@ -17124,6 +17179,15 @@
 "hub" = (
 /turf/closed/wall/r_wall,
 /area/security/prison)
+"huh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "hui" = (
 /obj/structure/lattice/catwalk,
 /obj/item/stack/cable_coil/random/five,
@@ -17762,6 +17826,21 @@
 /obj/machinery/porta_turret/ai,
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
+"hHT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "hIt" = (
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
@@ -20641,6 +20720,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"jeq" = (
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "jes" = (
 /obj/structure/chair/stool,
 /obj/structure/disposalpipe/segment{
@@ -21526,6 +21611,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"jwS" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "jxw" = (
 /obj/machinery/light,
 /obj/structure/chair/office/light{
@@ -22905,11 +23008,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"jWG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "jWK" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -23244,6 +23342,10 @@
 /obj/machinery/door/poddoor/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
+"kds" = (
+/obj/structure/barricade/wooden,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "kdx" = (
 /obj/machinery/nanite_program_hub,
 /turf/open/floor/plasteel/dark,
@@ -23925,6 +24027,15 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"ktw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "ktA" = (
 /obj/machinery/atmospherics/components/binary/valve/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -23953,6 +24064,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"kuW" = (
+/obj/docking_port/stationary{
+	dir = 2;
+	dwidth = 11;
+	height = 22;
+	id = "whiteship_home";
+	name = "SS13: Auxiliary Dock, Station-Port";
+	width = 35
+	},
+/turf/open/space/basic,
+/area/space)
 "kvm" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger{
@@ -24328,6 +24450,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"kII" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "kIX" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/metal/fifty,
@@ -25817,12 +25948,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"lqA" = (
-/obj/structure/sign/warning/pods{
-	pixel_y = -32
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "lqF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -26468,6 +26593,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"lFF" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "lFL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
@@ -26974,6 +27106,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"lQA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "lQO" = (
 /obj/machinery/button/door{
 	id = "cargowarehouse";
@@ -27204,6 +27345,18 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"lTT" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "lUc" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -27961,6 +28114,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
+"mnp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "mnt" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
@@ -29108,6 +29276,13 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"mMT" = (
+/obj/machinery/advanced_airlock_controller{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "mNb" = (
 /obj/machinery/field/generator,
 /obj/machinery/camera/emp_proof{
@@ -29258,18 +29433,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"mQn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/aft";
-	dir = 8;
-	name = "Aft Maintenance APC";
-	pixel_x = -25
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "mQu" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
@@ -29309,6 +29472,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"mQH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "0"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "mQR" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -31213,21 +31397,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"nGc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "nGg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -31379,6 +31548,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"nIj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "nIq" = (
 /obj/machinery/newscaster{
 	pixel_x = -32
@@ -31720,16 +31900,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
-"nOg" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod Two"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "nOh" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -33324,6 +33494,10 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"oxD" = (
+/obj/effect/turf_decal/trimline/yellow/corner,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "oxG" = (
 /obj/item/grenade/barrier{
 	pixel_x = 4
@@ -33596,15 +33770,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"oGy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "oGB" = (
 /obj/machinery/meter{
 	layer = 3.4
@@ -35353,13 +35518,6 @@
 "ptU" = (
 /turf/open/floor/plasteel/stairs/goon/wood_stairs_wide2,
 /area/tcommsat/computer)
-"ptZ" = (
-/obj/machinery/advanced_airlock_controller{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "puy" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Custodial Maintenance";
@@ -36860,6 +37018,27 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"pZV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/unres{
+	icon_state = "airlock_unres_helper"
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "qaj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/trimline/white/filled/corner/lower{
@@ -37609,6 +37788,16 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"qpA" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/airlock/external{
+	name = "Auxiliary Docking Port"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "qpH" = (
 /obj/machinery/conveyor{
 	dir = 0;
@@ -37999,17 +38188,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"qxG" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/door/airlock/external{
-	name = "AISat External Access";
-	req_one_access_txt = "32;19"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "qxX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -38692,6 +38870,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"qQw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/sign/warning/docking{
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "qQQ" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -38843,6 +39036,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"qUm" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Two"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "qUw" = (
 /obj/structure/rack,
 /obj/item/storage/bag/plants/portaseeder,
@@ -39360,6 +39566,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"rgf" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "rgj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -39798,6 +40009,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"rqQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "rrg" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -40452,6 +40672,15 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"rFE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "rFJ" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/purple/visible{
@@ -41070,18 +41299,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"rUp" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "rUI" = (
 /obj/structure/sign/warning/pods{
 	pixel_y = 32
@@ -43610,21 +43827,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"sXN" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "sYX" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -44373,6 +44575,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"tqV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "tqW" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -44971,6 +45185,15 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"tBc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Auxiliary Docking Port"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "tBD" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
@@ -45021,6 +45244,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"tDu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/aft";
+	dir = 8;
+	name = "Aft Maintenance APC";
+	pixel_x = -25
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "tDD" = (
 /obj/machinery/air_sensor/atmos/nitrous_tank,
 /turf/open/floor/engine/n2o{
@@ -45695,6 +45933,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"tRU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "tRV" = (
 /obj/machinery/door/airlock/external{
 	name = "External Freight Airlock"
@@ -45822,17 +46075,6 @@
 "tUg" = (
 /turf/open/floor/plating/broken/two,
 /area/maintenance/starboard)
-"tUA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "tUC" = (
 /obj/effect/landmark/start/security_officer,
 /obj/structure/chair{
@@ -46018,6 +46260,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"tYV" = (
+/obj/structure/sign/warning/vacuum{
+	name = "EXTERNAL AIRLOCK";
+	pixel_y = -32
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "tYZ" = (
 /obj/item/target/alien/anchored,
 /obj/effect/turf_decal/stripes/line{
@@ -46944,6 +47196,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"utW" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "uua" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -47273,6 +47529,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"uDG" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Two"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "uDW" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -49085,27 +49351,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"vsg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "vsp" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -49177,11 +49422,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
-"vtx" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "vtS" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
@@ -49194,11 +49434,37 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
+"vtW" = (
+/obj/machinery/door/airlock/maintenance_hatch,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "vus" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/rods,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"vuy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "vuQ" = (
 /obj/machinery/telecomms/server/presets/common,
 /obj/machinery/light{
@@ -49977,10 +50243,6 @@
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
-"vMl" = (
-/obj/structure/sign/warning/docking,
-/turf/closed/wall,
-/area/maintenance/aft)
 "vMQ" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -50308,18 +50570,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"vSl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "vSJ" = (
 /obj/structure/closet,
 /turf/open/floor/plating,
@@ -51066,6 +51316,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"wlj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "wlo" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
@@ -51107,6 +51371,19 @@
 "wmD" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"wmQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "wnn" = (
 /obj/structure/displaycase/trophy,
 /turf/open/floor/carpet,
@@ -52409,6 +52686,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"wNQ" = (
+/obj/machinery/light/small,
+/obj/effect/turf_decal/trimline/yellow/arrow_cw,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "wNV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -54545,6 +54827,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"xFy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "xFF" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/surgery,
@@ -55305,6 +55596,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"xTP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/yellow/corner{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "xUh" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/satellite)
@@ -74863,7 +75165,7 @@ ylr
 ylr
 ylr
 ylr
-xSu
+ylr
 ylr
 xSu
 ylr
@@ -75114,13 +75416,13 @@ hhi
 lJE
 vgR
 jyB
+jyB
+jyB
 ylr
 ylr
 ylr
 ylr
 ylr
-ylr
-xSu
 ylr
 ylr
 ylr
@@ -75369,14 +75671,14 @@ vgR
 jyB
 jyB
 lJE
-vgR
-jyB
+xFy
+qUm
+rgf
+uDG
+spx
 ylr
 ylr
-ylr
-ylr
-ylr
-ylr
+vRn
 ylr
 ylr
 ylr
@@ -75626,10 +75928,10 @@ vgR
 vgR
 vgR
 vgR
-vgR
+cDI
 jyB
-ylr
-ylr
+mMT
+jyB
 ylr
 ylr
 ylr
@@ -75883,10 +76185,10 @@ jyB
 jyB
 vgR
 jyB
-vgR
+aUo
 jyB
-ylr
-ylr
+jyB
+jyB
 ylr
 ylr
 ylr
@@ -76139,8 +76441,8 @@ fDZ
 oLF
 jyB
 vgR
-vgR
-vgR
+xFy
+rFE
 jyB
 jyB
 jyB
@@ -76396,7 +76698,7 @@ fDZ
 fDZ
 hAx
 vgR
-jyB
+aUo
 jyB
 jyB
 fDZ
@@ -76653,7 +76955,7 @@ fDZ
 fDZ
 jyB
 vgR
-vgR
+lQA
 vgR
 hAx
 fDZ
@@ -76910,7 +77212,7 @@ vDp
 vDp
 vDp
 vDp
-cvK
+vtW
 vDp
 jyB
 fDZ
@@ -77167,7 +77469,7 @@ clM
 clM
 lBV
 vDp
-gIJ
+rqQ
 gIJ
 jyB
 jyB
@@ -77424,7 +77726,7 @@ clM
 clM
 clM
 vDp
-gIJ
+rqQ
 gIJ
 gIJ
 vQX
@@ -77681,7 +77983,7 @@ clM
 clM
 clM
 vDp
-gIJ
+rqQ
 vDp
 vDp
 gIJ
@@ -77938,7 +78240,7 @@ vDp
 lKc
 vDp
 vDp
-gIJ
+rqQ
 gIJ
 vDp
 vDp
@@ -78192,10 +78494,10 @@ jyB
 rai
 jyB
 gIJ
-gIJ
-gIJ
-gIJ
-gIJ
+kII
+dMJ
+dMJ
+huh
 gIJ
 gIJ
 gIJ
@@ -78449,7 +78751,7 @@ gIJ
 arm
 vDp
 vDp
-gIJ
+eYp
 vDp
 vDp
 vDp
@@ -78706,7 +79008,7 @@ gIJ
 arm
 gIJ
 vDp
-gIJ
+eYp
 gIJ
 gIJ
 gIJ
@@ -78961,9 +79263,9 @@ iSE
 xQL
 gIJ
 frf
-rUp
-lbf
-gIJ
+abC
+lTT
+ktw
 vDp
 vDp
 gIJ
@@ -85712,12 +86014,12 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 bIB
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -85974,17 +86276,17 @@ ylr
 ylr
 ylr
 ylr
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
 ylr
 ylr
 ylr
 ylr
 ylr
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
 ylr
 ylr
 ylr
@@ -86228,6 +86530,11 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 dJY
 dJY
 dJY
@@ -86245,11 +86552,6 @@ ylr
 ylr
 ylr
 bIB
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -86483,25 +86785,25 @@ ylr
 ylr
 ylr
 ylr
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
 ylr
 ylr
 ylr
 ylr
 ylr
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
 ylr
 ylr
 ylr
@@ -86738,28 +87040,28 @@ ylr
 ylr
 ylr
 ylr
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
 ylr
 ylr
 ylr
 ylr
 ylr
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
 ylr
 ylr
 ylr
@@ -86994,30 +87296,30 @@ ylr
 ylr
 ylr
 ylr
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
 ylr
 ylr
 ylr
 ylr
 ylr
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
 ylr
 ylr
 ylr
@@ -87251,6 +87553,11 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 dJY
 aCv
 aCv
@@ -87270,11 +87577,6 @@ dJY
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -87507,6 +87809,11 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 dJY
 dJY
 dJY
@@ -87527,11 +87834,6 @@ dJY
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -87764,6 +88066,11 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 dJY
 dJY
 aCv
@@ -87784,11 +88091,6 @@ dJY
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -88021,32 +88323,32 @@ ylr
 ylr
 ylr
 ylr
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
 ylr
 ylr
 ylr
 ylr
 ylr
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
+dJY
 ylr
 ylr
 ylr
@@ -88277,6 +88579,11 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 dJY
 dJY
 dJY
@@ -88299,11 +88606,6 @@ dJY
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -88534,6 +88836,11 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 dJY
 dJY
 dJY
@@ -88563,11 +88870,6 @@ dJY
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -88741,9 +89043,14 @@ rSz
 rSz
 rSz
 rSz
-vsg
+mQH
 akr
 myW
+ylr
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -88819,11 +89126,6 @@ ylr
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -89048,6 +89350,11 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 dJY
 dJY
 dJY
@@ -89076,11 +89383,6 @@ ylr
 ylr
 ylr
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -89256,8 +89558,13 @@ mPL
 jWl
 pwz
 tpZ
-gIJ
+oxD
 vDp
+ylr
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -89327,11 +89634,6 @@ dJY
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -89513,8 +89815,13 @@ mvx
 jQt
 mew
 lEP
-gIJ
+cQm
 vDp
+ylr
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -89584,11 +89891,6 @@ dJY
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -89770,7 +90072,7 @@ mvc
 xnb
 mew
 jTD
-gIJ
+cQm
 vDp
 ylr
 ylr
@@ -89819,6 +90121,11 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 dJY
 dJY
 dJY
@@ -89842,11 +90149,6 @@ dJY
 dJY
 qxi
 qxi
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -90027,12 +90329,17 @@ mvc
 fSn
 mew
 jTD
-kLY
+wNQ
 vDp
 vDp
 vDp
 vDp
 vDp
+ylr
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -90103,16 +90410,11 @@ ylr
 ylr
 ylr
 ylr
-ylr
-ylr
-ylr
-dJY
-dJY
 ylr
 bIB
 ylr
-ylr
-ylr
+dJY
+dJY
 ylr
 ylr
 ylr
@@ -90284,14 +90586,19 @@ mvc
 mvc
 mew
 jvO
-gIJ
-gIJ
-eae
+gxc
+jeq
+tYV
 vDp
 vxU
 vDp
 fNO
 ulR
+ylr
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -90365,11 +90672,6 @@ ylr
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -90543,12 +90845,17 @@ mew
 kSE
 fEn
 fEn
-fEn
+eBt
 jhB
 sxy
 qrg
 bHj
 xSu
+ylr
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -90623,11 +90930,6 @@ dJY
 dJY
 aCv
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -90800,29 +91102,34 @@ mew
 jTD
 gIJ
 gIJ
-gIJ
+cQm
 vDp
 eMS
 vDp
 bHj
 xSu
-bHj
-xSu
-xSu
-xSu
-bHj
-bHj
-xSu
-bHj
-bHj
-xSu
-xSu
-bHj
-xSu
-bHj
-bHj
-bHj
-bHj
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -90880,11 +91187,6 @@ ylr
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -91057,38 +91359,43 @@ dyp
 arm
 gIJ
 gIJ
-gIJ
+cQm
 vDp
 vDp
 vDp
 vDp
 vDp
-bHj
-bHj
-bHj
-bHj
-bHj
-xSu
-xSu
-bHj
-bHj
-bHj
-bHj
-bHj
-xSu
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-fNO
-fNO
-fNO
-fNO
-fNO
-ulR
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -91136,11 +91443,6 @@ ylr
 ylr
 ylr
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -91314,11 +91616,11 @@ nfI
 arm
 gIJ
 gIJ
-gIJ
-gIJ
-gIJ
-gIJ
-gIJ
+gxc
+jeq
+jeq
+jeq
+eJh
 xbB
 xbB
 xbB
@@ -91335,17 +91637,22 @@ xbB
 xbB
 xbB
 xbB
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-xwY
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -91385,11 +91692,6 @@ dJY
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -91575,22 +91877,22 @@ gOO
 gOO
 gOO
 gOO
-gOO
-nGc
-dNe
-dNe
-dNe
-oGy
-dNe
-tUA
-dNe
-dNe
-gwF
-noR
-noR
-noR
-vSl
-sPW
+xTP
+pZV
+hpE
+hpE
+hpE
+tqV
+hpE
+wlj
+hpE
+hpE
+mnp
+gel
+gel
+gel
+hHT
+tRU
 xbB
 xbB
 mMC
@@ -91599,10 +91901,15 @@ mMC
 xbB
 xbB
 xbB
-mMC
-xbB
-bHj
-bHj
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -91642,11 +91949,6 @@ dJY
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -91847,19 +92149,15 @@ oLK
 oLK
 oLK
 uix
-jEe
-dNe
-sXN
-dNe
-dNe
-dNe
-mQn
-jWG
-cui
-mtF
-qxG
-bHj
-bHj
+fJM
+hpE
+jwS
+hpE
+hpE
+hpE
+tDu
+wmQ
+xbB
 ylr
 ylr
 ylr
@@ -91870,8 +92168,17 @@ ylr
 ylr
 ylr
 ylr
-dJY
-dJY
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -91898,11 +92205,6 @@ qxi
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -92108,15 +92410,11 @@ uJr
 uJr
 iKZ
 uJr
-uJr
-uJr
-uJr
-uJr
+aHR
+aHR
+aHR
+vuy
 xbB
-xbB
-xbB
-bHj
-bHj
 ylr
 ylr
 ylr
@@ -92127,9 +92425,18 @@ ylr
 ylr
 ylr
 ylr
-dJY
-dJY
-dJY
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -92155,11 +92462,6 @@ dJY
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -92366,14 +92668,12 @@ uix
 iGK
 sAg
 xbB
-uJr
-uJr
-uJr
-uJr
-uJr
+aHR
+kds
+qQw
 xbB
-cIi
-ouK
+xbB
+xbB
 ylr
 ylr
 ylr
@@ -92384,9 +92684,16 @@ ylr
 ylr
 ylr
 ylr
-dJY
-dJY
-dJY
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -92412,11 +92719,6 @@ dJY
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -92623,12 +92925,13 @@ oLK
 iKZ
 uJr
 xbB
-uJr
-uJr
-uJr
-uJr
-uJr
-xbB
+aHR
+kds
+nIj
+tBc
+mtF
+qpA
+kuW
 ylr
 ylr
 ylr
@@ -92642,7 +92945,11 @@ ylr
 ylr
 ylr
 ylr
-dJY
+ylr
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -92669,11 +92976,6 @@ dJY
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -92907,6 +93209,11 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 dJY
 dJY
 dJY
@@ -92925,11 +93232,6 @@ dJY
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -93164,6 +93466,11 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 dJY
 dJY
 dJY
@@ -93182,11 +93489,6 @@ dJY
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -93421,6 +93723,11 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 dJY
 dJY
 dJY
@@ -93439,11 +93746,6 @@ dJY
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -93679,6 +93981,11 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 dJY
 dJY
 dJY
@@ -93696,11 +94003,6 @@ dJY
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -93938,6 +94240,11 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 dJY
 dJY
 dJY
@@ -93953,11 +94260,6 @@ dJY
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -94196,6 +94498,11 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 dJY
 dJY
 dJY
@@ -94210,11 +94517,6 @@ dJY
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -94455,6 +94757,11 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 dJY
 dJY
 dJY
@@ -94467,11 +94774,6 @@ dJY
 dJY
 dJY
 dJY
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -94684,7 +94986,12 @@ aGn
 aGn
 aGn
 aGn
-vMl
+xbB
+ylr
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -94723,11 +95030,6 @@ qxi
 qxi
 qxi
 qxi
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -94970,6 +95272,11 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 dJY
 dJY
 dJY
@@ -94980,11 +95287,6 @@ qxi
 qxi
 qxi
 qxi
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -95192,17 +95494,22 @@ xSu
 oLK
 iKZ
 uJr
+lFF
 uJr
 uJr
 uJr
 uJr
-gtg
-vtx
-nOg
-spx
+uJr
+xbB
 ylr
 ylr
-vRn
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -95235,11 +95542,6 @@ dJY
 qxi
 qxi
 qxi
-ylr
-ylr
-ylr
-ylr
-ylr
 ylr
 ylr
 ylr
@@ -95449,13 +95751,13 @@ uix
 uix
 iKZ
 uJr
-uJr
+lFF
 tTS
 uJr
-lqA
+uJr
+uJr
+uJr
 xbB
-ptZ
-xbB
 ylr
 ylr
 ylr
@@ -95465,8 +95767,8 @@ ylr
 ylr
 ylr
 ylr
-dJY
-dJY
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -95711,25 +96013,25 @@ xbB
 xbB
 xbB
 xbB
-xbB
-xbB
-xbB
-xbB
-xbB
+uJr
 xbB
 ylr
 ylr
 ylr
 ylr
 ylr
-dJY
-dJY
-dJY
 ylr
-dJY
-dJY
-dJY
-dJY
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -95969,23 +96271,23 @@ aGn
 eDJ
 xbB
 uJr
-xbB
-aGn
-aGn
-eDJ
-xbB
+mMC
 ylr
 ylr
 ylr
 ylr
 ylr
 ylr
-dJY
-dJY
-dJY
-dJY
-dJY
-dJY
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -96226,11 +96528,7 @@ aGn
 aGn
 fhT
 uJr
-fhT
-aGn
-aGn
-aGn
-xbB
+mMC
 ylr
 ylr
 ylr
@@ -96238,10 +96536,14 @@ ylr
 ylr
 ylr
 ylr
-dJY
-dJY
-dJY
-dJY
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -96483,11 +96785,11 @@ aGn
 aGn
 xbB
 uJr
-xbB
-aGn
-aGn
-aGn
-xbB
+mMC
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -96741,10 +97043,10 @@ xbB
 xbB
 uJr
 xbB
-xbB
-lUo
-xbB
-xbB
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -96997,11 +97299,11 @@ uJr
 uJr
 uJr
 uJr
-uJr
-uJr
-uJr
-uJr
 xbB
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -97247,18 +97549,18 @@ uJr
 uJr
 fhT
 uJr
-xbB
-uJr
-uJr
 uJr
 xbB
 xbB
 xbB
-lUo
 xbB
 xbB
 xbB
 xbB
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -97504,9 +97806,6 @@ xbB
 xbB
 xbB
 uJr
-nSr
-uJr
-mHP
 uJr
 xbB
 aGn
@@ -97515,6 +97814,9 @@ aGn
 aGn
 nsA
 xbB
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -97761,9 +98063,6 @@ aGn
 nsA
 xbB
 uJr
-xbB
-xbB
-xbB
 uJr
 fhT
 aGn
@@ -97787,7 +98086,10 @@ ylr
 ylr
 ylr
 ylr
-dJY
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -98017,11 +98319,8 @@ aGn
 aGn
 aGn
 xbB
-uJr
-uJr
-uJr
-uJr
-uJr
+utW
+vfk
 xbB
 aGn
 aGn
@@ -98043,9 +98342,12 @@ ylr
 ylr
 ylr
 ylr
-dJY
-dJY
-dJY
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -98278,9 +98580,6 @@ xbB
 xbB
 xbB
 xbB
-xbB
-xbB
-xbB
 mMC
 mMC
 mMC
@@ -98300,9 +98599,12 @@ ylr
 ylr
 ylr
 ylr
-dJY
-dJY
-dJY
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -98557,9 +98859,9 @@ ylr
 ylr
 ylr
 ylr
-dJY
-dJY
-dJY
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -98814,8 +99116,8 @@ ylr
 ylr
 ylr
 ylr
-dJY
-dJY
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -99843,7 +100145,7 @@ ylr
 ylr
 ylr
 ylr
-ylr
+dJY
 ylr
 ylr
 ylr
@@ -100099,9 +100401,9 @@ ylr
 ylr
 ylr
 ylr
-ylr
-ylr
-ylr
+dJY
+dJY
+dJY
 ylr
 ylr
 ylr
@@ -100356,9 +100658,9 @@ ylr
 ylr
 ylr
 ylr
-ylr
-ylr
-ylr
+dJY
+dJY
+dJY
 ylr
 ylr
 ylr
@@ -100613,9 +100915,9 @@ ylr
 ylr
 ylr
 ylr
-ylr
-ylr
-ylr
+dJY
+dJY
+dJY
 ylr
 ylr
 ylr
@@ -100870,8 +101172,8 @@ ylr
 ylr
 ylr
 ylr
-ylr
-ylr
+dJY
+dJY
 ylr
 ylr
 ylr


### PR DESCRIPTION
# Document the changes in your pull request

follow up of my last donut pr, this will allow freeminers and whiteship to dock directly with the station.  the dock IS in maint but access has been edited to resolve any issues this may cause

also fixes some out of date consoles

# Changelog

:cl:  cark
mapping: Due to budget cuts, NT has retrofitted an old escape pod dock on Donutstation to accept shuttles instead.  Additionally, console software in numerous Head of Staff offices has been updated to the newest version.
/:cl:
