### PR TITLE
Cyborgs Can AltClick to use Hacked Shock Paddles's Disarm instead of Harm

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -16,13 +16,18 @@
 	actions_types = list(/datum/action/item_action/toggle_paddles)
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
 
-	var/on = FALSE //if the paddles are equipped (1) or on the defib (0)
-	var/safety = TRUE //if you can zap people with the defibs on harm mode
-	var/powered = FALSE //if there's a cell in the defib with enough power for a revive, blocks paddles from reviving otherwise
+	/// If the paddles are equipped (1) or on the defib (0).
+	var/on = FALSE
+	/// If you can zap people with the defibs on disarm/harm mode.
+	var/safety = TRUE
+	/// If there's a cell in the defib with enough power for a revive, blocks paddles from reviving otherwise.
+	var/powered = FALSE
 	var/obj/item/shockpaddles/paddles
 	var/obj/item/stock_parts/cell/high/cell
-	var/combat = FALSE //can we revive through space suits?
-	var/grab_ghost = TRUE // Do we pull the ghost back into their body?
+	/// Can we revive through space suits?
+	var/combat = FALSE
+	/// Do we pull the ghost back into their body?
+	var/grab_ghost = TRUE
 
 /obj/item/defibrillator/get_cell()
 	return cell

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -302,6 +302,8 @@
 	var/combat = FALSE //If it penetrates armor and gives additional functionality
 	var/grab_ghost = TRUE
 	var/tlimit = DEFIB_TIME_LIMIT
+	/// If safety is true, this determines if harm mode will act like disarm (true) or harm (false).
+	var/cyborg_alternative = FALSE
 
 	var/mob/listeningTo
 
@@ -438,6 +440,9 @@
 		return
 
 	if(user.a_intent == INTENT_HARM)
+		if(cyborg_alternative) // Since cyborgs do not have access to other intents (like disarm), this is a workaround for that.
+			do_disarm(M, user)
+			return
 		do_harm(H, user)
 		return
 
@@ -645,6 +650,16 @@
 				playsound(src, 'sound/machines/defib_failed.ogg', 50, 0)
 	busy = FALSE
 	update_appearance(UPDATE_ICON)
+
+/obj/item/shockpaddles/AltClick(mob/user)
+	if(iscyborg(user) && combat == TRUE)
+		cyborg_alternative = !cyborg_alternative
+		if(cyborg_alternative)
+			to_chat(user, "Your shock paddles will now instead shock others on immediate contact.") // Disarm 
+		else
+			to_chat(user, "Your shock paddles will now instead charge up to give a heart attack on defib completion.") // Harm
+		return
+	..()
 
 /obj/item/shockpaddles/cyborg
 	name = "cyborg defibrillator paddles"

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -16,18 +16,13 @@
 	actions_types = list(/datum/action/item_action/toggle_paddles)
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 50)
 
-	/// If the paddles are equipped (1) or on the defib (0).
-	var/on = FALSE
-	/// If you can zap people with the defibs on disarm/harm mode.
-	var/safety = TRUE
-	/// If there's a cell in the defib with enough power for a revive, blocks paddles from reviving otherwise.
-	var/powered = FALSE
+	var/on = FALSE //if the paddles are equipped (1) or on the defib (0)
+	var/safety = TRUE //if you can zap people with the defibs on harm mode
+	var/powered = FALSE //if there's a cell in the defib with enough power for a revive, blocks paddles from reviving otherwise
 	var/obj/item/shockpaddles/paddles
 	var/obj/item/stock_parts/cell/high/cell
-	/// Can we revive through space suits?
-	var/combat = FALSE
-	/// Do we pull the ghost back into their body?
-	var/grab_ghost = TRUE
+	var/combat = FALSE //can we revive through space suits?
+	var/grab_ghost = TRUE // Do we pull the ghost back into their body?
 
 /obj/item/defibrillator/get_cell()
 	return cell

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -655,9 +655,9 @@
 	if(iscyborg(user) && combat == TRUE)
 		cyborg_alternative = !cyborg_alternative
 		if(cyborg_alternative)
-			to_chat(user, "Your shock paddles will now instead shock others on immediate contact.") // Disarm 
+			to_chat(user, span_notice("Your shock paddles will now instead shock others on immediate contact.")) // Disarm 
 		else
-			to_chat(user, "Your shock paddles will now instead charge up to give a heart attack on defib completion.") // Harm
+			to_chat(user, span_notice("Your shock paddles will now instead charge up to give a heart attack on defib completion.")) // Harm
 		return
 	..()
 


### PR DESCRIPTION
# Document the changes in your pull request
Cyborgs can alt-click their shock paddles to toggle whether they will do disarm actions with it instead of harm actions.

# Why is this good for the game?
Oversight. If a coder can forget that drones and borgs don't have access to disarm intent (cough), then it is not a surprise if it was the same here. Probably qualifies as a bugfix, but tweak is likely more accurate.

# Testing
I alt-click. It works. I click Moja. It works.

# Wiki Documentation
There is likely a tip in cyborg's wiki that talks about the defib. Mention this along side it.

# Changelog
:cl:  
tweak: Hacked shock paddles can be alt-clicked by cyborgs to switch between using disarm and harm actions.
/:cl:
