### PR TITLE
fix HOS gun name in hallucination text

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -749,7 +749,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 					"hybrid taser","stun baton","flash","syringe gun","circular saw","tank transfer valve",\
 					"ritual dagger","clockwork slab","spellbook",\
 					"Codex Cicatrix", "living heart", "sickly blade", "medallion",\
-					"pulse rifle","captain's spare ID","hand teleporter","hypospray","antique laser gun","X-01 MultiPhase Energy Gun","station's blueprints"\
+					"pulse rifle","captain's spare ID","hand teleporter","hypospray","antique laser gun","NT-S02 MultiPhase Energy Gun","station's blueprints"\
 					)] into [equipped_backpack].</span>")
 
 		message_pool.Add("<B>[other]</B> [pick("sneezes","coughs")].")


### PR DESCRIPTION
hallucination still used the old name, this changes it to the current name. i dont think something this minor needs a changelog

# Why is this good for the game?
so the name is correct idk

# Testing
no dont make me test this
