### PR TITLE
Makes command blue again

### DIFF
--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -334,7 +334,7 @@ em {
 }
 
 .comradio {
-  color: #fcdf03;
+  color: #204090;
 }
 
 .secradio {

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -351,7 +351,7 @@ em {
 }
 
 .comradio {
-  color: #948f02;
+  color: #204090;
 }
 
 .secradio {


### PR DESCRIPTION
# Document the changes in your pull request

Reverts undocumented change in https://github.com/yogstation13/Yogstation/pull/20914 that made command chat in dark mode bright yellow (it was seemingly supposed to also change light mode but didn't for some reason)

# Why is this good for the game?
MY EYES

# Changelog

:cl:  
tweak: Command channel is now blue once more
/:cl:
