### PR TITLE
Nerfs reactive radiation armor.

### DIFF
--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -371,8 +371,8 @@
 
 /obj/item/clothing/suit/armor/reactive/radiation/reactive_activation(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	owner.visible_message(span_danger("[src] blocks [attack_text], sending out radiation pulses and nuclear particles!"))
-	radiation_pulse(src, 1000, effect_range)
-	for(var/i = 1 to 15)
+	radiation_pulse(src, 500, effect_range)
+	for(var/i = 1 to 5)
 		fire_nuclear_particle()
 	return TRUE
 


### PR DESCRIPTION
# Document the changes in your pull request

Nerfs the reactive radiation armor by a significant margin, why? Ided.
Hit multiple times during a round by it, noted the levels being able to reach nearly 2,000 rads and significant burn damage. Not fun to fight against at all. Unless you're immune to radiation this armor is unfun.

# Why is this good for the game?
Armor shouldn't punish you for playing the game, likewise something that causes burn,toxin, and lethal levels of radiation exposure is not balanced.

# Testing
Tuned the levels down in the current PR, still extremely strong.
Compiles w/o issues.

# Changelog

:cl:  

tweak: Lowered radiation pulse from 1000 to 500
tweak: Lowered particle max spawn from 15 to 5.

/:cl:
