### PR TITLE
Guardian's Frenzy Ability Respects Cooldown

### DIFF
--- a/yogstation/code/modules/guardian/abilities/major/frenzy.dm
+++ b/yogstation/code/modules/guardian/abilities/major/frenzy.dm
@@ -70,9 +70,14 @@ GLOBAL_LIST_INIT(guardian_frenzy_speedup, list(
 		return
 	if (!guardian.stats)
 		return
+	if(!guardian.stats.ability)
+		return
+	if (!istype(guardian.stats.ability, /datum/guardian_ability/major/frenzy))
+		return
 	if (get_dist_euclidian(guardian.summoner?.current, target) > guardian.range)
 		to_chat(guardian, span_italics(span_danger("[target] is out of your range!")))
 		return
+
 	guardian.forceMove(get_step(get_turf(target), turn(target.dir, 180)))
 	playsound(guardian, 'yogstation/sound/effects/vector_appear.ogg', 100, FALSE)
 	guardian.target = target
@@ -81,5 +86,6 @@ GLOBAL_LIST_INIT(guardian_frenzy_speedup, list(
 		span_italics("You hear a fast wooosh."))
 	guardian.AttackingTarget()
 	target.throw_at(get_edge_target_turf(guardian, get_dir(guardian, target)), world.maxx / 6, 5, guardian, TRUE)
-	next_rush = world.time + 3 SECONDS
+	var/datum/guardian_ability/major/frenzy/ability = guardian.stats.ability
+	ability.next_rush = world.time + 3 SECONDS
 	Finished()

--- a/yogstation/code/modules/guardian/abilities/major/frenzy.dm
+++ b/yogstation/code/modules/guardian/abilities/major/frenzy.dm
@@ -81,4 +81,5 @@ GLOBAL_LIST_INIT(guardian_frenzy_speedup, list(
 		span_italics("You hear a fast wooosh."))
 	guardian.AttackingTarget()
 	target.throw_at(get_edge_target_turf(guardian, get_dir(guardian, target)), world.maxx / 6, 5, guardian, TRUE)
+	next_rush = world.time + 3 SECONDS
 	Finished()

--- a/yogstation/code/modules/guardian/abilities/major/frenzy.dm
+++ b/yogstation/code/modules/guardian/abilities/major/frenzy.dm
@@ -75,7 +75,7 @@ GLOBAL_LIST_INIT(guardian_frenzy_speedup, list(
 	if (!istype(guardian.stats.ability, /datum/guardian_ability/major/frenzy))
 		return
 	var/datum/guardian_ability/major/frenzy/ability = guardian.stats.ability
-	if(world.time >= ability.next_rush)
+	if(world.time < ability.next_rush)
 		return
 	if (get_dist_euclidian(guardian.summoner?.current, target) > guardian.range)
 		to_chat(guardian, span_italics(span_danger("[target] is out of your range!")))

--- a/yogstation/code/modules/guardian/abilities/major/frenzy.dm
+++ b/yogstation/code/modules/guardian/abilities/major/frenzy.dm
@@ -74,6 +74,9 @@ GLOBAL_LIST_INIT(guardian_frenzy_speedup, list(
 		return
 	if (!istype(guardian.stats.ability, /datum/guardian_ability/major/frenzy))
 		return
+	var/datum/guardian_ability/major/frenzy/ability = guardian.stats.ability
+	if(world.time >= ability.next_rush)
+		return
 	if (get_dist_euclidian(guardian.summoner?.current, target) > guardian.range)
 		to_chat(guardian, span_italics(span_danger("[target] is out of your range!")))
 		return
@@ -86,6 +89,5 @@ GLOBAL_LIST_INIT(guardian_frenzy_speedup, list(
 		span_italics("You hear a fast wooosh."))
 	guardian.AttackingTarget()
 	target.throw_at(get_edge_target_turf(guardian, get_dir(guardian, target)), world.maxx / 6, 5, guardian, TRUE)
-	var/datum/guardian_ability/major/frenzy/ability = guardian.stats.ability
 	ability.next_rush = world.time + 3 SECONDS
 	Finished()


### PR DESCRIPTION
# Document the changes in your pull request
You can no longer bypass frenzy's teleport attack by spamming the teleport attack action ability.

# Testing
Cannot spam it anymore on Moja.

# Changelog

:cl:  
bugfix: Guardian's Frenzy Ability now respects the three second cooldown that it is suppose to be limited by.
/:cl:
