### PR TITLE
Too Many Cooks: Reduces amount of cook job slots to 1

### DIFF
--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -4,7 +4,7 @@
 	orbit_icon = "utensils"
 	department_head = list("Head of Personnel")
 	faction = "Station"
-	total_positions = 2
+	total_positions = 1
 	spawn_positions = 1
 	supervisors = "the head of personnel"
 	selection_color = "#bbe291"

--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -16,7 +16,7 @@ Cargo Technician=2,1
 Shaft Miner=3,3
 
 Bartender=1,1
-Cook=2,1
+Cook=1,1
 Botanist=3,2
 Janitor=2,1
 


### PR DESCRIPTION
# Document the changes in your pull request

does what it says in the title, was 2 before.

# Why is this good for the game?
This was spurred on by a post on r/ss13 (I know im a heretic for using the reddit)

Quoting from that post "When I'm in my kitchen I want to be alone. I want to chose what I want to cook, do fun gimmicks. I don't like when there is a lizard butchering a monkey in the middle of the kitchen to make some fried livers. I don't like when the other cook takes the already limited ingredients. And please do not throw the food on the floor..."

This sums up pretty much how I feel about playing cook - there is no need to have 2.  One cook is more the capable of supplying all the food the station needs.  This is just my take though, putting it out there for yoggites to decide what they want.

# Changelog

:cl:  cark
tweak: reduced total cook job slots to 1
/:cl:
