### PR TITLE
Gorilla mode gangrel transformation armor reduced to 15

### DIFF
--- a/code/modules/antagonists/bloodsuckers/powers/gangrel.dm
+++ b/code/modules/antagonists/bloodsuckers/powers/gangrel.dm
@@ -85,7 +85,7 @@
 			user.dna.species.punchdamagehigh += 10 //very stronk
 			user.dna.species.punchstunthreshold += 10
 			user.dna.species.action_speed_coefficient *= 1.3
-			user.dna.species.armor += 40
+			user.dna.species.armor += 15
 			bloodsuckerdatum.AddBloodVolume(50)
 		if("Bat")
 			var/mob/living/simple_animal/hostile/bloodsucker/giantbat/gb


### PR DESCRIPTION
# Document the changes in your pull request

40% innate damage resistance on the silly frenzy bloodsucker clan reduced to 15% innate damage resistance on the silly frenzy bloodsucker clan (additively stacks with armor. If you know what additively stacking and armor mean you know what this means)

# Why is this good for the game?
Reduces the chance a bloodsucker attains functional immortality

# Testing
the number is usable by computers for multiplying and adding

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

gangrel gorilla transformation is now 15 armor down from 40

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: gangrel gorilla transformation is now 15 armor down from 40
/:cl:
