### PR TITLE
Revert "Makes the jetpack slower"

### DIFF
--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -15,7 +15,6 @@
 	var/full_speed = TRUE // If the jetpack will have a speedboost in space/nograv or not
 	var/classic = TRUE // If the jetpack uses the classic two-tank sprite. False if it has its own special sprite (syndicate jetpack, or void jetpack)
 	var/datum/effect_system/trail_follow/ion/ion_trail
-	var/jetspeed = -0.3 // Negative increases speed
 
 /obj/item/tank/jetpack/Initialize(mapload)
 	. = ..()
@@ -58,7 +57,7 @@
 	ion_trail.start()
 	RegisterSignal(user, COMSIG_MOVABLE_MOVED, PROC_REF(move_react))
 	if(full_speed)
-		user.add_movespeed_modifier(MOVESPEED_ID_JETPACK, priority=100, multiplicative_slowdown=jetspeed, movetypes=FLOATING, conflict=MOVE_CONFLICT_JETPACK)
+		user.add_movespeed_modifier(MOVESPEED_ID_JETPACK, priority=100, multiplicative_slowdown=-2, movetypes=FLOATING, conflict=MOVE_CONFLICT_JETPACK)
 
 /obj/item/tank/jetpack/update_icon_state()
 	. = ..()


### PR DESCRIPTION
Reverts #9397 

# Why is this good for the game?

I hated this change so much because space exploration is such an unholy pain in the ass and the potential rewards from doing it really aren't that good the vast majority of the time.  Jetpacks are useless to the point where nobody will use them and instead use alternative, faster methods which get removed when spotted with the justification of essentially "unintended, use jetpack"

This makes them useful again, because it's stupid to restrict space travel when there's literally next to nothing out there most rounds - and the ruins where there are loot are mostly large to the point where you'll always bump into them regardless.  Having fast jetpacks makes finding the smaller ruins more likely instead of wandering aimlessly for 40 minutes in the most unengaging place in the whole game despite this being a fucking space game.

I would lock this to not give the insane meth speed on station z-level but I don't have the knowledge to do that so this is what we get. 

:cl:  cark
tweak: Reverts #9397 - making jetpacks useful for space exploration again.
/:cl: