### PR TITLE
HFR uses process_atmos() instead of process()

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -4,7 +4,7 @@
  * fusion_process() handles all the main fusion reaction logic and consequences (lightning, radiation, particles) from an active fusion reaction.
  */
 
-/obj/machinery/atmospherics/components/unary/hypertorus/core/process(delta_time)
+/obj/machinery/atmospherics/components/unary/hypertorus/core/process_atmos(delta_time)
 	/*
 	 *Pre-checks
 	 */


### PR DESCRIPTION
# Document the changes in your pull request

Changes HFR to process on atmos processing ticks. This does not increase the speed of production/consumption though, delta_time is already taken into account for pretty much everything in the HFR.

# Why is this good for the game?

HFR currently processes 4x slower than all other atmos machines which makes it feel a bit weird to use, this fixes that.

# Testing
Ran the HFR for a while, worked just fine.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: HFR processes at the same rate as other atmos machines now
/:cl:
