### PR TITLE
Station side legion core soft-rework

### DIFF
--- a/code/datums/status_effects/buffs/buffs.dm
+++ b/code/datums/status_effects/buffs/buffs.dm
@@ -546,7 +546,7 @@
 /datum/status_effect/regenerative_core/refresh(effect, ...) //apply the buffs and heals again when it's refreshed
 	var/efficiency = 1
 	if(!mining_check()) //only get weaker station side
-		debuffCounter += 25
+		debuffCounter += 30
 		efficiency *= ((100 - debuffCounter)/100) //multiplies by anywhere from 1 to -infinity
 	if(efficiency < 1)//if they've userused them to the point of ineffectivity
 		to_chat(owner, span_danger("The power infused into your body struggles to knit you back together, weakened by it's distance from the necropolis!"))

--- a/code/datums/status_effects/buffs/buffs.dm
+++ b/code/datums/status_effects/buffs/buffs.dm
@@ -547,14 +547,19 @@
 	var/efficiency = 1
 	if(!mining_check()) //only get weaker station side
 		debuffCounter += 30
-		efficiency *= ((100 - debuffCounter)/100) //multiplies by anywhere from 1 to -infinity
-	if(efficiency < 1)//if they've userused them to the point of ineffectivity
+		efficiency *= ((100 - debuffCounter)/100) //multiplies by anywhere from 0.7 to -infinity
 		to_chat(owner, span_danger("The power infused into your body struggles to knit you back together, weakened by it's distance from the necropolis!"))
+
 	owner.adjustBruteLoss(healing * efficiency, TRUE, FALSE, BODYPART_ANY)
 	owner.adjustFireLoss(healing * efficiency, TRUE, FALSE, BODYPART_ANY)
-	if(efficiency > 0.5) //if they're down below half efficiency, stop removing CC and fixing body temp
+	if(debuffCounter > 50) //if they're down below half efficiency, stop removing CC and fixing body temp
 		owner.remove_CC()
 		owner.bodytemperature = BODYTEMP_NORMAL
+	else
+		owner.add_movespeed_modifier(type, TRUE, 101, multiplicative_slowdown = 1, blacklisted_movetypes=(FLOATING))
+		if(textNotif)
+			textNotif = FALSE
+			to_chat(owner, span_danger("Your body feels sluggish as the strange force holding it together yearns for energy from the necropolis."))
 	. = ..()
 
 /datum/status_effect/regenerative_core/on_remove()

--- a/code/datums/status_effects/buffs/buffs.dm
+++ b/code/datums/status_effects/buffs/buffs.dm
@@ -532,7 +532,7 @@
 	if(!mining_check())
 		debuffCounter += 5 * delta_time
 	if(debuffCounter > 50 && !mining_check())
-		owner.add_movespeed_modifier(type, TRUE, 101, multiplicate_slowdown = 1, blacklisted_movetypes=(FLOATING))
+		owner.add_movespeed_modifier(type, TRUE, 101, multiplicative_slowdown = 1, blacklisted_movetypes=(FLOATING))
 		if(textNotif)
 			textNotif = FALSE
 			to_chat(owner, span_danger("Your body feels sluggish as the strange force holding it together yearns for energy from the necropolis."))
@@ -546,15 +546,17 @@
 
 /datum/status_effect/regenerative_core/refresh(effect, ...) //apply the buffs and heals again when it's refreshed
 	. = ..()
-	debuffCounter += 10
 	var/efficiency = 1
 	if(!mining_check()) //only get weaker station side
-		efficiency *= ((maxDebuff - debuffCounter)/maxDebuff) //multiplies by 0 - 1
+		debuffCounter += 25
+		efficiency *= ((maxDebuff - debuffCounter)/maxDebuff) //multiplies by anywhere from 1 to -infinity
 	owner.adjustBruteLoss(healing * efficiency, TRUE, FALSE, BODYPART_ANY)
 	owner.adjustFireLoss(healing * efficiency, TRUE, FALSE, BODYPART_ANY)
 	if(efficiency > 0.5) //if they're down below half efficiency, stop removing CC and fixing body temp
 		owner.remove_CC()
 		owner.bodytemperature = BODYTEMP_NORMAL
+	if(efficiency < 0)//if they've REALLY overused them, give them some sort of text to know why they're taking damage
+		to_chat(owner, span_userdanger("The power infused into your body starts to cannibalize it for more energy!"))
 
 /datum/status_effect/regenerative_core/on_remove()
 	REMOVE_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, id)

--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -76,7 +76,6 @@
 	. = ..()
 	if(proximity_flag && ishuman(target))
 		var/mob/living/carbon/human/H = target
-		var/turf/user_turf = get_turf(user)
 		if(inert)
 			to_chat(user, span_notice("[src] has decayed and can no longer be used to heal."))
 			return
@@ -85,29 +84,10 @@
 				to_chat(user, span_notice("[src] are useless on the dead."))
 				return
 			if(H != user)
-			
-				if(!is_station_level(user_turf.z) || is_reserved_level(user_turf.z))
-					H.visible_message(span_notice("[user] crushes [src] against [H]'s body, causing black tendrils to encover and reinforce [H.p_them()]!"))
-				else
-					H.visible_message(span_notice("[user] holds [src] against [H]'s body, coaxing the regenerating tendrils from [src]..."))
-					balloon_alert(user, "Applying core...")
-					if(!do_after(user, 2 SECONDS, H)) //come on teamwork bonus?
-						to_chat(user, span_warning("You are interrupted, causing [src]'s tendrils to retreat back into its form."))
-						return
-					balloon_alert(user, "Core applied!")
-					H.visible_message(span_notice("[src] explodes into a flurry of tendrils, rapidly covering and reinforcing [H]'s body."))
+				H.visible_message(span_notice("[user] crushes [src] against [H]'s body, causing black tendrils to encover and reinforce [H.p_them()]!"))
 				SSblackbox.record_feedback("nested tally", "hivelord_core", 1, list("[type]", "used", "other"))
 			else
-				if(!is_station_level(user_turf.z) || is_reserved_level(user_turf.z))
-					to_chat(user, span_notice("You crush [src] within your hand. Disgusting tendrils spread across your body, hold you together and allow you to keep moving, but for how long?"))
-				else
-					to_chat(user, span_notice("You hold [src] against your body, coaxing the regenerating tendrils from [src]..."))
-					balloon_alert(user, "Applying core...")
-					if(!do_after(user, 4 SECONDS, src))
-						to_chat(user, span_warning("You are interrupted, causing [src]'s tendrils to retreat back into its form."))
-						return
-					balloon_alert(user, "Core applied!")
-					to_chat(user, span_notice("[src] explodes into a flurry of tendrils, rapidly spreading across your body. They will hold you together and allow you to keep moving, but for how long?"))
+				to_chat(user, span_notice("You crush [src] within your hand. Disgusting tendrils spread across your body, hold you together and allow you to keep moving, but for how long?"))
 				SSblackbox.record_feedback("nested tally", "hivelord_core", 1, list("[type]", "used", "self"))
 			H.apply_status_effect(STATUS_EFFECT_REGENERATIVE_CORE)
 			SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "core", /datum/mood_event/healsbadman) //Now THIS is a miner buff (fixed - nerf)


### PR DESCRIPTION
# Why is this good for the game?
Adding a delay to use, while decent, didn't weaken implanting at all, and adding a second check for implant abuse prevention seems hacky
instead i'm making the effect itself weaker when used outside of a mining level, and repeated use makes it worse, to the point of being useless

Nuke their abuse station side, 
first one will heal decently reduced amounts
second onward won't cleanse CC or reset bodytemp and heal well under half the original amount
third onward won't do anything

also applies a slowdown, either after using two, or using one and waiting a bit

NOTE: THIS DOESN'T AFFECT MINING LEVEL USE AT ALL

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/d597beb0-0d39-404a-a348-ce52b733c250)


:cl:  
tweak: Legion cores no longer take extra time to use on the station
tweak: Legion cores now progressively heal less (and eventually damage) as they are used station side
tweak: Overusing Legion cores station side now applies a slowdown during the effect
/:cl:
