### PR TITLE
Prevents catching the syndicate fedora when it's blades are extended

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -129,6 +129,7 @@
 		attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut", "tipped")
 		hitsound = 'sound/weapons/bladeslice.ogg'
 		hattable = FALSE //So you don't accidentally throw it onto somebody's head instead of decapitating them
+		item_flags = UNCATCHABLE //so it isn't just immediately caught
 	else
 		force = 0
 		throwforce = 0
@@ -138,6 +139,7 @@
 		attack_verb = list("poked", "tipped")
 		hitsound = 'sound/weapons/genhit.ogg'
 		hattable = TRUE
+		item_flags = NONE
 
 /obj/item/clothing/head/det_hat/evil/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
 	if(fedora_man && hit_atom == fedora_man)


### PR DESCRIPTION
Fun fact, I fixed a bug that caused weird on_hit reactions, that also fixed the bug that prevented catching
so i've given it uncatchable so it isn't immediately countered by a single person using throw_mode

:cl:  
tweak: Syndicate fedora can no longer be caught using throw mode
/:cl:
