### PR TITLE
Switching to your knife makes you run faster

### DIFF
--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -100,6 +100,8 @@
 	custom_price = 30
 	wound_bonus = 5
 	bare_wound_bonus = 15
+	item_flags = SLOWS_WHILE_IN_HAND
+	slowdown = -0.2 // Run faster with knife out
 
 /obj/item/kitchen/knife/Initialize(mapload)
 	. = ..()
@@ -131,16 +133,16 @@
 	w_class = WEIGHT_CLASS_NORMAL
 
 /obj/item/kitchen/knife/ritual/holy
-	name = "ruinous knife" 
+	name = "ruinous knife"
 	desc = "The runes inscribed on the knife radiate a strange power. It looks like it could have more runes inscribed upon it..."
 
 /obj/item/kitchen/knife/ritual/holy/strong
-	name = "great ruinous knife" 
+	name = "great ruinous knife"
 	desc = "A heavy knife inscribed with dozens of runes."
 	force = 15
 
 /obj/item/kitchen/knife/ritual/holy/strong/blood
-	name = "blood-soaked ruinous knife" 
+	name = "blood-soaked ruinous knife"
 	desc = "Runes stretch across the surface of the knife, seemingly endless."
 	wound_bonus = 20 //a bit better than a butcher cleaver, you've earned it for finding blood cult metal and doing the previous steps
 
@@ -273,7 +275,7 @@
 /obj/item/kitchen/rollingpin/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] begins flattening [user.p_their()] head with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return BRUTELOSS
-	
+
 /obj/item/kitchen/knife/makeshift
 	name = "makeshift knife"
 	icon_state = "knife_makeshift"

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -404,6 +404,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	hitsound = 'sound/weapons/genhit.ogg'
 	attack_verb = list("stubbed", "poked")
 	resistance_flags = FIRE_PROOF
+	item_flags = SLOWS_WHILE_IN_HAND
 	var/extended = 0
 
 /obj/item/switchblade/attack_self(mob/user)
@@ -417,6 +418,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 		hitsound = 'sound/weapons/bladeslice.ogg'
 		sharpness = SHARP_EDGED
+		slowdown = -0.2 // Run faster with knife out
 	else
 		force = 3
 		w_class = WEIGHT_CLASS_SMALL
@@ -425,6 +427,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		attack_verb = list("stubbed", "poked")
 		hitsound = 'sound/weapons/genhit.ogg'
 		sharpness = SHARP_NONE
+		slowdown = initial(slowdown)
 
 /obj/item/switchblade/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] is slitting [user.p_their()] own throat with [src]! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -197,6 +197,7 @@
 /obj/item/pen/red/edagger
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut") //these wont show up if the pen is off
 	sharpness = SHARP_EDGED
+	item_flags = SLOWS_WHILE_IN_HAND
 	var/on = FALSE
 
 /obj/item/pen/red/edagger/Initialize(mapload)
@@ -221,6 +222,7 @@
 		hitsound = initial(hitsound)
 		embedding = embedding.setRating(embed_chance = EMBED_CHANCE)
 		throwforce = initial(throwforce)
+		slowdown = initial(slowdown)
 		playsound(user, 'sound/weapons/saberoff.ogg', 5, 1)
 		to_chat(user, span_warning("[src] can now be concealed."))
 	else
@@ -235,6 +237,7 @@
 		hitsound = 'sound/weapons/blade1.ogg'
 		embedding = embedding.setRating(embed_chance = 100) //rule of cool
 		throwforce = 35
+		slowdown = -0.2 // Run faster with knife out
 		playsound(user, 'sound/weapons/saberon.ogg', 5, 1)
 		to_chat(user, span_warning("[src] is now active."))
 	var/datum/component/butchering/butchering = src.GetComponent(/datum/component/butchering)


### PR DESCRIPTION
# Document the changes in your pull request

Knives now make you faster when holding them in hand

This applies to
- Kitchen knife subtypes
- Edagger (on)
- Switchblade (on)

# Why is this good for the game?
Knives are dangerous and agile

# Testing
works

# Wiki Documentation
-0.2 slowdown

# Changelog

:cl:   
tweak: Running with your knife out makes you faster
/:cl:
