### PR TITLE
New virology symptom: symbiotic regeneration

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -505,15 +505,74 @@
 			M.update_damage_overlays()
 	return 1
 
-#define SYMPTOM_PARASYMPATHETIC_MIN_DELAY (1 SECONDS)
-
-/datum/symptom/heal/parasympathetic
-	name = "Parasympathetic Regulation"
-	desc = "The virus accelerates the body's natural healing, causing the body to heal wounds quickly while resting."
+#define SYMPTOM_SUPERFICIAL_LOWER_THRESHOLD 0.7
+/datum/symptom/heal/surface
+	name = "Superficial Healing"
+	desc = "The virus accelerates the body's natural healing, causing the body to heal minor wounds quickly."
 	stealth = -2
 	resistance = -2
 	stage_speed = -2
 	transmittable = 1
+
+	level = 3
+	passive_message = span_notice("Your skin tingles")
+
+	var/threshold = 0.9 // Percentual total health we check against. This is less than a toolbox hit, so probably wont save you in combat
+	var/healing_power = 0.5 // 0.5 brute and fire, slightly better than the worst case starlight with its 0.3
+
+	threshold_descs = list(
+		"Stage Speed 8" = "Improves healing significantly.",
+		"Resistance 10" = "Improves healing threshhold. This comes at the downside of exhausting the body more as heavier wounds heal",
+	)
+
+/datum/symptom/heal/surface/Start(datum/disease/advance/A)
+	. = ..()
+	if(!.)
+		return
+	if(A.properties["stage_rate"] >= 8) //stronger healing
+		healing_power = 1.5
+	if(A.properties["resistance"] >= 10)
+		threshold = SYMPTOM_SUPERFICIAL_LOWER_THRESHOLD
+
+/datum/symptom/heal/surface/CanHeal(datum/disease/advance/A)
+	var/mob/living/M = A.affected_mob
+	if(M.health == M.maxHealth)
+		return FALSE
+	return TRUE
+	
+
+/datum/symptom/heal/surface/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
+	if(M.health == M.maxHealth)
+		return
+	if(((M.health/M.maxHealth) > threshold))
+		healing_power = healing_power * actual_power
+
+		// We don't actually heal all damage types at once, but prioritise one over the other.
+		// Since the virus focuses mainly on surface damage, it will firstly heal those
+		// If it can't find any then it will consider healing some toxins (Not affected by healing power)
+		if(M.getBruteLoss() || M.getFireLoss())
+			M.heal_bodypart_damage(healing_power, healing_power) 				
+		else if(M.getToxLoss())
+			M.adjustToxLoss(-0.5)
+		else
+			return	// Still continues IF we healed something
+
+		// A downside to the better threshold
+		if(threshold == SYMPTOM_SUPERFICIAL_LOWER_THRESHOLD)
+			// Interesting downside
+			if(M.getStaminaLoss() < 65)
+				M.adjustStaminaLoss(20)
+		return TRUE
+#undef SYMPTOM_SUPERFICIAL_LOWER_THRESHOLD
+
+
+/datum/symptom/heal/symbiotic
+	name = "Symbiotic Regeneration"
+	desc = "The virus forms a symbiotic relationship with vital organs in the host's body, accelerating the host's natural healing processes while resting."
+	stealth = -3
+	resistance = -1
+	stage_speed = 2
+	transmittable = -4
 
 	level = 3
 	passive_message = span_notice("You feel calm.")
@@ -522,50 +581,46 @@
 	var/last_moved = 0
 	/// How long do you need to stand still to start healing?
 	var/heal_delay = 3 SECONDS
-	/// How much damage does this heal?
-	var/healing_power = 0.5 // 0.5 brute and fire, slightly better than the worst case starlight with its 0.3
 
 	compatible_biotypes = ALL_BIOTYPES // bungus
 	threshold_descs = list(
-		"Stage Speed 8" = "Improves healing significantly.",
-		"Resistance 10" = "Shorter delay until healing starts.",
+		"Stage speed 9" = "Shorter delay until healing starts.",
+		"Resistance 9" = "Increased rate of healing.",
 	)
 
-/datum/symptom/heal/parasympathetic/Start(datum/disease/advance/A)
+/datum/symptom/heal/symbiotic/Start(datum/disease/advance/A)
 	. = ..()
 	if(!.)
 		return
-	if(A.properties["stage_rate"] >= 8) //stronger healing
-		healing_power = 1.5
-	if(A.properties["resistance"] >= 10) //no delay
-		heal_delay = SYMPTOM_PARASYMPATHETIC_MIN_DELAY
+	if(A.totalStealth() >= 5) //stronger healing
+		heal_delay = 1 SECONDS
+	if(A.totalResistance() >= 10) //no delay
+		power = 3
 	RegisterSignal(A.affected_mob, COMSIG_MOB_CLIENT_PRE_MOVE, PROC_REF(on_move))
 
-/datum/symptom/heal/parasympathetic/End(datum/disease/advance/A)
+/datum/symptom/heal/symbiotic/End(datum/disease/advance/A)
 	UnregisterSignal(A.affected_mob, COMSIG_MOB_CLIENT_PRE_MOVE)
 	return ..()
 
-/datum/symptom/heal/parasympathetic/proc/on_move(mob/living/mover, dir)
+/datum/symptom/heal/symbiotic/proc/on_move(mob/living/mover, dir)
 	last_moved = world.time
 
-/datum/symptom/heal/parasympathetic/CanHeal(datum/disease/advance/A)
+/datum/symptom/heal/symbiotic/CanHeal(datum/disease/advance/A)
 	if(last_moved + heal_delay > world.time)
 		return FALSE
-	return TRUE
+	return power
 
-/datum/symptom/heal/parasympathetic/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
+/datum/symptom/heal/symbiotic/Heal(mob/living/carbon/M, datum/disease/advance/A, actual_power)
 	if(M.health == M.maxHealth)
 		return
 	if(last_moved + heal_delay > world.time)
 		return
 
-	healing_power = healing_power * actual_power
+	var/heal_amount = actual_power * 0.5
 	if(M.getBruteLoss() || M.getFireLoss() || M.getToxLoss())
-		M.heal_bodypart_damage(healing_power, healing_power, required_status=((A.infectable_biotypes & MOB_ROBOTIC) ? BODYPART_ANY : BODYPART_ORGANIC))
-		M.adjustToxLoss(-healing_power)
+		M.heal_bodypart_damage(heal_amount, heal_amount, required_status=((A.infectable_biotypes & MOB_ROBOTIC) ? BODYPART_ANY : BODYPART_ORGANIC))
+		M.adjustToxLoss(-heal_amount)
 	else
-		return	// Still continues IF we healed something
+		return // stop healing if there's no damage to heal
 
 	return TRUE
-
-#undef SYMPTOM_PARASYMPATHETIC_MIN_DELAY

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -616,11 +616,13 @@
 	if(last_moved + heal_delay > world.time)
 		return
 
-	var/heal_amount = actual_power * 0.5
 	if(M.getBruteLoss() || M.getFireLoss() || M.getToxLoss())
+		var/heal_amount = actual_power * 0.5
 		M.heal_bodypart_damage(heal_amount, heal_amount, required_status=((A.infectable_biotypes & MOB_ROBOTIC) ? BODYPART_ANY : BODYPART_ORGANIC))
 		M.adjustToxLoss(-heal_amount)
-	else
-		return // stop healing if there's no damage to heal
+		if(prob(1) && IS_ENGINEERING(M))
+			M.adjust_wet_stacks(0.1) // there seems to be a danger of precipitation...
+			to_chat(M, span_notice("You can smell rain."))
+		return TRUE
 
-	return TRUE
+	return FALSE // stop healing if there isn't any damage to heal

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -561,7 +561,7 @@
 
 	healing_power = healing_power * actual_power
 	if(M.getBruteLoss() || M.getFireLoss() || M.getToxLoss())
-		M.heal_bodypart_damage(healing_power, healing_power)
+		M.heal_bodypart_damage(healing_power, healing_power, required_status=((A.infectable_biotypes & MOB_ROBOTIC) ? BODYPART_ANY : BODYPART_ORGANIC))
 		M.adjustToxLoss(-healing_power)
 	else
 		return	// Still continues IF we healed something


### PR DESCRIPTION
# Document the changes in your pull request

Adds a new virology symptom: symbiotic regeneration.

This new symptom heals you slowly while standing still for longer than 3 seconds. Heal rate is 0.5 brute/burn/toxin every 2 seconds.

# Why is this good for the game?

Adds more variety to the types of beneficial viruses that can be made, so it's less of the exact same thing every round.

# Testing
<!-- Describe what testing you did with this PR. Try to be thorough, especially if this is a larger project. -->
Made a virus with this symptom, gave it to myself, the symptom healed when standing still for long enough and stopped when moving.

# Wiki Documentation

Add this to the list of symptoms on the guide to infections

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: new virology symptom: symbiotic regeneration
/:cl:
