### PR TITLE
Examining a human mob as an observer displays "Quirks", not "Traits"

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -479,7 +479,7 @@
 							"<a href='?src=[REF(src)];hud=s;view_comment=1'>\[View comment log\]</a>",
 							"<a href='?src=[REF(src)];hud=s;add_comment=1'>\[Add comment\]</a>"), "")
 	else if(isobserver(user) && traitstring)
-		. += "<span class='info'><b>Traits:</b> [traitstring]</span><br>"
+		. += "<span class='info'><b>Quirks:</b> [traitstring]</span><br>"
 	. += "</span>"
 
 /mob/living/proc/status_effect_examines(pronoun_replacement) //You can include this in any mob's examine() to show the examine texts of status effects!


### PR DESCRIPTION
https://github.com/tgstation/tgstation/pull/79853

# Document the changes in your pull request

Makes it so when observers examine someone, it displays "quirks" instead of "traits".

# Why is this good for the game?
what the original pr says, Taking care of a long-lasting oversight.

# Testing
yes

:cl:  Ghommie
spellcheck: Examining a human mob as an observer displays "Quirks", not "Traits"
/:cl: