### PR TITLE
Adds a new lavaland lava type that you can't replace with shelter, and surrounds lavaland syndie base with it.

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -3,7 +3,7 @@
 /turf/template_noop,
 /area/template_noop)
 "ab" = (
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/lava/smooth/lava_land_surface/no_shelter,
 /area/lavaland/surface/outdoors)
 "ac" = (
 /obj/structure/disposaloutlet{
@@ -448,7 +448,7 @@
 /area/ruin/powered/syndicate_lava_base/dormitories)
 "dS" = (
 /obj/structure/lattice/catwalk,
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/lava/smooth/lava_land_surface/no_shelter,
 /area/lavaland/surface/outdoors)
 "dT" = (
 /obj/effect/turf_decal/siding/blue/end{
@@ -3599,7 +3599,7 @@
 	name = "Syndicate Lavaland Base: Cargo Bay Dock";
 	width = 11
 	},
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/lava/smooth/lava_land_surface/no_shelter,
 /area/lavaland/surface/outdoors)
 "ne" = (
 /turf/open/floor/engine/o2,
@@ -4366,7 +4366,7 @@
 	name = "Syndicate Lavaland Base: Arivals Dock";
 	width = 13
 	},
-/turf/open/lava/smooth/lava_land_surface,
+/turf/open/lava/smooth/lava_land_surface/no_shelter,
 /area/lavaland/surface/outdoors)
 "tu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{

--- a/code/game/turfs/simulated/lava.dm
+++ b/code/game/turfs/simulated/lava.dm
@@ -172,5 +172,7 @@
 	planetary_atmos = TRUE
 	baseturfs = /turf/open/lava/smooth/lava_land_surface
 
+/turf/open/lava/smooth/lava_land_surface/no_shelter //snowflake version that survival pods won't spawn in
+
 /turf/open/lava/smooth/airless
 	initial_gas_mix = AIRLESS_ATMOS

--- a/code/modules/mining/shelters.dm
+++ b/code/modules/mining/shelters.dm
@@ -8,7 +8,7 @@
 
 /datum/map_template/shelter/New()
 	. = ..()
-	blacklisted_turfs = typecacheof(/turf/closed)
+	blacklisted_turfs = typecacheof(/turf/closed, /turf/open/lava/smooth/lava_land_surface/no_shelter)
 	whitelisted_turfs = list()
 	banned_areas = typecacheof(/area/shuttle)
 	banned_objects = list()


### PR DESCRIPTION
# Document the changes in your pull request

In the endless pursuit of making it so miners don't get free antag loot:

# Why is this good for the game?
Antags raiding the base get to be their antag + free traitor loot


# Testing
<!-- Describe what testing you did with this PR. Try to be thorough, especially if this is a larger project. -->

# Changelog

:cl:  
rscadd: Adds a new lavaland lava type that you can't replace with shelter
tweak: lavaland syndie base is surrounded by no-shelter lavaland lava
/:cl:
