### PR TITLE
Hides Asay and Dsay for non-admins

### DIFF
--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -1,7 +1,5 @@
 /client/verb/cmd_admin_say(msg as text)
-	set hidden = TRUE
-
-	set category = "Admin"
+	set category = "Misc.Unused"
 	set name = "Asay" //Gave this shit a shorter name so you only have to time out "asay" rather than "admin say" to use it --NeoFite
 	
 	if(!check_rights(0))

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -1,7 +1,7 @@
 /client/verb/cmd_admin_say(msg as text)
 	set hidden = TRUE
 
-	set category = "Admin"
+	set category = "Misc.Unused"
 	set name = "Asay" //Gave this shit a shorter name so you only have to time out "asay" rather than "admin say" to use it --NeoFite
 	
 	if(!check_rights(0))

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -1,7 +1,7 @@
 /client/verb/cmd_admin_say(msg as text)
 	set hidden = TRUE
 
-	set category = "Misc.Unused"
+	set category = "Admin"
 	set name = "Asay" //Gave this shit a shorter name so you only have to time out "asay" rather than "admin say" to use it --NeoFite
 	
 	if(!check_rights(0))

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -1,7 +1,6 @@
 /client/verb/dsay(msg as text)
 	set category = "Misc.Unused"
 	set name = "Dsay"
-	set hidden = TRUE
 
 	if(!holder)
 		to_chat(src, "Only administrators may use this command.", confidential=TRUE)

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -1,5 +1,5 @@
 /client/verb/dsay(msg as text)
-	set category = "Admin"
+	set category = "Misc.Unused"
 	set name = "Dsay"
 	set hidden = TRUE
 

--- a/code/modules/admin/verbs/deadsay.dm
+++ b/code/modules/admin/verbs/deadsay.dm
@@ -1,5 +1,5 @@
 /client/verb/dsay(msg as text)
-	set category = "Misc.Unused"
+	set category = "Admin"
 	set name = "Dsay"
 	set hidden = TRUE
 


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

People who are not admins should not be able to see it now

# Why is this good for the game?
Moves it so non-admins don't have to see it

# Testing
Works as intended

# Wiki Documentation

No

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: ASay and DSay are now no longer visible to non-admins
/:cl:
