### PR TITLE
Gives more skeleton access to the paramedic type jobs

### DIFF
--- a/yogstation/code/modules/jobs/job_types/brig_physician.dm
+++ b/yogstation/code/modules/jobs/job_types/brig_physician.dm
@@ -23,7 +23,7 @@
 		/datum/job_department/security,
 	)
 
-	added_access = list(ACCESS_SURGERY)
+	added_access = list(ACCESS_SURGERY, ACCESS_CLONING, ACCESS_EXTERNAL_AIRLOCKS)
 	base_access = list(ACCESS_MEDICAL, ACCESS_MORGUE, ACCESS_BRIG, ACCESS_SEC_DOORS, ACCESS_COURT, ACCESS_MAINT_TUNNELS, ACCESS_MECH_MEDICAL, ACCESS_BRIG_PHYS)
 	paycheck = PAYCHECK_MEDIUM
 	paycheck_department = ACCOUNT_MED

--- a/yogstation/code/modules/jobs/job_types/mining_medic.dm
+++ b/yogstation/code/modules/jobs/job_types/mining_medic.dm
@@ -24,7 +24,8 @@
 		/datum/job_department/cargo,
 	)
 
-	added_access = list(ACCESS_SURGERY, ACCESS_CARGO)
+	//if it's skeleton there's probably no paramedic to save spaced miners that jaunted away from danger
+	added_access = list(ACCESS_SURGERY, ACCESS_CARGO, ACCESS_CLONING, ACCESS_MAINT_TUNNELS, ACCESS_EXTERNAL_AIRLOCKS)
 	base_access = list(ACCESS_MEDICAL, ACCESS_MORGUE, ACCESS_MINING, ACCESS_MINING_STATION, ACCESS_MAILSORTING, ACCESS_MINERAL_STOREROOM, ACCESS_MECH_MINING, ACCESS_MECH_MEDICAL)
 	paycheck = PAYCHECK_HARD
 	paycheck_department = ACCOUNT_MED

--- a/yogstation/code/modules/jobs/job_types/paramedic.dm
+++ b/yogstation/code/modules/jobs/job_types/paramedic.dm
@@ -12,7 +12,7 @@
 
 	outfit = /datum/outfit/job/paramedic
 
-	added_access = list(ACCESS_CLONING)
+	added_access = list(ACCESS_SURGERY, ACCESS_CLONING)
 	base_access = list(ACCESS_MEDICAL, ACCESS_MORGUE, ACCESS_MAINT_TUNNELS, ACCESS_EXTERNAL_AIRLOCKS, ACCESS_PARAMEDIC, ACCESS_MECH_MEDICAL)
 	paycheck = PAYCHECK_MEDIUM
 	paycheck_department = ACCOUNT_MED


### PR DESCRIPTION
# Why is this good for the game?
Any time it's skeleton crew, there's a good chance of there being literally only one of the paramedic type jobs
This gives mining medic and brig physician the full capabilities of a paramedic during skeleton crew
This way they're able to retrieve their dead charges from mostly anywhere in the station, that would otherwise be handled by the paramedic that doesn't exist

Also gives paramedic surgery access during skeleton crew because it's not uncommon they're the only medical staff


:cl:  
tweak: Brig physician also gets cloning and airlock access during skeleton crew
tweak: Paramedic also gets surgery access during skeleton crew
tweak: Mining medic also gets cloning, maint, and airlock access during skeleton crew
/:cl:
