### PR TITLE
Minor Bloodsucker code cleanup

### DIFF
--- a/code/modules/antagonists/bloodsuckers/structures/bloodsucker_life.dm
+++ b/code/modules/antagonists/bloodsuckers/structures/bloodsucker_life.dm
@@ -463,13 +463,12 @@
 		return
 	//If we're on Masquerade, we appear to have full blood, unless we are REALLY low, in which case we don't look as bad.
 	if(HAS_TRAIT(owner.current, TRAIT_MASQUERADE))
-		switch(bloodsucker_blood_volume)
-			if(BLOOD_VOLUME_OKAY(owner.current) to INFINITY) // 336 and up, we are perfectly fine.
-				owner.current.blood_volume = initial(bloodsucker_blood_volume)
-			if(BLOOD_VOLUME_BAD(owner.current) to BLOOD_VOLUME_OKAY(owner.current)) // 224 to 336
-				owner.current.blood_volume = BLOOD_VOLUME_SAFE(owner.current)
-			else // 224 and below
-				owner.current.blood_volume = BLOOD_VOLUME_OKAY(owner.current)
+		if(bloodsucker_blood_volume >= BLOOD_VOLUME_OKAY(owner.current) && bloodsucker_blood_volume <= INFINITY) // 336 and up, we are perfectly fine.
+			owner.current.blood_volume = initial(bloodsucker_blood_volume)
+		else if(bloodsucker_blood_volume >= BLOOD_VOLUME_BAD(owner.current) && bloodsucker_blood_volume < BLOOD_VOLUME_OKAY(owner.current)) // 224 to 336
+			owner.current.blood_volume = BLOOD_VOLUME_SAFE(owner.current)
+		else // 224 and below
+			owner.current.blood_volume = BLOOD_VOLUME_OKAY(owner.current)
 		return
 	owner.current.blood_volume = bloodsucker_blood_volume
 

--- a/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
+++ b/yogstation/code/game/gamemodes/vampire/vampire_powers.dm
@@ -154,16 +154,16 @@
 
 	var/protection = T.get_eye_protection()
 	switch(protection)
-		if(INFINITY)
-			to_chat(user, span_vampirewarning("[T] is blind and is unaffected by your gaze!"))
-			return FALSE
-		if(INFINITY to 1)
-			T.adjust_confusion(5 SECONDS)
-			return TRUE
 		if(0)
 			to_chat(target, span_userdanger("You are paralyzed with fear!"))
 			to_chat(user, span_notice("You paralyze [T]."))
 			T.Stun(5 SECONDS)
+		if(1 to INFINITY)
+			T.adjust_confusion(5 SECONDS)
+			return TRUE
+		if(INFINITY)
+			to_chat(user, span_vampirewarning("[T] is blind and is unaffected by your gaze!"))
+			return FALSE
 	return TRUE
 
 
@@ -214,12 +214,13 @@
 	var/protection = T.get_eye_protection()
 	var/sleep_duration = 30 SECONDS
 	switch(protection)
+		if(1 to INFINITY)
+			to_chat(user, span_vampirewarning("Your hypnotic powers are dampened by [T]'s eye protection."))
+			sleep_duration = 10 SECONDS
 		if(INFINITY)
 			to_chat(user, span_vampirewarning("[T] is blind and is unaffected by hypnosis!"))
 			return FALSE
-		if(INFINITY to 1)
-			to_chat(user, span_vampirewarning("Your hypnotic powers are dampened by [T]'s eye protection."))
-			sleep_duration = 10 SECONDS
+		
 
 	to_chat(T, span_boldwarning("Your knees suddenly feel heavy. Your body begins to sink to the floor."))
 	to_chat(user, span_notice("[T] is now under your spell. In four seconds they will be rendered unconscious as long as they are within close range."))


### PR DESCRIPTION
My brother in christ the comment above the defines say not to use the blood level defines in a switch statement because they're non constant.

Also who tf makes a switch statement in descending order?

# Changelog

:cl:  
tweak: fix bloodsucker code compiler errors  
/:cl:
