### PR TITLE
Preternis chemical purge rework

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -177,8 +177,8 @@
 				addtimer(VARSET_CALLBACK(src, eating_msg_cooldown, FALSE), 2 MINUTES)
 				to_chat(H,span_info("NOTICE: Digestive subroutines are inefficient. Seek sustenance via power-cell C.O.N.S.U.M.E. technology induction."))
 
-	if(chem.current_cycle >= 20)
-		H.reagents.del_reagent(chem.type)
+	if(chem.volume >= 1) // remove 10% of existing reagent, if the current volume is over 1 unit
+		H.reagents.remove_reagent(chem.type, round(chem.volume / 10, 0.1))
 
 	return FALSE
 

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -177,8 +177,8 @@
 				addtimer(VARSET_CALLBACK(src, eating_msg_cooldown, FALSE), 2 MINUTES)
 				to_chat(H,span_info("NOTICE: Digestive subroutines are inefficient. Seek sustenance via power-cell C.O.N.S.U.M.E. technology induction."))
 
-	if(chem.volume >= 1) // remove 10% of existing reagent, if the current volume is over 1 unit
-		H.reagents.remove_reagent(chem.type, round(chem.volume / 10, 0.1))
+	// remove 4% of existing reagent, minimum of 0.1 units at a time
+	H.reagents.remove_reagent(chem.type, max(round(chem.volume / 25, 0.1), 0.1))
 
 	return FALSE
 


### PR DESCRIPTION
# Document the changes in your pull request

Preternis now purge 4% of the volume of existing chems each tick instead of deleting everything that has been processing for 20 ticks.

This means preternis are no longer functionally immune to morphine and certain other chemicals just because their effects only happen after a certain number of ticks. Now it's possible to make them experience those effects by giving them too much for them to purge it in time.

# Why is this good for the game?

Makes preternis no longer immune to certain chems they probably weren't supposed to be immune to.

# Testing
<!-- Describe what testing you did with this PR. Try to be thorough, especially if this is a larger project. -->
Asleep after drinking a bottle of morphine
![image](https://github.com/yogstation13/Yogstation/assets/93578146/fb5b2335-d0d4-41d1-8a33-7069fbe30dd0)

# Wiki Documentation
The wiki page for preternis doesn't even mention the chemical purge, so there should probably be a mention of it in the strengths and weaknesses section.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: preternis now purge 4% of internal chemicals every tick, instead of purging everything after 20 ticks
tweak: preternis are no longer immune to the effects of morphine and a few other chemicals
/:cl:
