### PR TITLE
Ion Storms No Longer Pointless w/ No AI - Affects APCs/Airlocks

### DIFF
--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -136,7 +136,6 @@
 					if(apc.environ)
 						apc.environ = 0
 						log_game("Ion storm disabled environment on APC ([apc.name]) at [COORD(turf)].")
-					apc.environ = 0
 				if(4)
 					if(apc.lighting || apc.equipment || apc.environ)
 						apc.environ = 0

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -1,5 +1,6 @@
 #define ION_RANDOM 0
 #define ION_ANNOUNCE 1
+
 /datum/round_event_control/ion_storm
 	name = "Ion Storm"
 	typepath = /datum/round_event/ion_storm
@@ -7,14 +8,23 @@
 	min_players = 2
 
 /datum/round_event/ion_storm
-	var/addIonLawChance = 100 // chance a new ion law will be added in addition to other ion effects
-	var/replaceLawsetChance = 25 //chance the AI's lawset is completely replaced with something else per config weights
-	var/removeRandomLawChance = 10 //chance the AI has one random supplied or inherent law removed
-	var/removeDontImproveChance = 10 //chance the randomly created law replaces a random law instead of simply being added
-	var/shuffleLawsChance = 10 //chance the AI's laws are shuffled afterwards
+	/// Chance a new ion law will be added in addition to other ion effects.
+	var/addIonLawChance = 100
+	/// Chance the AI's lawset is completely replaced with something else per config weights.
+	var/replaceLawsetChance = 25
+	/// Chance the AI has one random supplied or inherent law removed.
+	var/removeRandomLawChance = 10
+	/// Chance the ion law will replace a random law instead of simply being added.
+	var/removeDontImproveChance = 10
+	/// Chance the AI's laws are shuffled afterwards.
+	var/shuffleLawsChance = 10
+	/// Chance that bots on the station will become emagged.
 	var/botEmagChance = 10
-	var/announceEvent = ION_RANDOM // -1 means don't announce, 0 means have it randomly announce, 1 means
+	/// Should it announce? -1 = No | 0 = Random | 1 = Always.
+	var/announceEvent = ION_RANDOM
+	/// Custom ion law, if not null.
 	var/ionMessage = null
+	/// If announceEvent is 0, what is the chance it is will accounce?
 	var/ionAnnounceChance = 33
 	announceWhen	= 1
 

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -121,6 +121,8 @@
 		for(var/obj/machinery/power/apc/apc in apcs)
 			if(!prob(apcChance))
 				continue
+			if(apc.aidisabled)
+				continue
 			var/turf/turf = get_turf(apc)
 			var/luck = rand(1, 4)
 			switch(luck)


### PR DESCRIPTION
# Document the changes in your pull request
Autodocs some ion storm variables.

Ion storms can mess with airlocks and APCs on-station, if there is no AI.
Airlocks (5% per airlock - 20 airlocks maximum):
- Toggle bolts.
- Toggle emergency access.
- Shock for 30 seconds.
- Toggle safety and speed.

APCs (5% per APC - 10 APCs maximum):
- Turn off lighting.
- Turn off equipment.
- Turn off environment.
- Above of all.

# Why is this good for the game?
Really brings out the word "ion" in ion storms by making it affect things that isn't just the AI and station bots. Makes ion storms more impactful/eventful instead of something to ignore besides saying "state laws" and forgetting it.

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/30399783/4a2ff231-1273-4904-b5b6-973d9bd871ae)

# Wiki Documentation
Add to random events for ion storm that airlocks and APCs are affected by it. Details above.

# Changelog
:cl:  
rscadd: Ion storms can affect up to 20 airlocks and 10 APCs with random effects, only if is no AI.
rscadd: Airlocks affected by ion storms will randomly have one of the following effects: toggle bolts, toggle emergency access, shock temporarily or have their safety & speed toggled.
rscadd: APCs affected by ion storms will have one of three or all of their power channels turned off.
/:cl:
