### PR TITLE
Fixes extinguishers again (real)

### DIFF
--- a/code/game/objects/effects/effect_system/effects_water.dm
+++ b/code/game/objects/effects/effect_system/effects_water.dm
@@ -29,6 +29,10 @@
 	var/starting_loc = loc
 	step_towards(src, target_turf)
 	if(starting_loc == loc)
+		if(reagents) // react again if it got stuck
+			reagents.reaction(loc, transfer_methods)
+			for(var/atom/A in loc)
+				reagents.reaction(A, transfer_methods)
 		qdel(src) // delete itself if it got blocked and can't move
 		return
 	addtimer(CALLBACK(src, PROC_REF(move_particle)), 2)


### PR DESCRIPTION
If an extinguisher particle never has the opportunity to move it never gets to actually react its reagent contents on anything, this fixes that

:cl:  
bugfix: fixed fire extinguishers not working if the particle never moves
/:cl:
