### PR TITLE
[PORT] Demolition Modifier

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -123,7 +123,7 @@
 	if(!attacking_item.force)
 		return
 	
-	var/damage = take_damage(attacking_item.force * attacking_item.demolition_mod, attacking_item.damtype, MELEE, 1)
+	var/damage = take_damage(attacking_item.force * attacking_item.demolition_mod, attacking_item.damtype, MELEE, 1, armour_penetration = attacking_item.armour_penetration)
 	var/damage_verb = "hit"
 	if(attacking_item.demolition_mod > 1 && damage)
 		damage_verb = "pulverized"

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -119,12 +119,20 @@
 /atom/movable/proc/attacked_by()
 	return
 
-/obj/attacked_by(obj/item/I, mob/living/user)
-	if(I.force)
-		visible_message(span_danger("[user] has hit [src] with [I]!"), null, null, COMBAT_MESSAGE_RANGE)
-		//only witnesses close by and the victim see a hit message.
-		log_combat(user, src, "attacked", I)
-	take_damage(I.force, I.damtype, MELEE, 1)
+/obj/attacked_by(obj/item/attacking_item, mob/living/user)
+	if(!attacking_item.force)
+		return
+	
+	var/damage = take_damage(attacking_item.force * attacking_item.demolition_mod, attacking_item.damtype, MELEE, 1)
+	var/damage_verb = "hit"
+	if(attacking_item.demolition_mod > 1 && damage)
+		damage_verb = "pulverized"
+	if(attacking_item.demolition_mod < 1 || !damage)
+		damage_verb = "ineffectively pierced"
+
+	visible_message(span_danger("[user] [damage_verb] [src] with [attacking_item][damage ? "" : ", without leaving a mark"]!"), null, null, COMBAT_MESSAGE_RANGE)
+	//only witnesses close by and the victim see a hit message.
+	log_combat(user, src, "attacked", attacking_item)
 
 /mob/living/attacked_by(obj/item/I, mob/living/user)
 	send_item_attack_message(I, user)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -296,6 +296,11 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(HAS_TRAIT(src, TRAIT_NO_STORAGE))
 		. += "[gender == PLURAL ? "They are" : "It is"] too bulky, fragile, or cumbersome to fit in a container."
 
+	if(demolition_mod > 1)
+		. += "[src] seems exceptionally good at breaking things!"
+	else if(demolition_mod < 1)
+		. += "[src] seems exceptionally bad at breaking things."
+
 	if(resistance_flags & INDESTRUCTIBLE)
 		. += "[src] seems extremely robust! It'll probably withstand anything that could happen to it!"
 	else

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -92,6 +92,7 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	throw_speed = 3
 	throw_range = 6
+	demolition_mod = 0.8
 	materials = list(/datum/material/iron=12000)
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	sharpness = SHARP_EDGED

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -10,6 +10,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	force = 5
 	throwforce = 7
+	demolition_mod = 2 // the right tool in the wrong place can make all the difference
 	w_class = WEIGHT_CLASS_SMALL
 	materials = list(/datum/material/iron=50)
 	drop_sound = 'sound/items/handling/crowbar_drop.ogg'

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -9,6 +9,7 @@
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
 	force = 5
+	demolition_mod = 0.5
 	w_class = WEIGHT_CLASS_TINY
 	throwforce = 5
 	throw_speed = 3

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -23,6 +23,7 @@
 	light_on = FALSE
 	throw_speed = 3
 	throw_range = 5
+	demolition_mod = 0.5 // not very good at smashing
 	w_class = WEIGHT_CLASS_SMALL
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 100, ACID = 30)
 	resistance_flags = FIRE_PROOF
@@ -225,6 +226,7 @@
 			playsound(loc, acti_sound, 50, 1)
 			force = 12
 			damtype = BURN
+			demolition_mod = 1.5 // pretty good at cutting
 			hitsound = 'sound/items/welder.ogg'
 			update_appearance(UPDATE_ICON)
 			START_PROCESSING(SSobj, src)
@@ -243,6 +245,7 @@
 	force = 3
 	damtype = "brute"
 	hitsound = "swing_hit"
+	demolition_mod = initial(demolition_mod)
 	update_appearance(UPDATE_ICON)
 
 

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -9,6 +9,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	force = 5
 	throwforce = 7
+	demolition_mod = 1.5
 	w_class = WEIGHT_CLASS_SMALL
 	usesound = 'sound/items/ratchet.ogg'
 	materials = list(/datum/material/iron=150)

--- a/code/game/objects/items/two_handed/chainsaw.dm
+++ b/code/game/objects/items/two_handed/chainsaw.dm
@@ -14,6 +14,7 @@
 	throwforce = 13
 	throw_speed = 2
 	throw_range = 4
+	demolition_mod = 1.5
 	materials = list(/datum/material/iron=13000)
 	attack_verb = list("sawed", "torn", "cut", "chopped", "diced")
 	hitsound = "swing_hit"

--- a/code/game/objects/items/two_handed/fireaxe.dm
+++ b/code/game/objects/items/two_handed/fireaxe.dm
@@ -8,6 +8,7 @@
 	desc = "Truly, the weapon of a madman. Who would think to fight fire with an axe?"
 	force = 5
 	throwforce = 15
+	demolition_mod = 3 // specifically designed for breaking things
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
 	attack_verb = list("attacked", "chopped", "cleaved", "torn", "cut", "axed")
@@ -42,6 +43,8 @@
 	. = ..()
 	if(!proximity)
 		return
+	if(QDELETED(A))
+		return
 	if(HAS_TRAIT(src, TRAIT_WIELDED)) //destroys shit faster, generally in 1-2 hits.
 		if(istype(A, /obj/structure/window))
 			var/obj/structure/window/W = A
@@ -49,12 +52,6 @@
 		else if(istype(A, /obj/structure/grille))
 			var/obj/structure/grille/G = A
 			G.take_damage(G.max_integrity*2, BRUTE, MELEE, FALSE, null, armour_penetration)
-		else if(istype(A, /obj/machinery/door)) //Nines hits for reinforced airlock, seven for normal
-			var/obj/machinery/door/D = A
-			D.take_damage((force+25), BRUTE, MELEE, FALSE, null, armour_penetration)
-		else if(istype(A, /obj/structure/door_assembly)) //Two hits for frames left behind
-			var/obj/machinery/door/D = A
-			D.take_damage((force+25), BRUTE, MELEE, FALSE, null, armour_penetration)
 
 /*
  * Metal Hydrogen Axe
@@ -85,6 +82,7 @@
 	icon = 'icons/obj/weapons/energy.dmi'
 	icon_state = "energy-fireaxe0"
 	base_icon_state = "energy-fireaxe"
+	demolition_mod = 4 // DESTROY
 	armour_penetration = 50 // Probably doesn't care much for armor given how it can destroy solid metal structures
 	block_chance = 50 // Big handle and large flat energy blade, good for blocking things
 	heat = 1800 // It's a FIRE axe
@@ -129,15 +127,6 @@
 /obj/item/fireaxe/energy/attack(mob/living/M, mob/living/user)
 	..()
 	M.ignite_mob() // Ignites you if you're flammable
-
-/obj/item/fireaxe/energy/afterattack(atom/A, mob/user, proximity)
-	. = ..()
-	if(!proximity)
-		return
-	if(HAS_TRAIT(src, TRAIT_WIELDED)) // Does x2 damage against inanimate objects like machines, structures, mechs, etc
-		if(isobj(A) && !isitem(A))
-			var/obj/O = A
-			O.take_damage(force, BRUTE, MELEE, FALSE, null, armour_penetration)
 
 /obj/item/fireaxe/energy/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text, final_block_chance, damage, attack_type)
 	if(!HAS_TRAIT(src, TRAIT_WIELDED))

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -80,7 +80,7 @@
 	playsound(src, P.hitsound, 50, 1)
 	visible_message(span_danger("[src] is hit by \a [P]!"), null, null, COMBAT_MESSAGE_RANGE)
 	if(!QDELETED(src)) //Bullet on_hit effect might have already destroyed this object
-		take_damage(P.damage, P.damage_type, P.armor_flag, 0, turn(P.dir, 180), P.armour_penetration)
+		take_damage(P.damage * P.demolition_mod, P.damage_type, P.armor_flag, 0, turn(P.dir, 180), P.armour_penetration)
 
 ///Called to get the damage that hulks will deal to the obj.
 /obj/proc/hulk_damage()

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -16,6 +16,8 @@
 	var/wound_bonus = 0
 	/// If this attacks a human with no wound armor on the affected body part, add this to the wound mod. Some attacks may be significantly worse at wounding if there's even a slight layer of armor to absorb some of it vs bare flesh
 	var/bare_wound_bonus = 0
+	/// Damage multiplier against structures, machines, mechs, and to a lesser extent silicons
+	var/demolition_mod = 1
 
 	var/datum/armor/armor
 	var/obj_integrity	//defaults to max_integrity

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -13,6 +13,7 @@
 	volume = 100
 	force = 15 //Smashing bottles over someone's head hurts.
 	throwforce = 15
+	demolition_mod = 0.25
 	item_state = "broken_beer" //Generic held-item sprite until unique ones are made.
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
@@ -166,6 +167,7 @@
 	throwforce = 5
 	throw_speed = 3
 	throw_range = 5
+	demolition_mod = 0.25
 	w_class = WEIGHT_CLASS_TINY
 	item_state = "beer"
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -7,6 +7,7 @@
 	slot_flags = ITEM_SLOT_BELT | ITEM_SLOT_BACK
 	force = 15
 	throwforce = 10
+	demolition_mod = 1.2
 	item_state = "pickaxe"
 	lefthand_file = 'icons/mob/inhands/equipment/mining_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/mining_righthand.dmi'

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -529,16 +529,17 @@
 	return clamp(damage_amount * (1 - armor_protection/100), 1, damage_amount) // Minimum of 1 damage.
 
 /// Copy of '/mob/living/attacked_by', except it sets damage to what is returned by 'proc/run_armor'.
-/mob/living/silicon/attacked_by(obj/item/I, mob/living/user)
-	send_item_attack_message(I, user)
-	if(I.force)
-		var/damage = run_armor(I.force, I.damtype, MELEE)
-		apply_damage(damage, I.damtype)
-		if(I.damtype == BRUTE)
-			if(prob(33))
-				I.add_mob_blood(src)
-				var/turf/location = get_turf(src)
-				add_splatter_floor(location)
-				if(get_dist(user, src) <= 1)
-					user.add_mob_blood(src)
-		return TRUE
+/mob/living/silicon/attacked_by(obj/item/attacking_item, mob/living/user)
+	send_item_attack_message(attacking_item, user)
+	if(!attacking_item.force)
+		return FALSE
+	// Demolition mod has half the effect on silicons that it does on structures (ex. 2x will act as 1.5x, 0.5x will act as 0.75x)
+	var/damage = run_armor(attacking_item.force * (1 + attacking_item.demolition_mod)/2, attacking_item.damtype, MELEE)
+	apply_damage(damage, attacking_item.damtype)
+	if(attacking_item.damtype == BRUTE && prob(33))
+		attacking_item.add_mob_blood(src)
+		var/turf/location = get_turf(src)
+		add_splatter_floor(location)
+		if(get_dist(user, src) <= 1)
+			user.add_mob_blood(src)
+	return TRUE

--- a/code/modules/mob/living/silicon/silicon_defense.dm
+++ b/code/modules/mob/living/silicon/silicon_defense.dm
@@ -125,7 +125,7 @@
 /mob/living/silicon/bullet_act(obj/projectile/Proj, def_zone)
 	SEND_SIGNAL(src, COMSIG_ATOM_BULLET_ACT, Proj, def_zone)
 	if((Proj.damage_type == BRUTE || Proj.damage_type == BURN))
-		var/damage = run_armor(Proj.damage, Proj.damage_type, Proj.armor_flag, Proj.armour_penetration)
+		var/damage = run_armor(Proj.damage * (1 + Proj.demolition_mod)/2, Proj.damage_type, Proj.armor_flag, Proj.armour_penetration)
 		adjustBruteLoss(damage)
 		if(prob(damage*1.5))
 			for(var/mob/living/M in buckled_mobs)

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -425,6 +425,7 @@
 	armor_flag = ENERGY
 	range = 150
 	jitter = 10
+	demolition_mod = 4
 	var/obj/item/gun/gun
 	var/structure_pierce_amount = 0				//All set to 0 so the gun can manually set them during firing.
 	var/structure_bleed_coeff = 0

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -153,6 +153,7 @@
 	damage = 30
 	wound_bonus = -40
 	bare_wound_bonus = 70
+	demolition_mod = 3 // industrial laser
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN
 

--- a/code/modules/projectiles/projectile/bullets/_incendiary.dm
+++ b/code/modules/projectiles/projectile/bullets/_incendiary.dm
@@ -1,6 +1,7 @@
 /obj/projectile/bullet/incendiary
 	damage = 20
 	var/fire_stacks = 4
+	demolition_mod = 0.75
 
 /obj/projectile/bullet/incendiary/on_hit(atom/target, blocked = FALSE)
 	. = ..()

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -44,6 +44,7 @@
 	damage = 60
 	wound_bonus = -35
 	wound_falloff_tile = 0
+	demolition_mod = 1.2
 
 /obj/projectile/bullet/a762/raze
 	name = "7.62mm Raze bullet"
@@ -63,6 +64,7 @@
 	penetrating = TRUE //Passes through two objects, stops on a mob or on a third object
 	penetrations = 2
 	penetration_type = 1
+	demolition_mod = 1.5 // anti-armor
 
 /obj/projectile/bullet/a762/vulcan
 	name = "7.62mm Vulcan bullet"

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -203,11 +203,11 @@
 	desc = "A breaching round designed to destroy airlocks and windows with only a few shots, but is ineffective against other targets."
 	hitsound = 'sound/weapons/sonic_jackhammer.ogg'
 	damage = 10 //does shit damage to everything except doors and windows
-	demolition_mod = 50 //extremely good at breaking things
+	demolition_mod = 6 //not that bad at breaking things
 
 /obj/projectile/bullet/shotgun/slug/breaching/on_hit(atom/target)
-	if(issilicon(target) || ismecha(target))
-		demolition_mod = 4 // no don't one-shot mechs and borgs what the fuck
+	if(istype(target, /obj/structure/window) || istype(target, /obj/machinery/door) || istype(target, /obj/structure/door_assembly) || istype(target, /obj/structure/grille))
+		demolition_mod = 50 //one shot to break a window or 3 shots to breach an airlock door
 	..()
 
 /obj/projectile/bullet/pellet/hardlight

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -6,6 +6,7 @@
 	damage = 46 //About 2/3's the damage of buckshot but doesn't suffer from spread or negative AP
 	sharpness = SHARP_POINTY
 	wound_bonus = -30
+	demolition_mod = 2 // good at smashing through stuff
 
 /obj/projectile/bullet/shotgun/slug/syndie
 	name = "12g syndicate shotgun slug"
@@ -74,6 +75,7 @@
 	damage = 35 //Most certainly to drop below 3-shot threshold because of damage falloff
 	armour_penetration = 60 // he he funny round go through armor
 	wound_bonus = -40
+	demolition_mod = 3 // very good at smashing through stuff
 	penetrating = TRUE //Goes through an infinite number of mobs
 
 /obj/projectile/bullet/shotgun/slug/Range()
@@ -88,6 +90,7 @@
 	var/tile_dropoff = 0.4
 	var/tile_dropoff_s = 0.3
 	armour_penetration = -20 //Armor is 25% stronger against pellets
+	demolition_mod = 0.5 // bad at smashing through stuff
 
 /obj/projectile/bullet/pellet/shotgun_buckshot
 	name = "buckshot pellet"
@@ -200,10 +203,11 @@
 	desc = "A breaching round designed to destroy airlocks and windows with only a few shots, but is ineffective against other targets."
 	hitsound = 'sound/weapons/sonic_jackhammer.ogg'
 	damage = 10 //does shit damage to everything except doors and windows
+	demolition_mod = 50 //extremely good at breaking things
 
 /obj/projectile/bullet/shotgun/slug/breaching/on_hit(atom/target)
-	if(istype(target, /obj/structure/window) || istype(target, /obj/machinery/door) || istype(target, /obj/structure/door_assembly))
-		damage = 500 //one shot to break a window or 3 shots to breach an airlock door
+	if(issilicon(target) || ismecha(target))
+		demolition_mod = 8 // no don't one-shot mechs and borgs what the fuck
 	..()
 
 /obj/projectile/bullet/pellet/hardlight

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -207,7 +207,7 @@
 
 /obj/projectile/bullet/shotgun/slug/breaching/on_hit(atom/target)
 	if(issilicon(target) || ismecha(target))
-		demolition_mod = 8 // no don't one-shot mechs and borgs what the fuck
+		demolition_mod = 4 // no don't one-shot mechs and borgs what the fuck
 	..()
 
 /obj/projectile/bullet/pellet/hardlight

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -7,13 +7,8 @@
 	paralyze = 100
 	dismemberment = 50
 	armour_penetration = 50
+	demolition_mod = 2.2 // very effective against armored structures and vehicles
 	var/breakthings = TRUE
-
-/obj/projectile/bullet/p50/on_hit(atom/target, blocked = 0)
-	if(isobj(target) && (blocked != 100) && breakthings)
-		var/obj/O = target
-		O.take_damage(80, BRUTE, BULLET, FALSE, null, armour_penetration)
-	return ..()
 
 /obj/projectile/bullet/p50/soporific
 	name = ".50 soporific bullet"
@@ -36,6 +31,7 @@
 	penetrating = TRUE //Passes through everything and anything until it reaches the end of its range
 	penetration_type = 2
 	dismemberment = 0 //It goes through you cleanly.
+	demolition_mod = 1 // it just goes right through
 	paralyze = 0
 
 /obj/projectile/bullet/p50/penetrator/shuttle //Nukeop Shuttle Variety

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -8,7 +8,6 @@
 	dismemberment = 50
 	armour_penetration = 50
 	demolition_mod = 2.2 // very effective against armored structures and vehicles
-	var/breakthings = TRUE
 
 /obj/projectile/bullet/p50/soporific
 	name = ".50 soporific bullet"
@@ -16,7 +15,6 @@
 	damage = 0
 	dismemberment = 0
 	paralyze = 0
-	breakthings = FALSE
 
 /obj/projectile/bullet/p50/soporific/on_hit(atom/target, blocked = FALSE)
 	if((blocked != 100) && isliving(target))
@@ -31,7 +29,6 @@
 	penetrating = TRUE //Passes through everything and anything until it reaches the end of its range
 	penetration_type = 2
 	dismemberment = 0 //It goes through you cleanly.
-	demolition_mod = 1 // it just goes right through
 	paralyze = 0
 
 /obj/projectile/bullet/p50/penetrator/shuttle //Nukeop Shuttle Variety

--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -6,6 +6,7 @@
 	damage = 5
 	range = 4
 	dismemberment = 20
+	demolition_mod = 2 // industrial strength plasma cutter designed to cut things
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/purple_laser
 	var/mine_range = 3 //mines this many additional tiles of rock
 	tracer_type = /obj/effect/projectile/tracer/plasma_cutter

--- a/code/modules/projectiles/projectile/special/rocket.dm
+++ b/code/modules/projectiles/projectile/special/rocket.dm
@@ -75,23 +75,18 @@
 	icon_state = "cannonball"
 	desc = "Not for bowling purposes"
 	damage = 30
-	demolition_mod = 4
+	demolition_mod = 20 // YARRR
 
 /obj/projectile/bullet/cball/on_hit(atom/target, blocked=0)
-	var/mob/living/carbon/human/H = firer
-	var/atom/throw_target = get_edge_target_turf(target, H.dir)
-	if(istype(target, /obj/structure/window) || istype(target, /obj/machinery/door) || istype(target, /obj/structure/door_assembly))
-		damage = 500 
+	var/atom/throw_target = get_edge_target_turf(target, firer.dir)
+	if(ismecha(target) || isliving(target))
+		demolition_mod = 5 // woah there let's not one-shot mechs and borgs
 	. = ..()
-	if(isliving(target))
-		var/mob/living/L = target
-		if(!L.anchored && !L.throwing)//avoid double hits
-			if(iscarbon(L))
-				var/mob/living/carbon/C = L
-				var/mob/M = firer
-				if(istype(M))
-					C.throw_at(throw_target, 2, 4, H, 3)
-					return BULLET_ACT_HIT
+	if(!ismovable(target)) // if it's not movable then don't bother trying to throw it
+		return
+	var/atom/movable/movable_target = target
+	if(!movable_target.anchored && !movable_target.throwing)//avoid double hits
+		movable_target.throw_at(throw_target, 2, 4, firer, 3)
 
 /obj/projectile/bullet/bolt
 	name = "bolt"

--- a/code/modules/projectiles/projectile/special/rocket.dm
+++ b/code/modules/projectiles/projectile/special/rocket.dm
@@ -12,21 +12,15 @@
 	name ="\improper HEDP rocket"
 	desc = "USE A WEEL GUN"
 	icon_state= "84mm-hedp"
+	armor_flag = BOMB
 	damage = 80
-	var/anti_armour_damage = 200
+	demolition_mod = 4
 	armour_penetration = 100
 	dismemberment = 100
 
 /obj/projectile/bullet/a84mm/on_hit(atom/target, blocked = FALSE)
 	..()
 	explosion(target, -1, 1, 3, 1, 0, flame_range = 4)
-
-	if(ismecha(target))
-		var/obj/mecha/M = target
-		M.take_damage(anti_armour_damage, BRUTE, BOMB, FALSE, null, armour_penetration)
-	if(issilicon(target))
-		var/mob/living/silicon/S = target
-		S.take_overall_damage(anti_armour_damage*0.75, anti_armour_damage*0.25)
 	return BULLET_ACT_HIT
 
 /obj/projectile/bullet/a84mm_he
@@ -34,6 +28,7 @@
 	desc = "Boom."
 	icon_state = "missile"
 	damage = 30
+	demolition_mod = 4
 	ricochets_max = 0 //it's a MISSILE
 
 /obj/projectile/bullet/a84mm_he/on_hit(atom/target, blocked=0)
@@ -49,6 +44,7 @@
 	desc = "Boom."
 	icon_state = "missile"
 	damage = 30
+	demolition_mod = 4
 	ricochets_max = 0 //it's a MISSILE
 	var/sturdy = list(
 	/turf/closed,
@@ -79,6 +75,7 @@
 	icon_state = "cannonball"
 	desc = "Not for bowling purposes"
 	damage = 30
+	demolition_mod = 4
 
 /obj/projectile/bullet/cball/on_hit(atom/target, blocked=0)
 	var/mob/living/carbon/human/H = firer

--- a/code/modules/projectiles/projectile/special/rocket.dm
+++ b/code/modules/projectiles/projectile/special/rocket.dm
@@ -82,7 +82,7 @@
 	var/atom/throw_target = get_edge_target_turf(target, H.dir)
 	if(istype(target, /obj/structure/window) || istype(target, /obj/machinery/door) || istype(target, /obj/structure/door_assembly))
 		damage = 500 
-		..()
+	. = ..()
 	if(isliving(target))
 		var/mob/living/L = target
 		if(!L.anchored && !L.throwing)//avoid double hits

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -169,6 +169,7 @@
 	throwforce = 5
 	throw_speed = 3
 	throw_range = 5
+	demolition_mod = 0.25
 	materials = list(/datum/material/iron=4000, /datum/material/glass=1000)
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -400,6 +400,7 @@
 	light_range = 1
 	light_color = LIGHT_COLOR_GREEN
 	light_power = 0.2	//Barely glows on low power
+	demolition_mod = 1.5 // lasers are good at cutting metal
 	sharpness = SHARP_EDGED
 
 

--- a/yogstation/code/game/objects/items/wielded/sledgehammer.dm
+++ b/yogstation/code/game/objects/items/wielded/sledgehammer.dm
@@ -14,6 +14,7 @@
 	throwforce = 18
 	throw_range = 3 /// Doesn't throw very far
 	sharpness = SHARP_NONE
+	demolition_mod = 3 // BREAK THINGS
 	armour_penetration = -20
 	hitsound = 'sound/weapons/smash.ogg' /// Hitsound when thrown at someone
 	attack_verb = list("attacked", "hit", "struck", "bludgeoned", "bashed", "smashed")
@@ -54,8 +55,6 @@
 			var/obj/structure/S = target
 			if(istype(S, /obj/structure/window)) // Sledgehammer really good at smashing windows. 2-7 hits to kill a window
 				S.take_damage(S.max_integrity/2, BRUTE, MELEE, FALSE, null, armour_penetration)
-			else // Sledgehammer can kill airlocks in 17-23 hits, against most other things it's almost as good as a fireaxe
-				S.take_damage(force*2, BRUTE, MELEE, FALSE, null, armour_penetration)
 		playsound(src, 'sound/effects/bang.ogg', 50, 1)
 
 /obj/item/melee/sledgehammer/throw_at(atom/target, range, speed, mob/thrower, spin, diagonals_first, datum/callback/callback, force, quickstart)

--- a/yogstation/code/game/objects/items/wielded/vxtvulhammer.dm
+++ b/yogstation/code/game/objects/items/wielded/vxtvulhammer.dm
@@ -11,6 +11,7 @@
 	desc = "A relic sledgehammer with charge packs wired to two blast pads on its head. \
 			While wielded in two hands, the user can charge a massive blow that will shatter construction and hurl bodies."
 	force = 4 //It's heavy as hell
+	demolition_mod = 3 // it's a big hammer, what do you expect
 	armour_penetration = 50 //Designed for shattering walls in a single blow, I don't think it cares much about armor
 	throwforce = 18
 	attack_verb = list("attacked", "hit", "struck", "bludgeoned", "bashed", "smashed")


### PR DESCRIPTION
# Document the changes in your pull request

Adds a modifier for items and projectiles that makes them better or worse at destroying things. Machines, structures, mechs, and to a lesser extent cyborgs are all affected by this modifier.

Silicons are affected by the modifier half as much, so 2x will be 1.5x, 0.5 will be 0.75x, etc)

All modified items/projectiles are:
- bottles/broken bottles - 0.25x
- scalpels - 0.25x
- screwdrivers - 0.5x
- shotgun pellets - 0.5x
- all incendiary bullets - 0.75x
- knives - 0.8x
- pickaxes - 1.2x
- 7.62mm bullets - 1.2x
- 7.62mm AP bullets -1.5x
- welders - 1.5x (0.5x inactive)
- laser scalpel - 1.5x
- chainsaw - 1.5x
- crowbars - 2x
- plasma cutter beams - 2x
- shotgun slugs - 2x
- .50 BMG rounds - 2.2x (replaces special check)
- uranium slugs - 3x
- emitter beams - 3x
- sledgehammer - 3x (replaces special check)
- vxtvul hammer - 3x
- fire axe - 3x (replaces special check)
- energy fire axe - 4x (replaces special check)
- rockets - 4x
- particle acceleration rifle - 4x
- breaching slugs - 6x (50x against windows/doors, replaces special check)
- cannonballs - 20x (5x against mechs/silicons, replaces special check)

Let me know of any suggestions or balance concerns, these values are subject to change.

Ported from tgstation/tgstation#66967

# Why is this good for the game?

1) Removes the need for many special checks that currently exist in the code, that no longer need to be there (like with fire axes and sledgehammers)

2) Making an item or projectile stronger or weaker against structures without affecting damage against players will be much easier in the future (for example, making a weapon that does more than 20 damage without having it be able to break airlocks)

3) Adds slightly more depth to the weapons and items in the game, raw damage output alone is no longer the only thing to consider depending on your situation (breaking and entering? rogue mech? subverted AI/borgs? just need to break something in your way?)

# Testing
Demolition mod correctly affects the damage items and projectiles do to structures/machines/etc

Sledgehammers, fire axes, and breaching slugs break doors and windows in the same number of hits as before.

Examining an item lets you know if it's good or bad at demolition:
![image](https://github.com/yogstation13/Yogstation/assets/93578146/54de286b-ac43-4f8e-93c4-beda285314cb)


# Wiki Documentation

This probably needs to be mentioned on the guide to combat

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  itseasytosee, sapphicoverload
tweak: some items and projectiles are now better or worse than others at destroying things
tweak: chat messages from hitting an object now tell whether you can damage it
bugfix: fixed machines/structures/etc not caring about armor penetration when hit by a melee weapon
bugfix: fixed cannonballs not doing any damage to mobs
/:cl: