### PR TITLE
Outrageous Amounts of Radiation No Longer Instant Kills You

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1122,7 +1122,7 @@
 	var/blocked = getarmor(null, RAD)
 
 	if(amount > RAD_BURN_THRESHOLD)
-		var/dmg = max((amount-RAD_BURN_THRESHOLD)/RAD_BURN_THRESHOLD, 20) // Prevents near-instant death because that wouldn't be fun.
+		var/dmg = max((amount-RAD_BURN_THRESHOLD)/RAD_BURN_THRESHOLD, 25) // Prevents near-instant death because that wouldn't be fun.
 		apply_damage(dmg, BURN, null, blocked)
 
 	apply_effect((amount*RAD_MOB_COEFFICIENT)/max(1, (radiation**2)*RAD_OVERDOSE_REDUCTION), EFFECT_IRRADIATE, blocked)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1122,7 +1122,8 @@
 	var/blocked = getarmor(null, RAD)
 
 	if(amount > RAD_BURN_THRESHOLD)
-		apply_damage((amount-RAD_BURN_THRESHOLD)/RAD_BURN_THRESHOLD, BURN, null, blocked)
+		var/dmg = max((amount-RAD_BURN_THRESHOLD)/RAD_BURN_THRESHOLD, 20) // Prevents near-instant death because that wouldn't be fun.
+		apply_damage(dmg, BURN, null, blocked)
 
 	apply_effect((amount*RAD_MOB_COEFFICIENT)/max(1, (radiation**2)*RAD_OVERDOSE_REDUCTION), EFFECT_IRRADIATE, blocked)
 


### PR DESCRIPTION
# Document the changes in your pull request
Burn damage caused by radiation is limited to 25 burn damage (pre-armor).

# Why is this good for the game?
Makes radiation not so crippling that you don't instantly die from touching it and instead gives you a few seconds to at least walk away (and still die) or walk closer (and still die). Near instant, if not instant, death is not fun in this video game if you can't put up any resistance to it.

# Testing
Trit burnt for radiation. Damage is limited. Only went from fully healthy to death in 2 seconds instead of 0.1 seconds.

# Changelog
:cl:  
tweak: Burn damage caused by radiation is limited to 25 burn damage (pre-armor).
/:cl:
