### PR TITLE
Merge the helmets and body armor in the same cargo crates

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -80,7 +80,6 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	var/antags_rolled = 0
 	/// CRATE DISCOUNT
 	var/discountedcrates = list(	/datum/supply_pack/security/laser,
-									/datum/supply_pack/security/helmets,
 									/datum/supply_pack/security/vending/security,
 									/datum/supply_pack/service/party)
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -276,12 +276,15 @@
 
 /datum/supply_pack/security/armor
 	name = "Armor Crate"
-	desc = "Three vests of well-rounded, decently-protective armor. Requires Security access to open."
-	cost = 1000
+	desc = "Three sets of well-rounded, decently-protective armor and helmet. Requires Security access to open."
+	cost = 2000
 	access_view = ACCESS_SECURITY
-	contains = list(/obj/item/clothing/suit/armor/vest,
-					/obj/item/clothing/suit/armor/vest,
-					/obj/item/clothing/suit/armor/vest)
+	contains = list(/obj/item/clothing/suit/armor/vest/alt,
+					/obj/item/clothing/suit/armor/vest/alt,
+					/obj/item/clothing/suit/armor/vest/alt,
+					/obj/item/clothing/head/helmet/sec,
+					/obj/item/clothing/head/helmet/sec,
+					/obj/item/clothing/head/helmet/sec)
 	crate_name = "armor crate"
 
 /datum/supply_pack/security/disabler
@@ -314,15 +317,6 @@
 					/obj/item/toy/crayon/white,
 					/obj/item/clothing/head/fedora/det_hat)
 	crate_name = "forensics crate"
-
-/datum/supply_pack/security/helmets
-	name = "Helmets Crate"
-	desc = "Contains three standard-issue brain buckets. Requires Security access to open."
-	cost = 1000
-	contains = list(/obj/item/clothing/head/helmet/sec,
-					/obj/item/clothing/head/helmet/sec,
-					/obj/item/clothing/head/helmet/sec)
-	crate_name = "helmet crate"
 
 /datum/supply_pack/security/laser
 	name = "Lasers Crate"
@@ -522,21 +516,15 @@
 
 /datum/supply_pack/security/armory/bulletarmor
 	name = "Bulletproof Armor Crate"
-	desc = "Contains three sets of bulletproof armor. Guaranteed to reduce a bullet's stopping power by over half. Requires Armory access to open."
-	cost = 1500
+	desc = "Contains three sets of bulletproof armor and helmet. Guaranteed to reduce a bullet's stopping power by over half. Requires Armory access to open."
+	cost = 3000
 	contains = list(/obj/item/clothing/suit/armor/bulletproof,
 					/obj/item/clothing/suit/armor/bulletproof,
-					/obj/item/clothing/suit/armor/bulletproof)
-	crate_name = "bulletproof armor crate"
-
-/datum/supply_pack/security/armory/bullethelmets
-	name = "Bulletproof Helmet Crate"
-	desc = "Contains three bulletproof helmets, perfect for protecting the void inside your skull. Requires Armory access to open."
-	cost = 1500
-	contains = list(/obj/item/clothing/head/helmet/alt,
+					/obj/item/clothing/suit/armor/bulletproof,
+					/obj/item/clothing/head/helmet/alt,
 					/obj/item/clothing/head/helmet/alt,
 					/obj/item/clothing/head/helmet/alt)
-	crate_name = "bulletproof helmet crate"
+	crate_name = "bulletproof armor crate"
 
 /datum/supply_pack/security/armory/chemimp
 	name = "Chemical Implants Crate"
@@ -579,21 +567,15 @@
 
 /datum/supply_pack/security/armory/riotarmor
 	name = "Riot Armor Crate"
-	desc = "Contains three sets of heavy body armor. Advanced padding protects against close-ranged weaponry, making melee attacks feel only half as potent to the user. Requires Armory access to open."
-	cost = 1500
+	desc = "Contains three sets of heavy body armor and helmet. Advanced padding protects against close-ranged weaponry, making melee attacks feel only half as potent to the user. Requires Armory access to open."
+	cost = 3000
 	contains = list(/obj/item/clothing/suit/armor/riot,
 					/obj/item/clothing/suit/armor/riot,
-					/obj/item/clothing/suit/armor/riot)
-	crate_name = "riot armor crate"
-
-/datum/supply_pack/security/armory/riothelmets
-	name = "Riot Helmets Crate"
-	desc = "Contains three riot helmets. Requires Armory access to open."
-	cost = 1500
-	contains = list(/obj/item/clothing/head/helmet/riot,
+					/obj/item/clothing/suit/armor/riot,
+					/obj/item/clothing/head/helmet/riot,
 					/obj/item/clothing/head/helmet/riot,
 					/obj/item/clothing/head/helmet/riot)
-	crate_name = "riot helmets crate"
+	crate_name = "riot armor crate"
 
 /datum/supply_pack/security/armory/riotshields
 	name = "Riot Shields Crate"


### PR DESCRIPTION
# Document the changes in your pull request

Merge the helmets and armor in the same crate for basic sec armor, bulletproof and riot.
Increase the price of the crates to cost the same as before.
Also change the basic sec armor found in the cargo crate to be the one that spawn on security officer rather than the one found in security lockers, the stats are the same.

# Why is this good for the game?
There's never a reason to not wear both a helmet and a body armor since having your head or torso exposed result in you being almost as vulnerable as if you had nothing at all. As a result helmets and body armors are always bought together. By merging those into one crate for each type of set it unclog a bit the security and armory tabs.

Riot shield are still in a separate crate from the rest of the riot gear because they are occasionally used without riot suits and riot suits are commonly used without the riot shields (either because teleshield is available or just to not be slowed).

The vests in the Armor Crate being changed from the ones found in lockers to the ones spawning on secoffs is just to make the vests and helmets match more in their design.

# Testing
It compile.

# Wiki Documentation

Helmets crate, Bulletproof helmet crate and Riot helmet crate have been removed.
Armor crate now contain 3 armor vests and 3 helmets, price changed from 1000 to 2000
Bulletproof armor crate now contain 3 bulletproof vests and 3 bulletproof helmets, price changed from 1500 to 3000
Riot armor crate now contain 3 riot suits and 3 riot helmets, price changed from 1500 to 3000

# Changelog

:cl:  
rscdel: Removed helmet, bulletproof helmet and riot helmet crates
tweak: armor, bulletproof armor and riot armor crates now contain helmets as well, price adjusted to cost the same as before
/:cl:
