### PR TITLE
Tweaks the Marine quirk text to be clearer

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -376,7 +376,7 @@
 	value = 2
 	mob_trait = TRAIT_MARINE
 	gain_text = span_notice("You've graduated top of your class and have over 300 confirmed kills.")
-	lose_text = span_danger("You've lost the fierceless spirit of being a Marine, alongside your appetite for crayons.")
+	lose_text = span_danger("You've lost the fierceless spirit of a Marine, alongside your appetite for crayons.")
 	medical_record_text = ("Patient's stomach is unusually proficient at digesting wax.")
 
 /datum/quirk/multilingual

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -371,7 +371,7 @@
 
 /datum/quirk/marine
 	name = "Marine"
-	desc = "Whether inherited from family or gained from years of service, you have the rugged blood of a Marine coursing through your veins. Crayons look quite tasty to you, and you aren't phased by eating them.")
+	desc = "Whether inherited from family or gained from years of service, you have the rugged blood of a Marine coursing through your veins. Crayons look quite tasty to you, and you aren't phased by eating them."
 	icon = "chevron-up"
 	value = 2
 	mob_trait = TRAIT_MARINE

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -371,13 +371,13 @@
 
 /datum/quirk/marine
 	name = "Marine"
-	desc = "You've unlocked your ancestory past and it has been revealed that you have hard-core Marine blood in your veins"
+	desc = "Whether inherited from family or gained from years of service, you have the rugged blood of a Marine coursing through your veins. Crayons look quite tasty to you, and you aren't phased by eating them.
 	icon = "chevron-up"
 	value = 2
 	mob_trait = TRAIT_MARINE
-	gain_text = span_notice("You've graduated top of your class and have over 300 confirmed kills")
-	lose_text = span_danger("The rage and prestige of being a Marine is lost to you now")
-	medical_record_text = ("Patient has heightened aggression and irritability, it would be wise not to anger them")
+	gain_text = span_notice("You've graduated top of your class and have over 300 confirmed kills.")
+	lose_text = span_danger("You've lost the fierceless spirit of being a Marine, alongside your appetite for crayons.")
+	medical_record_text = ("Patient's stomach is unusually proficient at digesting wax.")
 
 /datum/quirk/multilingual
 	name = "Multilingual"

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -371,7 +371,7 @@
 
 /datum/quirk/marine
 	name = "Marine"
-	desc = "Whether inherited from family or gained from years of service, you have the rugged blood of a Marine coursing through your veins. Crayons look quite tasty to you, and you aren't phased by eating them.
+	desc = "Whether inherited from family or gained from years of service, you have the rugged blood of a Marine coursing through your veins. Crayons look quite tasty to you, and you aren't phased by eating them.")
 	icon = "chevron-up"
 	value = 2
 	mob_trait = TRAIT_MARINE


### PR DESCRIPTION
# Document the changes in your pull request
The current description text has a bunch of grammatical errors, and doesn't actually explain what the quirk does.
The changes I've made should be clearer, while not straying too far from what was originally written.

# Why is this good for the game?
- Is the vagueness funny?
Sure.

- Is this good for new players/any player who didn't read the PR?
No, because the quirk's effects aren't explained at all anywhere.

# Testing
Doesn't need testing.

# Wiki Documentation
Apparently Marine hasn't been added in yet on [the wiki](https://wiki.yogstation.net/wiki/Quirks) so I'll go do that real quick with the current text.
...Which should be updated to these changes should this PR be merged.

# Changelog
:cl:  
tweak: Marine quirk text now explains what it does
/:cl: