### PR TITLE
Remove the portable pump cargo pack

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1002,17 +1002,6 @@
 	crate_name = "power cell crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
-/datum/supply_pack/engineering/portable_pumps
-	name = "Portable Pumps"
-	desc = "A set of spare portable pumps. Perfect for larger atmospheric projects or restocking after a toxins problem goes wrong."
-	cost = 1500
-	contains = list(
-		/obj/machinery/portable_atmospherics/pump,
-		/obj/machinery/portable_atmospherics/pump
-	)
-	crate_name = "portable pump crate"
-	crate_type = /obj/structure/closet/crate/large
-
 /datum/supply_pack/engineering/portable_scrubbers
 	name = "Portable Scrubbers"
 	desc = "A set of spare portable scrubbers. Perfect for when plasma 'accidentally' gets into the air supply."


### PR DESCRIPTION


# Document the changes in your pull request
Remove the portable pump cargo pack

# Why is this good for the game?
You can already craft it with 10 metals, this is obsolete

# Testing
dont need to



# Wiki Documentation
remove the portable pump from the cargo pack wiki

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

rscdel: Remove the portable pump cargo pack

/:cl:
