### PR TITLE
Reverts Sheltered back to base form

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -677,7 +677,7 @@
 
 /datum/quirk/sheltered/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
-	H.remove_language(/datum/language/common, FALSE, TRUE)
+	H.remove_language(/datum/language/common)
 	if(!H.get_selected_language())
 		H.grant_language(/datum/language/japanese)
 


### PR DESCRIPTION
# Document the changes in your pull request

Reverts #11994 - JamieD1's "nerf" for Sheltered.

# Why is this good for the game?
It's not really used often, and it's meant to be, uh, immersive... with your lack of understanding the anything. That being said, it can be countered generally by being alone. Or not using speech very often. And with how _every_ race now has their own language, this shouldn't be that much of a problem.
(well, okay, **if you don't speak galactic common people ignore you,** but that's more of a player problem rather than a code problem. Original point will stand otherwise.)

# Testing
This is a reversion.

# Wiki Documentation
Sheltered no longer understands Common. Again.

# Changelog

:cl:  
rscdel: Sheltered goes back to not understanding something they can't speak, rather than simply say they never learned it, but proceed to hear it just fine.
/:cl:
