### PR TITLE
Constructing anchored emitter sets the correct state

### DIFF
--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -52,6 +52,7 @@
 
 /obj/machinery/power/emitter/anchored
 	anchored = TRUE
+	state = EMITTER_WRENCHED
 
 /obj/machinery/power/emitter/ctf
 	name = "Energy Cannon"
@@ -76,6 +77,10 @@
 	ADD_TRAIT(src, TRAIT_EMPPROOF_SELF, "innate_empproof")
 	ADD_TRAIT(src, TRAIT_EMPPROOF_CONTENTS, "innate_empproof")
 	AddComponent(/datum/component/simple_rotation, ROTATION_ALTCLICK | ROTATION_CLOCKWISE | ROTATION_COUNTERCLOCKWISE | ROTATION_VERBS, null, CALLBACK(src, PROC_REF(can_be_rotated)))
+
+/obj/machinery/power/emitter/on_construction()
+	if(anchored && state == EMITTER_UNWRENCHED)
+		state = EMITTER_WRENCHED
 
 /obj/machinery/power/emitter/RefreshParts()
 	var/max_reload = initial(maximum_reload_time) + 20


### PR DESCRIPTION
# Document the changes in your pull request
Upon construction completion, anchored emitters have their state correctly set to wrenched.

# Testing
Construct emitters from wrenched machine frame. State is correct.

# Changelog
:cl:  
bugfix: Constructed anchored emitters are correctly recognized as wrenched; you no longer need to wrench these anchored emitters twice to make it work.
/:cl:
