### PR TITLE
some punctuation and category things for pdas

### DIFF
--- a/code/modules/modular_computers/file_system/programs/command/crewmanifest.dm
+++ b/code/modules/modular_computers/file_system/programs/command/crewmanifest.dm
@@ -3,7 +3,7 @@
 	filedesc = "Crew Manifest"
 	category = PROGRAM_CATEGORY_CMD
 	program_icon_state = "id"
-	extended_desc = "Program for viewing and printing the current crew manifest"
+	extended_desc = "Program for viewing and printing the current crew manifest."
 	requires_ntnet = FALSE
 	size = 4
 	tgui_id = "NtosCrewManifest"

--- a/code/modules/modular_computers/file_system/programs/command/jobmanagement.dm
+++ b/code/modules/modular_computers/file_system/programs/command/jobmanagement.dm
@@ -3,7 +3,7 @@
 	filedesc = "Job Manager"
 	category = PROGRAM_CATEGORY_CMD
 	program_icon_state = "id"
-	extended_desc = "Program for viewing and changing job slot avalibility."
+	extended_desc = "Program for viewing and changing job slot availability."
 	transfer_access = ACCESS_HEADS
 	usage_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP | PROGRAM_TABLET | PROGRAM_PHONE | PROGRAM_PDA
 	size = 4

--- a/code/modules/modular_computers/file_system/programs/engineering/energyharvestercontrol.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/energyharvestercontrol.dm
@@ -2,6 +2,7 @@
 /datum/computer_file/program/energy_harvester_control
 	filename = "energy_harvester_control"
 	filedesc = "Energy Harvester Control"
+	category = PROGRAM_CATEGORY_ENGI
 	ui_header = "energy_harvester_null.gif"
 	program_icon_state = "energy_harvester_null"
 	extended_desc = "This program connects remotely to the onboard energy harvester, allowing a chief engineer to control the input rates and check for cashflow."

--- a/code/modules/modular_computers/file_system/programs/engineering/powermonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/powermonitor.dm
@@ -5,7 +5,7 @@
 	filedesc = "Power Monitor"
 	category = PROGRAM_CATEGORY_ENGI
 	program_icon_state = "power_monitor"
-	extended_desc = "This program connects to sensors around the station to provide information about electrical systems"
+	extended_desc = "This program connects to sensors around the station to provide information about electrical systems."
 	ui_header = "power_norm.gif"
 	transfer_access = ACCESS_ENGINE
 	usage_flags = PROGRAM_ALL

--- a/code/modules/modular_computers/file_system/programs/ntmonitor.dm
+++ b/code/modules/modular_computers/file_system/programs/ntmonitor.dm
@@ -1,9 +1,9 @@
 /datum/computer_file/program/ntnetmonitor
 	filename = "ntmonitor"
 	filedesc = "NTNet Diagnostics and Monitoring"
-	category = PROGRAM_CATEGORY_MISC
+	category = PROGRAM_CATEGORY_ENGI
 	program_icon_state = "comm_monitor"
-	extended_desc = "This program monitors stationwide NTNet network, provides access to logging systems, and allows for configuration changes"
+	extended_desc = "This program monitors stationwide NTNet network, provides access to logging systems, and allows for configuration changes."
 	size = 12
 	requires_ntnet = TRUE
 	usage_flags = PROGRAM_CONSOLE | PROGRAM_LAPTOP | PROGRAM_TABLET | PROGRAM_PHONE | PROGRAM_TELESCREEN | PROGRAM_PDA

--- a/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
+++ b/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
@@ -4,7 +4,7 @@
 	filedesc = "Paperwork Printing"
 	category = PROGRAM_CATEGORY_MISC
 	program_icon_state = "id"
-	extended_desc = "Program for dispensing paperwork"
+	extended_desc = "Program for dispensing paperwork."
 	requires_ntnet = FALSE
 	size = 4
 	tgui_id = "NtosPaperworkPrinter"
@@ -38,7 +38,7 @@
 			if(initial(P.id)==paperworkToPick)
 				src.print(P)
 				break
-			
+
 
 /datum/computer_file/program/paperwork_printer/proc/print(obj/item/paper/paperwork/T)
 	var/obj/item/computer_hardware/printer/printer

--- a/code/modules/modular_computers/file_system/programs/supply/bounty_board.dm
+++ b/code/modules/modular_computers/file_system/programs/supply/bounty_board.dm
@@ -3,7 +3,7 @@
 	filedesc = "Bounty Board Request Network"
 	category = PROGRAM_CATEGORY_SUPL
 	program_icon_state = "bountyboard"
-	extended_desc = "A multi-platform network for placing requests across the station, with payment across the network being possible.."
+	extended_desc = "A multi-platform network for placing requests across the station, with payment across the network being possible."
 	requires_ntnet = TRUE
 	network_destination = "bounty board interface"
 	size = 10


### PR DESCRIPTION
Adds punctuation where it's missing in pda programs, plus fixes spelling on a word.

Moves Energy Harvester Control and NTNet Diagnostics and Monitoring programs from misc category to engineering.

# Why is this good for the game?
idk looks nicer??

# Testing
yes i checked the categories worked

:cl:  ktlwjec
tweak: Energy Harvester Control and NTNet Diagnostics and Monitoring PDA programs moved from misc to engineering category.
/:cl: