### PR TITLE
Putting your damaged pAI into a bowl of rice now fixes it (realism update)

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_salad.dm
+++ b/code/modules/food_and_drinks/food/snacks_salad.dm
@@ -84,6 +84,25 @@
 	tastes = list("rice" = 1)
 	foodtype = GRAIN | RAW
 
+/obj/item/reagent_containers/food/snacks/salad/ricebowl/attackby(obj/item/W, mob/user, params)
+	if(!istype(W, /obj/item/paicard))
+		return ..()
+	var/obj/item/paicard/ricephone = W
+	if(!ricephone.pai)
+		return ..()
+	if(!ricephone.pai.has_status_effect(/datum/status_effect/speech/slurring) && !ricephone.pai.has_status_effect(/datum/status_effect/speech/stutter/derpspeech))
+		to_chat(user, span_notice("There are rumors that burying a pAI in rice can fix some internal damage, but yours seems to be working fine for now."))
+		return ..()
+	user.visible_message(span_notice("[user] buries [ricephone] into [src]..."), span_notice("You bury [ricephone] in [src]..."))
+	if(do_after(user, 10 SECONDS, src))
+		if(!ricephone.pai)
+			return FALSE
+		user.visible_message(span_notice("[user] removes [ricephone] from [src]."), span_notice("You remove [ricephone] from [src], the diagnostics showing significantly fewer warnings."))
+		to_chat(ricephone.pai, span_notice("System recovery complete."))
+		ricephone.pai.emote("ping")
+		ricephone.pai.remove_status_effect(/datum/status_effect/speech/slurring/drunk)
+		ricephone.pai.remove_status_effect(/datum/status_effect/speech/stutter/derpspeech)
+
 /obj/item/reagent_containers/food/snacks/salad/boiledrice
 	name = "boiled rice"
 	desc = "A warm bowl of rice."

--- a/code/modules/food_and_drinks/food/snacks_salad.dm
+++ b/code/modules/food_and_drinks/food/snacks_salad.dm
@@ -90,7 +90,7 @@
 	var/obj/item/paicard/ricephone = W
 	if(!ricephone.pai)
 		return ..()
-	if(!ricephone.pai.has_status_effect(/datum/status_effect/speech/slurring) && !ricephone.pai.has_status_effect(/datum/status_effect/speech/stutter/derpspeech))
+	if(!ricephone.pai.has_status_effect(/datum/status_effect/speech/slurring/drunk) && !ricephone.pai.has_status_effect(/datum/status_effect/speech/stutter/derpspeech))
 		to_chat(user, span_notice("There are rumors that burying a pAI in rice can fix some internal damage, but yours seems to be working fine for now."))
 		return ..()
 	user.visible_message(span_notice("[user] buries [ricephone] into [src]..."), span_notice("You bury [ricephone] in [src]..."))


### PR DESCRIPTION
# Document the changes in your pull request

pAIs getting EMPed has a 2/3 chance to give them a permanent speech impediment, only fixable by having the pAI wiped and re-downloaded

Considering the only effective solution is counterintuitive, I've produced an even more counterintuitive solution: putting the pAI into a bowl of rice to get the EMP/water damage out. If this is what we do when our phones stop working now, it's likely what we'll be doing when our self-aware hyperintelligent AI phones stop working in the future.

# Why is this good for the game?
<!-- Describe why you think this change is good for the game. This section is not required for bugfixes. -->

# Testing
<!-- Describe what testing you did with this PR. Try to be thorough, especially if this is a larger project. -->

Tested locally, pAI was purged of EMP stutter/slurring after being put into the rice bowl.
While the EMP effect adjusts slurring, not drunkenness, the actual variant used is in fact drunken slurring.

# Wiki Documentation

You can now fix damaged pAIs by submerging their card in a bowl of rice for a few seconds.

# Changelog


:cl:  
rscadd: You can now fix damaged pAIs by submerging their card in a bowl of rice for a few seconds.
/:cl:
