### PR TITLE
Make FastDMM2 able to open our repository again

### DIFF
--- a/code/__byond_version_compat.dm
+++ b/code/__byond_version_compat.dm
@@ -1,9 +1,17 @@
 // This file contains defines allowing targeting byond versions newer than the supported
 
+#ifdef FASTDMM // fastdmm is on 514 currently
+#define IGNORE_MIN_BYOND_VERSION
+#endif
+
+#ifdef SPACEMAN_DMM // moved out from the !defined check below
+#define IGNORE_MIN_BYOND_VERSION
+#endif
+
 //Update this whenever you need to take advantage of more recent byond features
 #define MIN_COMPILER_VERSION 515
 #define MIN_COMPILER_BUILD 1620
-#if (DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD) && !defined(SPACEMAN_DMM)
+#if (DM_VERSION < MIN_COMPILER_VERSION || DM_BUILD < MIN_COMPILER_BUILD) && !defined(IGNORE_MIN_BYOND_VERSION)
 //Don't forget to update this part
 #error Your version of BYOND is too out-of-date to compile this project. Go to https://secure.byond.com/download and update.
 #error You need version 515.1620 or higher
@@ -19,7 +27,7 @@
 #define IGNORE_MAX_BYOND_VERSION
 #endif
 
-#ifdef SPACEMAN_DMM // dm-langserver is now on 515 and we aren't
+#ifdef SPACEMAN_DMM // dm-langserver is now on 515 and... we also are, but i'll leave this here for now
 #define IGNORE_MAX_BYOND_VERSION
 #endif
 


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

Currently FastDMM2 has its `DM_VERSION` set at 514. Since we just updated to 515 for auxmos, this means fastdmm can no longer open our repository, since it parses and runs all the preprocessor macros.

Fix this by skipping the version check if the `FASTDMM` macro is defined, indicating the code is being run in fastdmm

# Testing

FastDMM successfully loads this branch (`hedgehog1029/Yogstation`,`fix/fastdmm-version-compat`) and I can edit maps successfully

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: allowed fastdmm2 to work again  
/:cl: 