### PR TITLE
Disable demonic frost miner ruin on icemoon

### DIFF
--- a/config/iceruinblacklist.txt
+++ b/config/iceruinblacklist.txt
@@ -11,7 +11,7 @@
 #_maps/RandomRuins/IceRuins/icemoon_surface_asteroid.dmm
 #_maps/RandomRuins/IceRuins/icemoon_surface_hotsprings.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_puzzle.dmm
-#_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_village.dmm
+_maps/RandomRuins/IceRuins/icemoon_underground_abandoned_village.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_mining_site.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_library.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_wrath.dmm


### PR DESCRIPTION
# Describe the changes in your pull request

Disable the ruin that spawns the demonic ice miner megafauna

# Why is this good for the game?
<!-- Describe why you think this change is good for the game. This section is not required for bugfixes. -->
Shit megafauna with shit AI, shit attacks, and drops literally nothing. No reason for it to exist unless someone improves it for some reason
# Testing
I didn’t test this but it should work as long as the ice ruin blacklist works
# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: demonic frost miner no longer spawns
/:cl:
