### PR TITLE
Fixes replay lighting and player directionality

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -236,7 +236,9 @@
 				AA.copy_overlays(changed_on, TRUE);\
 			}\
 		} \
-	}
+	}\
+	if(isturf(changed_on)){SSdemo.mark_turf(changed_on);}\
+	if(isobj(changed_on) || ismob(changed_on)){SSdemo.mark_dirty(changed_on);}\
 
 /**
 	Create a new timer and add it to the queue.

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -342,7 +342,7 @@
 	return ((y) % 4 == 0 && ((y) % 100 != 0 || (y) % 400 == 0))
 
 /// For finding out what body parts a body zone covers, the inverse of the below basically
-/proc/zone2body_parts_covered(def_zone)
+/proc/body_zone2cover_flags(def_zone)
 	switch(def_zone)
 		if(BODY_ZONE_CHEST)
 			return list(CHEST, GROIN)
@@ -359,7 +359,7 @@
 
 //Turns a Body_parts_covered bitfield into a list of organ/limb names.
 //(I challenge you to find a use for this)-I found a use for it!!
-/proc/body_parts_covered2organ_names(bpc)
+/proc/cover_flags2body_zones(bpc)
 	var/list/covered_parts = list()
 
 	if(!bpc)

--- a/code/controllers/subsystem/demo.dm
+++ b/code/controllers/subsystem/demo.dm
@@ -189,7 +189,7 @@ SUBSYSTEM_DEF(demo)
 		marked_dirty.len--
 		if(M.gc_destroyed || !M)
 			continue
-		if(M.loc == M.demo_last_loc && M.appearance == M.demo_last_appearance)
+		if(M.loc == M.demo_last_loc)
 			continue
 		var/loc_string = "="
 		if(M.loc != M.demo_last_loc)
@@ -200,8 +200,11 @@ SUBSYSTEM_DEF(demo)
 				loc_string = "\ref[M.loc]"
 			M.demo_last_loc = M.loc
 		var/appearance_string = "="
-		if(M.appearance != M.demo_last_appearance)
-			appearance_string = encode_appearance(M.appearance, M.demo_last_appearance)
+		if(ismob(M))
+			appearance_string = encode_appearance(M.appearance, target = M)
+			M.demo_last_appearance = M.appearance
+		else if(M.appearance != M.demo_last_appearance)
+			appearance_string = encode_appearance(M.appearance, M.demo_last_appearance, target = M)
 			M.demo_last_appearance = M.appearance
 		dirty_updates += "\ref[M] [loc_string] [appearance_string]"
 		if(MC_TICK_CHECK)
@@ -228,7 +231,7 @@ SUBSYSTEM_DEF(demo)
 		else if(ismovable(M.loc))
 			loc_string = "\ref[M.loc]"
 		M.demo_last_appearance = M.appearance
-		new_updates += "\ref[M] [loc_string] [encode_appearance(M.appearance)]"
+		new_updates += "\ref[M] [loc_string] [encode_appearance(M.appearance, target = M)]"
 		if(MC_TICK_CHECK)
 			canceled = TRUE
 			break
@@ -260,7 +263,7 @@ SUBSYSTEM_DEF(demo)
 /datum/controller/subsystem/demo/proc/encode_init_obj(atom/movable/M)
 	M.demo_last_loc = M.loc
 	M.demo_last_appearance = M.appearance
-	var/encoded_appearance = encode_appearance(M.appearance)
+	var/encoded_appearance = encode_appearance(M.appearance, target = M)
 	var/list/encoded_contents = list()
 	for(var/C in M.contents)
 		if(isobj(C) || ismob(C))
@@ -268,7 +271,7 @@ SUBSYSTEM_DEF(demo)
 	return "\ref[M]=[encoded_appearance][(encoded_contents.len ? "([jointext(encoded_contents, ",")])" : "")]"
 
 // please make sure the order you call this function in is the same as the order you write
-/datum/controller/subsystem/demo/proc/encode_appearance(image/appearance, image/diff_appearance, diff_remove_overlays = FALSE)
+/datum/controller/subsystem/demo/proc/encode_appearance(image/appearance, image/diff_appearance, diff_remove_overlays = FALSE, atom/movable/target)
 	if(appearance == null)
 		return "n"
 	if(appearance == diff_appearance)
@@ -305,7 +308,7 @@ SUBSYSTEM_DEF(demo)
 		var/list/overlays_list = list()
 		for(var/i in 1 to appearance_overlays.len)
 			var/image/overlay = appearance_overlays[i]
-			overlays_list += encode_appearance(overlay, appearance, TRUE)
+			overlays_list += encode_appearance(overlay, appearance, TRUE, target = target)
 		overlays_string = "\[[jointext(overlays_list, ",")]]"
 
 	var/underlays_string = "\[]"
@@ -314,7 +317,7 @@ SUBSYSTEM_DEF(demo)
 		var/list/underlays_list = list()
 		for(var/i in 1 to appearance_underlays.len)
 			var/image/underlay = appearance_underlays[i]
-			underlays_list += encode_appearance(underlay, appearance, TRUE)
+			underlays_list += encode_appearance(underlay, appearance, TRUE, target = target)
 		underlays_string = "\[[jointext(underlays_list, ",")]]"
 
 	var/appearance_transform_string = "i"
@@ -323,6 +326,13 @@ SUBSYSTEM_DEF(demo)
 		appearance_transform_string = "[M.a],[M.b],[M.c],[M.d],[M.e],[M.f]"
 		if(appearance_transform_string == "1,0,0,0,1,0")
 			appearance_transform_string = "i"
+	
+	var/tmp_dir = appearance.dir
+	
+	if(target)
+		//message_admins("demo target is [target] \nappearance dir: [appearance.dir] and target dir: [target.dir]")
+		tmp_dir = target.dir
+	
 	var/list/appearance_list = list(
 		json_encode(cached_icon),
 		json_encode(cached_icon_state),
@@ -330,7 +340,7 @@ SUBSYSTEM_DEF(demo)
 		appearance.appearance_flags,
 		appearance.layer,
 		appearance.plane == -32767 ? "" : appearance.plane,
-		appearance.dir == 2 ? "" : appearance.dir,
+		tmp_dir == 2 ? "" : tmp_dir,
 		appearance.color ? color_string : "",
 		appearance.alpha == 255 ? "" : appearance.alpha,
 		appearance.pixel_x == 0 ? "" : appearance.pixel_x,

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -44,7 +44,7 @@ SUBSYSTEM_DEF(lighting)
 		var/datum/light_source/L = queue[i]
 
 		L.update_corners()
-
+		for(var/turf/turf_to_update in view(CEILING(L.light_range, 1), L.source_turf))
 		L.needs_update = LIGHTING_NO_UPDATE
 
 		if(init_tick_checks)

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -44,7 +44,7 @@ SUBSYSTEM_DEF(lighting)
 		var/datum/light_source/L = queue[i]
 
 		L.update_corners()
-		for(var/turf/turf_to_update in view(CEILING(L.light_range, 1), L.source_turf))
+
 		L.needs_update = LIGHTING_NO_UPDATE
 
 		if(init_tick_checks)

--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -47,12 +47,12 @@ SUBSYSTEM_DEF(overlays)
 			continue
 		if (istext(overlay))
 			// This is too expensive to run normally but running it during CI is a good test
-			if (PERFORM_ALL_TESTS(focus_only/invalid_overlays))
-				var/list/icon_states_available = icon_states(icon)
-				if(!(overlay in icon_states_available))
-					var/icon_file = "[icon]" || "Unknown Generated Icon"
-					stack_trace("Invalid overlay: Icon object '[icon_file]' [REF(icon)] used in '[src]' [type] is missing icon state [overlay].")
-					continue
+			// if (PERFORM_ALL_TESTS(focus_only/invalid_overlays))
+			// 	var/list/icon_states_available = icon_states(icon)
+			// 	if(!(overlay in icon_states_available))
+			// 		var/icon_file = "[icon]" || "Unknown Generated Icon"
+			// 		stack_trace("Invalid overlay: Icon object '[icon_file]' [REF(icon)] used in '[src]' [type] is missing icon state [overlay].")
+			// 		continue
 
 			var/index = build_overlays.Find(overlay)
 			build_overlays[index] = iconstate2appearance(icon, overlay)

--- a/code/controllers/subsystem/overlays.dm
+++ b/code/controllers/subsystem/overlays.dm
@@ -38,7 +38,7 @@ SUBSYSTEM_DEF(overlays)
 	iconbro.icon = icon
 	return iconbro.appearance
 
-/atom/proc/build_appearance_list(build_overlays)
+/atom/proc/build_appearance_list(list/build_overlays)
 	if (!islist(build_overlays))
 		build_overlays = list(build_overlays)
 	for (var/overlay in build_overlays)
@@ -46,11 +46,19 @@ SUBSYSTEM_DEF(overlays)
 			build_overlays -= overlay
 			continue
 		if (istext(overlay))
-			build_overlays -= overlay
-			build_overlays += iconstate2appearance(icon, overlay)
+			// This is too expensive to run normally but running it during CI is a good test
+			if (PERFORM_ALL_TESTS(focus_only/invalid_overlays))
+				var/list/icon_states_available = icon_states(icon)
+				if(!(overlay in icon_states_available))
+					var/icon_file = "[icon]" || "Unknown Generated Icon"
+					stack_trace("Invalid overlay: Icon object '[icon_file]' [REF(icon)] used in '[src]' [type] is missing icon state [overlay].")
+					continue
+
+			var/index = build_overlays.Find(overlay)
+			build_overlays[index] = iconstate2appearance(icon, overlay)
 		else if(isicon(overlay))
-			build_overlays -= overlay
-			build_overlays += icon2appearance(overlay)
+			var/index = build_overlays.Find(overlay)
+			build_overlays[index] = icon2appearance(overlay)
 	return build_overlays
 
 /atom/proc/cut_overlays()
@@ -125,3 +133,99 @@ SUBSYSTEM_DEF(overlays)
 			overlays |= cached_other
 	else if(cut_old)
 		cut_overlays()
+
+
+/atom
+	/// List of overlay "keys" (info about the appearance) -> mutable versions of static appearances
+	/// Drawn from the overlays list
+	var/list/realized_overlays
+	/// List of underlay "keys" (info about the appearance) -> mutable versions of static appearances
+	/// Drawn from the underlays list
+	var/list/realized_underlays
+
+/image
+	/// List of overlay "keys" (info about the appearance) -> mutable versions of static appearances
+	/// Drawn from the overlays list
+	var/list/realized_overlays
+	/// List of underlay "keys" (info about the appearance) -> mutable versions of static appearances
+	/// Drawn from the underlays list
+	var/list/realized_underlays
+
+/// Takes the atoms's existing overlays and underlays, and makes them mutable so they can be properly vv'd in the realized_overlays/underlays list
+/atom/proc/realize_overlays()
+	realized_overlays = realize_appearance_queue(overlays)
+	realized_underlays = realize_appearance_queue(underlays)
+
+/// Takes the image's existing overlays, and makes them mutable so they can be properly vv'd in the realized_overlays list
+/image/proc/realize_overlays()
+	realized_overlays = realize_appearance_queue(overlays)
+	realized_underlays = realize_appearance_queue(underlays)
+
+/// Takes a list of appearnces, makes them mutable so they can be properly vv'd and inspected
+/proc/realize_appearance_queue(list/appearances)
+	var/list/real_appearances = list()
+	var/list/queue = appearances.Copy()
+	var/queue_index = 0
+	while(queue_index < length(queue))
+		queue_index++
+		// If it's not a command, we assert that it's an appearance
+		var/mutable_appearance/appearance = queue[queue_index]
+		if(!appearance) // Who fucking adds nulls to their sublists god you people are the worst
+			continue
+
+		var/mutable_appearance/new_appearance = new /mutable_appearance()
+		new_appearance.appearance = appearance
+		var/key = "[appearance.icon]-[appearance.icon_state]-[appearance.plane]-[appearance.layer]-[appearance.dir]-[appearance.color]"
+		var/tmp_key = key
+		var/appearance_indx = 1
+		while(real_appearances[tmp_key])
+			tmp_key = "[key]-[appearance_indx]"
+			appearance_indx++
+
+		real_appearances[tmp_key] = new_appearance
+		var/add_index = queue_index
+		// Now check its children
+		for(var/mutable_appearance/child_appearance as anything in appearance.overlays)
+			add_index++
+			queue.Insert(add_index, child_appearance)
+		for(var/mutable_appearance/child_appearance as anything in appearance.underlays)
+			add_index++
+			queue.Insert(add_index, child_appearance)
+	return real_appearances
+
+/// Takes two appearances as args, prints out, logs, and returns a text representation of their differences
+/// Including suboverlays
+/proc/diff_appearances(mutable_appearance/first, mutable_appearance/second, iter = 0)
+	var/list/diffs = list()
+	var/list/firstdeet = first.vars
+	var/list/seconddeet = second.vars
+	var/diff_found = FALSE
+	for(var/name in first.vars)
+		var/firstv = firstdeet[name]
+		var/secondv = seconddeet[name]
+		if(firstv ~= secondv)
+			continue
+		if((islist(firstv) || islist(secondv)) && length(firstv) == 0 && length(secondv) == 0)
+			continue
+		if(name == "vars") // Go away
+			continue
+		if(name == "_listen_lookup") // This is just gonna happen with marked datums, don't care
+			continue
+		if(name == "overlays")
+			first.realize_overlays()
+			second.realize_overlays()
+			var/overlays_differ = FALSE
+			for(var/i in 1 to length(first.realized_overlays))
+				if(diff_appearances(first.realized_overlays[i], second.realized_overlays[i], iter + 1))
+					overlays_differ = TRUE
+
+			if(!overlays_differ)
+				continue
+
+		diff_found = TRUE
+		diffs += "Diffs detected at [name]: First ([firstv]), Second ([secondv])"
+
+	var/text = "Depth of: [iter]\n\t[diffs.Join("\n\t")]"
+	message_admins(text)
+	log_world(text)
+	return diff_found

--- a/code/datums/components/overlay_lighting.dm
+++ b/code/datums/components/overlay_lighting.dm
@@ -135,6 +135,7 @@
 /datum/component/overlay_lighting/proc/clean_old_turfs()
 	for(var/turf/lit_turf as anything in affected_turfs)
 		lit_turf.dynamic_lumcount -= used_lum_power
+		SSdemo.mark_turf(lit_turf)
 	affected_turfs = null
 
 
@@ -144,6 +145,7 @@
 		return
 	for(var/turf/lit_turf in view(lumcount_range, get_turf(current_holder)))
 		lit_turf.dynamic_lumcount += used_lum_power
+		SSdemo.mark_turf(lit_turf)
 		LAZYADD(affected_turfs, lit_turf)
 
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -138,7 +138,7 @@
 /obj/item/clothing/proc/take_damage_zone(def_zone, damage_amount, damage_type, armour_penetration)
 	if(!def_zone || !limb_integrity || (initial(body_parts_covered) in GLOB.bitflags)) // the second check sees if we only cover one bodypart anyway and don't need to bother with this
 		return
-	var/list/covered_limbs = body_parts_covered2organ_names(body_parts_covered) // what do we actually cover?
+	var/list/covered_limbs = cover_flags2body_zones(body_parts_covered) // what do we actually cover?
 	if(!(def_zone in covered_limbs))
 		return
 
@@ -160,7 +160,7 @@
   * * damage_type: Only really relevant for the verb for describing the breaking, and maybe obj_destruction()
   */
 /obj/item/clothing/proc/disable_zone(def_zone, damage_type)
-	var/list/covered_limbs = body_parts_covered2organ_names(body_parts_covered)
+	var/list/covered_limbs = cover_flags2body_zones(body_parts_covered)
 	if(!(def_zone in covered_limbs))
 		return
 
@@ -173,7 +173,7 @@
 		RegisterSignal(C, COMSIG_MOVABLE_MOVED, PROC_REF(bristle), override = TRUE)
 
 	zones_disabled++
-	for(var/i in zone2body_parts_covered(def_zone))
+	for(var/i in body_zone2cover_flags(def_zone))
 		body_parts_covered &= ~i
 
 	if(body_parts_covered == NONE) // if there are no more parts to break then the whole thing is kaput
@@ -487,7 +487,7 @@ BLIND     // can't see anything
 				return adjusted
 			for(var/zone in list(BODY_ZONE_CHEST, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM)) // ugly check to make sure we don't reenable protection on a disabled part
 				if(damage_by_parts[zone] > limb_integrity)
-					for(var/part in zone2body_parts_covered(zone))
+					for(var/part in body_zone2cover_flags(zone))
 						body_parts_covered &= part
 	return adjusted
 

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -136,6 +136,10 @@
 	for (var/datum/lighting_corner/corner as anything in effect_str)
 		REMOVE_CORNER(corner)
 		LAZYREMOVE(corner.affecting, src)
+		SSdemo.mark_turf(corner.master_NE)
+		SSdemo.mark_turf(corner.master_SE)
+		SSdemo.mark_turf(corner.master_SW)
+		SSdemo.mark_turf(corner.master_NW)
 
 /datum/light_source/proc/recalc_corner(datum/lighting_corner/corner)
 	LAZYINITLIST(effect_str)
@@ -223,6 +227,7 @@
 				corners[T.lighting_corner_SW] = 0
 				corners[T.lighting_corner_NW] = 0
 			turfs += T
+			SSdemo.mark_turf(T)
 		source_turf.luminosity = oldlum
 
 	var/list/datum/lighting_corner/new_corners = (corners - effect_str)

--- a/code/modules/unit_tests/focus_only_tests.dm
+++ b/code/modules/unit_tests/focus_only_tests.dm
@@ -10,4 +10,4 @@
 /datum/unit_test/focus_only/multiple_space_initialization
 
 /// Checks that every overlay passed into build_appearance_list exists in the icon
-/datum/unit_test/focus_only/invalid_overlays
+///datum/unit_test/focus_only/invalid_overlays

--- a/code/modules/unit_tests/focus_only_tests.dm
+++ b/code/modules/unit_tests/focus_only_tests.dm
@@ -8,3 +8,6 @@
 
 /// Checks that every created emissive has a valid icon_state
 /datum/unit_test/focus_only/multiple_space_initialization
+
+/// Checks that every overlay passed into build_appearance_list exists in the icon
+/datum/unit_test/focus_only/invalid_overlays


### PR DESCRIPTION
# Document the changes in your pull request
currently the replay system doesn't catch lighting updates and only updates in response to specific interactions leading to chunky looking like this 
![image](https://github.com/yogstation13/Yogstation/assets/46236974/da2879ce-09de-4468-a7b0-9c42303cd335)
additionally players' directionality doesn't update so i did my best to fix that as well.

## Here's how it looks now with my fixes

https://github.com/yogstation13/Yogstation/assets/46236974/fdb4d2ae-8e14-4ccf-bf63-6e29cf779a5b

It's still a bit chunky but at least it updates. Also replay overlays seem to be broken but only on non chromium browsers??
i also mostly fixed console screen directionality on accident lmao
before:
![image](https://github.com/yogstation13/Yogstation/assets/46236974/268ab2d6-9c00-4530-912b-71c1f6f55ed8)
after:
![image](https://github.com/yogstation13/Yogstation/assets/46236974/858bb982-4dae-46c4-bf0a-6040e7a28e68)


# Testing

https://github.com/yogstation13/Yogstation/assets/46236974/fcac3032-a0ce-4ede-8e34-76480f5ad268

game seems fine. no idea if updating the cached appearance of players on tick in the demo viewer will make the server's performance shit.


# Why is this good for the game?
Having better replays is good


# Changelog

:cl:  
bugfix: lighting should actually update in replays 
bugfix: player directionality should actually update in replays  
/:cl:
