### PR TITLE
Fixes overlays with stasis units

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -488,8 +488,8 @@ Class Procs:
 		I.play_tool_sound(src, 50)
 		setDir(turn(dir,-90))
 		to_chat(user, span_notice("You rotate [src]."))
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /obj/proc/can_be_unfasten_wrench(mob/user, silent) //if we can unwrench this object; returns SUCCESSFUL_UNFASTEN and FAILED_UNFASTEN, which are both TRUE, or CANT_UNFASTEN, which isn't.
 	if(!(isfloorturf(loc) || istype(loc, /turf/open/indestructible)) && !anchored)

--- a/code/game/machinery/stasis.dm
+++ b/code/game/machinery/stasis.dm
@@ -3,6 +3,7 @@
 	desc = "A not so comfortable looking bed with some nozzles at the top and bottom. It will keep someone in stasis."
 	icon = 'icons/obj/machines/stasis.dmi'
 	icon_state = "stasis"
+	base_icon_state = "stasis"
 	density = FALSE
 	can_buckle = TRUE
 	buckle_lying = 90
@@ -92,19 +93,20 @@
 		last_stasis_sound = _running
 
 /obj/machinery/stasis/AltClick(mob/user)
-	if(world.time >= stasis_can_toggle && user.canUseTopic(src, !issilicon(user)))
-		stasis_enabled = !stasis_enabled
-		stasis_can_toggle = world.time + stasis_cooldown
-		playsound(src, 'sound/machines/click.ogg', 60, TRUE)
-		play_power_sound()
-		update_appearance(UPDATE_ICON)
+	if(world.time < stasis_can_toggle || !user.canUseTopic(src, !issilicon(user)))
+		return
+	stasis_enabled = !stasis_enabled
+	stasis_can_toggle = world.time + stasis_cooldown
+	playsound(src, 'sound/machines/click.ogg', 60, TRUE)
+	play_power_sound()
+	update_appearance(UPDATE_ICON)
 
 /obj/machinery/stasis/Exited(atom/movable/AM, atom/newloc)
 	if(AM == occupant)
 		var/mob/living/L = AM
 		if(L.has_status_effect(STATUS_EFFECT_STASIS))
 			thaw_them(L)
-	. = ..()
+	return ..()
 
 /obj/machinery/stasis/proc/stasis_running()
 	return stasis_enabled && is_operational()
@@ -112,30 +114,36 @@
 /obj/machinery/stasis/update_icon_state()
 	. = ..()
 	if(stat & BROKEN)
-		icon_state = "stasis_broken"
+		icon_state = "[base_icon_state]_broken"
 		return
 	if(panel_open || stat & MAINT)
-		icon_state = "stasis_maintenance"
+		icon_state = "[base_icon_state]_maintenance"
 		return
-	icon_state = "stasis"
+	icon_state = base_icon_state
+
+/obj/machinery/stasis/setDir()
+	. = ..()
+	update_appearance(UPDATE_ICON)
 
 /obj/machinery/stasis/update_overlays()
 	. = ..()
+	if(!mattress_state)
+		return
 	var/_running = stasis_running()
-	var/list/overlays_to_remove = managed_vis_overlays
+	if(!mattress_on)
+		mattress_on = SSvis_overlays.add_vis_overlay(src, icon, mattress_state, layer, plane, dir, alpha = 0, unique = TRUE)
+	else
+		vis_contents += mattress_on
+		mattress_on.dir = dir
+		if(managed_vis_overlays)
+			managed_vis_overlays += mattress_on
+		else
+			managed_vis_overlays = list(mattress_on)
 
-	if(mattress_state)
-		if(!mattress_on || !managed_vis_overlays)
-			mattress_on = SSvis_overlays.add_vis_overlay(src, icon, mattress_state, layer, plane, dir, alpha = 0, unique = TRUE)
-
-		if(mattress_on.alpha ? !_running : _running) //check the inverse of _running compared to truthy alpha, to see if they differ
-			var/new_alpha = _running ? 255 : 0
-			var/easing_direction = _running ? EASE_OUT : EASE_IN
-			animate(mattress_on, alpha = new_alpha, time = stasis_cooldown, easing = CUBIC_EASING|easing_direction)
-
-		overlays_to_remove = managed_vis_overlays - mattress_on
-
-	SSvis_overlays.remove_vis_overlay(src, overlays_to_remove)
+	if(mattress_on.alpha ? !_running : _running) //check the inverse of _running compared to truthy alpha, to see if they differ
+		var/new_alpha = _running ? 255 : 0
+		var/easing_direction = _running ? EASE_OUT : EASE_IN
+		animate(mattress_on, alpha = new_alpha, time = 50, easing = CUBIC_EASING|easing_direction)
 
 /obj/machinery/stasis/obj_break(damage_flag)
 	. = ..()

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -152,6 +152,7 @@
 /obj/machinery/stasis/survival_pod
 	icon = 'icons/obj/lavaland/survival_pod.dmi'
 	icon_state = "sleeper"
+	base_icon_state = "sleeper"
 	mattress_state = null
 	buckle_lying = 270
 


### PR DESCRIPTION
# Document the changes in your pull request

Stasis units now respect the direction it's facing for the overlay.
Lavaland sleeper is now also no longer invisible.

# Why is this good for the game?

# Testing

# Spriting

# Wiki Documentation

# Changelog

:cl:  
bugfix: Stasis units and sleepers now have proper overlays and lavaland sleepers aren't invisible anymore.
/:cl:
