### PR TITLE
Adds a preference to the cybernetic organ quirk

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -315,33 +315,32 @@
 	icon = "building-ngo"
 	value = 4
 	var/slot_string = "organ"
-	var/list/organ_list = list(ORGAN_SLOT_LUNGS, ORGAN_SLOT_HEART, ORGAN_SLOT_LIVER)
+	var/list/organ_list = list(
+		ORGAN_SLOT_LUNGS = /obj/item/organ/lungs/cybernetic/upgraded, 
+		ORGAN_SLOT_HEART = /obj/item/organ/heart/cybernetic/upgraded, 
+		ORGAN_SLOT_LIVER = /obj/item/organ/liver/cybernetic/upgraded,
+	)
 	medical_record_text = "During physical examination, patient was found to have an upgraded cybernetic organ."
 
 /datum/quirk/cyberorgan/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/list/temp = organ_list.Copy() //pretty sure this is global so i dont want to bugger with it :)
-	if(isjellyperson(H))
+	if(HAS_TRAIT_FROM(H, TRAIT_TOXINLOVER, SPECIES_TRAIT))
 		temp -= ORGAN_SLOT_LIVER
-	var/organ_slot = pick(temp)
-	var/obj/item/organ/old_part = H.getorganslot(organ_slot)
-	var/obj/item/organ/prosthetic
-	switch(organ_slot)
-		if(ORGAN_SLOT_LUNGS)
-			prosthetic = new/obj/item/organ/lungs/cybernetic/upgraded(quirk_holder)
-			slot_string = "lungs"
-		if(ORGAN_SLOT_HEART)
-			prosthetic = new/obj/item/organ/heart/cybernetic/upgraded(quirk_holder)
-			slot_string = "heart"
-		if(ORGAN_SLOT_LIVER)
-			prosthetic = new/obj/item/organ/liver/cybernetic/upgraded(quirk_holder)
-			slot_string = "liver"
+	if(HAS_TRAIT_FROM(H, TRAIT_NOBREATH, SPECIES_TRAIT))
+		temp -= ORGAN_SLOT_LUNGS
+	if(NOBLOOD in H.dna?.species.species_traits)
+		temp -= ORGAN_SLOT_HEART
+	var/organ_type = organ_list[pick(temp)]
+	var/obj/item/organ/prosthetic = new organ_type(quirk_holder)
+	var/obj/item/organ/old_part = H.getorganslot(prosthetic.slot)
+	slot_string = prosthetic.slot
 	prosthetic.Insert(H)
 	qdel(old_part)
 	H.regenerate_icons()
 
 /datum/quirk/cyberorgan/post_add()
-	to_chat(quirk_holder, "<span class='boldannounce'>Your [slot_string] has been replaced with an upgraded cybernetic variant.</span>")
+	to_chat(quirk_holder, span_boldannounce("Your [slot_string] has been replaced with an upgraded cybernetic variant."))
 
 /datum/quirk/cyberorgan/check_quirk(datum/preferences/prefs)
 	var/species_type = prefs.read_preference(/datum/preference/choiced/species)
@@ -349,6 +348,45 @@
 	if(species_type == /datum/species/ipc) // IPCs are already cybernetic
 		return "You already have cybernetic organs!"
 	return FALSE
+
+/datum/quirk/cyberorgan/lungs
+	name = "Cybernetic Organ (Lungs)"
+	desc = "Due to a past incident you lost function of your lungs, but now have fancy upgraded cybernetic lungs!"
+	organ_list = list(ORGAN_SLOT_LUNGS = /obj/item/organ/lungs/cybernetic/upgraded)
+	medical_record_text = "During physical examination, patient was found to have upgraded cybernetic lungs."
+
+/datum/quirk/cyberorgan/lungs/check_quirk(datum/preferences/prefs)
+	var/species_type = prefs.read_preference(/datum/preference/choiced/species)
+	var/datum/species/species = new species_type
+	if(TRAIT_NOBREATH in species.inherent_traits) // species with TRAIT_NOBREATH don't have lungs
+		return "You don't have lungs!"
+	return ..()
+
+/datum/quirk/cyberorgan/heart
+	name = "Cybernetic Organ (Heart)"
+	desc = "Due to a past incident you lost function of your heart, but now have a fancy upgraded cybernetic heart!"
+	organ_list = list(ORGAN_SLOT_HEART = /obj/item/organ/heart/cybernetic/upgraded)
+	medical_record_text = "During physical examination, patient was found to have an upgraded cybernetic heart."
+
+/datum/quirk/cyberorgan/heart/check_quirk(datum/preferences/prefs)
+	var/species_type = prefs.read_preference(/datum/preference/choiced/species)
+	var/datum/species/species = new species_type
+	if(NOBLOOD in species.species_traits) // species with NOBLOOD don't have a heart
+		return "You don't have a heart!"
+	return ..()
+
+/datum/quirk/cyberorgan/liver
+	name = "Cybernetic Organ (Liver)"
+	desc = "Due to a past incident you lost function of your liver, but now have a fancy upgraded cybernetic liver!"
+	organ_list = list(ORGAN_SLOT_LIVER = /obj/item/organ/liver/cybernetic/upgraded)
+	medical_record_text = "During physical examination, patient was found to have an upgraded cybernetic liver."
+
+/datum/quirk/cyberorgan/liver/check_quirk(datum/preferences/prefs)
+	var/species_type = prefs.read_preference(/datum/preference/choiced/species)
+	var/datum/species/species = new species_type
+	if(TRAIT_TOXINLOVER in species.inherent_traits) // species with TRAIT_TOXINLOVER slowly die when given upgraded livers
+		return "You aren't compatible with upgraded livers!"
+	return ..()
 
 /datum/quirk/telomeres_long
 	name = "Long Telomeres"

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -349,6 +349,7 @@
 		return "You already have cybernetic organs!"
 	
 	var/datum/species/species = new species_type
+	var/list/temp = organ_list.Copy()
 	if(TRAIT_TOXINLOVER in species.inherent_traits)
 		temp -= ORGAN_SLOT_LIVER
 	if(TRAIT_NOBREATH in species.inherent_traits)

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -310,10 +310,10 @@
 	medical_record_text = "Patient is unusually speedy when creating crafts."
 
 /datum/quirk/cyberorgan //random upgraded cybernetic organ
-	name = "Cybernetic Organ"
-	desc = "Due to a past incident you lost function of one of your organs, but now have a fancy upgraded cybernetic organ!"
+	name = "Upgraded Cybernetic Organ"
+	desc = "Due to a past incident you lost function of one of your organs, but now have a random upgraded cybernetic organ!"
 	icon = "building-ngo"
-	value = 4
+	value = 3
 	var/slot_string = "organ"
 	var/list/organ_list = list(
 		ORGAN_SLOT_LUNGS = /obj/item/organ/lungs/cybernetic/upgraded, 
@@ -347,13 +347,25 @@
 
 	if(species_type == /datum/species/ipc) // IPCs are already cybernetic
 		return "You already have cybernetic organs!"
+	
+	var/datum/species/species = new species_type
+	if(TRAIT_TOXINLOVER in species.inherent_traits)
+		temp -= ORGAN_SLOT_LIVER
+	if(TRAIT_NOBREATH in species.inherent_traits)
+		temp -= ORGAN_SLOT_LUNGS
+	if(NOBLOOD in species.species_traits)
+		temp -= ORGAN_SLOT_HEART
+	if(temp.len <= 0)
+		return "You have no organs to replace!"
+
 	return FALSE
 
 /datum/quirk/cyberorgan/lungs
 	name = "Cybernetic Organ (Lungs)"
-	desc = "Due to a past incident you lost function of your lungs, but now have fancy upgraded cybernetic lungs!"
-	organ_list = list(ORGAN_SLOT_LUNGS = /obj/item/organ/lungs/cybernetic/upgraded)
+	desc = "Due to a past incident you lost function of your lungs, but now have cybernetic lungs!"
+	organ_list = list(ORGAN_SLOT_LUNGS = /obj/item/organ/lungs/cybernetic)
 	medical_record_text = "During physical examination, patient was found to have upgraded cybernetic lungs."
+	value = 0
 
 /datum/quirk/cyberorgan/lungs/check_quirk(datum/preferences/prefs)
 	var/species_type = prefs.read_preference(/datum/preference/choiced/species)
@@ -364,9 +376,10 @@
 
 /datum/quirk/cyberorgan/heart
 	name = "Cybernetic Organ (Heart)"
-	desc = "Due to a past incident you lost function of your heart, but now have a fancy upgraded cybernetic heart!"
-	organ_list = list(ORGAN_SLOT_HEART = /obj/item/organ/heart/cybernetic/upgraded)
-	medical_record_text = "During physical examination, patient was found to have an upgraded cybernetic heart."
+	desc = "Due to a past incident you lost function of your heart, but now have a cybernetic heart!"
+	organ_list = list(ORGAN_SLOT_HEART = /obj/item/organ/heart/cybernetic)
+	medical_record_text = "During physical examination, patient was found to have a cybernetic heart."
+	value = 0
 
 /datum/quirk/cyberorgan/heart/check_quirk(datum/preferences/prefs)
 	var/species_type = prefs.read_preference(/datum/preference/choiced/species)
@@ -377,9 +390,10 @@
 
 /datum/quirk/cyberorgan/liver
 	name = "Cybernetic Organ (Liver)"
-	desc = "Due to a past incident you lost function of your liver, but now have a fancy upgraded cybernetic liver!"
-	organ_list = list(ORGAN_SLOT_LIVER = /obj/item/organ/liver/cybernetic/upgraded)
-	medical_record_text = "During physical examination, patient was found to have an upgraded cybernetic liver."
+	desc = "Due to a past incident you lost function of your liver, but now have a cybernetic liver!"
+	organ_list = list(ORGAN_SLOT_LIVER = /obj/item/organ/liver/cybernetic)
+	medical_record_text = "During physical examination, patient was found to have a cybernetic liver."
+	value = 0
 
 /datum/quirk/cyberorgan/liver/check_quirk(datum/preferences/prefs)
 	var/species_type = prefs.read_preference(/datum/preference/choiced/species)


### PR DESCRIPTION
# Document the changes in your pull request

Cybernetic organ quirk can now choose which organ they get, the same way the prosthetic limb quirk works. The choiced versions give standard non-upgraded cybernetics and are neutral (0 points).  Also refactors it to be less bad.

# Why is this good for the game?

Improves character customization, allows you have a character that has a specific cybernetic organ.

# Testing

![image](https://github.com/yogstation13/Yogstation/assets/93578146/49375687-c6f8-463e-a25e-353a6e88a1d6)
![image](https://github.com/yogstation13/Yogstation/assets/93578146/eb2ed9d3-1b93-4911-a9cf-353eb220c54f)

# Wiki Documentation

Add the above quirks to the list of quirks.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: added preference for non-upgraded cybernetic organs as quirk options
tweak: random cybernetic organ quirk costs 3 instead of 4
/:cl:
