### PR TITLE
Nerfs pseudocider

### DIFF
--- a/code/game/objects/items/devices/pseudocider.dm
+++ b/code/game/objects/items/devices/pseudocider.dm
@@ -9,7 +9,7 @@
 	var/active = FALSE
 	var/mob/living/carbon/fake_corpse
 	COOLDOWN_DECLARE(fake_death_timer)
-	var/fake_death_cooldown = 20 SECONDS
+	var/fake_death_cooldown = 30 SECONDS
 
 /obj/item/pseudocider/update_icon_state()
 	icon_state = "[base_icon_state][active ? "-open" : "-closed"]"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1462,7 +1462,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			completely silent as you slip away from the scene, or into a better position! You will not be able to take \
 			any actions for the 7 second duration."
 	item = /obj/item/pseudocider
-	cost = 6
+	cost = 8
 	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/stealthy_tools/shadowcloak


### PR DESCRIPTION
# Why is this good for the game?
It was merged initially as a very hypothetical idea, balancing of such an effect being not super straight forward
It was found to be too strong when combined with martial arts, as well as have a cooldown so short it can be mostly ignored

Increasing TC to 8 brings it in line with antistun implants and adrenals, as well as prevents it from being bought with most martial arts
Increasing the cooldown by 10 seconds shouldn't make a huge impact, but it does mean it likely won't be used multiple times in the same encounter anymore

:cl:  
tweak: Pseudocider costs 8tc instead of 6tc
tweak: Pseudocider has a 30s cooldown instead of 20s
/:cl:
