### PR TITLE
Felinid body color is now the same as their hair color

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -37,8 +37,13 @@
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
 		if(H.hair_color && H.hair_color != "mutcolor" && H.hair_color != "fixedmutcolor")
+			// Converts the hair color to HSV so we can desaturate it
+			var/hsv_hair_color = RGBtoHSV(H.hair_color)
+			var/list/hsv_list = ReadHSV(hsv_hair_color)
+			// Also caps the value, so we don't have "shadowling viro" catperson
+			var/desaturated_hair_color = HSVtoRGB(hsv( hsv_list[1], max(hsv_list[2] - 20, 0), clamp(hsv_list[3], 50, 200) ))
 			old_mcolor = H.dna.features["mcolor"]
-			H.dna.features["mcolor"] = H.hair_color
+			H.dna.features["mcolor"] = desaturated_hair_color
 			old_facial_hair_color = H.facial_hair_color
 			H.facial_hair_color = H.hair_color
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request
Felinids now have mutcolors
Upon taking the felinid species, your `mcolor` and `facial_hair_color` will be set to your `hair_color`

Body color is slightly desaturated to give a distinction (requested by Cuackles) as well as capping the values between 50 and 200 (0-255 scale) so bodies do not appear pitch black

# Why is this good for the game?

Catbeasts must come to terms that this is what they look like
![image](https://github.com/yogstation13/Yogstation/assets/28408322/04959fdc-dada-4c1a-a27c-6ef86df3c392)

Garfield
![image](https://github.com/yogstation13/Yogstation/assets/28408322/c06e3acc-7835-4786-80f7-80a18caa31d5)


![image](https://github.com/yogstation13/Yogstation/assets/28408322/61c4eb34-ad74-414c-a8d8-4bad1fc73705)

# Testing
See above

# Changelog

:cl:  
tweak: Felinids now have excessive body hair
/:cl:
