### PR TITLE
MMIs can be removed from mechs

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1114,6 +1114,17 @@
 	GrantActions(brainmob)
 	return TRUE
 
+/obj/mecha/proc/remove_mmi(mob/user)
+	if(!silicon_pilot) // this should be impossible unless someone is messing with the client to do unintended things
+		CRASH("[type] called remove_mmi() without having a silicon pilot!")
+	var/mob/living/brain/brainmob = occupant
+	go_out(FALSE, get_turf(src)) // eject any silicon pilot, including AIs
+	if(!istype(brainmob)) // if there wasn't a brain inside, no need to continue
+		return
+	var/obj/item/mmi/mmi = brainmob.container
+	if(user && !user.put_in_hands(mmi))
+		mmi.forceMove(get_turf(user))
+
 /obj/mecha/container_resist(mob/living/user)
 	is_currently_ejecting = TRUE
 	to_chat(occupant, "<span class='notice'>You begin the ejection procedure. Equipment is disabled during this process. Hold still to finish ejecting.<span>")
@@ -1192,6 +1203,7 @@
 			if(mmi.brainmob)
 				L.forceMove(mmi)
 				L.reset_perspective()
+				L.remote_control = null
 			mmi.mecha = null
 			mmi.update_appearance(UPDATE_ICON)
 			L.mobility_flags = NONE

--- a/code/game/mecha/mecha_topic.dm
+++ b/code/game/mecha/mecha_topic.dm
@@ -210,6 +210,7 @@
 				[(state == 3) ?"[cell?"<a href='?src=[REF(src)];drop_cell=1;id_card=[REF(id_card)];user=[REF(user)]'>Drop power cell</a>":"No cell installed</br>"]":null]
 				[(state == 3) ?"[scanmod?"<a href='?src=[REF(src)];drop_scanmod=1;id_card=[REF(id_card)];user=[REF(user)]'>Drop scanning module</a>":"No scanning module installed</br>"]":null]
 				[(state == 3) ?"[capacitor?"<a href='?src=[REF(src)];drop_cap=1;id_card=[REF(id_card)];user=[REF(user)]'>Drop capacitor</a>":"No capacitor installed</br>"]":null]
+				[(state == 3) ?"[(silicon_pilot&&occupant)?"<a href='?src=[REF(src)];drop_mmi=1;id_card=[REF(id_card)];user=[REF(user)]'>Drop neural interface</a>":"No neural interface installed</br>"]":null]
 				[(state == 3) ?"--------------------</br>":null]
 				[(state>0) ?"<a href='?src=[REF(src)];set_internal_tank_valve=1;user=[REF(user)]'>Set Cabin Air Pressure</a>":null]
 			</body>
@@ -234,9 +235,15 @@
 
 	if(in_range(src, usr))
 		var/obj/item/card/id/id_card
-		if (href_list["id_card"])
+		if(href_list["id_card"])
 			id_card = locate(href_list["id_card"])
-			if (!istype(id_card))
+			if(!istype(id_card))
+				return
+		
+		var/mob/user
+		if(href_list["user"])
+			user = locate(href_list["user"])
+			if(!istype(user))
 				return
 
 		if(href_list["req_access"] && add_req_access && id_card)
@@ -258,20 +265,28 @@
 
 		if(href_list["drop_cell"])
 			if(state == 3)
-				cell.forceMove(get_turf(src))
+				if(!user.put_in_hands(cell))
+					cell.forceMove(get_turf(user))
 				cell = null
 			output_maintenance_dialog(id_card,usr)
 			return
 		if(href_list["drop_scanmod"])
 			if(state == 3)
-				scanmod.forceMove(get_turf(src))
+				if(!user.put_in_hands(scanmod))
+					scanmod.forceMove(get_turf(user))
 				scanmod = null
 			output_maintenance_dialog(id_card,usr)
 			return
 		if(href_list["drop_cap"])
 			if(state == 3)
-				capacitor.forceMove(get_turf(src))
+				if(!user.put_in_hands(capacitor))
+					capacitor.forceMove(get_turf(user))
 				capacitor = null
+			output_maintenance_dialog(id_card,usr)
+			return
+		if(href_list["drop_mmi"])
+			if(state == 3)
+				remove_mmi(user)
 			output_maintenance_dialog(id_card,usr)
 			return
 


### PR DESCRIPTION
# Document the changes in your pull request

Adds the ability to remove an MMI or positronic brain from a mech using the maintenance panel, the same way you'd remove the power cell or capacitor.

# Why is this good for the game?
Someone forgot to add this so you have to destroy the whole mech to get the MMI out, it's very silly.

# Testing
Added MMI to mech, used maintenance protocols to remove it.

# Wiki Documentation

Should probably mention this on the guide to robotics
https://wiki.yogstation.net/wiki/Guide_to_robotics#Exosuits

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: MMIs and positronic brains can be removed from mechs using maintenance protocols
/:cl:
