### PR TITLE
Deletes "How to suck blood 101"

### DIFF
--- a/tgui/packages/tgui/interfaces/AntagInfoVampire.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoVampire.tsx
@@ -42,6 +42,7 @@ export const AntagInfoVampire = (props, context) => {
               <div>This <span style={vampireRed}>WILL</span> alert everyone who can see it, as well as make a noise.</div>
               <div>{loud ? '' : 'You can extract blood '}<span style={vampireRed}>{loud ? '' : 'stealthily'}</span>{loud ? '' : ' by initiating without a grab.'}</div>
               <div>{loud ? '' : 'This will reduce the amount of blood taken by 50%.'}</div>
+              <div>{loud ? 'You can no longer drain blood stealthily.' : 'The ability to drain blood stealthily will be lost above 150 total blood.'}</div>
               <div>Note that you <b>cannot</b> draw blood from <b>catatonics or corpses</b>.</div>
             </Stack.Item>
             <Stack.Item>

--- a/tgui/packages/tgui/interfaces/AntagInfoVampire.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoVampire.tsx
@@ -1,0 +1,73 @@
+import { useBackend } from '../backend';
+import { Section, Stack } from '../components';
+import { BooleanLike } from 'common/react';
+import { Window } from '../layouts';
+
+type Objective = {
+  count: number;
+  name: string;
+  explanation: string;
+  complete: BooleanLike;
+  was_uncompleted: BooleanLike;
+  reward: number;
+};
+
+type Info = {
+  antag_name: string;
+  objectives: Objective[];
+  loud: boolean;
+};
+
+const vampireRed = {
+  fontWeight: 'bold',
+  color: 'red',
+};
+
+export const AntagInfoVampire = (props, context) => {
+  const { data } = useBackend<Info>(context);
+  const { antag_name } = data;
+  const { loud } = data;
+  return (
+    <Window width={620} height={250}>
+      <Window.Content>
+        <Section scrollable fill>
+          <Stack vertical>
+            <Stack.Item textColor="red" fontSize="20px">
+              You are the {antag_name}!
+            </Stack.Item>
+            <Stack.Item>
+              <div>You can consume blood from humanoid life by <span style={vampireRed}>punching their head while on the harm intent</span>.</div>
+              <div>Your bloodsucking speed depends on grab strength.</div>
+              <div>Having a <b>neck grab or stronger</b> increases blood drain rate by 50%.</div>
+              <div>This <span style={vampireRed}>WILL</span> alert everyone who can see it, as well as make a noise.</div>
+              <div>{loud ? '' : 'You can extract blood '}<span style={vampireRed}>{loud ? '' : 'stealthily'}</span>{loud ? '' : ' by initiating without a grab.'}</div>
+              <div>{loud ? '' : 'This will reduce the amount of blood taken by 50%.'}</div>
+              <div>Note that you <b>cannot</b> draw blood from <b>catatonics or corpses</b>.</div>
+            </Stack.Item>
+            <Stack.Item>
+              <ObjectivePrintout />
+            </Stack.Item>
+          </Stack>
+        </Section>
+      </Window.Content>
+    </Window>
+  );
+};
+
+const ObjectivePrintout = (props, context) => {
+  const { data } = useBackend<Info>(context);
+  const { objectives } = data;
+  return (
+    <Stack vertical>
+      <Stack.Item bold>Your objectives:</Stack.Item>
+      <Stack.Item>
+        {(!objectives && 'None!') ||
+          objectives.map((objective) => (
+            <Stack.Item key={objective.count}>
+              #{objective.count}: {objective.explanation}
+            </Stack.Item>
+          ))}
+      </Stack.Item>
+    </Stack>
+  );
+};

--- a/yogstation/code/datums/antagonists/vampire.dm
+++ b/yogstation/code/datums/antagonists/vampire.dm
@@ -9,6 +9,8 @@
 	job_rank = ROLE_VAMPIRE
 	antag_hud_name = "vampire"
 
+	ui_name = "AntagInfoVampire"
+
 	var/usable_blood = 0
 	var/total_blood = 0
 	var/converted = 0
@@ -24,7 +26,6 @@
 	var/obj/item/clothing/suit/draculacoat/coat
 
 	var/list/upgrade_tiers = list(
-		/datum/action/cooldown/spell/vampire_help = 0,
 		/datum/action/cooldown/spell/rejuvenate = 0,
 		/datum/action/cooldown/spell/pointed/gaze = 0,
 		/datum/action/cooldown/spell/pointed/hypno = 0,
@@ -40,6 +41,13 @@
 		/datum/action/cooldown/spell/summon_coat = 400,
 		/datum/vampire_passive/full = 400,
 		/datum/action/cooldown/spell/pointed/vampirize = 450)
+
+/datum/antagonist/vampire/ui_static_data(mob/user)
+	var/list/data = list()
+	data["antag_name"] = name
+	data["objectives"] = get_objectives()
+	data["loud"] = get_ability(/datum/vampire_passive/nostealth)
+	return data
 
 /datum/antagonist/vampire/new_blood
 	full_vampire = FALSE

--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -72,40 +72,6 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-/datum/action/cooldown/spell/vampire_help
-	name = "How to suck blood 101"
-	desc = "Explains how the vampire blood sucking system works."
-	button_icon_state = "bloodymaryglass"
-	button_icon = 'icons/obj/drinks.dmi'
-	background_icon_state = "bg_vampire"
-	overlay_icon_state = "bg_vampire_border"
-
-	school = SCHOOL_SANGUINE
-
-	vamp_req = TRUE //YES YOU NEED TO BE A VAMPIRE TO KNOW HOW TO BE A VAMPIRE SHOCKING
-
-/datum/action/cooldown/spell/vampire_help/cast(mob/living/user)
-	. = ..()
-	var/datum/antagonist/vampire/V = user.mind.has_antag_datum(/datum/antagonist/vampire)
-	if(!V) //sanity check
-		return
-	var/stealth = TRUE
-	if(V.get_ability(/datum/vampire_passive/nostealth))//different help text if you no longer have stealth
-		stealth = FALSE
-
-	var/list/string = list()
-	string += span_notice("You can consume blood from humanoid life by [span_red("punching their head while on the harm intent")]")
-	string += span_notice("Your bloodsucking speed depends on grab strength.")
-	string += span_notice("Having a <b>neck grab or stronger</b> increases blood drain rate by 50%.")
-	string += span_notice("This [span_red("WILL")] alert everyone who can see it, as well as make a noise.")
-	if(stealth)
-		string += span_notice("You can extract blood [span_red("<i>stealthily</i>")] by initiating without a grab.")
-		string += span_notice("This will reduce the amount of blood taken by 50%.")
-	string += span_notice("Note that you <b>cannot</b> draw blood from <b>catatonics or corpses</b>.")
-	to_chat(user, string.Join("<br>"))
-	return TRUE
-
 /datum/action/cooldown/spell/rejuvenate
 	name = "Rejuvenate (20)"
 	desc= "Flush your system with some spare blood to restore stamina over time."


### PR DESCRIPTION
# Why is this good for the game?
reduce button bloat

# Testing (with and without stealthiness)
![before](https://github.com/yogstation13/Yogstation/assets/108117184/02fea771-3bca-4017-83af-eda6d8a0fb58)
![after](https://github.com/yogstation13/Yogstation/assets/108117184/1ff3891b-ea23-4d73-acae-267e4e3db2db)

:cl:  
rscdel: Deletes "How to suck blood 101"
tweak: Adds vampire blood sucking guide to the antag menu
/:cl:
