### PR TITLE
Flying Fang's Harmful Disarms Now Respects Pacifism

### DIFF
--- a/code/datums/martial/flying_fang.dm
+++ b/code/datums/martial/flying_fang.dm
@@ -120,7 +120,7 @@
 	add_to_streak("D",D)
 	if(!can_use(A))
 		return
-	if(HAS_TRAIT(A, TRAIT_PACIFISM)) // All disarm attacks are harmful; including this and disarm combos.
+	if(HAS_TRAIT(A, TRAIT_PACIFISM)) // All disarm attacks/combos deal non-stamina damage, yet pacifism is not accounted for in base disarm.
 		to_chat(A, span_warning("You don't want to harm [D]!"))
 		return
 	if(check_streak(A,D))

--- a/code/datums/martial/flying_fang.dm
+++ b/code/datums/martial/flying_fang.dm
@@ -118,10 +118,13 @@
 //headbutt, deals moderate brute and stamina damage with an eye blur, causes poor aim for a few seconds to the target if they have no helmet on
 /datum/martial_art/flyingfang/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	add_to_streak("D",D)
-	if(check_streak(A,D))
-		return TRUE
 	if(!can_use(A))
 		return
+	if(HAS_TRAIT(A, TRAIT_PACIFISM)) // All disarm attacks are harmful; including this and disarm combos.
+		to_chat(A, span_warning("You don't want to harm [D]!"))
+		return
+	if(check_streak(A,D))
+		return TRUE
 	var/obj/item/bodypart/affecting = D.get_bodypart(check_zone(BODY_ZONE_HEAD))
 	var/armor_block = D.run_armor_check(affecting, MELEE)
 	var/disarm_damage = A.get_punchdamagehigh() / 2 	//5 damage


### PR DESCRIPTION
# Document the changes in your pull request
Disarming while using Flying Fang now causes you to do the base disarm instead of headbutt or any of the combos which ALL cause brute damage. This was oversight.

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/30399783/783f2337-c4e2-4ba2-878c-2c7b75632f63)

# Changelog
:cl:  
bugfix: Flying Fang's damage-dealing disarms respects pacifism as intended.
/:cl:
