### PR TITLE
Makes clockwork golems no longer robotic (they don't suffer EMP from their own weapons anymore).

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -731,7 +731,6 @@
 	limbs_id = "clockgolem"
 	info_text = "<span class='bold alloy'>As a </span><span class='bold brass'>Clockwork Golem</span><span class='bold alloy'>, you are faster than other types of golems. On death, you will break down into scrap.</span>"
 	species_traits = list(NOBLOOD,NO_UNDERWEAR,NOEYESPRITES,NOFLASH)
-	inherent_biotypes = MOB_ROBOTIC|MOB_HUMANOID
 	armor = 20 //Reinforced, but much less so to allow for fast movement
 	attack_verb = "smash"
 	attack_sound = 'sound/magic/clockwork/anima_fragment_attack.ogg'


### PR DESCRIPTION
# Document the changes in your pull request
Replaces MOB_ROBOTIC with MOB_INORGANIC like the rest of the golems.

# Why is this good for the game?
The golems being robotic is a cool flavor, but since the change to bodyparts this made them like other robotic races like IPC.
They have no use for robotic limbs mechanics, they have their own source of healing (sentinels compromise).
This mostly makes anyone who uses EMP-based weaponry (warhammer and brass sword) not die to themselves.

# Testing
Uuh single line of code just makes the clock golems behave like other golems.

# Changelog
:cl:  
tweak: clockwork golems are now golems and not robots made of brass, making them immune to the effects of their own EMP
/:cl:
