### PR TITLE
Plasma cutter projectile tweaks

### DIFF
--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -1,6 +1,7 @@
 /obj/projectile/plasma
 	name = "plasma blast"
 	icon_state = "plasmacutter"
+	armor_flag = ENERGY
 	damage_type = BRUTE
 	damage = 5
 	range = 4
@@ -10,6 +11,10 @@
 	tracer_type = /obj/effect/projectile/tracer/plasma_cutter
 	muzzle_type = /obj/effect/projectile/muzzle/plasma_cutter
 	impact_type = /obj/effect/projectile/impact/plasma_cutter
+	light_system = MOVABLE_LIGHT
+	light_color = LIGHT_COLOR_PURPLE
+	light_flags = LIGHT_NO_LUMCOUNT
+	light_range = 2
 
 /obj/projectile/plasma/weak
 	name = "weak plasma blast"
@@ -17,6 +22,7 @@
 	damage = 3
 	dismemberment = 5
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/red_laser
+	light_color = LIGHT_COLOR_RED
 	mine_range = 0
 
 /obj/projectile/plasma/on_hit(atom/target)
@@ -65,6 +71,7 @@
 	tracer_type = /obj/effect/projectile/tracer/laser/blue
 	muzzle_type = /obj/effect/projectile/muzzle/laser/blue
 	impact_type = /obj/effect/projectile/impact/laser/blue
+	light_color = LIGHT_COLOR_BLUE
 	damage_type = STAMINA
 	damage = 5
 	range = 4


### PR DESCRIPTION
# Document the changes in your pull request

Plasma cutter projectiles now glow, and check against energy armor instead of bullet armor (why was it bullet armor??)

# Why is this good for the game?
The glow looks cool, and I think it fits as an energy projectile a lot more than as a bullet projectile. I'm aware that energy armor is lower on most things, but considering the projectile only does 5 damage and fires very slowly, it shouldn't make any meaningful difference.

# Testing
<!-- Describe what testing you did with this PR. Try to be thorough, especially if this is a larger project. -->
![plasma_cutter](https://github.com/yogstation13/Yogstation/assets/93578146/edee5315-4c5b-4b68-8b12-bb1a39858028)

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: plasma cutter projectiles glow and check against energy armor
/:cl:
