### PR TITLE
Death Alarm Implants

### DIFF
--- a/code/game/objects/items/implants/implant_deathalarm.dm
+++ b/code/game/objects/items/implants/implant_deathalarm.dm
@@ -1,0 +1,53 @@
+/obj/item/implant/deathalarm
+	name = "death alarm implant"
+	desc = "Monitors host vital signs and transmits a radio message upon death."
+	actions_types = null
+	var/obj/item/radio/radio
+
+/obj/item/implant/deathalarm/Initialize(mapload)
+	. = ..()
+	radio = new(src)
+	radio.keyslot = new /obj/item/encryptionkey/headset_med // Medical only should know if people die (because paramedics). Consider changing to Command-only if something like Blueshield is added. 
+	radio.listening = FALSE
+	radio.recalculateChannels()
+
+/obj/item/implant/deathalarm/activate(cause)
+	if(!imp_in)
+		return FALSE
+
+	// Location.
+	var/area/turf = get_area(imp_in)
+	// Name of implant user.
+	var/mobname = imp_in.name
+	// What is to be said.
+	var/message = "[mobname] has died-zzzzt in-in-in..." // Default message for unexpected causes.
+	switch(cause)
+		if("death")
+			message = "[mobname] has died in [turf.name]!"
+		if("emp")
+			if(isemptylist(GLOB.teleportlocs) || prob(50)) // 50% chance of broadcasting as if they died (or no tracking beacons available).
+				message = "[mobname] has died in [turf.name]!"
+			else // Otherwise, random location.
+				message = "[mobname] has died in [pick(GLOB.teleportlocs)]!"
+
+	name = "[mobname]'s Death Alarm"
+	radio.talk_into(src, message, RADIO_CHANNEL_MEDICAL)
+	qdel(src) // One-time use implant. Use it and lose it.
+
+/obj/item/implant/deathalarm/on_mob_death(mob/living/L, gibbed)
+	if(gibbed)
+		activate("gibbed") // Will use default message.
+	else
+		activate("death")
+
+/obj/item/implant/deathalarm/emp_act(severity)
+	activate("emp")
+
+/obj/item/implant/deathalarm/get_data()
+	. = {"<b>Implant Specifications:</b><BR>
+		<b>Name:</b> Death Alarm Implant<BR>
+		<b>Life:</b> Until death<BR>
+		<b>Important Notes:</b> Notifies medical upon death.<BR>
+		<HR>
+		<b>Implant Details:</b><BR>
+		<b>Function:</b> Contains a small radio device and a microphone. Immediately broadcasts the user's location to available medical personnel when vital signs appear to have ceased.<BR>"}

--- a/code/game/objects/items/implants/implant_deathalarm.dm
+++ b/code/game/objects/items/implants/implant_deathalarm.dm
@@ -51,3 +51,6 @@
 		<HR>
 		<b>Implant Details:</b><BR>
 		<b>Function:</b> Contains a small radio device and a microphone. Immediately broadcasts the user's location to available medical personnel when vital signs appear to have ceased.<BR>"}
+
+/obj/item/implanter/deathalarm
+	imp_type = /obj/item/implant/deathalarm

--- a/code/game/objects/items/implants/implantcase.dm
+++ b/code/game/objects/items/implants/implantcase.dm
@@ -67,7 +67,6 @@
 		imp = new imp_type(src)
 	update_appearance(UPDATE_ICON)
 
-
 /obj/item/implantcase/tracking
 	name = "implant case - 'Tracking'"
 	desc = "A glass case containing a tracking implant."
@@ -82,3 +81,8 @@
 	name = "implant case - 'Adrenaline'"
 	desc = "A glass case containing an adrenaline implant."
 	imp_type = /obj/item/implant/adrenalin
+
+/obj/item/implantcase/deathalarm
+	name = "implant case - 'Death Alarm'"
+	desc = "A glass case containing a death alarm implant."
+	imp_type = /obj/item/implant/deathalarm

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -388,6 +388,18 @@
 		/obj/item/computer_hardware/hard_drive/portable/implant_tracker = 1)
 	generate_items_inside(items_inside,src)
 
+/obj/item/storage/box/deathimp
+	name = "boxed death implant kit"
+	desc = "For knowing when someone has died."
+	illustration = "implant"
+
+/obj/item/storage/box/deathimp/PopulateContents()
+	var/static/items_inside = list(
+		/obj/item/implantcase/deathalarm = 5,
+		/obj/item/implanter = 1,
+		/obj/item/implantpad = 1)
+	generate_items_inside(items_inside,src)
+
 /obj/item/storage/box/chemimp
 	name = "boxed chemical implant kit"
 	desc = "Box of stuff used to implant chemicals."

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1759,6 +1759,15 @@
 					/obj/item/vending_refill/wallmed,
 					/obj/item/vending_refill/wallhypo)
 	crate_name = "medical vending crate"
+	crate_type = /obj/structure/closet/crate/secure/medical
+	
+/datum/supply_pack/medical/deathimp
+	name = "Death Alarm Implants Crate"
+	desc = "Contains a box with five death alarm implants. Requires CMO access to open."
+	cost = 8000
+	access = ACCESS_CMO
+	contains = list(/obj/item/storage/box/deathimp)
+	crate_name = "death alarm implant crate"
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Science /////////////////////////////////////////
@@ -1858,7 +1867,6 @@
 	cost = 750
 	contains = list(/obj/item/vending_refill/wallgene)
 	crate_name = "Genetics Crate"
-
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////////////// Service //////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1759,8 +1759,7 @@
 					/obj/item/vending_refill/wallmed,
 					/obj/item/vending_refill/wallhypo)
 	crate_name = "medical vending crate"
-	crate_type = /obj/structure/closet/crate/secure/medical
-	
+
 /datum/supply_pack/medical/deathimp
 	name = "Death Alarm Implants Crate"
 	desc = "Contains a box with five death alarm implants. Requires CMO access to open."
@@ -1768,7 +1767,8 @@
 	access = ACCESS_CMO
 	contains = list(/obj/item/storage/box/deathimp)
 	crate_name = "death alarm implant crate"
-
+	crate_type = /obj/structure/closet/crate/secure/medical
+	
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////// Science /////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -1303,6 +1303,7 @@
 #include "code\game\objects\items\implants\implant_bb.dm"
 #include "code\game\objects\items\implants\implant_chem.dm"
 #include "code\game\objects\items\implants\implant_clown.dm"
+#include "code\game\objects\items\implants\implant_deathalarm.dm"
 #include "code\game\objects\items\implants\implant_exile.dm"
 #include "code\game\objects\items\implants\implant_explosive.dm"
 #include "code\game\objects\items\implants\implant_freedom.dm"


### PR DESCRIPTION
# Document the changes in your pull request
A crate containing 5 death alarm implants are available to be purchased at cargo under the medical section for 8,000 credits. It requires CMO access to open.

Death alarms:
- Trigger when you die or hit with an EMP of any severity.
- On trigger, tries to broadcasts your name and location onto the Medical channel.
- EMPs have a 50% chance to cause the location to be randomized to a tracking/teleport beacon instead when triggered this way.
- Disappears when triggered (one-time use).

Example when Moja dies in Cargo:
![image](https://github.com/yogstation13/Yogstation/assets/30399783/25c2e865-68e9-46c7-b55b-a8ddfc28b306)

# Why is this good for the game?
Gives cargo something spend their money on. Gives a reason for medical to use NT IRN and use medical department budget. Gives people comfort knowing that they won't be completely forgotten in the middle of the round if they suddenly die or disappear. Promotes kidnapping instead of instantly killing people who use this implant.

# Testing
Purchased the crate: it starts locked and only (un)locks to CMO access. 
Killing Moja with an energy axewhile they have a death implant properly sends a message to Medical.

# Changelog
:cl:  
rscadd: Death alarm implants. They broadcast your location when you die or get EMP'd.
rscadd: A crate containing 5 death alarm implants can be purchased under the medical section. It costs 8,000 credits and requires CMO access.
/:cl:
