### PR TITLE
Only Delta alert gets red lights

### DIFF
--- a/code/modules/security_levels/security_levels.dm
+++ b/code/modules/security_levels/security_levels.dm
@@ -104,7 +104,7 @@ GLOBAL_VAR_INIT(security_level, SEC_LEVEL_GREEN)
 					D.visible_message(span_notice("[D] whirrs as it automatically lifts access requirements!"))
 					playsound(D, 'sound/machines/boltsup.ogg', 50, TRUE)
 
-		if(level >= SEC_LEVEL_GAMMA)
+		if(level == SEC_LEVEL_DELTA)
 			change_areas_lights_alarm()
 		else
 			change_areas_lights_alarm(FALSE)


### PR DESCRIPTION
# Why is this good for the game?
In theory it was a good idea, in practice, everything being red during an entire gamemode is terrible for gameplay (see virtual boy)
it's made worse when one of the gamemodes that's affected is nukies, where all the antags are already red

Don't even get me started on colourblind people

Also it ruins the ambience of epsilon alert which is admin only, if they want everything to be red, they can set it to be red

:cl:  
tweak: Only Delta alert gets red lights
/:cl:
