### PR TITLE
Slipping Proc Properly Returns Something of Value

### DIFF
--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -19,10 +19,10 @@
 	var/wagging = FALSE
 	if(src.dna.species.is_wagging_tail())
 		wagging = TRUE
-	loc.handle_slip(src, knockdown_amount, O, lube, stun, force_drop)
+	var ret = loc.handle_slip(src, knockdown_amount, O, lube, stun, force_drop)
 	if(wagging)
 		src.dna.species.start_wagging_tail(src)
-	return
+	return ret
 	
 /mob/living/carbon/Process_Spacemove(movement_dir = 0)
 	if(!.)

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -22,7 +22,7 @@
 	. = loc.handle_slip(src, knockdown_amount, O, lube, stun, force_drop)
 	if(wagging)
 		src.dna.species.start_wagging_tail(src)
-	return ret
+	return .
 	
 /mob/living/carbon/Process_Spacemove(movement_dir = 0)
 	if(!.)

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -22,7 +22,6 @@
 	. = loc.handle_slip(src, knockdown_amount, O, lube, stun, force_drop)
 	if(wagging)
 		src.dna.species.start_wagging_tail(src)
-	return .
 	
 /mob/living/carbon/Process_Spacemove(movement_dir = 0)
 	if(!.)

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -19,7 +19,7 @@
 	var/wagging = FALSE
 	if(src.dna.species.is_wagging_tail())
 		wagging = TRUE
-	var ret = loc.handle_slip(src, knockdown_amount, O, lube, stun, force_drop)
+	. = loc.handle_slip(src, knockdown_amount, O, lube, stun, force_drop)
 	if(wagging)
 		src.dna.species.start_wagging_tail(src)
 	return ret


### PR DESCRIPTION
# Document the changes in your pull request
Slipping proc properly returns something of value. Was causing issues like making slippery component not invoking a callback.

# Testing
Yes. Slipped on something that should callback. It callbacked.

# Changelog
:cl:  
bugfix: Slipping on certain things (e.g. liquid-content slippery-skin plants) now trigger their callback.
/:cl:
