### PR TITLE
Removes mediator from roundstart AI.

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -501,8 +501,6 @@ LAW_WEIGHT fitnesscoach,0
 ION_LAW_WEIGHT fitnesscoach,3
 LAW_WEIGHT educator,0
 ION_LAW_WEIGHT educator,3
-LAW_WEIGHT mediator,1
-ION_LAW_WEIGHT mediator,3
 
 ## Bad idea laws. Probably shouldn't enable these
 LAW_WEIGHT commie,0

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -501,6 +501,8 @@ LAW_WEIGHT fitnesscoach,0
 ION_LAW_WEIGHT fitnesscoach,3
 LAW_WEIGHT educator,0
 ION_LAW_WEIGHT educator,3
+LAW_WEIGHT mediator,0
+ION_LAW_WEIGHT mediator,3
 
 ## Bad idea laws. Probably shouldn't enable these
 LAW_WEIGHT commie,0


### PR DESCRIPTION
# Document the changes in your pull request
Lawset is highly vague, unhelpful to crew and not fun to play.
Does not have anything to do with harm, reducing harm, helping dead people or anything of the sorts.
Causes issues when implementing it in-game, as, AI's that do all the things listed are not fun to play with or against, and is incredibly hard to interpret in most situations. Just use asimov, it does everything this wants to do but better.

# Why is this good for the game?
As stated in the previous paragraph.

# Testing
Does not need.

# Changelog
:cl:  
rscdel: Mediator is no longer roundstart.
/:cl:
