### PR TITLE
Boxstation its time to go. You won't be missed 🖖 

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -13,8 +13,7 @@ Format:
 	votable (is this map votable)
 
 map yogstation
-	voteweight 0.7
-	votable
+	disabled
 endmap
 
 map icemeta


### PR DESCRIPTION
# Document the changes in your pull request

I carry this torch for @LoliconSlayer . For too long, Boxstation has been the main staple. People like it for its familiarity to other servers, the maints, the locations all of it. But nay, no more. We need to move on, we are separating ourselves from the dastardly servers that we take our code from. It will be sad, it will feel like you're losing a part of yourself. But this needs to be done so we can finally be MRP

# Why is this good for the game?

Encourages Players to try new things, get out of their comfort zone, be someone not some boring copycat ripoff of john wick going around the same map day in and day out. It has to be cut loose.

# Wiki Documentation

A memorial page should be dedicated to Boxstation to at least give it honour for the time it served us.

# Changelog

:cl:  

rscdel: Removed the blight and mangey appendage that is boxstation, long live the other stations

/:cl:
