### PR TITLE
auxiliary armory - security now has access

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -12134,7 +12134,7 @@
 "dcK" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Armoury";
-	req_access_txt = "3"
+	req_access_txt = "1"
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -61684,7 +61684,7 @@
 "umX" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Armory";
-	req_access_txt = "3";
+	req_access_txt = "1";
 	security_level = 1
 	},
 /obj/machinery/door/firedoor/border_only{


### PR DESCRIPTION
# Document the changes in your pull request

Security now gets access to the auxiliary armory from the actual armory

![image](https://github.com/yogstation13/Yogstation/assets/28408322/575b04c3-d5fe-437b-8d20-a5b3e222376a)

Gax and Donut do not have an auxiliary armory area, so changes are not needed there

# Why is this good for the game?
Some important things are trapped in the 'armory' like the firing pins, barrier grenades, etc that security cannot access even when armory is open

This sets the door between the armory and auxiliary armory to be security access, so that it can be accessed freely when the armory is available to security and no holds are barred

# Changelog

:cl:   
tweak: The door between the armory and the auxiliary armory are now default security access
/:cl:
