### PR TITLE
Adjusts what objects are considered "robust" and "high" in damage

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -842,9 +842,9 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 			force_string = "low"
 		if(7 to 10)
 			force_string = "medium"
-		if(10 to 11)
+		if(10 to 14)
 			force_string = "high"
-		if(11 to 20) //12 is the force of a toolbox
+		if(14 to 20) //15 is the force of a toolbox
 			force_string = "robust"
 		if(20 to 25)
 			force_string = "very robust"


### PR DESCRIPTION
# Document the changes in your pull request
Objects dealing 10-14 (from 10-11) damage would now be considered  "high" in force.
Objects dealing 14-20 (from 11-20) damage would now be considered "robust" in force.

This would make toolboxes the bar for what items are considered robust and what aren't.

# Why is this good for the game?
Was taking a look at what objects are considered "robust" and why, and saw the comment about toolboxes dealing 12 damage (which is out of date). I'm assuming here that the bar for robustness is a toolbox, and as seeing as [they were buffed a while ago](https://github.com/yogstation13/Yogstation/pull/20447) it makes sense that this should be changed too. Feel free to correct me if I'm wrong.

I don't feel strongly for this, and I'm making this mostly to see if people agree with it or not. 

# Testing
This shouldn't need testing

# Changelog
:cl:  
tweak: Items dealing 14-20 force are now "robust," changed from 11-20
tweak: Items dealing 10-14 force are now "high," changed from 10-11
/:cl: