### PR TITLE
Returns AI chamber on Boxstation to its primordial form, in the center of the station.

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -296,17 +296,14 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "abx" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
+	dir = 1;
+	name = "AI Antechamber APC";
+	pixel_y = 24
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/grimy,
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "aby" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -3192,9 +3189,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"axV" = (
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "ayd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -6361,6 +6355,15 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port)
+"aTs" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "aTw" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -6451,13 +6454,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
-"aTP" = (
-/obj/machinery/telecomms/processor/preset_four,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "aTQ" = (
 /obj/machinery/light{
 	dir = 1
@@ -7271,10 +7267,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"bcc" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "bcd" = (
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -7694,6 +7686,7 @@
 /area/bridge/meeting_room)
 "bfr" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
+/obj/machinery/porta_turret/ai,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "bfv" = (
@@ -9854,25 +9847,6 @@
 "byf" = (
 /turf/closed/wall/r_wall,
 /area/science/server)
-"byg" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room South";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
-	},
-/obj/machinery/telecomms/processor/preset_three,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "byi" = (
 /turf/closed/wall,
 /area/security/checkpoint/science)
@@ -12898,9 +12872,6 @@
 /obj/item/beacon,
 /turf/open/floor/engine,
 /area/science/misc_lab)
-"cbd" = (
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
 "cbe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -13206,6 +13177,10 @@
 /obj/machinery/power/emitter,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cfh" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "cfm" = (
 /obj/item/c_tube,
 /obj/structure/disposalpipe/segment,
@@ -16755,6 +16730,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"djF" = (
+/obj/machinery/ai/server_cabinet/prefilled,
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "dkq" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -16942,8 +16921,10 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
 "dnj" = (
-/obj/machinery/telecomms/message_server/preset,
-/turf/open/floor/circuit/green/telecomms/mainframe,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "dno" = (
 /obj/machinery/requests_console{
@@ -18272,6 +18253,9 @@
 	name = "server vent"
 	},
 /turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
+"dOp" = (
+/turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "dOt" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
@@ -21285,9 +21269,18 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "eTe" = (
-/obj/machinery/ai/server_cabinet/prefilled,
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 7;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "eTh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -22185,9 +22178,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "fkC" = (
-/obj/machinery/pipedispenser,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
@@ -23202,12 +23196,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/lawoffice)
-"fCV" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
-	dir = 1
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
 "fDx" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -27447,15 +27435,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hjk" = (
-/obj/machinery/telecomms/broadcaster/preset_left{
-	name = "subspace broadcaster A"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "hjA" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -29971,6 +29950,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"ieo" = (
+/obj/structure/cable{
+	icon_state = "1-4";
+	tag = ""
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "ier" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -31351,6 +31337,25 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
+"iHu" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room South";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/obj/machinery/telecomms/processor/preset_three,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "iHI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -31396,15 +31401,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"iII" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "iJa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -33681,10 +33677,6 @@
 /obj/effect/turf_decal/box/corners,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"jCM" = (
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
 "jDa" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -35574,16 +35566,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"krI" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
-	},
-/obj/machinery/camera{
-	c_tag = "East AI Server"
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
 "krO" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer_R";
@@ -37396,6 +37378,14 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"lfM" = (
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "lfW" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -38423,13 +38413,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
-"lyX" = (
-/obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "lza" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -38694,15 +38677,6 @@
 "lFj" = (
 /turf/template_noop,
 /area/maintenance/port/fore)
-"lFm" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "lFG" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -38768,14 +38742,6 @@
 /obj/item/mop,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
-"lHO" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "lIb" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -39043,6 +39009,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"lMT" = (
+/obj/machinery/telecomms/receiver/preset_left{
+	name = "subspace receiver A"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "lMW" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -39409,12 +39384,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"lWl" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
 "lWz" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -40542,13 +40511,12 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "mqO" = (
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = 22
+/obj/machinery/pipedispenser,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "mqR" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable{
@@ -40608,22 +40576,12 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "mrS" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room South";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 8
 	},
-/obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "msb" = (
@@ -41356,6 +41314,15 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"mFE" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "mFO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -42415,9 +42382,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/storage/satellite)
-"naq" = (
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "naz" = (
 /obj/effect/spawner/structure/solars/solar_96,
 /obj/structure/cable/yellow{
@@ -44110,6 +44074,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"nHT" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "nHU" = (
 /obj/machinery/requests_console{
 	department = "Science";
@@ -45601,14 +45571,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"opJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "oqf" = (
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine{
@@ -47498,14 +47460,15 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "paH" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 8
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "West AI Server"
 	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "paQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 4
@@ -47592,8 +47555,9 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "pen" = (
-/turf/closed/wall/r_wall,
-/area/tcommsat/entrance)
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/satellite)
 "pew" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -47846,11 +47810,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "phR" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
+/area/tcommsat/computer)
 "pia" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4
@@ -47982,13 +47949,10 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "pkb" = (
-/obj/machinery/telecomms/receiver/preset_left{
-	name = "subspace receiver A"
-	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 5
+	dir = 10
 	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
+/turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "pkD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -52600,13 +52564,13 @@
 /turf/open/floor/wood,
 /area/library)
 "qVN" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 1
+/obj/machinery/telecomms/broadcaster/preset_left{
+	name = "subspace broadcaster A"
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
+	dir = 6
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "qVZ" = (
 /obj/machinery/door/firedoor/border_only,
@@ -53009,13 +52973,13 @@
 /area/solar/port/fore)
 "rdR" = (
 /obj/structure/window/reinforced{
-	dir = 1
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
+/obj/machinery/airalarm{
+	pixel_y = 24
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "rfl" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -53069,6 +53033,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"rfJ" = (
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "rfK" = (
 /obj/machinery/light{
 	dir = 4
@@ -55383,16 +55350,24 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
 "rYz" = (
-/obj/effect/turf_decal/ramp_middle{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 6
 	},
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide2{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room South";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
 	},
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/telecomms/bus/preset_one,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "rYI" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -56145,7 +56120,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "snF" = (
@@ -59014,6 +58988,13 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"tto" = (
+/obj/machinery/telecomms/processor/preset_four,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "ttQ" = (
 /obj/structure/rack,
 /obj/machinery/light{
@@ -59935,16 +59916,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"tNs" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	dir = 1;
-	name = "AI Antechamber APC";
-	pixel_y = 24
-	},
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
 "tNA" = (
 /obj/machinery/camera{
 	c_tag = "Dormitory South";
@@ -60331,9 +60302,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "tTK" = (
-/obj/machinery/porta_turret/ai,
-/turf/open/floor/circuit/telecomms/server,
-/area/ai_monitored/turret_protected/ai)
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "tUe" = (
 /obj/machinery/keycard_auth{
 	pixel_x = 24;
@@ -62536,11 +62512,14 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "uNG" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 10
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "uNH" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -64628,11 +64607,10 @@
 /obj/effect/turf_decal/ramp_middle{
 	dir = 1
 	},
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = -22
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide2{
 	dir = 1
 	},
 /area/ai_monitored/turret_protected/ai)
@@ -66245,6 +66223,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"wer" = (
+/obj/machinery/telecomms/message_server/preset,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "weD" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -66915,6 +66897,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"wrK" = (
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
+	dir = 1
+	},
+/area/ai_monitored/turret_protected/ai)
 "wrN" = (
 /obj/structure/chair/comfy/beige,
 /turf/open/floor/plasteel/grimy,
@@ -68982,6 +68976,9 @@
 /obj/structure/closet/secure_closet/warden,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"xnr" = (
+/turf/closed/wall/r_wall,
+/area/tcommsat/entrance)
 "xnF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -69383,15 +69380,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "xwL" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
+	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "West AI Server"
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "xwU" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/machinery/light{
@@ -69502,6 +69495,16 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/white,
 /area/engine/atmos/mix)
+"xyb" = (
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
+	},
+/obj/machinery/camera{
+	c_tag = "East AI Server"
+	},
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "xyG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -70320,14 +70323,8 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "xPL" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
+/area/ai_monitored/turret_protected/aisat_interior)
 "xPQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -99842,7 +99839,7 @@ cva
 cva
 cva
 gtB
-eTe
+djF
 qKi
 kqB
 gtB
@@ -100098,9 +100095,9 @@ vJJ
 ume
 cva
 cva
-xwL
-naq
-naq
+paH
+xPL
+xPL
 nQP
 gtB
 tgv
@@ -100353,14 +100350,14 @@ nDA
 nDA
 nDA
 rjo
-tTK
+sAu
 cva
 mDO
 gLt
 kMi
 uuG
 ieK
-lyX
+ieo
 azq
 rRA
 lmN
@@ -100606,9 +100603,9 @@ pqr
 cva
 hWd
 fiF
-bcc
-mqO
-bcc
+cfh
+lfM
+cfh
 bfr
 qjk
 cva
@@ -100617,7 +100614,7 @@ tgv
 fXb
 suV
 tgv
-abx
+eTe
 pSY
 lhk
 rdw
@@ -100866,19 +100863,19 @@ nDA
 cva
 cva
 hsq
-rdR
+uNG
 rJJ
-vAP
+wrK
 uAV
 tgv
 cqT
 xxd
 tgv
-jCM
+pen
 pTL
-axV
-axV
-axV
+rfJ
+rfJ
+rfJ
 aJw
 pvo
 sXZ
@@ -101134,8 +101131,8 @@ fJN
 aJy
 nyj
 rPo
-opJ
-opJ
+fkC
+fkC
 psj
 hsn
 sYk
@@ -101380,18 +101377,18 @@ nDA
 cva
 cva
 mfG
-rdR
+uNG
 rJJ
-rYz
+vAP
 gCs
 tgv
 naj
 rCq
 tgv
-tNs
+abx
 hYy
-axV
-axV
+rfJ
+rfJ
 gOE
 aJw
 hvG
@@ -101636,7 +101633,7 @@ hWd
 qoQ
 jJK
 prN
-bcc
+cfh
 bfr
 laN
 cva
@@ -101645,10 +101642,10 @@ tgv
 fXb
 suV
 tgv
-iII
+rdR
 rzx
 iRV
-fkC
+mqO
 agz
 aJw
 qHo
@@ -101895,14 +101892,14 @@ nDA
 nDA
 nDA
 rjo
-tTK
+sAu
 cva
 mDO
 sAr
 tmm
 pJS
 vzc
-axV
+rfJ
 dne
 bxL
 lmN
@@ -102154,9 +102151,9 @@ sAu
 wkd
 cva
 cva
-krI
-naq
-naq
+xyb
+xPL
+xPL
 nQP
 gtB
 tgv
@@ -102412,7 +102409,7 @@ cva
 cva
 cva
 gtB
-eTe
+djF
 mUg
 uMi
 gtB
@@ -109676,15 +109673,15 @@ aaa
 aaa
 aaa
 ucZ
-pen
-pen
-pen
+xnr
+xnr
+xnr
 vbw
 fjN
 kRG
-pen
-pen
-pen
+xnr
+xnr
+xnr
 pEf
 aaa
 aaa
@@ -110190,17 +110187,17 @@ aaa
 ucZ
 bVJ
 bVJ
-pen
-pen
-pen
+xnr
+xnr
+xnr
 aDW
 sxE
 vvS
-pen
-pen
-pen
-pen
-pen
+xnr
+xnr
+xnr
+xnr
+xnr
 pEf
 gXs
 aKN
@@ -110457,7 +110454,7 @@ vmm
 ody
 kfG
 xnR
-pen
+xnr
 pEf
 gXs
 aKN
@@ -110714,7 +110711,7 @@ iek
 cZu
 cLg
 sdl
-pen
+xnr
 pEf
 aaa
 aaa
@@ -110971,7 +110968,7 @@ pJB
 gBP
 vxS
 qlI
-pen
+xnr
 pEf
 pEf
 pEf
@@ -111734,11 +111731,11 @@ qTh
 phH
 iDE
 fYE
-snB
-snB
+phR
+phR
 cqk
 bhL
-lHO
+snB
 dEd
 pyZ
 dTb
@@ -113276,11 +113273,11 @@ pEf
 pEf
 fmC
 fmC
-hjk
+qVN
 bRu
 xFg
 gTY
-pkb
+lMT
 fmC
 fmC
 pEf
@@ -113534,10 +113531,10 @@ fmC
 fmC
 gQa
 jzm
-cbd
+dOp
 soe
-cbd
-qVN
+dOp
+aTs
 yap
 fmC
 fmC
@@ -113791,11 +113788,11 @@ fmC
 fmC
 gNr
 npc
-cbd
-aTP
-cbd
-fCV
-xPL
+dOp
+tto
+dOp
+xwL
+mFE
 fmC
 fmC
 fmC
@@ -114047,11 +114044,11 @@ fmC
 fmC
 bjE
 qQw
-lWl
-cbd
+dnj
+dOp
 jKN
-cbd
-lWl
+dOp
+dnj
 loF
 xlV
 fmC
@@ -114307,9 +114304,9 @@ jcz
 cWY
 lQv
 grq
-phR
+nHT
 tGz
-lFm
+mrS
 ikV
 fmC
 fmC
@@ -114561,11 +114558,11 @@ fmC
 fmC
 kVh
 qKK
-lWl
-cbd
+dnj
+dOp
 car
-cbd
-lWl
+dOp
+dnj
 bdd
 bcd
 fmC
@@ -114819,11 +114816,11 @@ fmC
 fmC
 dOn
 sPc
-cbd
+dOp
 rlo
-cbd
-uNG
-paH
+dOp
+pkb
+tTK
 fmC
 fmC
 fmC
@@ -115074,13 +115071,13 @@ pEf
 pEf
 fmC
 fmC
-byg
+iHu
 ikV
-cbd
+dOp
 xzh
-cbd
-phR
-mrS
+dOp
+nHT
+rYz
 fmC
 fmC
 pEf
@@ -115333,7 +115330,7 @@ ogh
 jXD
 fmC
 mDn
-dnj
+wer
 fmC
 dTU
 eKD

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -295,6 +295,16 @@
 /obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"abx" = (
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
+	dir = 1;
+	name = "AI Antechamber APC";
+	pixel_y = 24
+	},
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/circuit,
+/area/ai_monitored/storage/satellite)
 "aby" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -3171,8 +3181,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "axV" = (
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
+	},
+/obj/machinery/camera{
+	c_tag = "East AI Server"
+	},
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "ayd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -6339,6 +6356,15 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port)
+"aTs" = (
+/obj/machinery/telecomms/receiver/preset_left{
+	name = "subspace receiver A"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "aTw" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -6590,6 +6616,12 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
+"aVE" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/closed/wall/r_wall,
+/area/ai_monitored/turret_protected/ai)
 "aVX" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/dark,
@@ -7242,6 +7274,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"bcc" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "bcd" = (
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -7659,6 +7695,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge/meeting_room)
+"bfr" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "bfv" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -9818,18 +9858,11 @@
 /turf/closed/wall/r_wall,
 /area/science/server)
 "byg" = (
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "byi" = (
 /turf/closed/wall,
 /area/security/checkpoint/science)
@@ -13160,10 +13193,6 @@
 /obj/machinery/power/emitter,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cfh" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "cfm" = (
 /obj/item/c_tube,
 /obj/structure/disposalpipe/segment,
@@ -14631,9 +14660,8 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "cyY" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable/yellow,
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
 "czl" = (
@@ -15663,6 +15691,9 @@
 /area/engine/atmos/mix)
 "cOE" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "cOJ" = (
@@ -16907,6 +16938,12 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
+"dnj" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "dno" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -18236,11 +18273,14 @@
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "dOp" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "dOt" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /obj/machinery/light,
@@ -19614,10 +19654,6 @@
 /area/science/robotics/lab)
 "erb" = (
 /obj/machinery/ai/data_core/primary,
-/obj/machinery/power/apc/highcap{
-	name = "AI Chamber APC";
-	pixel_y = -24
-	},
 /obj/item/radio/intercom{
 	anyai = 1;
 	freerange = 1;
@@ -21253,13 +21289,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "eTe" = (
-/obj/machinery/telecomms/receiver/preset_left{
-	name = "subspace receiver A"
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 5
+	dir = 4
 	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
+/turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "eTh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -23177,6 +23213,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/lawoffice)
+"fCV" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "fDx" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -23795,6 +23839,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"fMm" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "fMp" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall,
@@ -27416,6 +27469,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hjk" = (
+/obj/machinery/gulag_item_reclaimer,
+/turf/open/space/basic,
+/area/space)
 "hjA" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -27632,7 +27689,7 @@
 	external_pressure_bound = 120;
 	name = "server vent"
 	},
-/turf/open/floor/circuit/telecomms/server,
+/turf/open/floor/circuit/green/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "hmO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -27900,6 +27957,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
+"hsq" = (
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "hsA" = (
 /obj/machinery/computer/camera_advanced/base_construction{
 	dir = 1
@@ -29285,6 +29350,12 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "hUM" = (
@@ -29487,14 +29558,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
 "hXu" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/pipedispenser,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "hYy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -29943,16 +30012,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"ieo" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
-	},
-/obj/machinery/camera{
-	c_tag = "West AI Server"
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
 "ier" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -31379,20 +31438,8 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "iIj" = (
-/obj/machinery/telecomms/broadcaster/preset_left{
-	name = "subspace broadcaster A"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
-"iII" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 10
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
+/turf/closed/wall/r_wall,
+/area/tcommsat/entrance)
 "iJa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -32986,13 +33033,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"jnr" = (
-/obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "jnA" = (
 /obj/structure/grille,
 /turf/open/space/basic,
@@ -33676,13 +33716,6 @@
 /obj/effect/turf_decal/box/corners,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"jCM" = (
-/obj/machinery/pipedispenser,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "jDa" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -34068,6 +34101,13 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/science/research)
+"jJK" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "jJP" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/holopad,
@@ -34820,10 +34860,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/security/prison)
-"kcr" = (
-/obj/machinery/gulag_item_reclaimer,
-/turf/open/space/basic,
-/area/space)
 "kcy" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
@@ -35155,12 +35191,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"kit" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "kiy" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
@@ -35574,14 +35604,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"krI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "aiserverdoor";
-	name = "AI Server Shutters"
-	},
-/turf/open/floor/circuit/green,
-/area/ai_monitored/storage/satellite)
 "krO" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer_R";
@@ -36865,6 +36887,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"kTy" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/highcap{
+	dir = 1;
+	name = "AI Chamber APC";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "kTM" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -37126,6 +37159,9 @@
 /obj/effect/turf_decal/stripes/white/corner{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "laR" = (
@@ -37209,6 +37245,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"lbX" = (
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
+	dir = 1
+	},
+/area/ai_monitored/turret_protected/ai)
 "lcb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -37403,7 +37451,7 @@
 	external_pressure_bound = 140;
 	pressure_checks = 0
 	},
-/turf/open/floor/circuit/telecomms/server,
+/turf/open/floor/circuit/green/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "lfW" = (
 /obj/structure/cable{
@@ -38764,6 +38812,15 @@
 /obj/item/mop,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
+"lHO" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "lIb" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -39031,10 +39088,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"lMT" = (
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/circuit,
-/area/ai_monitored/storage/satellite)
 "lMW" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -40518,15 +40571,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
-"mqO" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "mqR" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable{
@@ -40586,13 +40630,11 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "mrS" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 4
+/obj/machinery/telecomms/processor/preset_four,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "msb" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
@@ -41225,7 +41267,9 @@
 	anchored = 1;
 	state = 2
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/camera{
+	c_tag = "West AI Server"
+	},
 /turf/open/floor/circuit/green/telecomms,
 /area/ai_monitored/turret_protected/aisat_interior)
 "mEa" = (
@@ -41325,11 +41369,10 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "mFE" = (
-/obj/machinery/telecomms/processor/preset_four,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
+	dir = 1
 	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
+/turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "mFO" = (
 /obj/effect/turf_decal/stripes/line{
@@ -42211,15 +42254,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"mWE" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "mWH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -42399,16 +42433,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/storage/satellite)
-"naq" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
-	},
-/obj/machinery/camera{
-	c_tag = "East AI Server"
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
 "naz" = (
 /obj/effect/spawner/structure/solars/solar_96,
 /obj/structure/cable/yellow{
@@ -44101,6 +44125,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"nHT" = (
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/circuit,
+/area/ai_monitored/storage/satellite)
 "nHU" = (
 /obj/machinery/requests_console{
 	department = "Science";
@@ -44402,14 +44430,11 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "nQP" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 8
-	},
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
+/area/ai_monitored/turret_protected/aisat_interior)
 "nRs" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Genetics Research";
@@ -47168,18 +47193,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"oUc" = (
-/obj/effect/turf_decal/ramp_middle{
-	dir = 1
-	},
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = -22
-	},
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
-	dir = 1
-	},
-/area/ai_monitored/turret_protected/ai)
 "oUl" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -47588,6 +47601,13 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"pen" = (
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "pew" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -48381,6 +48401,9 @@
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "prQ" = (
@@ -48492,11 +48515,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "ptV" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 10
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "put" = (
 /obj/machinery/door/airlock/external{
 	name = "Security Secure External Airlock";
@@ -48989,9 +49012,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"pBl" = (
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
 "pBm" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -50141,11 +50161,11 @@
 "pZI" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/ai_slipper{
 	uses = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
@@ -50923,6 +50943,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"qoQ" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "qoX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -52587,25 +52616,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"qVN" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room South";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
-	},
-/obj/machinery/telecomms/processor/preset_three,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "qVZ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -53009,6 +53019,9 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
+"rdR" = (
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "rfl" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -53062,6 +53075,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"rfJ" = (
+/obj/machinery/telecomms/message_server/preset,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "rfK" = (
 /obj/machinery/light{
 	dir = 4
@@ -54597,6 +54614,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
+"rJJ" = (
+/obj/effect/turf_decal/stripes/white/line,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "rKk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -55371,6 +55395,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
+"rYz" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "rYI" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -56123,6 +56156,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "snF" = (
@@ -56438,6 +56472,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"suV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "aiserverdoor";
+	name = "AI Server Shutters"
+	},
+/turf/open/floor/circuit/green,
+/area/ai_monitored/storage/satellite)
 "svh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -58554,25 +58596,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"tjY" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room South";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
-	},
-/obj/machinery/telecomms/bus/preset_one,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "tkd" = (
 /obj/machinery/camera{
 	c_tag = "Engineering East";
@@ -59003,8 +59026,24 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "tto" = (
-/turf/closed/wall/r_wall,
-/area/tcommsat/entrance)
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room South";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/obj/machinery/telecomms/processor/preset_three,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "ttQ" = (
 /obj/structure/rack,
 /obj/machinery/light{
@@ -59926,6 +59965,13 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"tNs" = (
+/obj/structure/cable{
+	icon_state = "1-4";
+	tag = ""
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "tNA" = (
 /obj/machinery/camera{
 	c_tag = "Dormitory South";
@@ -62102,14 +62148,6 @@
 	},
 /area/ai_monitored/turret_protected/ai)
 "uGc" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = 8;
-	pixel_y = 23
-	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
 	},
@@ -62521,14 +62559,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"uNG" = (
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = 22
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "uNH" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -66902,6 +66932,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"wrK" = (
+/obj/machinery/telecomms/broadcaster/preset_left{
+	name = "subspace broadcaster A"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "wrN" = (
 /obj/structure/chair/comfy/beige,
 /turf/open/floor/plasteel/grimy,
@@ -67319,6 +67358,9 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "wBN" = (
@@ -67614,8 +67656,13 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "wIB" = (
-/obj/machinery/telecomms/message_server/preset,
-/turf/open/floor/circuit/green/telecomms/mainframe,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "wJc" = (
 /obj/effect/decal/cleanable/dirt/dust,
@@ -68982,15 +69029,16 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "xnr" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	dir = 1;
-	name = "AI Antechamber APC";
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
 	},
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/circuit,
-/area/ai_monitored/storage/satellite)
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 8;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "xnF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -69391,6 +69439,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"xwL" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room South";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/obj/machinery/telecomms/bus/preset_one,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "xwU" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/machinery/light{
@@ -69501,6 +69568,14 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/white,
 /area/engine/atmos/mix)
+"xyb" = (
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "xyG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -70318,6 +70393,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"xPL" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 7;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "xPQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -70882,13 +70970,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "ybM" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "ycf" = (
 /obj/machinery/meter{
@@ -100097,10 +100179,10 @@ vJJ
 ume
 cva
 cva
-ieo
+mDO
 lyX
 lyX
-kit
+nQP
 gtB
 tgv
 wJL
@@ -100354,12 +100436,12 @@ nDA
 rjo
 tTK
 cva
-mDO
+xyb
 gLt
 kMi
 uuG
 ieK
-jnr
+tNs
 azq
 rRA
 lmN
@@ -100605,18 +100687,18 @@ pqr
 cva
 hWd
 fiF
-cfh
-uNG
-cfh
-cOE
+bcc
+hsq
+bcc
+bfr
 qjk
 cva
 cva
 tgv
 fXb
-krI
+suV
 tgv
-byg
+xPL
 pSY
 lhk
 rdw
@@ -100861,23 +100943,23 @@ hRj
 oeF
 cva
 cuZ
-hUA
+pen
 hmx
 cva
 cva
-ptV
+xnr
 qZK
-oUc
+lbX
 uAV
 tgv
 cqT
 xxd
 tgv
-lMT
+nHT
 pTL
-axV
-axV
-axV
+rdR
+rdR
+rdR
 aJw
 pvo
 sXZ
@@ -101374,23 +101456,23 @@ nvA
 hRj
 rMA
 cva
-nDA
+kTy
 hUA
 lfM
 cva
 cva
-ptV
-qZK
+byg
+rJJ
 vAP
 gCs
 tgv
 naj
 rCq
 tgv
-xnr
+abx
 hYy
-axV
-axV
+rdR
+rdR
 gOE
 aJw
 hvG
@@ -101632,8 +101714,8 @@ gFO
 jfG
 cva
 hWd
-fiF
-cfh
+qoQ
+jJK
 prN
 wBI
 cOE
@@ -101642,12 +101724,12 @@ cva
 cva
 tgv
 fXb
-krI
+suV
 tgv
-mWE
+dOp
 rzx
 iRV
-jCM
+hXu
 agz
 aJw
 qHo
@@ -101890,18 +101972,18 @@ vrT
 cva
 iXp
 pyn
-nDA
-nDA
+dnj
+lHO
 nDA
 rjo
 tTK
 cva
-mDO
+xyb
 sAr
 tmm
 pJS
 vzc
-axV
+rdR
 dne
 bxL
 lmN
@@ -102147,16 +102229,16 @@ wVO
 cva
 cva
 guR
-sAu
+aVE
 cyY
-sAu
+cva
 wkd
 cva
 cva
-naq
+axV
 lyX
 lyX
-kit
+nQP
 gtB
 tgv
 wJL
@@ -108396,7 +108478,7 @@ aaa
 xrX
 aaa
 slA
-kcr
+hjk
 aaa
 gXs
 pEf
@@ -109675,15 +109757,15 @@ aaa
 aaa
 aaa
 ucZ
-tto
-tto
-tto
+iIj
+iIj
+iIj
 vbw
 fjN
 kRG
-tto
-tto
-tto
+iIj
+iIj
+iIj
 pEf
 aaa
 aaa
@@ -110189,17 +110271,17 @@ aaa
 ucZ
 bVJ
 bVJ
-tto
-tto
-tto
+iIj
+iIj
+iIj
 aDW
 sxE
 vvS
-tto
-tto
-tto
-tto
-tto
+iIj
+iIj
+iIj
+iIj
+iIj
 pEf
 gXs
 aKN
@@ -110456,7 +110538,7 @@ vmm
 ody
 kfG
 xnR
-tto
+iIj
 pEf
 gXs
 aKN
@@ -110713,7 +110795,7 @@ iek
 cZu
 cLg
 sdl
-tto
+iIj
 pEf
 aaa
 aaa
@@ -110970,7 +111052,7 @@ pJB
 gBP
 vxS
 qlI
-tto
+iIj
 pEf
 pEf
 pEf
@@ -111733,11 +111815,11 @@ qTh
 phH
 iDE
 fYE
-hXu
-hXu
+snB
+snB
 cqk
 bhL
-snB
+fCV
 dEd
 pyZ
 dTb
@@ -113275,11 +113357,11 @@ pEf
 pEf
 fmC
 fmC
-iIj
+wrK
 bRu
 xFg
 gTY
-eTe
+aTs
 fmC
 fmC
 pEf
@@ -113533,10 +113615,10 @@ fmC
 fmC
 gQa
 jzm
-pBl
+ybM
 soe
-pBl
-mqO
+ybM
+eTe
 yap
 fmC
 fmC
@@ -113790,11 +113872,11 @@ fmC
 fmC
 gNr
 npc
-pBl
-mFE
-pBl
-dOp
+ybM
 mrS
+ybM
+mFE
+fMm
 fmC
 fmC
 fmC
@@ -114047,9 +114129,9 @@ fmC
 bjE
 qQw
 lWl
-pBl
+ybM
 jKN
-pBl
+ybM
 lWl
 loF
 xlV
@@ -114308,7 +114390,7 @@ lQv
 grq
 phR
 tGz
-nQP
+wIB
 ikV
 fmC
 fmC
@@ -114561,9 +114643,9 @@ fmC
 kVh
 qKK
 lWl
-pBl
+ybM
 car
-pBl
+ybM
 lWl
 bdd
 bcd
@@ -114818,11 +114900,11 @@ fmC
 fmC
 dOn
 sPc
-pBl
-rlo
-pBl
-iII
 ybM
+rlo
+ybM
+ptV
+rYz
 fmC
 fmC
 fmC
@@ -115073,13 +115155,13 @@ pEf
 pEf
 fmC
 fmC
-qVN
+tto
 ikV
-pBl
+ybM
 xzh
-pBl
+ybM
 phR
-tjY
+xwL
 fmC
 fmC
 pEf
@@ -115332,7 +115414,7 @@ ogh
 jXD
 fmC
 mDn
-wIB
+rfJ
 fmC
 dTU
 eKD

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -296,13 +296,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "abx" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "aby" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -837,15 +834,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"afK" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "afL" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -3188,12 +3176,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"axV" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "ayd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -6450,15 +6432,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
-"aTP" = (
-/obj/machinery/telecomms/receiver/preset_left{
-	name = "subspace receiver A"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 5
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "aTQ" = (
 /obj/machinery/light{
 	dir = 1
@@ -7279,11 +7252,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bcc" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
-	dir = 1
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "bcd" = (
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -9864,18 +9835,15 @@
 /turf/closed/wall/r_wall,
 /area/science/server)
 "byg" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
+/obj/machinery/camera{
+	c_tag = "West AI Server"
 	},
-/obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "byi" = (
 /turf/closed/wall,
 /area/security/checkpoint/science)
@@ -12901,6 +12869,10 @@
 /obj/item/beacon,
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"cbd" = (
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/circuit,
+/area/ai_monitored/storage/satellite)
 "cbe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -13207,9 +13179,14 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cfh" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "cfm" = (
 /obj/item/c_tube,
 /obj/structure/disposalpipe/segment,
@@ -14145,9 +14122,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"cqT" = (
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "cqW" = (
 /obj/effect/decal/cleanable/xenoblood,
 /turf/open/floor/engine,
@@ -16754,6 +16728,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"djF" = (
+/obj/machinery/ai/server_cabinet/prefilled,
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "dkq" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -21290,9 +21268,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "eTe" = (
-/obj/machinery/ai/server_cabinet/prefilled,
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/telecomms/processor/preset_four,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "eTh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -25698,21 +25679,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "gCs" = (
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = 25;
-	pixel_y = 6
+/obj/machinery/telecomms/broadcaster/preset_left{
+	name = "subspace broadcaster A"
 	},
-/obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = 28
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
 	},
-/obj/machinery/camera{
-	c_tag = "AI Access"
-	},
-/obj/machinery/porta_turret/ai,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "gCF" = (
 /obj/machinery/camera{
 	c_tag = "Prison Yard";
@@ -27745,7 +27719,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/turf/open/floor/circuit,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "hoR" = (
 /obj/machinery/disposal/bin,
@@ -29536,24 +29510,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
 "hXu" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 8
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = 22
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room South";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
-	},
-/obj/machinery/telecomms/processor/preset_three,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "hYy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -31383,13 +31346,13 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "iHu" = (
-/obj/machinery/telecomms/broadcaster/preset_left{
-	name = "subspace broadcaster A"
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
+/turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "iHI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -31436,16 +31399,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"iIj" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
-	},
-/obj/machinery/camera{
-	c_tag = "West AI Server"
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
 "iJa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -33994,7 +33947,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/circuit,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "jHq" = (
 /obj/machinery/camera{
@@ -35192,9 +35145,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "kit" = (
-/obj/machinery/telecomms/message_server/preset,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "kiy" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
@@ -36901,14 +36856,11 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "kTy" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
 	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "kTM" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -37256,10 +37208,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"lbX" = (
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/circuit,
-/area/ai_monitored/storage/satellite)
 "lcb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -38484,8 +38432,14 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "lyX" = (
-/turf/closed/wall/r_wall,
-/area/tcommsat/entrance)
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "lza" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -38751,22 +38705,12 @@
 /turf/template_noop,
 /area/maintenance/port/fore)
 "lFm" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room South";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 8
 	},
-/obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "lFG" = (
@@ -38834,6 +38778,25 @@
 /obj/item/mop,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
+"lHO" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room South";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/obj/machinery/telecomms/processor/preset_three,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "lIb" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -39475,11 +39438,12 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "lWl" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 10
+/obj/structure/cable{
+	icon_state = "1-4";
+	tag = ""
 	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "lWz" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -39962,6 +39926,22 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"mfG" = (
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 25;
+	pixel_y = 6
+	},
+/obj/machinery/light_switch{
+	pixel_x = 7;
+	pixel_y = 28
+	},
+/obj/machinery/camera{
+	c_tag = "AI Access"
+	},
+/obj/machinery/porta_turret/ai,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "mfN" = (
 /obj/machinery/camera{
 	c_tag = "Aft Starboard Solar Access";
@@ -40592,12 +40572,14 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "mqO" = (
-/obj/machinery/telecomms/processor/preset_four,
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "mqR" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable{
@@ -40657,14 +40639,12 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "mrS" = (
-/obj/machinery/power/terminal{
+/obj/machinery/pipedispenser,
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "msb" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/meter,
@@ -41296,9 +41276,7 @@
 	anchored = 1;
 	state = 2
 	},
-/obj/machinery/camera{
-	c_tag = "East AI Server"
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/circuit/green/telecomms,
 /area/ai_monitored/turret_protected/aisat_interior)
 "mEa" = (
@@ -42283,6 +42261,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"mWE" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 10
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "mWH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -42437,9 +42421,9 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/engine/atmos/distro)
-"naq" = (
+"naj" = (
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/ai_monitored/turret_protected/ai)
 "naz" = (
 /obj/effect/spawner/structure/solars/solar_96,
 /obj/structure/cable/yellow{
@@ -44133,17 +44117,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "nHT" = (
-/obj/effect/turf_decal/ramp_middle{
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
 	dir = 1
 	},
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = -22
-	},
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
-	dir = 1
-	},
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "nHU" = (
 /obj/machinery/requests_console{
 	department = "Science";
@@ -44444,12 +44422,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
-"nQP" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "nRs" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Genetics Research";
@@ -47208,6 +47180,15 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"oUc" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "oUl" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -47875,11 +47856,18 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "phR" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 7;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "pia" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4
@@ -48010,14 +47998,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"pkb" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "pkD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -52655,6 +52635,10 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"qVN" = (
+/obj/machinery/telecomms/message_server/preset,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "qVZ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -53058,9 +53042,6 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
-"rdR" = (
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "rfl" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -53115,9 +53096,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "rfJ" = (
-/obj/machinery/gulag_item_reclaimer,
-/turf/open/space/basic,
-/area/space)
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "rfK" = (
 /obj/machinery/light{
 	dir = 4
@@ -55444,6 +55424,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
+"rYz" = (
+/turf/closed/wall/r_wall,
+/area/tcommsat/entrance)
 "rYI" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -56196,7 +56179,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "snF" = (
@@ -56301,7 +56283,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/circuit,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "sqE" = (
 /obj/structure/sign/warning/fire{
@@ -56504,6 +56486,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"suV" = (
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide2{
+	dir = 1
+	},
+/area/ai_monitored/turret_protected/ai)
 "svh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -58620,13 +58613,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"tjY" = (
-/obj/machinery/pipedispenser,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "tkd" = (
 /obj/machinery/camera{
 	c_tag = "Engineering East";
@@ -59054,15 +59040,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"tto" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "ttQ" = (
 /obj/structure/rack,
 /obj/machinery/light{
@@ -59984,6 +59961,15 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"tNs" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "tNA" = (
 /obj/machinery/camera{
 	c_tag = "Dormitory South";
@@ -61840,13 +61826,6 @@
 /obj/structure/sign/departments/minsky/medical/medical1,
 /turf/closed/wall,
 /area/medical/paramedic)
-"uAV" = (
-/obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "uAW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -62571,15 +62550,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"uNG" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "uNH" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -64667,10 +64637,11 @@
 /obj/effect/turf_decal/ramp_middle{
 	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = -22
 	},
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide2{
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
 	dir = 1
 	},
 /area/ai_monitored/turret_protected/ai)
@@ -66283,14 +66254,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"wer" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
 "weD" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -67675,6 +67638,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"wIB" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
 "wJc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/reagent_dispensers/fueltank,
@@ -69039,6 +69008,25 @@
 /obj/structure/closet/secure_closet/warden,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"xnr" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room South";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/obj/machinery/telecomms/bus/preset_one,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "xnF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -69440,13 +69428,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "xwL" = (
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = 22
+/obj/machinery/telecomms/receiver/preset_left{
+	name = "subspace receiver A"
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "xwU" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/machinery/light{
@@ -69565,6 +69554,16 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/white,
 /area/engine/atmos/mix)
+"xyb" = (
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
+	},
+/obj/machinery/camera{
+	c_tag = "East AI Server"
+	},
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "xyG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -70382,6 +70381,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"xPL" = (
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "xPQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -70945,6 +70947,10 @@
 /obj/effect/turf_decal/trimline/chemorange/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"ybM" = (
+/obj/machinery/gulag_item_reclaimer,
+/turf/open/space/basic,
+/area/space)
 "ycf" = (
 /obj/machinery/meter{
 	pixel_x = -5;
@@ -99896,7 +99902,7 @@ cva
 cva
 cva
 gtB
-eTe
+djF
 qKi
 kqB
 gtB
@@ -100152,10 +100158,10 @@ vJJ
 ume
 cva
 cva
-iIj
-naq
-naq
-nQP
+byg
+xPL
+xPL
+kit
 gtB
 tgv
 wJL
@@ -100409,12 +100415,12 @@ nDA
 rjo
 tTK
 cva
-wer
+mDO
 gLt
 kMi
 uuG
 ieK
-uAV
+lWl
 azq
 rRA
 lmN
@@ -100660,9 +100666,9 @@ pqr
 cva
 hWd
 fiF
-cfh
-xwL
-cfh
+bcc
+hXu
+bcc
 bfr
 qjk
 cva
@@ -100671,7 +100677,7 @@ cva
 cva
 krI
 cva
-byg
+phR
 pSY
 lhk
 rdw
@@ -100920,19 +100926,19 @@ pen
 hmx
 cva
 cva
-axV
+kTy
 qZK
-nHT
+vAP
 cva
 lMT
-cqT
+naj
 xxd
 cva
-lbX
+cbd
 pTL
-rdR
-rdR
-rdR
+rfJ
+rfJ
+rfJ
 aJw
 pvo
 sXZ
@@ -101434,18 +101440,18 @@ hUA
 lfM
 cva
 cva
-axV
+kTy
 rJJ
-vAP
+suV
 cva
-gCs
-cqT
+mfG
+naj
 rCq
 cva
 fCV
 hYy
-rdR
-rdR
+rfJ
+rfJ
 gOE
 aJw
 hvG
@@ -101699,10 +101705,10 @@ cva
 cva
 krI
 cva
-kTy
+cfh
 rzx
 iRV
-tjY
+mrS
 agz
 aJw
 qHo
@@ -101946,17 +101952,17 @@ cva
 iXp
 pyn
 dnj
-mrS
+oUc
 nDA
 rjo
 tTK
 cva
-wer
+mDO
 sAr
 tmm
 pJS
 vzc
-rdR
+rfJ
 dne
 bxL
 lmN
@@ -102208,10 +102214,10 @@ cva
 wkd
 cva
 cva
-mDO
-naq
-naq
-nQP
+xyb
+xPL
+xPL
+kit
 gtB
 tgv
 wJL
@@ -102466,7 +102472,7 @@ cva
 cva
 cva
 gtB
-eTe
+djF
 mUg
 uMi
 gtB
@@ -102974,7 +102980,7 @@ xxK
 qNB
 kVQ
 bbw
-bbw
+wIB
 pUK
 sZn
 gtE
@@ -108451,7 +108457,7 @@ aaa
 xrX
 aaa
 slA
-rfJ
+ybM
 aaa
 gXs
 pEf
@@ -109730,15 +109736,15 @@ aaa
 aaa
 aaa
 ucZ
-lyX
-lyX
-lyX
+rYz
+rYz
+rYz
 vbw
 fjN
 kRG
-lyX
-lyX
-lyX
+rYz
+rYz
+rYz
 pEf
 aaa
 aaa
@@ -110244,17 +110250,17 @@ aaa
 ucZ
 bVJ
 bVJ
-lyX
-lyX
-lyX
+rYz
+rYz
+rYz
 aDW
 sxE
 vvS
-lyX
-lyX
-lyX
-lyX
-lyX
+rYz
+rYz
+rYz
+rYz
+rYz
 pEf
 gXs
 aKN
@@ -110511,7 +110517,7 @@ vmm
 ody
 kfG
 xnR
-lyX
+rYz
 pEf
 gXs
 aKN
@@ -110768,7 +110774,7 @@ iek
 cZu
 cLg
 sdl
-lyX
+rYz
 pEf
 aaa
 aaa
@@ -111025,7 +111031,7 @@ pJB
 gBP
 vxS
 qlI
-lyX
+rYz
 pEf
 pEf
 pEf
@@ -111788,11 +111794,11 @@ qTh
 phH
 iDE
 fYE
-snB
-snB
+mqO
+mqO
 cqk
 bhL
-pkb
+snB
 dEd
 pyZ
 dTb
@@ -113330,11 +113336,11 @@ pEf
 pEf
 fmC
 fmC
-iHu
+gCs
 bRu
 xFg
 gTY
-aTP
+xwL
 fmC
 fmC
 pEf
@@ -113591,7 +113597,7 @@ jzm
 pBl
 soe
 pBl
-tto
+tNs
 yap
 fmC
 fmC
@@ -113846,10 +113852,10 @@ fmC
 gNr
 npc
 pBl
-mqO
+eTe
 pBl
-bcc
 abx
+iHu
 fmC
 fmC
 fmC
@@ -114361,9 +114367,9 @@ jcz
 cWY
 lQv
 grq
-phR
+nHT
 tGz
-uNG
+lFm
 ikV
 fmC
 fmC
@@ -114876,8 +114882,8 @@ sPc
 pBl
 rlo
 pBl
-lWl
-afK
+mWE
+lyX
 fmC
 fmC
 fmC
@@ -115128,13 +115134,13 @@ pEf
 pEf
 fmC
 fmC
-hXu
+lHO
 ikV
 pBl
 xzh
 pBl
-phR
-lFm
+nHT
+xnr
 fmC
 fmC
 pEf
@@ -115387,7 +115393,7 @@ ogh
 jXD
 fmC
 mDn
-kit
+qVN
 fmC
 dTU
 eKD

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -295,16 +295,6 @@
 /obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"abx" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	dir = 1;
-	name = "AI Antechamber APC";
-	pixel_y = 24
-	},
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
 "aby" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -6356,13 +6346,10 @@
 	},
 /area/maintenance/port)
 "aTs" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "aTw" = (
 /obj/structure/table,
@@ -6615,6 +6602,15 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
+"aVE" = (
+/obj/machinery/telecomms/broadcaster/preset_left{
+	name = "subspace broadcaster A"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "aVX" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/dark,
@@ -7684,11 +7680,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge/meeting_room)
-"bfr" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
-/obj/machinery/porta_turret/ai,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "bfv" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -9847,6 +9838,15 @@
 "byf" = (
 /turf/closed/wall/r_wall,
 /area/science/server)
+"byg" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "byi" = (
 /turf/closed/wall,
 /area/security/checkpoint/science)
@@ -12872,6 +12872,13 @@
 /obj/item/beacon,
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"cbd" = (
+/obj/machinery/pipedispenser,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "cbe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -13306,6 +13313,13 @@
 /obj/item/stack/rods/fifty,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"chg" = (
+/obj/structure/cable{
+	icon_state = "1-4";
+	tag = ""
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "chq" = (
 /obj/machinery/processor/slime,
 /obj/item/radio/intercom{
@@ -15678,6 +15692,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
+"cOE" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
+/obj/machinery/porta_turret/ai,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "cOJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -16730,10 +16749,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"djF" = (
-/obj/machinery/ai/server_cabinet/prefilled,
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
 "dkq" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -18254,9 +18269,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
-"dOp" = (
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
 "dOt" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /obj/machinery/light,
@@ -18511,6 +18523,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "dTe" = (
@@ -21269,18 +21282,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "eTe" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
+/obj/machinery/ai/server_cabinet/prefilled,
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "eTh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -22183,6 +22187,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
 "fkH" = (
@@ -23814,6 +23819,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"fMm" = (
+/turf/closed/wall/r_wall,
+/area/tcommsat/entrance)
 "fMp" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall,
@@ -24249,16 +24257,15 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "fXb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "aiserverdoor";
-	name = "AI Server Shutters"
+/obj/machinery/camera{
+	c_tag = "West AI Server"
 	},
-/turf/open/floor/circuit/green,
-/area/ai_monitored/storage/satellite)
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "fXm" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -27435,6 +27442,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hjk" = (
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
+	},
+/obj/machinery/camera{
+	c_tag = "East AI Server"
+	},
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "hjA" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -27642,6 +27659,10 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
+"hmx" = (
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/satellite)
 "hmO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -29951,11 +29972,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "ieo" = (
-/obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "aiserverdoor";
+	name = "AI Server Shutters"
+	},
+/turf/open/floor/circuit/green,
 /area/ai_monitored/storage/satellite)
 "ier" = (
 /obj/item/radio/intercom{
@@ -31337,25 +31362,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
-"iHu" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room South";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
-	},
-/obj/machinery/telecomms/processor/preset_three,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "iHI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -31401,6 +31407,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"iII" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 10
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "iJa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -34822,6 +34834,15 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/security/prison)
+"kcr" = (
+/obj/machinery/telecomms/receiver/preset_left{
+	name = "subspace receiver A"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "kcy" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
@@ -35153,6 +35174,12 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"kit" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "kiy" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
@@ -35566,6 +35593,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"krI" = (
+/obj/machinery/telecomms/message_server/preset,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "krO" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer_R";
@@ -36849,6 +36880,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"kTy" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "kTM" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -37378,14 +37418,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"lfM" = (
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = 22
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "lfW" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -38742,6 +38774,25 @@
 /obj/item/mop,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
+"lHO" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room South";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/obj/machinery/telecomms/bus/preset_one,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "lIb" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -39009,15 +39060,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"lMT" = (
-/obj/machinery/telecomms/receiver/preset_left{
-	name = "subspace receiver A"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 5
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "lMW" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -40511,12 +40553,13 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "mqO" = (
-/obj/machinery/pipedispenser,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = 22
 	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "mqR" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable{
@@ -40575,15 +40618,6 @@
 /obj/structure/transit_tube_pod,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"mrS" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "msb" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/meter,
@@ -41314,15 +41348,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"mFE" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "mFO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -42382,6 +42407,9 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/storage/satellite)
+"naq" = (
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "naz" = (
 /obj/effect/spawner/structure/solars/solar_96,
 /obj/structure/cable/yellow{
@@ -44074,12 +44102,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"nHT" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "nHU" = (
 /obj/machinery/requests_console{
 	department = "Science";
@@ -44381,11 +44403,16 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "nQP" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide2{
+	dir = 1
+	},
+/area/ai_monitored/turret_protected/ai)
 "nRs" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Genetics Research";
@@ -45571,6 +45598,14 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"opJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "oqf" = (
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine{
@@ -47136,6 +47171,14 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"oUc" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "oUl" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -47459,16 +47502,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"paH" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
-	},
-/obj/machinery/camera{
-	c_tag = "West AI Server"
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
 "paQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 4
@@ -47555,8 +47588,17 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "pen" = (
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/plasteel/dark,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 7;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
 "pew" = (
 /obj/structure/disposalpipe/segment,
@@ -47810,14 +47852,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "phR" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "pia" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4
@@ -47948,12 +47987,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"pkb" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 10
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
 "pkD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -48470,6 +48503,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"ptV" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "put" = (
 /obj/machinery/door/airlock/external{
 	name = "Security Secure External Airlock";
@@ -52563,15 +52605,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"qVN" = (
-/obj/machinery/telecomms/broadcaster/preset_left{
-	name = "subspace broadcaster A"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "qVZ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -52972,14 +53005,24 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
 "rdR" = (
-/obj/structure/window/reinforced{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 8
 	},
-/obj/machinery/airalarm{
-	pixel_y = 24
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 5
 	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room South";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/obj/machinery/telecomms/processor/preset_three,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "rfl" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -53034,7 +53077,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "rfJ" = (
-/turf/open/floor/plasteel/grimy,
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
+	dir = 1;
+	name = "AI Antechamber APC";
+	pixel_y = 24
+	},
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "rfK" = (
 /obj/machinery/light{
@@ -55349,25 +55399,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
-"rYz" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room South";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
-	},
-/obj/machinery/telecomms/bus/preset_one,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "rYI" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -56120,6 +56151,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "snF" = (
@@ -58988,13 +59020,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"tto" = (
-/obj/machinery/telecomms/processor/preset_four,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "ttQ" = (
 /obj/structure/rack,
 /obj/machinery/light{
@@ -62104,6 +62129,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "uGf" = (
@@ -62511,15 +62537,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"uNG" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "uNH" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -64607,10 +64624,11 @@
 /obj/effect/turf_decal/ramp_middle{
 	dir = 1
 	},
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = -22
 	},
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide2{
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
 	dir = 1
 	},
 /area/ai_monitored/turret_protected/ai)
@@ -66223,10 +66241,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"wer" = (
-/obj/machinery/telecomms/message_server/preset,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "weD" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -66897,18 +66911,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"wrK" = (
-/obj/effect/turf_decal/ramp_middle{
-	dir = 1
-	},
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = -22
-	},
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
-	dir = 1
-	},
-/area/ai_monitored/turret_protected/ai)
 "wrN" = (
 /obj/structure/chair/comfy/beige,
 /turf/open/floor/plasteel/grimy,
@@ -67320,6 +67322,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"wBI" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "wBN" = (
 /obj/effect/turf_decal/tile{
 	dir = 8
@@ -68977,8 +68988,12 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "xnr" = (
-/turf/closed/wall/r_wall,
-/area/tcommsat/entrance)
+/obj/machinery/telecomms/processor/preset_four,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "xnF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -69379,12 +69394,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"xwL" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
-	dir = 1
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
 "xwU" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/machinery/light{
@@ -69496,15 +69505,8 @@
 /turf/open/floor/plasteel/white,
 /area/engine/atmos/mix)
 "xyb" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
-	},
-/obj/machinery/camera{
-	c_tag = "East AI Server"
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "xyG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -70323,8 +70325,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "xPL" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/server)
 "xPQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -70888,6 +70896,9 @@
 /obj/effect/turf_decal/trimline/chemorange/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"ybM" = (
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "ycf" = (
 /obj/machinery/meter{
 	pixel_x = -5;
@@ -99839,7 +99850,7 @@ cva
 cva
 cva
 gtB
-djF
+eTe
 qKi
 kqB
 gtB
@@ -100095,10 +100106,10 @@ vJJ
 ume
 cva
 cva
-paH
-xPL
-xPL
-nQP
+fXb
+naq
+naq
+kit
 gtB
 tgv
 wJL
@@ -100357,7 +100368,7 @@ gLt
 kMi
 uuG
 ieK
-ieo
+chg
 azq
 rRA
 lmN
@@ -100604,17 +100615,17 @@ cva
 hWd
 fiF
 cfh
-lfM
+mqO
 cfh
-bfr
+cOE
 qjk
 cva
 cva
 tgv
-fXb
+ieo
 suV
 tgv
-eTe
+pen
 pSY
 lhk
 rdw
@@ -100863,19 +100874,19 @@ nDA
 cva
 cva
 hsq
-uNG
+wBI
 rJJ
-wrK
+vAP
 uAV
 tgv
 cqT
 xxd
 tgv
-pen
+hmx
 pTL
-rfJ
-rfJ
-rfJ
+xyb
+xyb
+xyb
 aJw
 pvo
 sXZ
@@ -101132,7 +101143,7 @@ aJy
 nyj
 rPo
 fkC
-fkC
+opJ
 psj
 hsn
 sYk
@@ -101377,18 +101388,18 @@ nDA
 cva
 cva
 mfG
-uNG
+wBI
 rJJ
-vAP
+nQP
 gCs
 tgv
 naj
 rCq
 tgv
-abx
+rfJ
 hYy
-rfJ
-rfJ
+xyb
+xyb
 gOE
 aJw
 hvG
@@ -101634,18 +101645,18 @@ qoQ
 jJK
 prN
 cfh
-bfr
+cOE
 laN
 cva
 cva
 tgv
-fXb
+ieo
 suV
 tgv
-rdR
+byg
 rzx
 iRV
-mqO
+cbd
 agz
 aJw
 qHo
@@ -101899,7 +101910,7 @@ sAr
 tmm
 pJS
 vzc
-rfJ
+xyb
 dne
 bxL
 lmN
@@ -102151,10 +102162,10 @@ sAu
 wkd
 cva
 cva
-xyb
-xPL
-xPL
-nQP
+hjk
+naq
+naq
+kit
 gtB
 tgv
 wJL
@@ -102409,7 +102420,7 @@ cva
 cva
 cva
 gtB
-djF
+eTe
 mUg
 uMi
 gtB
@@ -109673,15 +109684,15 @@ aaa
 aaa
 aaa
 ucZ
-xnr
-xnr
-xnr
+fMm
+fMm
+fMm
 vbw
 fjN
 kRG
-xnr
-xnr
-xnr
+fMm
+fMm
+fMm
 pEf
 aaa
 aaa
@@ -110187,17 +110198,17 @@ aaa
 ucZ
 bVJ
 bVJ
-xnr
-xnr
-xnr
+fMm
+fMm
+fMm
 aDW
 sxE
 vvS
-xnr
-xnr
-xnr
-xnr
-xnr
+fMm
+fMm
+fMm
+fMm
+fMm
 pEf
 gXs
 aKN
@@ -110454,7 +110465,7 @@ vmm
 ody
 kfG
 xnR
-xnr
+fMm
 pEf
 gXs
 aKN
@@ -110711,7 +110722,7 @@ iek
 cZu
 cLg
 sdl
-xnr
+fMm
 pEf
 aaa
 aaa
@@ -110968,7 +110979,7 @@ pJB
 gBP
 vxS
 qlI
-xnr
+fMm
 pEf
 pEf
 pEf
@@ -111731,11 +111742,11 @@ qTh
 phH
 iDE
 fYE
-phR
-phR
+snB
+snB
 cqk
 bhL
-snB
+oUc
 dEd
 pyZ
 dTb
@@ -113273,11 +113284,11 @@ pEf
 pEf
 fmC
 fmC
-qVN
+aVE
 bRu
 xFg
 gTY
-lMT
+kcr
 fmC
 fmC
 pEf
@@ -113531,10 +113542,10 @@ fmC
 fmC
 gQa
 jzm
-dOp
+ybM
 soe
-dOp
-aTs
+ybM
+kTy
 yap
 fmC
 fmC
@@ -113788,11 +113799,11 @@ fmC
 fmC
 gNr
 npc
-dOp
-tto
-dOp
-xwL
-mFE
+ybM
+xnr
+ybM
+aTs
+xPL
 fmC
 fmC
 fmC
@@ -114045,9 +114056,9 @@ fmC
 bjE
 qQw
 dnj
-dOp
+ybM
 jKN
-dOp
+ybM
 dnj
 loF
 xlV
@@ -114304,9 +114315,9 @@ jcz
 cWY
 lQv
 grq
-nHT
+phR
 tGz
-mrS
+ptV
 ikV
 fmC
 fmC
@@ -114559,9 +114570,9 @@ fmC
 kVh
 qKK
 dnj
-dOp
+ybM
 car
-dOp
+ybM
 dnj
 bdd
 bcd
@@ -114816,10 +114827,10 @@ fmC
 fmC
 dOn
 sPc
-dOp
+ybM
 rlo
-dOp
-pkb
+ybM
+iII
 tTK
 fmC
 fmC
@@ -115071,13 +115082,13 @@ pEf
 pEf
 fmC
 fmC
-iHu
+rdR
 ikV
-dOp
+ybM
 xzh
-dOp
-nHT
-rYz
+ybM
+phR
+lHO
 fmC
 fmC
 pEf
@@ -115330,7 +115341,7 @@ ogh
 jXD
 fmC
 mDn
-wer
+krI
 fmC
 dTU
 eKD

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -296,12 +296,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "abx" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/closed/wall/r_wall,
+/area/tcommsat/entrance)
 "aby" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -3186,12 +3182,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"axV" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
-	dir = 1
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
 "ayd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -6358,15 +6348,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port)
-"aTs" = (
-/obj/machinery/telecomms/receiver/preset_left{
-	name = "subspace receiver A"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 5
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "aTw" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -6618,15 +6599,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
-"aVE" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "aVX" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/dark,
@@ -7696,6 +7668,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge/meeting_room)
+"bfr" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "bfv" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -9854,15 +9830,6 @@
 "byf" = (
 /turf/closed/wall/r_wall,
 /area/science/server)
-"byg" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "byi" = (
 /turf/closed/wall,
 /area/security/checkpoint/science)
@@ -12849,13 +12816,7 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "car" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "caI" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -14147,6 +14108,9 @@
 /obj/item/clothing/suit/hooded/wintercoat,
 /obj/item/clothing/shoes/winterboots,
 /obj/item/clothing/shoes/winterboots,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/storage/satellite)
 "cqW" = (
@@ -14463,6 +14427,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"cuZ" = (
+/obj/machinery/camera/motion{
+	c_tag = "AI Chamber North";
+	network = list("RD")
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "cva" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
@@ -15690,10 +15661,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
-"cOE" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "cOJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -16746,10 +16713,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"djF" = (
-/obj/machinery/ai/server_cabinet/prefilled,
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
 "dkq" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -16937,9 +16900,14 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
 "dnj" = (
-/obj/machinery/telecomms/message_server/preset,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "dno" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -18269,7 +18237,13 @@
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "dOp" = (
-/turf/open/floor/circuit/telecomms/server,
+/obj/machinery/telecomms/receiver/preset_left{
+	name = "subspace receiver A"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "dOt" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
@@ -19972,6 +19946,10 @@
 	},
 /obj/item/crowbar,
 /obj/item/mmi,
+/obj/machinery/camera{
+	c_tag = "Telecomms Tech Storage";
+	network = list("ss13","minisat")
+	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "evg" = (
@@ -21278,6 +21256,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"eTe" = (
+/obj/machinery/ai/server_cabinet/prefilled,
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "eTh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -22118,7 +22100,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
 "fjN" = (
-/obj/effect/landmark/start/cyborg,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/entrance)
 "fjZ" = (
@@ -22175,6 +22156,19 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"fkC" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 7;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "fkH" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/structure/cable{
@@ -23186,6 +23180,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/lawoffice)
+"fCV" = (
+/obj/machinery/telecomms/broadcaster/preset_left{
+	name = "subspace broadcaster A"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "fDx" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -24239,9 +24242,15 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "fXb" = (
-/obj/machinery/pipedispenser,
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
+	},
+/obj/machinery/camera{
+	c_tag = "West AI Server"
+	},
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "fXm" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -26271,6 +26280,9 @@
 /obj/machinery/airalarm/tcomms{
 	pixel_y = 24
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "gQb" = (
@@ -27685,6 +27697,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/start/cyborg,
 /turf/open/floor/circuit,
 /area/ai_monitored/storage/satellite)
 "hoR" = (
@@ -29480,6 +29493,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
+"hXu" = (
+/obj/machinery/pipedispenser,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "hYy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -30826,7 +30846,7 @@
 "ixb" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Starboard";
+	c_tag = "Telecomms Exterior - Starboard";
 	dir = 4;
 	network = list("minisat","ss13")
 	},
@@ -31320,14 +31340,12 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "iHu" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-4";
+	tag = ""
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "iHI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -31374,23 +31392,35 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "iIj" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
-"iII" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room South";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
+"iII" = (
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
+	dir = 1
+	},
+/area/ai_monitored/turret_protected/ai)
 "iJa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -33942,7 +33972,7 @@
 /area/ai_monitored/storage/satellite)
 "jHq" = (
 /obj/machinery/camera{
-	c_tag = "AI Satellite Access"
+	c_tag = "Telecomms Satellite Access"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -34619,7 +34649,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Port Aft";
+	c_tag = "Telecomms Exterior - Port Aft";
 	dir = 8;
 	network = list("minisat","ss13")
 	},
@@ -35137,14 +35167,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "kit" = (
-/obj/machinery/telecomms/broadcaster/preset_left{
-	name = "subspace broadcaster A"
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "kiy" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
@@ -35412,7 +35439,7 @@
 "koy" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Fore";
+	c_tag = "Telecomms Exterior - Fore";
 	dir = 1;
 	network = list("minisat")
 	},
@@ -35492,6 +35519,9 @@
 	external_pressure_bound = 120;
 	name = "server vent"
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/circuit/green/telecomms,
 /area/ai_monitored/turret_protected/aisat_interior)
 "kqJ" = (
@@ -35555,13 +35585,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"krI" = (
-/obj/machinery/telecomms/processor/preset_four,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "krO" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer_R";
@@ -35775,7 +35798,7 @@
 /area/security/prison)
 "kyA" = (
 /obj/machinery/camera{
-	c_tag = "MiniSat  Antechamber";
+	c_tag = "Telecomms  Antechamber";
 	dir = 8;
 	network = list("minisat","ss13")
 	},
@@ -36845,12 +36868,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"kTy" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 10
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
 "kTM" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -37195,6 +37212,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"lbX" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room South";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "lcb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -37380,6 +37415,15 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"lfM" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "lfW" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -38408,14 +38452,14 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "lyX" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "lza" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -38746,17 +38790,15 @@
 /turf/open/floor/plasteel/dark,
 /area/janitor)
 "lHO" = (
-/obj/effect/turf_decal/ramp_middle{
-	dir = 1
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
+	dir = 1;
+	name = "AI Antechamber APC";
+	pixel_y = 24
 	},
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = -22
-	},
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
-	dir = 1
-	},
-/area/ai_monitored/turret_protected/ai)
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/satellite)
 "lIb" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -40522,6 +40564,15 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
+"mqO" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "mqR" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable{
@@ -41310,9 +41361,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"mFE" = (
-/turf/closed/wall/r_wall,
-/area/tcommsat/entrance)
 "mFO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -42078,6 +42126,9 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "mUg" = (
+/obj/machinery/light_switch{
+	pixel_x = 27
+	},
 /turf/open/floor/circuit/green/telecomms,
 /area/ai_monitored/turret_protected/aisat_interior)
 "mUk" = (
@@ -42360,8 +42411,18 @@
 /obj/item/clothing/mask/breath,
 /obj/item/tank/internals/emergency_oxygen,
 /obj/item/tank/internals/emergency_oxygen,
+/obj/machinery/light_switch{
+	pixel_x = 7;
+	pixel_y = 28
+	},
+/obj/machinery/camera{
+	c_tag = "AI Access"
+	},
 /turf/open/floor/circuit,
 /area/ai_monitored/storage/satellite)
+"naq" = (
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "naz" = (
 /obj/effect/spawner/structure/solars/solar_96,
 /obj/structure/cable/yellow{
@@ -43667,7 +43728,7 @@
 "nzG" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Fore Port";
+	c_tag = "Telecomms Exterior - Fore Port";
 	dir = 1;
 	network = list("minisat")
 	},
@@ -44053,6 +44114,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"nHT" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "nHU" = (
 /obj/machinery/requests_console{
 	department = "Science";
@@ -44353,12 +44420,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
-"nQP" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "nRs" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Genetics Research";
@@ -45119,7 +45180,7 @@
 "ogh" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Fore Starboard";
+	c_tag = "Telecomms Exterior - Fore Starboard";
 	dir = 1;
 	network = list("minisat")
 	},
@@ -47441,9 +47502,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "paH" = (
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "paQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 4
@@ -47529,6 +47595,12 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"pen" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
+	dir = 1
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "pew" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -47781,8 +47853,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "phR" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 1
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
@@ -48432,13 +48507,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"ptV" = (
-/obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "put" = (
 /obj/machinery/door/airlock/external{
 	name = "Security Secure External Airlock";
@@ -51310,7 +51378,7 @@
 "qAp" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Aft Port";
+	c_tag = "Telecomms Exterior - Aft Port";
 	network = list("minisat")
 	},
 /turf/open/space/basic,
@@ -51864,6 +51932,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"qKi" = (
+/obj/machinery/light_switch{
+	pixel_x = -27
+	},
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "qKn" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry Lab";
@@ -52703,10 +52777,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/entrance)
-"qZK" = (
-/obj/effect/turf_decal/stripes/white/line,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "ras" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -52882,6 +52952,14 @@
 /obj/machinery/computer/ai_overclocking{
 	dir = 1
 	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "AIControl Room";
+	dir = 4;
+	network = list("ss13","tcomms")
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
 "rdx" = (
@@ -52921,6 +52999,9 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
+"rdR" = (
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "rfl" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -52974,9 +53055,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"rfJ" = (
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "rfK" = (
 /obj/machinery/light{
 	dir = 4
@@ -54513,15 +54591,9 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
 "rJJ" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	dir = 1;
-	name = "AI Antechamber APC";
-	pixel_y = 24
-	},
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "rKk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -55297,13 +55369,10 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
 "rYz" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 10
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "rYI" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
@@ -58496,9 +58565,6 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"tjY" = (
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "tkd" = (
 /obj/machinery/camera{
 	c_tag = "Engineering East";
@@ -58928,6 +58994,10 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"tto" = (
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/satellite)
 "ttQ" = (
 /obj/structure/rack,
 /obj/machinery/light{
@@ -59560,11 +59630,6 @@
 /turf/open/floor/plating,
 /area/bridge/meeting_room)
 "tHJ" = (
-/obj/machinery/camera{
-	c_tag = "AI Chamber - Port";
-	dir = 4;
-	network = list("aicore")
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -59572,6 +59637,11 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room Access";
+	dir = 4;
+	network = list("ss13","minisat")
+	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "tHZ" = (
@@ -59850,14 +59920,9 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "tNs" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
+/obj/machinery/telecomms/message_server/preset,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "tNA" = (
 /obj/machinery/camera{
 	c_tag = "Dormitory South";
@@ -60492,14 +60557,15 @@
 	pixel_x = 24;
 	pixel_y = -10
 	},
-/obj/machinery/camera/motion{
-	c_tag = "MiniSat Foyer";
-	dir = 8;
-	network = list("minisat","ss13")
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Sattelite Access";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/entrance)
@@ -61715,6 +61781,15 @@
 /obj/structure/sign/departments/minsky/medical/medical1,
 /turf/closed/wall,
 /area/medical/paramedic)
+"uAV" = (
+/obj/effect/turf_decal/ramp_middle,
+/obj/machinery/camera/motion{
+	c_tag = "AI Chamber South";
+	dir = 1;
+	network = list("RD")
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "uAW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -62181,13 +62256,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/camera{
-	c_tag = "MiniSat Maintenance";
-	dir = 8;
-	name = "ai camera";
-	network = list("minisat","ss13");
-	start_active = 1
-	},
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plating,
@@ -62356,6 +62424,9 @@
 	external_pressure_bound = 120;
 	name = "server vent"
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/circuit/green/telecomms,
 /area/ai_monitored/turret_protected/aisat_interior)
 "uMB" = (
@@ -62442,6 +62513,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"uNG" = (
+/obj/machinery/telecomms/processor/preset_four,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "uNH" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -64043,7 +64121,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Port Fore";
+	c_tag = "Telecomms Exterior - Port Fore";
 	dir = 8;
 	network = list("minisat")
 	},
@@ -65085,12 +65163,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "vJJ" = (
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = 22
+/obj/machinery/light_switch{
+	pixel_x = -27
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
+/turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
 "vKb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -65582,7 +65658,7 @@
 "vUh" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Aft";
+	c_tag = "Telecomms Exterior - Aft";
 	network = list("minisat","ss13")
 	},
 /turf/open/space/basic,
@@ -66144,6 +66220,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"wer" = (
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
+	},
+/obj/machinery/camera{
+	c_tag = "East AI Server"
+	},
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "weD" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -67375,6 +67461,11 @@
 	pixel_x = 8;
 	pixel_y = 5
 	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Control Room";
+	dir = 4;
+	network = list("ss13","minisat")
+	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "wFh" = (
@@ -67406,7 +67497,7 @@
 "wGq" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Aft Starboard";
+	c_tag = "Telecomms Exterior - Aft Starboard";
 	network = list("minisat")
 	},
 /turf/open/space/basic,
@@ -67513,11 +67604,11 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "wIB" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 1
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 8
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
@@ -68886,8 +68977,13 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "xnr" = (
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "xnF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -69317,7 +69413,6 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "xxd" = (
-/obj/machinery/recharge_station,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
@@ -70713,6 +70808,9 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 4
 	},
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "yaq" = (
@@ -70775,6 +70873,9 @@
 /obj/effect/turf_decal/trimline/chemorange/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"ybM" = (
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "ycf" = (
 /obj/machinery/meter{
 	pixel_x = -5;
@@ -99726,8 +99827,8 @@ cva
 cva
 cva
 gtB
-djF
-mUg
+eTe
+qKi
 kqB
 gtB
 gXs
@@ -99978,14 +100079,14 @@ cva
 ojM
 sAu
 fQt
-sAu
+vJJ
 ume
 cva
 cva
-abx
-xnr
-xnr
-nQP
+fXb
+naq
+naq
+kit
 gtB
 tgv
 wJL
@@ -100244,7 +100345,7 @@ gLt
 kMi
 uuG
 ieK
-ptV
+iHu
 azq
 rRA
 lmN
@@ -100491,9 +100592,9 @@ cva
 hWd
 fiF
 cfh
-vJJ
+xnr
 cfh
-cOE
+bfr
 qjk
 cva
 cva
@@ -100501,7 +100602,7 @@ tgv
 ieo
 suV
 tgv
-aVE
+fkC
 pSY
 lhk
 rdw
@@ -100745,24 +100846,24 @@ oXR
 hRj
 oeF
 cva
-nDA
+cuZ
 nDA
 cva
 cva
 hsq
-lyX
-qZK
-lHO
-gCs
+paH
+rJJ
+iII
+uAV
 tgv
 cqT
 xxd
 tgv
-paH
+tto
 pTL
-rfJ
-rfJ
-rfJ
+rdR
+rdR
+rdR
 aJw
 pvo
 sXZ
@@ -101264,18 +101365,18 @@ nDA
 cva
 cva
 mfG
-lyX
-qZK
+paH
+rJJ
 vAP
 gCs
 tgv
 naj
 rCq
 tgv
-rJJ
+lHO
 hYy
-rfJ
-rfJ
+rdR
+rdR
 gOE
 aJw
 hvG
@@ -101521,7 +101622,7 @@ qoQ
 jJK
 prN
 cfh
-cOE
+bfr
 laN
 cva
 cva
@@ -101529,10 +101630,10 @@ tgv
 ieo
 suV
 tgv
-iIj
+dnj
 rzx
 gOE
-fXb
+hXu
 agz
 aJw
 qHo
@@ -101786,7 +101887,7 @@ sAr
 tmm
 pJS
 vzc
-rfJ
+rdR
 dne
 bxL
 lmN
@@ -102038,10 +102139,10 @@ sAu
 wkd
 cva
 cva
-abx
-xnr
-xnr
-nQP
+wer
+naq
+naq
+kit
 gtB
 tgv
 wJL
@@ -102296,7 +102397,7 @@ cva
 cva
 cva
 gtB
-djF
+eTe
 mUg
 uMi
 gtB
@@ -109560,15 +109661,15 @@ aaa
 aaa
 aaa
 ucZ
-mFE
-mFE
-mFE
+abx
+abx
+abx
 vbw
 fjN
 kRG
-mFE
-mFE
-mFE
+abx
+abx
+abx
 pEf
 aaa
 aaa
@@ -110074,17 +110175,17 @@ aaa
 ucZ
 bVJ
 bVJ
-mFE
-mFE
-mFE
+abx
+abx
+abx
 aDW
 sxE
 vvS
-mFE
-mFE
-mFE
-mFE
-mFE
+abx
+abx
+abx
+abx
+abx
 pEf
 gXs
 aKN
@@ -110341,7 +110442,7 @@ vmm
 ody
 kfG
 xnR
-mFE
+abx
 pEf
 gXs
 aKN
@@ -110598,7 +110699,7 @@ iek
 cZu
 cLg
 sdl
-mFE
+abx
 pEf
 aaa
 aaa
@@ -110855,7 +110956,7 @@ pJB
 gBP
 vxS
 qlI
-mFE
+abx
 pEf
 pEf
 pEf
@@ -111618,8 +111719,8 @@ qTh
 phH
 iDE
 fYE
-tNs
-tNs
+lyX
+lyX
 cqk
 bhL
 snB
@@ -113160,11 +113261,11 @@ pEf
 pEf
 fmC
 fmC
-kit
+fCV
 bRu
 xFg
 gTY
-aTs
+dOp
 fmC
 fmC
 pEf
@@ -113418,10 +113519,10 @@ fmC
 fmC
 gQa
 jzm
-dOp
+ybM
 soe
-dOp
-iHu
+ybM
+lfM
 yap
 fmC
 fmC
@@ -113675,11 +113776,11 @@ fmC
 fmC
 gNr
 npc
-dOp
-krI
-dOp
-axV
-rYz
+ybM
+uNG
+ybM
+pen
+mqO
 fmC
 fmC
 fmC
@@ -113932,9 +114033,9 @@ fmC
 bjE
 qQw
 lWl
-dOp
+ybM
 jKN
-dOp
+ybM
 lWl
 loF
 xlV
@@ -114191,9 +114292,9 @@ jcz
 cWY
 lQv
 grq
-phR
+nHT
 tGz
-byg
+phR
 ikV
 fmC
 fmC
@@ -114446,9 +114547,9 @@ fmC
 kVh
 qKK
 lWl
-dOp
-tjY
-dOp
+ybM
+car
+ybM
 lWl
 bdd
 bcd
@@ -114703,11 +114804,11 @@ fmC
 fmC
 dOn
 sPc
-dOp
+ybM
 rlo
-dOp
-kTy
-iII
+ybM
+rYz
+wIB
 fmC
 fmC
 fmC
@@ -114958,13 +115059,13 @@ pEf
 pEf
 fmC
 fmC
-car
+lbX
 ikV
-dOp
+ybM
 xzh
-dOp
-phR
-wIB
+ybM
+nHT
+iIj
 fmC
 fmC
 pEf
@@ -115217,8 +115318,8 @@ ogh
 jXD
 fmC
 mDn
-dnj
-tjY
+tNs
+fmC
 dTU
 eKD
 fmC

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -296,17 +296,18 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "abx" = (
-/obj/effect/turf_decal/ramp_middle{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = -22
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
-	dir = 1
+/obj/machinery/light_switch{
+	pixel_x = 7;
+	pixel_y = 28
 	},
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "aby" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -3191,6 +3192,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"axV" = (
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "ayd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -6448,11 +6452,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
 "aTP" = (
-/obj/machinery/telecomms/broadcaster/preset_left{
-	name = "subspace broadcaster A"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
+/obj/machinery/telecomms/processor/preset_four,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
@@ -6617,15 +6619,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
-"aVE" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "aVX" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/dark,
@@ -7699,6 +7692,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge/meeting_room)
+"bfr" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "bfv" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -9857,6 +9854,25 @@
 "byf" = (
 /turf/closed/wall/r_wall,
 /area/science/server)
+"byg" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room South";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/obj/machinery/telecomms/processor/preset_three,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "byi" = (
 /turf/closed/wall,
 /area/security/checkpoint/science)
@@ -12883,13 +12899,7 @@
 /turf/open/floor/engine,
 /area/science/misc_lab)
 "cbd" = (
-/obj/machinery/telecomms/receiver/preset_left{
-	name = "subspace receiver A"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 5
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
+/turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "cbe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -15693,10 +15703,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
-"cOE" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "cOJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -16749,10 +16755,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"djF" = (
-/obj/machinery/ai/server_cabinet/prefilled,
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
 "dkq" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -16940,10 +16942,8 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
 "dnj" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/circuit/telecomms/server,
+/obj/machinery/telecomms/message_server/preset,
+/turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "dno" = (
 /obj/machinery/requests_console{
@@ -21284,6 +21284,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"eTe" = (
+/obj/machinery/ai/server_cabinet/prefilled,
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "eTh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -22181,10 +22185,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "fkC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/pipedispenser,
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
@@ -23199,6 +23202,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/lawoffice)
+"fCV" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
+	dir = 1
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "fDx" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -26294,6 +26303,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/telecomms/bus/preset_three,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "gQb" = (
@@ -27438,14 +27448,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hjk" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/telecomms/broadcaster/preset_left{
+	name = "subspace broadcaster A"
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "hjA" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -29513,15 +29523,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
-"hXu" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "hYy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -31395,6 +31396,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"iII" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "iJa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -33671,6 +33681,10 @@
 /obj/effect/turf_decal/box/corners,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"jCM" = (
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/satellite)
 "jDa" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -35147,10 +35161,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"kit" = (
-/obj/machinery/telecomms/message_server/preset,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "kiy" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
@@ -35565,13 +35575,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "krI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "aiserverdoor";
-	name = "AI Server Shutters"
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
 	},
-/turf/open/floor/circuit/green,
-/area/ai_monitored/storage/satellite)
+/obj/machinery/camera{
+	c_tag = "East AI Server"
+	},
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "krO" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer_R";
@@ -38411,6 +38423,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"lyX" = (
+/obj/structure/cable{
+	icon_state = "1-4";
+	tag = ""
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "lza" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -38675,6 +38694,15 @@
 "lFj" = (
 /turf/template_noop,
 /area/maintenance/port/fore)
+"lFm" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "lFG" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -38740,6 +38768,14 @@
 /obj/item/mop,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
+"lHO" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "lIb" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -39007,15 +39043,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"lMT" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "lMW" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -39382,6 +39409,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"lWl" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "lWz" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -40509,11 +40542,13 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "mqO" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
-	dir = 1
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = 22
 	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "mqR" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable{
@@ -40573,8 +40608,24 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "mrS" = (
-/turf/closed/wall/r_wall,
-/area/tcommsat/entrance)
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room South";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/obj/machinery/telecomms/bus/preset_one,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "msb" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/meter,
@@ -42185,15 +42236,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"mWE" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "mWH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -42374,13 +42416,8 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/storage/satellite)
 "naq" = (
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = 22
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "naz" = (
 /obj/effect/spawner/structure/solars/solar_96,
 /obj/structure/cable/yellow{
@@ -44073,12 +44110,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"nHT" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "nHU" = (
 /obj/machinery/requests_console{
 	department = "Science";
@@ -45571,11 +45602,10 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "opJ" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
@@ -47468,15 +47498,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "paH" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "West AI Server"
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "paQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 4
@@ -47563,23 +47592,8 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "pen" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room South";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
+/turf/closed/wall/r_wall,
+/area/tcommsat/entrance)
 "pew" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -47831,6 +47845,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"phR" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "pia" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4
@@ -47961,6 +47981,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"pkb" = (
+/obj/machinery/telecomms/receiver/preset_left{
+	name = "subspace receiver A"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "pkD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -48969,19 +48998,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"pBl" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "pBm" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -52583,6 +52599,15 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"qVN" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "qVZ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -52760,10 +52785,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/entrance)
-"qZK" = (
-/obj/effect/turf_decal/stripes/white/line,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "ras" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -52987,12 +53008,14 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
 "rdR" = (
-/obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "rfl" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -53046,24 +53069,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"rfJ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room South";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "rfK" = (
 /obj/machinery/light{
 	dir = 4
@@ -54599,6 +54604,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
+"rJJ" = (
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "rKk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -55374,12 +55383,16 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
 "rYz" = (
-/obj/machinery/telecomms/processor/preset_four,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
 	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide2{
+	dir = 1
+	},
+/area/ai_monitored/turret_protected/ai)
 "rYI" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -56448,6 +56461,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"suV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "aiserverdoor";
+	name = "AI Server Shutters"
+	},
+/turf/open/floor/circuit/green,
+/area/ai_monitored/storage/satellite)
 "svh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -58993,14 +59014,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"tto" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "ttQ" = (
 /obj/structure/rack,
 /obj/machinery/light{
@@ -59923,11 +59936,14 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "tNs" = (
-/obj/machinery/pipedispenser,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
+	dir = 1;
+	name = "AI Antechamber APC";
+	pixel_y = 24
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "tNA" = (
 /obj/machinery/camera{
@@ -62519,6 +62535,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"uNG" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 10
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "uNH" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -64606,7 +64628,11 @@
 /obj/effect/turf_decal/ramp_middle{
 	dir = 1
 	},
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide2{
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
 	dir = 1
 	},
 /area/ai_monitored/turret_protected/ai)
@@ -66889,12 +66915,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"wrK" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 10
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
 "wrN" = (
 /obj/structure/chair/comfy/beige,
 /turf/open/floor/plasteel/grimy,
@@ -67306,16 +67326,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"wBI" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
-	},
-/obj/machinery/camera{
-	c_tag = "East AI Server"
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
 "wBN" = (
 /obj/effect/turf_decal/tile{
 	dir = 8
@@ -67608,16 +67618,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"wIB" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	dir = 1;
-	name = "AI Antechamber APC";
-	pixel_y = 24
-	},
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
 "wJc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/reagent_dispensers/fueltank,
@@ -68982,10 +68982,6 @@
 /obj/structure/closet/secure_closet/warden,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"xnr" = (
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
 "xnF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -69386,6 +69382,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"xwL" = (
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
+	},
+/obj/machinery/camera{
+	c_tag = "West AI Server"
+	},
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "xwU" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/machinery/light{
@@ -69496,9 +69502,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/white,
 /area/engine/atmos/mix)
-"xyb" = (
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "xyG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -70317,8 +70320,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "xPL" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/server)
 "xPQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -70819,6 +70828,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/telecomms/processor/preset_one,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "yaq" = (
@@ -70881,9 +70891,6 @@
 /obj/effect/turf_decal/trimline/chemorange/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"ybM" = (
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
 "ycf" = (
 /obj/machinery/meter{
 	pixel_x = -5;
@@ -99835,7 +99842,7 @@ cva
 cva
 cva
 gtB
-djF
+eTe
 qKi
 kqB
 gtB
@@ -100091,9 +100098,9 @@ vJJ
 ume
 cva
 cva
-paH
-xPL
-xPL
+xwL
+naq
+naq
 nQP
 gtB
 tgv
@@ -100353,7 +100360,7 @@ gLt
 kMi
 uuG
 ieK
-rdR
+lyX
 azq
 rRA
 lmN
@@ -100600,17 +100607,17 @@ cva
 hWd
 fiF
 bcc
-naq
+mqO
 bcc
-cOE
+bfr
 qjk
 cva
 cva
 tgv
 fXb
-krI
+suV
 tgv
-pBl
+abx
 pSY
 lhk
 rdw
@@ -100859,19 +100866,19 @@ nDA
 cva
 cva
 hsq
-hjk
-qZK
-abx
+rdR
+rJJ
+vAP
 uAV
 tgv
 cqT
 xxd
 tgv
-xnr
+jCM
 pTL
-xyb
-xyb
-xyb
+axV
+axV
+axV
 aJw
 pvo
 sXZ
@@ -101127,8 +101134,8 @@ fJN
 aJy
 nyj
 rPo
-fkC
-fkC
+opJ
+opJ
 psj
 hsn
 sYk
@@ -101373,18 +101380,18 @@ nDA
 cva
 cva
 mfG
-hjk
-qZK
-vAP
+rdR
+rJJ
+rYz
 gCs
 tgv
 naj
 rCq
 tgv
-wIB
+tNs
 hYy
-xyb
-xyb
+axV
+axV
 gOE
 aJw
 hvG
@@ -101630,18 +101637,18 @@ qoQ
 jJK
 prN
 bcc
-cOE
+bfr
 laN
 cva
 cva
 tgv
 fXb
-krI
+suV
 tgv
-opJ
+iII
 rzx
 iRV
-tNs
+fkC
 agz
 aJw
 qHo
@@ -101895,7 +101902,7 @@ sAr
 tmm
 pJS
 vzc
-xyb
+axV
 dne
 bxL
 lmN
@@ -102147,9 +102154,9 @@ sAu
 wkd
 cva
 cva
-wBI
-xPL
-xPL
+krI
+naq
+naq
 nQP
 gtB
 tgv
@@ -102405,7 +102412,7 @@ cva
 cva
 cva
 gtB
-djF
+eTe
 mUg
 uMi
 gtB
@@ -109669,15 +109676,15 @@ aaa
 aaa
 aaa
 ucZ
-mrS
-mrS
-mrS
+pen
+pen
+pen
 vbw
 fjN
 kRG
-mrS
-mrS
-mrS
+pen
+pen
+pen
 pEf
 aaa
 aaa
@@ -110183,17 +110190,17 @@ aaa
 ucZ
 bVJ
 bVJ
-mrS
-mrS
-mrS
+pen
+pen
+pen
 aDW
 sxE
 vvS
-mrS
-mrS
-mrS
-mrS
-mrS
+pen
+pen
+pen
+pen
+pen
 pEf
 gXs
 aKN
@@ -110450,7 +110457,7 @@ vmm
 ody
 kfG
 xnR
-mrS
+pen
 pEf
 gXs
 aKN
@@ -110707,7 +110714,7 @@ iek
 cZu
 cLg
 sdl
-mrS
+pen
 pEf
 aaa
 aaa
@@ -110964,7 +110971,7 @@ pJB
 gBP
 vxS
 qlI
-mrS
+pen
 pEf
 pEf
 pEf
@@ -111731,7 +111738,7 @@ snB
 snB
 cqk
 bhL
-tto
+lHO
 dEd
 pyZ
 dTb
@@ -113269,11 +113276,11 @@ pEf
 pEf
 fmC
 fmC
-aTP
+hjk
 bRu
 xFg
 gTY
-cbd
+pkb
 fmC
 fmC
 pEf
@@ -113527,10 +113534,10 @@ fmC
 fmC
 gQa
 jzm
-ybM
+cbd
 soe
-ybM
-mWE
+cbd
+qVN
 yap
 fmC
 fmC
@@ -113784,11 +113791,11 @@ fmC
 fmC
 gNr
 npc
-ybM
-rYz
-ybM
-mqO
-hXu
+cbd
+aTP
+cbd
+fCV
+xPL
 fmC
 fmC
 fmC
@@ -114040,11 +114047,11 @@ fmC
 fmC
 bjE
 qQw
-dnj
-ybM
+lWl
+cbd
 jKN
-ybM
-dnj
+cbd
+lWl
 loF
 xlV
 fmC
@@ -114300,9 +114307,9 @@ jcz
 cWY
 lQv
 grq
-nHT
+phR
 tGz
-aVE
+lFm
 ikV
 fmC
 fmC
@@ -114554,11 +114561,11 @@ fmC
 fmC
 kVh
 qKK
-dnj
-ybM
+lWl
+cbd
 car
-ybM
-dnj
+cbd
+lWl
 bdd
 bcd
 fmC
@@ -114812,11 +114819,11 @@ fmC
 fmC
 dOn
 sPc
-ybM
+cbd
 rlo
-ybM
-wrK
-lMT
+cbd
+uNG
+paH
 fmC
 fmC
 fmC
@@ -115067,13 +115074,13 @@ pEf
 pEf
 fmC
 fmC
-rfJ
+byg
 ikV
-ybM
+cbd
 xzh
-ybM
-nHT
-pen
+cbd
+phR
+mrS
 fmC
 fmC
 pEf
@@ -115326,7 +115333,7 @@ ogh
 jXD
 fmC
 mDn
-kit
+dnj
 fmC
 dTU
 eKD

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -296,8 +296,17 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "abx" = (
-/turf/closed/wall/r_wall,
-/area/tcommsat/entrance)
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
+	dir = 1
+	},
+/area/ai_monitored/turret_protected/ai)
 "aby" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -6438,6 +6447,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
+"aTP" = (
+/obj/machinery/telecomms/broadcaster/preset_left{
+	name = "subspace broadcaster A"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "aTQ" = (
 /obj/machinery/light{
 	dir = 1
@@ -6599,6 +6617,15 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
+"aVE" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "aVX" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/dark,
@@ -7251,6 +7278,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"bcc" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "bcd" = (
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -7668,10 +7699,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge/meeting_room)
-"bfr" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "bfv" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -12855,6 +12882,15 @@
 /obj/item/beacon,
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"cbd" = (
+/obj/machinery/telecomms/receiver/preset_left{
+	name = "subspace receiver A"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "cbe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -13160,10 +13196,6 @@
 /obj/machinery/power/emitter,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cfh" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "cfm" = (
 /obj/item/c_tube,
 /obj/structure/disposalpipe/segment,
@@ -15661,6 +15693,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
+"cOE" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "cOJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -16713,6 +16749,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"djF" = (
+/obj/machinery/ai/server_cabinet/prefilled,
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "dkq" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -16900,14 +16940,11 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
 "dnj" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
 	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "dno" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -18235,15 +18272,6 @@
 	name = "server vent"
 	},
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
-"dOp" = (
-/obj/machinery/telecomms/receiver/preset_left{
-	name = "subspace receiver A"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 5
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "dOt" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
@@ -21256,10 +21284,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"eTe" = (
-/obj/machinery/ai/server_cabinet/prefilled,
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
 "eTh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -22157,15 +22181,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "fkC" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = 28
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
@@ -23180,15 +23199,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/lawoffice)
-"fCV" = (
-/obj/machinery/telecomms/broadcaster/preset_left{
-	name = "subspace broadcaster A"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "fDx" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -24242,15 +24252,16 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "fXb" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "West AI Server"
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "aiserverdoor";
+	name = "AI Server Shutters"
 	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/circuit/green,
+/area/ai_monitored/storage/satellite)
 "fXm" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -27426,6 +27437,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hjk" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "hjA" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -29494,12 +29514,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
 "hXu" = (
-/obj/machinery/pipedispenser,
-/obj/machinery/light{
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
 	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "hYy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -29948,17 +29970,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"ieo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "aiserverdoor";
-	name = "AI Server Shutters"
-	},
-/turf/open/floor/circuit/green,
-/area/ai_monitored/storage/satellite)
 "ier" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -31339,13 +31350,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
-"iHu" = (
-/obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "iHI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -31391,36 +31395,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"iIj" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room South";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
-"iII" = (
-/obj/effect/turf_decal/ramp_middle{
-	dir = 1
-	},
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = -22
-	},
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
-	dir = 1
-	},
-/area/ai_monitored/turret_protected/ai)
 "iJa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -31916,6 +31890,13 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"iRV" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start/yogs/network_admin,
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "iRY" = (
 /obj/structure/table,
 /obj/item/flashlight{
@@ -35167,11 +35148,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "kit" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/telecomms/message_server/preset,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "kiy" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
@@ -35585,6 +35564,14 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"krI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "aiserverdoor";
+	name = "AI Server Shutters"
+	},
+/turf/open/floor/circuit/green,
+/area/ai_monitored/storage/satellite)
 "krO" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer_R";
@@ -37212,24 +37199,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"lbX" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room South";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "lcb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -37415,15 +37384,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"lfM" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "lfW" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -38451,15 +38411,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
-"lyX" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "lza" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -38789,16 +38740,6 @@
 /obj/item/mop,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
-"lHO" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	dir = 1;
-	name = "AI Antechamber APC";
-	pixel_y = 24
-	},
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
 "lIb" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -39066,6 +39007,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"lMT" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "lMW" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -39432,12 +39382,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"lWl" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
 "lWz" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -40565,13 +40509,10 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "mqO" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "mqR" = (
 /obj/effect/spawner/structure/window,
@@ -40631,6 +40572,9 @@
 /obj/structure/transit_tube_pod,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"mrS" = (
+/turf/closed/wall/r_wall,
+/area/tcommsat/entrance)
 "msb" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/meter,
@@ -42241,6 +42185,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"mWE" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "mWH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -42421,8 +42374,13 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/storage/satellite)
 "naq" = (
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "naz" = (
 /obj/effect/spawner/structure/solars/solar_96,
 /obj/structure/cable/yellow{
@@ -42820,6 +42778,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/landmark/start/yogs/network_admin,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "nfK" = (
@@ -44420,6 +44379,12 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"nQP" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "nRs" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Genetics Research";
@@ -45606,10 +45571,11 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "opJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
@@ -47502,14 +47468,15 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "paH" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "West AI Server"
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "paQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 4
@@ -47596,10 +47563,22 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "pen" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 1
 	},
-/turf/open/floor/circuit/telecomms/server,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room South";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "pew" = (
 /obj/structure/disposalpipe/segment,
@@ -47852,15 +47831,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"phR" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "pia" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4
@@ -48999,6 +48969,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"pBl" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 7;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "pBm" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -52777,6 +52760,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/entrance)
+"qZK" = (
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "ras" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -53000,6 +52987,10 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
 "rdR" = (
+/obj/structure/cable{
+	icon_state = "1-4";
+	tag = ""
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
 "rfl" = (
@@ -53055,6 +53046,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"rfJ" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room South";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "rfK" = (
 /obj/machinery/light{
 	dir = 4
@@ -54590,10 +54599,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
-"rJJ" = (
-/obj/effect/turf_decal/stripes/white/line,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "rKk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -55369,10 +55374,11 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
 "rYz" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 10
+/obj/machinery/telecomms/processor/preset_four,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/circuit/telecomms/server,
+/turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "rYI" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
@@ -56126,6 +56132,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "snF" = (
@@ -56441,14 +56448,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"suV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "aiserverdoor";
-	name = "AI Server Shutters"
-	},
-/turf/open/floor/circuit/green,
-/area/ai_monitored/storage/satellite)
 "svh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -58995,9 +58994,13 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "tto" = (
-/obj/item/kirbyplants/photosynthetic,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "ttQ" = (
 /obj/structure/rack,
 /obj/machinery/light{
@@ -59920,9 +59923,12 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "tNs" = (
-/obj/machinery/telecomms/message_server/preset,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/machinery/pipedispenser,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "tNA" = (
 /obj/machinery/camera{
 	c_tag = "Dormitory South";
@@ -62513,13 +62519,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"uNG" = (
-/obj/machinery/telecomms/processor/preset_four,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "uNH" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -66220,16 +66219,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"wer" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
-	},
-/obj/machinery/camera{
-	c_tag = "East AI Server"
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
 "weD" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -66900,6 +66889,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"wrK" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 10
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "wrN" = (
 /obj/structure/chair/comfy/beige,
 /turf/open/floor/plasteel/grimy,
@@ -67311,6 +67306,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"wBI" = (
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
+	},
+/obj/machinery/camera{
+	c_tag = "East AI Server"
+	},
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "wBN" = (
 /obj/effect/turf_decal/tile{
 	dir = 8
@@ -67604,14 +67609,15 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "wIB" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 8
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
+	dir = 1;
+	name = "AI Antechamber APC";
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
+/obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
+/area/ai_monitored/storage/satellite)
 "wJc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/reagent_dispensers/fueltank,
@@ -68977,13 +68983,9 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "xnr" = (
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = 22
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/satellite)
 "xnF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -69494,6 +69496,9 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/white,
 /area/engine/atmos/mix)
+"xyb" = (
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "xyG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -70311,6 +70316,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"xPL" = (
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "xPQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -99827,7 +99835,7 @@ cva
 cva
 cva
 gtB
-eTe
+djF
 qKi
 kqB
 gtB
@@ -100083,10 +100091,10 @@ vJJ
 ume
 cva
 cva
-fXb
-naq
-naq
-kit
+paH
+xPL
+xPL
+nQP
 gtB
 tgv
 wJL
@@ -100345,7 +100353,7 @@ gLt
 kMi
 uuG
 ieK
-iHu
+rdR
 azq
 rRA
 lmN
@@ -100591,18 +100599,18 @@ pqr
 cva
 hWd
 fiF
-cfh
-xnr
-cfh
-bfr
+bcc
+naq
+bcc
+cOE
 qjk
 cva
 cva
 tgv
-ieo
-suV
+fXb
+krI
 tgv
-fkC
+pBl
 pSY
 lhk
 rdw
@@ -100851,19 +100859,19 @@ nDA
 cva
 cva
 hsq
-paH
-rJJ
-iII
+hjk
+qZK
+abx
 uAV
 tgv
 cqT
 xxd
 tgv
-tto
+xnr
 pTL
-rdR
-rdR
-rdR
+xyb
+xyb
+xyb
 aJw
 pvo
 sXZ
@@ -101119,8 +101127,8 @@ fJN
 aJy
 nyj
 rPo
-opJ
-opJ
+fkC
+fkC
 psj
 hsn
 sYk
@@ -101365,18 +101373,18 @@ nDA
 cva
 cva
 mfG
-paH
-rJJ
+hjk
+qZK
 vAP
 gCs
 tgv
 naj
 rCq
 tgv
-lHO
+wIB
 hYy
-rdR
-rdR
+xyb
+xyb
 gOE
 aJw
 hvG
@@ -101621,19 +101629,19 @@ hWd
 qoQ
 jJK
 prN
-cfh
-bfr
+bcc
+cOE
 laN
 cva
 cva
 tgv
-ieo
-suV
+fXb
+krI
 tgv
-dnj
+opJ
 rzx
-gOE
-hXu
+iRV
+tNs
 agz
 aJw
 qHo
@@ -101887,7 +101895,7 @@ sAr
 tmm
 pJS
 vzc
-rdR
+xyb
 dne
 bxL
 lmN
@@ -102139,10 +102147,10 @@ sAu
 wkd
 cva
 cva
-wer
-naq
-naq
-kit
+wBI
+xPL
+xPL
+nQP
 gtB
 tgv
 wJL
@@ -102397,7 +102405,7 @@ cva
 cva
 cva
 gtB
-eTe
+djF
 mUg
 uMi
 gtB
@@ -109661,15 +109669,15 @@ aaa
 aaa
 aaa
 ucZ
-abx
-abx
-abx
+mrS
+mrS
+mrS
 vbw
 fjN
 kRG
-abx
-abx
-abx
+mrS
+mrS
+mrS
 pEf
 aaa
 aaa
@@ -110175,17 +110183,17 @@ aaa
 ucZ
 bVJ
 bVJ
-abx
-abx
-abx
+mrS
+mrS
+mrS
 aDW
 sxE
 vvS
-abx
-abx
-abx
-abx
-abx
+mrS
+mrS
+mrS
+mrS
+mrS
 pEf
 gXs
 aKN
@@ -110442,7 +110450,7 @@ vmm
 ody
 kfG
 xnR
-abx
+mrS
 pEf
 gXs
 aKN
@@ -110699,7 +110707,7 @@ iek
 cZu
 cLg
 sdl
-abx
+mrS
 pEf
 aaa
 aaa
@@ -110956,7 +110964,7 @@ pJB
 gBP
 vxS
 qlI
-abx
+mrS
 pEf
 pEf
 pEf
@@ -111719,11 +111727,11 @@ qTh
 phH
 iDE
 fYE
-lyX
-lyX
+snB
+snB
 cqk
 bhL
-snB
+tto
 dEd
 pyZ
 dTb
@@ -113261,11 +113269,11 @@ pEf
 pEf
 fmC
 fmC
-fCV
+aTP
 bRu
 xFg
 gTY
-dOp
+cbd
 fmC
 fmC
 pEf
@@ -113522,7 +113530,7 @@ jzm
 ybM
 soe
 ybM
-lfM
+mWE
 yap
 fmC
 fmC
@@ -113777,10 +113785,10 @@ fmC
 gNr
 npc
 ybM
-uNG
+rYz
 ybM
-pen
 mqO
+hXu
 fmC
 fmC
 fmC
@@ -114032,11 +114040,11 @@ fmC
 fmC
 bjE
 qQw
-lWl
+dnj
 ybM
 jKN
 ybM
-lWl
+dnj
 loF
 xlV
 fmC
@@ -114294,7 +114302,7 @@ lQv
 grq
 nHT
 tGz
-phR
+aVE
 ikV
 fmC
 fmC
@@ -114546,11 +114554,11 @@ fmC
 fmC
 kVh
 qKK
-lWl
+dnj
 ybM
 car
 ybM
-lWl
+dnj
 bdd
 bcd
 fmC
@@ -114807,8 +114815,8 @@ sPc
 ybM
 rlo
 ybM
-rYz
-wIB
+wrK
+lMT
 fmC
 fmC
 fmC
@@ -115059,13 +115067,13 @@ pEf
 pEf
 fmC
 fmC
-lbX
+rfJ
 ikV
 ybM
 xzh
 ybM
 nHT
-iIj
+pen
 fmC
 fmC
 pEf
@@ -115318,7 +115326,7 @@ ogh
 jXD
 fmC
 mDn
-tNs
+kit
 fmC
 dTU
 eKD

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -296,15 +296,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "abx" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	dir = 1;
-	name = "AI Antechamber APC";
-	pixel_y = 24
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/circuit,
-/area/ai_monitored/storage/satellite)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "aby" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -838,6 +836,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"afK" = (
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "afL" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -3180,16 +3186,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"axV" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
-	},
-/obj/machinery/camera{
-	c_tag = "East AI Server"
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
 "ayd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -6356,15 +6352,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port)
-"aTs" = (
-/obj/machinery/telecomms/receiver/preset_left{
-	name = "subspace receiver A"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 5
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "aTw" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -6455,6 +6442,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
+"aTP" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "aTQ" = (
 /obj/machinery/light{
 	dir = 1
@@ -9858,11 +9854,14 @@
 /turf/closed/wall/r_wall,
 /area/science/server)
 "byg" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
+/obj/machinery/telecomms/broadcaster/preset_left{
+	name = "subspace broadcaster A"
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "byi" = (
 /turf/closed/wall,
 /area/security/checkpoint/science)
@@ -12888,6 +12887,13 @@
 /obj/item/beacon,
 /turf/open/floor/engine,
 /area/science/misc_lab)
+"cbd" = (
+/obj/machinery/telecomms/processor/preset_four,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "cbe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -18272,15 +18278,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
-"dOp" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "dOt" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /obj/machinery/light,
@@ -21289,11 +21286,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "eTe" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
@@ -23214,13 +23211,14 @@
 /turf/open/floor/plating,
 /area/lawoffice)
 "fCV" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "fDx" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -23839,15 +23837,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"fMm" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "fMp" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall,
@@ -24283,15 +24272,8 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "fXb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "aiserverdoor";
-	name = "AI Server Shutters"
-	},
-/turf/open/floor/circuit/green,
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/circuit,
 /area/ai_monitored/storage/satellite)
 "fXm" = (
 /obj/machinery/door/firedoor/border_only{
@@ -27470,9 +27452,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hjk" = (
-/obj/machinery/gulag_item_reclaimer,
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 10
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "hjA" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -27958,13 +27942,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
 "hsq" = (
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = 22
+/obj/machinery/telecomms/receiver/preset_left{
+	name = "subspace receiver A"
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "hsA" = (
 /obj/machinery/computer/camera_advanced/base_construction{
 	dir = 1
@@ -29353,9 +29338,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "hUM" = (
@@ -29558,11 +29540,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
 "hXu" = (
-/obj/machinery/pipedispenser,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
+	dir = 1;
+	name = "AI Antechamber APC";
+	pixel_y = 24
 	},
-/turf/open/floor/plasteel/grimy,
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/circuit,
 /area/ai_monitored/storage/satellite)
 "hYy" = (
 /obj/effect/turf_decal/stripes/line{
@@ -30012,6 +29997,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"ieo" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "aiserverdoor";
+	name = "AI Server Shutters"
+	},
+/turf/open/floor/circuit/green,
+/area/ai_monitored/storage/satellite)
 "ier" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -31392,6 +31388,25 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
+"iHu" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room South";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/obj/machinery/telecomms/processor/preset_three,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "iHI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -31437,9 +31452,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"iIj" = (
-/turf/closed/wall/r_wall,
-/area/tcommsat/entrance)
 "iJa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -35191,6 +35203,12 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"kit" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "kiy" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
@@ -35604,6 +35622,14 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"krI" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "aiserverdoor";
+	name = "AI Server Shutters"
+	},
+/turf/open/floor/circuit/green,
+/area/ai_monitored/storage/satellite)
 "krO" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer_R";
@@ -37246,17 +37272,14 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "lbX" = (
-/obj/effect/turf_decal/ramp_middle{
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
 	dir = 1
 	},
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = -22
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
-	dir = 1
-	},
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "lcb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -37524,7 +37547,6 @@
 /turf/open/floor/wood,
 /area/library)
 "lhk" = (
-/obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
 "lhG" = (
@@ -38813,12 +38835,11 @@
 /turf/open/floor/plasteel/dark,
 /area/janitor)
 "lHO" = (
-/obj/machinery/power/terminal{
-	dir = 4
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = 22
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "lIb" = (
@@ -39088,6 +39109,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"lMT" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "lMW" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -39942,6 +39967,25 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"mfG" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room South";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/obj/machinery/telecomms/bus/preset_one,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "mfN" = (
 /obj/machinery/camera{
 	c_tag = "Aft Starboard Solar Access";
@@ -40571,6 +40615,13 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
+"mqO" = (
+/obj/structure/cable{
+	icon_state = "1-4";
+	tag = ""
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "mqR" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable{
@@ -40630,12 +40681,8 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "mrS" = (
-/obj/machinery/telecomms/processor/preset_four,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/turf/closed/wall/r_wall,
+/area/tcommsat/entrance)
 "msb" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/meter,
@@ -42254,6 +42301,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"mWE" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "mWH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -44126,9 +44179,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "nHT" = (
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/circuit,
-/area/ai_monitored/storage/satellite)
+/obj/machinery/telecomms/message_server/preset,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "nHU" = (
 /obj/machinery/requests_console{
 	department = "Science";
@@ -44433,8 +44486,13 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 8;
+	pixel_y = 23
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "nRs" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Genetics Research";
@@ -47193,6 +47251,10 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"oUc" = (
+/obj/machinery/gulag_item_reclaimer,
+/turf/open/space/basic,
+/area/space)
 "oUl" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -48515,11 +48577,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "ptV" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 10
+/obj/machinery/pipedispenser,
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "put" = (
 /obj/machinery/door/airlock/external{
 	name = "Security Secure External Airlock";
@@ -53020,8 +53083,17 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
 "rdR" = (
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
+	dir = 1
+	},
+/area/ai_monitored/turret_protected/ai)
 "rfl" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -53075,10 +53147,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"rfJ" = (
-/obj/machinery/telecomms/message_server/preset,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "rfK" = (
 /obj/machinery/light{
 	dir = 4
@@ -55395,15 +55463,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
-"rYz" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "rYI" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -56473,13 +56532,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "suV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "aiserverdoor";
-	name = "AI Server Shutters"
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
 	},
-/turf/open/floor/circuit/green,
-/area/ai_monitored/storage/satellite)
+/obj/machinery/camera{
+	c_tag = "East AI Server"
+	},
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "svh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -59025,25 +59086,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"tto" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room South";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
-	},
-/obj/machinery/telecomms/processor/preset_three,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "ttQ" = (
 /obj/structure/rack,
 /obj/machinery/light{
@@ -59966,12 +60008,14 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "tNs" = (
-/obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 8
 	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "tNA" = (
 /obj/machinery/camera{
 	c_tag = "Dormitory South";
@@ -66932,15 +66976,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"wrK" = (
-/obj/machinery/telecomms/broadcaster/preset_left{
-	name = "subspace broadcaster A"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "wrN" = (
 /obj/structure/chair/comfy/beige,
 /turf/open/floor/plasteel/grimy,
@@ -67656,14 +67691,18 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "wIB" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
+/obj/machinery/light_switch{
+	pixel_x = 7;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "wJc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/reagent_dispensers/fueltank,
@@ -69028,17 +69067,6 @@
 /obj/structure/closet/secure_closet/warden,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"xnr" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = 8;
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "xnF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -69440,22 +69468,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "xwL" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/light/small{
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room South";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "xwU" = (
@@ -69568,14 +69586,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/white,
 /area/engine/atmos/mix)
-"xyb" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
 "xyG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -70393,19 +70403,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"xPL" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "xPQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -100182,7 +100179,7 @@ cva
 mDO
 lyX
 lyX
-nQP
+kit
 gtB
 tgv
 wJL
@@ -100436,12 +100433,12 @@ nDA
 rjo
 tTK
 cva
-xyb
+afK
 gLt
 kMi
 uuG
 ieK
-tNs
+mqO
 azq
 rRA
 lmN
@@ -100688,19 +100685,19 @@ cva
 hWd
 fiF
 bcc
-hsq
+lHO
 bcc
 bfr
 qjk
 cva
 cva
 tgv
-fXb
-suV
+ieo
+krI
 tgv
-xPL
+wIB
 pSY
-lhk
+lMT
 rdw
 pvf
 aJw
@@ -100947,19 +100944,19 @@ pen
 hmx
 cva
 cva
-xnr
+nQP
 qZK
-lbX
+rdR
 uAV
 tgv
 cqT
 xxd
 tgv
-nHT
+fXb
 pTL
-rdR
-rdR
-rdR
+lhk
+lhk
+lhk
 aJw
 pvo
 sXZ
@@ -101461,7 +101458,7 @@ hUA
 lfM
 cva
 cva
-byg
+mWE
 rJJ
 vAP
 gCs
@@ -101469,10 +101466,10 @@ tgv
 naj
 rCq
 tgv
-abx
+hXu
 hYy
-rdR
-rdR
+lhk
+lhk
 gOE
 aJw
 hvG
@@ -101723,13 +101720,13 @@ laN
 cva
 cva
 tgv
-fXb
-suV
+ieo
+krI
 tgv
-dOp
+fCV
 rzx
 iRV
-hXu
+ptV
 agz
 aJw
 qHo
@@ -101973,17 +101970,17 @@ cva
 iXp
 pyn
 dnj
-lHO
+aTP
 nDA
 rjo
 tTK
 cva
-xyb
+afK
 sAr
 tmm
 pJS
 vzc
-rdR
+lhk
 dne
 bxL
 lmN
@@ -102235,10 +102232,10 @@ cva
 wkd
 cva
 cva
-axV
+suV
 lyX
 lyX
-nQP
+kit
 gtB
 tgv
 wJL
@@ -108478,7 +108475,7 @@ aaa
 xrX
 aaa
 slA
-hjk
+oUc
 aaa
 gXs
 pEf
@@ -109757,15 +109754,15 @@ aaa
 aaa
 aaa
 ucZ
-iIj
-iIj
-iIj
+mrS
+mrS
+mrS
 vbw
 fjN
 kRG
-iIj
-iIj
-iIj
+mrS
+mrS
+mrS
 pEf
 aaa
 aaa
@@ -110271,17 +110268,17 @@ aaa
 ucZ
 bVJ
 bVJ
-iIj
-iIj
-iIj
+mrS
+mrS
+mrS
 aDW
 sxE
 vvS
-iIj
-iIj
-iIj
-iIj
-iIj
+mrS
+mrS
+mrS
+mrS
+mrS
 pEf
 gXs
 aKN
@@ -110538,7 +110535,7 @@ vmm
 ody
 kfG
 xnR
-iIj
+mrS
 pEf
 gXs
 aKN
@@ -110795,7 +110792,7 @@ iek
 cZu
 cLg
 sdl
-iIj
+mrS
 pEf
 aaa
 aaa
@@ -111052,7 +111049,7 @@ pJB
 gBP
 vxS
 qlI
-iIj
+mrS
 pEf
 pEf
 pEf
@@ -111819,7 +111816,7 @@ snB
 snB
 cqk
 bhL
-fCV
+abx
 dEd
 pyZ
 dTb
@@ -113357,11 +113354,11 @@ pEf
 pEf
 fmC
 fmC
-wrK
+byg
 bRu
 xFg
 gTY
-aTs
+hsq
 fmC
 fmC
 pEf
@@ -113618,7 +113615,7 @@ jzm
 ybM
 soe
 ybM
-eTe
+lbX
 yap
 fmC
 fmC
@@ -113873,10 +113870,10 @@ fmC
 gNr
 npc
 ybM
-mrS
+cbd
 ybM
 mFE
-fMm
+xwL
 fmC
 fmC
 fmC
@@ -114390,7 +114387,7 @@ lQv
 grq
 phR
 tGz
-wIB
+eTe
 ikV
 fmC
 fmC
@@ -114903,8 +114900,8 @@ sPc
 ybM
 rlo
 ybM
-ptV
-rYz
+hjk
+tNs
 fmC
 fmC
 fmC
@@ -115155,13 +115152,13 @@ pEf
 pEf
 fmC
 fmC
-tto
+iHu
 ikV
 ybM
 xzh
 ybM
 phR
-xwL
+mfG
 fmC
 fmC
 pEf
@@ -115414,7 +115411,7 @@ ogh
 jXD
 fmC
 mDn
-rfJ
+nHT
 fmC
 dTU
 eKD

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -296,11 +296,20 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "abx" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/ai/server_cabinet/prefilled,
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "aby" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -746,6 +755,19 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
+"aeC" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "aeI" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -835,19 +857,18 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "afK" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access_txt = "10;13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/turf/open/floor/plating,
+/area/space)
 "afL" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -958,22 +979,19 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "agz" = (
-/obj/machinery/light_switch{
-	pixel_y = -27
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/tcomms{
+	pixel_x = -4;
+	pixel_y = 5
 	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
+/obj/item/paper_bin{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/structure/rack,
-/obj/item/multitool,
-/obj/item/radio/off{
-	pixel_y = 4
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/toy/talking/AI,
+/obj/item/folder/blue,
+/obj/item/pen,
 /turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/area/ai_monitored/storage/satellite)
 "agA" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -2338,7 +2356,7 @@
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "aqQ" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -2500,6 +2518,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
+"asG" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel,
+/area/space)
 "asM" = (
 /obj/effect/turf_decal/pool/corner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -3194,9 +3216,23 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "axV" = (
-/mob/living/simple_animal/pet/axolotl/bop,
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "ayd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -3384,12 +3420,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "azq" = (
-/obj/structure/table/wood,
-/obj/machinery/microwave{
-	pixel_y = 4
-	},
+/obj/machinery/rack_creator,
 /turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/area/ai_monitored/storage/satellite)
 "azt" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable{
@@ -4170,7 +4203,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "aDX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -4886,28 +4919,8 @@
 /turf/closed/wall,
 /area/hallway/primary/central)
 "aJy" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Telecomms Tech Storage";
-	req_access_txt = "61"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
+/area/ai_monitored/storage/satellite)
 "aJz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -5227,6 +5240,14 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/security/processing)
+"aLy" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "aLz" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/dark,
@@ -5432,6 +5453,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
+"aMJ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/space/basic,
+/area/space)
 "aML" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
@@ -5591,6 +5619,15 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
+"aNW" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/shoes/winterboots,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "aNZ" = (
 /obj/machinery/camera{
 	c_tag = "Escape Podbay"
@@ -6135,6 +6172,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"aRB" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "aRJ" = (
 /obj/machinery/door/airlock/mining{
 	req_access_txt = "48"
@@ -6311,6 +6354,9 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"aSA" = (
+/turf/open/floor/plasteel/dark,
+/area/space)
 "aSG" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
@@ -6382,9 +6428,12 @@
 	},
 /area/maintenance/port)
 "aTs" = (
-/obj/machinery/telecomms/bus/preset_three,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/machinery/advanced_airlock_controller{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plating,
+/area/space)
 "aTw" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -6476,9 +6525,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
 "aTP" = (
-/obj/machinery/telecomms/bus/preset_one,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/machinery/vending/wardrobe/sig_wardrobe,
+/turf/open/floor/plasteel,
+/area/space)
 "aTQ" = (
 /obj/machinery/light{
 	dir = 1
@@ -6641,14 +6690,16 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "aVE" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 8
+/obj/machinery/power/smes/engineering{
+	charge = 5e+006;
+	input_level = 40000;
+	output_level = 30000
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/turf/open/floor/plating,
+/area/space)
 "aVX" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/dark,
@@ -7302,9 +7353,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bcc" = (
-/obj/machinery/telecomms/processor/preset_three,
+/obj/machinery/telecomms/processor/preset_one,
 /turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/area/space)
 "bcd" = (
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -7370,6 +7421,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"bcz" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "bcA" = (
 /obj/machinery/light{
 	dir = 4
@@ -7723,9 +7780,9 @@
 /turf/open/floor/plasteel,
 /area/bridge/meeting_room)
 "bfr" = (
-/obj/machinery/telecomms/processor/preset_one,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "bfv" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -7932,7 +7989,7 @@
 	req_access_txt = "65"
 	},
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "bhh" = (
 /obj/machinery/chem_dispenser,
 /obj/item/toy/figure/chemist{
@@ -7996,6 +8053,17 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"bhu" = (
+/obj/machinery/advanced_airlock_controller{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/space)
 "bhy" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 8
@@ -8075,7 +8143,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "bhM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -8449,6 +8517,10 @@
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"bkZ" = (
+/obj/machinery/telecomms/message_server/preset,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "blb" = (
 /obj/effect/landmark/stationroom/maint/tenxfive,
 /turf/template_noop,
@@ -8563,6 +8635,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"bmg" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/camera{
+	c_tag = "MiniSat Exterior - Aft Port";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "bmi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
@@ -8600,6 +8680,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bmX" = (
+/obj/machinery/pipedispenser,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "bnc" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/mechbay)
@@ -9409,6 +9493,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"btR" = (
+/obj/machinery/telecomms/processor/preset_two,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "btT" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
@@ -9640,6 +9738,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"bvC" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 8;
+	pixel_y = -23
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "bvD" = (
 /obj/item/chair,
 /obj/effect/decal/cleanable/blood,
@@ -9779,6 +9888,15 @@
 "bwZ" = (
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"bxc" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/space)
 "bxd" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -9857,9 +9975,21 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
 "bxL" = (
-/obj/machinery/rnd/production/circuit_imprinter/department/netmin,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/vodka{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 8;
+	pixel_y = 1
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_x = -6;
+	pixel_y = 1
+	},
 /turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/area/ai_monitored/storage/satellite)
 "bxZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -9873,20 +10003,12 @@
 /turf/closed/wall/r_wall,
 /area/science/server)
 "byg" = (
-/obj/machinery/camera{
-	c_tag = "AI Chamber - Fore";
-	dir = 4;
-	network = list("aicore")
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/porta_turret/ai,
-/turf/open/floor/circuit/telecomms/server,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/circuit/green/telecomms,
+/area/space)
 "byi" = (
 /turf/closed/wall,
 /area/security/checkpoint/science)
@@ -10691,6 +10813,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"bDr" = (
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "bDx" = (
 /obj/structure/table/wood,
 /obj/item/canvas/twentythreeXtwentythree{
@@ -10862,6 +10993,12 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"bFi" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	dir = 1
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
 "bFr" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -10937,6 +11074,15 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
+"bGo" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "bGq" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -11841,6 +11987,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"bOL" = (
+/obj/structure/table/wood,
+/obj/machinery/microwave{
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "bOQ" = (
 /obj/structure/table,
 /obj/item/t_scanner,
@@ -12025,6 +12178,17 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"bPG" = (
+/obj/machinery/announcement_system,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "bPH" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
@@ -12037,6 +12201,14 @@
 "bPN" = (
 /turf/closed/wall,
 /area/science/misc_lab)
+"bPO" = (
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "bPT" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -12233,11 +12405,12 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bRu" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "bRv" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -12269,6 +12442,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/foyer)
+"bRF" = (
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/turf/open/floor/plasteel/white,
+/area/space)
 "bRG" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -12368,18 +12546,18 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Antechamber";
-	req_access_txt = "65"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/door/airlock/hatch{
+	name = "Telecomms Access";
+	req_access_txt = "61"
+	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "bSN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -12492,6 +12670,15 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
+"bUO" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space)
 "bUV" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/machinery/light,
@@ -12568,14 +12755,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "bVI" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/ai_slipper{
+	uses = 10
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/machinery/light/small{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/area/ai_monitored/turret_protected/ai)
 "bVJ" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/computer)
@@ -12872,13 +13059,8 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "car" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "caI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -12917,14 +13099,8 @@
 /turf/open/floor/engine,
 /area/science/misc_lab)
 "cbd" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
 /turf/open/floor/circuit/telecomms/server,
-/area/ai_monitored/turret_protected/ai)
+/area/tcommsat/server)
 "cbe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -13231,20 +13407,18 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cfh" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/area/ai_monitored/turret_protected/ai)
 "cfm" = (
 /obj/item/c_tube,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"cfn" = (
+/obj/machinery/telecomms/server/presets/command,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "cfo" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -13299,6 +13473,16 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"cfN" = (
+/obj/item/radio/intercom{
+	dir = 8;
+	freerange = 1;
+	name = "Station Intercom (Command)";
+	pixel_x = -28
+	},
+/obj/structure/filingcabinet,
+/turf/open/floor/wood,
+/area/space)
 "cfY" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating{
@@ -13366,13 +13550,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "chg" = (
-/obj/machinery/computer/telecomms/traffic{
-	dir = 1;
-	network = "tcommsat"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/obj/structure/sign/plaques/kiddie{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "chq" = (
 /obj/machinery/processor/slime,
 /obj/item/radio/intercom{
@@ -13781,6 +13966,15 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"clN" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "cmb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -13977,6 +14171,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"cnX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "cob" = (
 /obj/machinery/camera{
 	c_tag = "Research Division South";
@@ -14103,6 +14306,15 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
+"cpN" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/camera{
+	c_tag = "MiniSat Exterior - Fore Starboard";
+	dir = 1;
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "cpO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -14142,8 +14354,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
 /turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "cqP" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
@@ -14184,14 +14399,12 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/camera/motion{
+	c_tag = "Telecomms Foyer";
+	network = list("ss13","minisat")
 	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/turf/open/floor/plasteel,
+/area/space)
 "cqW" = (
 /obj/effect/decal/cleanable/xenoblood,
 /turf/open/floor/engine,
@@ -14304,6 +14517,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"crS" = (
+/obj/structure/transit_tube/station{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "csl" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/dark,
@@ -14414,6 +14636,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ctL" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/space)
 "ctR" = (
 /turf/open/floor/engine/n2,
 /area/engine/atmos/distro)
@@ -14507,16 +14736,9 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "cuZ" = (
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room";
-	network = list("ss13","tcomms");
-	pixel_x = 22
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
 "cva" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
@@ -14572,7 +14794,7 @@
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "cwc" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -14593,6 +14815,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"cwu" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "cwH" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -14648,6 +14889,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"cxF" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "cxI" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/hydroponicsplants{
@@ -14714,17 +14964,11 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "cyY" = (
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/turf/open/floor/circuit/telecomms/server,
+/area/ai_monitored/turret_protected/ai)
 "czl" = (
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/open/floor/plating,
@@ -14776,6 +15020,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"cAw" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Telecomms Tech Storage";
+	req_access_txt = "61"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "cAA" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/AI,
@@ -14906,8 +15161,11 @@
 	},
 /obj/effect/mapping_helpers/teleport_anchor,
 /obj/machinery/space_heater,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "cBU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset,
@@ -15042,6 +15300,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/lawoffice)
+"cDJ" = (
+/obj/machinery/bluespace_beacon,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "cDK" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -15347,6 +15610,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"cJo" = (
+/turf/open/floor/plasteel/white,
+/area/space)
 "cJu" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 30
@@ -15474,7 +15740,7 @@
 /obj/machinery/bluespace_beacon,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "cLH" = (
 /obj/machinery/light{
 	dir = 1
@@ -15587,6 +15853,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"cMK" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/space)
 "cMO" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -15748,12 +16021,8 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
 "cOE" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/telecomms/processor/preset_four,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/turf/closed/wall/r_wall,
+/area/tcommsat/entrance)
 "cOJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -16134,6 +16403,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"cUN" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "cUP" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L7"
@@ -16178,6 +16456,20 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"cVE" = (
+/obj/structure/table,
+/obj/item/folder/blue,
+/obj/item/pen,
+/obj/item/multitool,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "cVS" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -16263,14 +16555,20 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "cWY" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "cXg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -16307,7 +16605,7 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "cZw" = (
 /obj/machinery/pipedispenser,
 /turf/open/floor/plating,
@@ -16527,6 +16825,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ddu" = (
+/obj/machinery/status_display/ai{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "ddA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -16612,6 +16920,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"dfA" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "dfD" = (
 /obj/structure/sink{
 	dir = 4;
@@ -16674,14 +16991,14 @@
 	},
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "dgZ" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "dhc" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/stripes/corner{
@@ -16766,6 +17083,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"diU" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/space)
 "dja" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -16801,12 +17125,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "djF" = (
-/obj/machinery/power/smes/fullycharged,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/white,
-/area/tcommsat/storage)
+/turf/open/floor/plating,
+/area/space)
 "dkq" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -16987,18 +17313,30 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "dne" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
+/obj/structure/table/wood,
+/obj/machinery/microwave{
+	pixel_y = 4
 	},
-/obj/machinery/rack_creator,
 /turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/area/ai_monitored/storage/satellite)
 "dnj" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/power/apc/tcomms{
+	areastring = "/area/tcommsat/server";
+	dir = 4;
+	name = "Telecomms Server APC";
+	pixel_x = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "dno" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -17021,6 +17359,27 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"dnq" = (
+/obj/machinery/door/airlock/public{
+	autoclose = 0;
+	frequency = 1449;
+	glass = 1;
+	id_tag = "telecomms_airlock_interior";
+	name = "Telecomms Server Room Access";
+	req_access_txt = "61"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/space)
 "doM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -17139,6 +17498,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"dqm" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/white,
+/area/space)
 "dqM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -17174,6 +17539,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"drk" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	external_pressure_bound = 120;
+	name = "server vent"
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/circuit/green/telecomms,
+/area/space)
 "drF" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -17222,6 +17601,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"dsI" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	piping_layer = 2
+	},
+/turf/open/floor/plating,
+/area/space)
 "dsQ" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable{
@@ -17336,6 +17721,11 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
+"dvh" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/teleport/station,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "dvj" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
@@ -17348,6 +17738,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"dvx" = (
+/obj/machinery/airalarm/tcomms{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "dvB" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -17472,6 +17879,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"dxx" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/space)
 "dxE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -17728,10 +18145,26 @@
 /obj/machinery/meter,
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/secondarydatacore)
+"dBM" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 1
+	},
+/obj/machinery/telecomms/hub/preset,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "dBV" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
+"dCa" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
 "dCj" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L4"
@@ -17832,14 +18265,14 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Monitoring Room";
-	req_access_txt = "65"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/airlock/hatch{
+	name = "Telecomms Control Room";
+	req_access_txt = "70"
+	},
 /turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "dEw" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
@@ -17939,6 +18372,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"dFP" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "dGd" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -18043,6 +18492,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"dHS" = (
+/obj/machinery/telecomms/receiver/preset_left,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "dId" = (
 /obj/machinery/light,
 /obj/structure/tank_dispenser,
@@ -18199,6 +18662,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"dLB" = (
+/obj/structure/transit_tube/curved/flipped{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space)
 "dLK" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/white,
@@ -18318,21 +18787,19 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
 "dOn" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/porta_turret/ai,
-/turf/open/floor/circuit/telecomms/server,
-/area/ai_monitored/turret_protected/ai)
-"dOp" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
 	dir = 8
 	},
-/obj/structure/cable/white{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	external_pressure_bound = 120;
+	name = "server vent"
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
+"dOp" = (
+/obj/machinery/telecomms/processor/preset_three,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "dOt" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /obj/machinery/light,
@@ -18430,6 +18897,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"dQd" = (
+/obj/machinery/power/smes/engineering{
+	charge = 5e+006;
+	input_level = 25000;
+	output_level = 20000
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "0-2"
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
 "dQj" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/decal/cleanable/dirt,
@@ -18580,19 +19061,15 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dTb" = (
-/obj/machinery/holopad,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/structure/chair/office/dark{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
 /turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "dTe" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/machinery/airalarm{
@@ -18632,14 +19109,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "dTU" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	dir = 8
-	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/blackbox_recorder,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "dUl" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
@@ -18712,6 +19184,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"dVn" = (
+/obj/structure/grille,
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/space)
 "dVy" = (
 /obj/machinery/light_switch{
 	pixel_x = 27
@@ -18884,6 +19361,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
+"dYN" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "dZg" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/sleeper";
@@ -18903,6 +19389,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"dZh" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/space)
 "dZi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -19012,6 +19502,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"ecb" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "ecl" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
@@ -19124,7 +19621,7 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "efb" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/metal/fifty,
@@ -19231,6 +19728,14 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"egy" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/camera{
+	c_tag = "MiniSat Exterior - Aft";
+	network = list("minisat","ss13")
+	},
+/turf/open/space/basic,
+/area/space)
 "egY" = (
 /obj/structure/closet/secure_closet/security,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -19422,6 +19927,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
+"ekV" = (
+/obj/machinery/computer/ai_overclocking{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "ekZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -19474,6 +19985,13 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"elv" = (
+/obj/machinery/blackbox_recorder,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "elK" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -19672,6 +20190,20 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"epV" = (
+/obj/machinery/holopad,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "eqA" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
@@ -19713,12 +20245,48 @@
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "erb" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 1
+/obj/machinery/ai/data_core/primary,
+/obj/machinery/power/apc/highcap{
+	dir = 1;
+	name = "AI Chamber APC";
+	pixel_y = 24
 	},
-/obj/machinery/telecomms/hub/preset,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/item/radio/intercom{
+	anyai = 1;
+	freerange = 1;
+	frequency = 1447;
+	name = "Private Channel";
+	pixel_x = -27;
+	pixel_y = -10
+	},
+/obj/item/radio/intercom{
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel";
+	pixel_x = -27;
+	pixel_y = 4
+	},
+/obj/item/radio/intercom{
+	freerange = 1;
+	name = "Common Channel";
+	pixel_x = 27;
+	pixel_y = 5
+	},
+/obj/machinery/turretid{
+	icon_state = "control_stun";
+	name = "AI Chamber turret control";
+	pixel_x = 27;
+	pixel_y = -4
+	},
+/obj/machinery/button/door{
+	id = "aicoredoor";
+	name = "AI Chamber entrance shutters control";
+	pixel_x = -23;
+	pixel_y = 21;
+	req_access_txt = "16"
+	},
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "erf" = (
 /obj/machinery/door/poddoor{
 	id = "auxincineratorvent";
@@ -19777,6 +20345,13 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/security/prison)
+"esq" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "esu" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -19910,6 +20485,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/interrogation)
+"eui" = (
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/structure/rack,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "eum" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -19998,7 +20583,7 @@
 /obj/item/crowbar,
 /obj/item/mmi,
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "evg" = (
 /obj/machinery/door/window/southleft{
 	name = "Armory";
@@ -20351,15 +20936,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "eAU" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
-	dir = 1
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 8;
+	pixel_y = -23
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/area/ai_monitored/turret_protected/ai)
 "eAY" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -20370,6 +20953,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"eBf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "eBC" = (
 /obj/machinery/requests_console{
 	department = "Hydroponics";
@@ -20604,7 +21200,7 @@
 	dir = 4
 	},
 /turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "eFl" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/suit_storage_unit/security,
@@ -20838,6 +21434,19 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"eJD" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "eJE" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/cmo";
@@ -20886,7 +21495,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "eKD" = (
 /obj/machinery/telecomms/broadcaster/preset_right{
 	name = "subspace broadcaster B"
@@ -21083,6 +21692,54 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/medical/psych)
+"eNA" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/obj/item/toy/figure/borg{
+	pixel_x = -4;
+	pixel_y = -2
+	},
+/obj/item/phone{
+	pixel_x = 7;
+	pixel_y = 1
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_y = -28
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
+"eNX" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
+"eOa" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/public{
+	autoclose = 0;
+	frequency = 1449;
+	glass = 1;
+	id_tag = "telecomms_airlock_interior";
+	name = "Telecomms Server Room Access";
+	req_access_txt = "61"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "eOj" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/dark,
@@ -21147,6 +21804,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"ePD" = (
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "ePH" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/detective,
@@ -21265,6 +21929,10 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"eRI" = (
+/obj/machinery/porta_turret/ai,
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
 "eRZ" = (
 /obj/machinery/light{
 	dir = 1;
@@ -21306,15 +21974,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "eTe" = (
-/obj/structure/table,
-/obj/item/stock_parts/subspace/analyzer,
-/obj/item/stock_parts/subspace/analyzer,
-/obj/item/stock_parts/subspace/analyzer,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/obj/machinery/ai/server_cabinet/prefilled,
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "eTh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -21812,6 +22474,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
+"fbL" = (
+/obj/structure/table,
+/obj/item/assembly/flash/handheld{
+	pixel_x = -8;
+	pixel_y = 2
+	},
+/obj/item/aicard{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/turf/open/floor/plating,
+/area/space)
 "fca" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -21956,6 +22630,14 @@
 "ffb" = (
 /turf/closed/wall,
 /area/maintenance/solars/port/aft)
+"ffl" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "ffo" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
@@ -22028,6 +22710,17 @@
 /obj/effect/turf_decal/arrows/white,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
+"fhe" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/multitool,
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/space)
 "fhF" = (
 /obj/structure/closet/crate,
 /obj/item/stack/license_plates/empty/fifty,
@@ -22128,16 +22821,11 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "fiF" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/area/ai_monitored/turret_protected/ai)
 "fiP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -22162,7 +22850,7 @@
 "fjN" = (
 /obj/effect/landmark/start/cyborg,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "fjZ" = (
 /obj/structure/plasticflaps{
 	density = 0;
@@ -22218,17 +22906,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "fkC" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "fkH" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/structure/cable{
@@ -22287,6 +22967,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"flJ" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "flL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -22369,6 +23063,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"fnl" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
+	dir = 1;
+	name = "AI Antechamber APC";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/satellite)
 "fnr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22412,7 +23116,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "fnX" = (
 /obj/machinery/vending/wardrobe/gene_wardrobe,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
@@ -22532,6 +23236,26 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"fpD" = (
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
+	dir = 4;
+	name = "MiniSat Antechamber APC";
+	pixel_x = 24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/rack,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/space)
 "fpR" = (
 /obj/machinery/computer/shuttle/labor,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -22539,6 +23263,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"fqr" = (
+/obj/structure/table,
+/obj/machinery/camera{
+	c_tag = "Telecomms Tech Storage";
+	network = list("ss13","minisat")
+	},
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/capacitor,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "fqv" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -22716,6 +23458,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"ftO" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
 "ftR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -22751,6 +23502,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"fvb" = (
+/obj/machinery/space_heater,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "fvc" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -22799,6 +23560,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"fvy" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "fvz" = (
 /obj/machinery/light_switch{
 	pixel_x = 15;
@@ -22886,6 +23666,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"fvW" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 5;
+	pixel_y = -32
+	},
+/obj/machinery/vending/wardrobe/sig_wardrobe,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "fwa" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/structure/cable{
@@ -23240,13 +24029,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/lawoffice)
-"fCV" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
+"fCL" = (
+/obj/machinery/telecomms/server/presets/service,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
+"fCV" = (
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/area/space)
 "fDx" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -23480,6 +24272,13 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"fHw" = (
+/obj/machinery/computer/telecomms/traffic{
+	dir = 8;
+	network = "tcommsat"
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "fHC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -23571,6 +24370,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
+"fJa" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/bottle/vodka{
+	pixel_x = 8;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
+	pixel_x = 8;
+	pixel_y = 1
+	},
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "fJb" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
@@ -23623,17 +24438,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "fJN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/highsecurity{
+	id_tag = "ai_core_airlock_exterior";
+	name = "AI Core";
+	req_access_txt = "65"
 	},
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/area/ai_monitored/turret_protected/aisat_interior)
 "fJS" = (
 /obj/machinery/button/door{
 	id = "bridge blast";
@@ -23715,6 +24529,13 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"fKE" = (
+/obj/machinery/ntnet_relay,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "fKM" = (
 /obj/machinery/door/airlock/command/glass{
 	id_tag = "secondary_aicore_interior";
@@ -23858,14 +24679,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "fMm" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plating/airless,
+/area/space)
 "fMp" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall,
@@ -23898,6 +24713,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"fME" = (
+/obj/structure/chair/office/dark,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "fMR" = (
 /obj/machinery/power/smes,
 /obj/structure/cable/yellow{
@@ -24031,18 +24856,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"fPW" = (
+/obj/machinery/door/airlock/hatch{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "telecomms_airlock_exterior";
+	name = "Telecomms Server Room Access";
+	req_access_txt = "61"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "fQt" = (
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/turf/open/floor/circuit/telecomms/server,
+/area/ai_monitored/turret_protected/ai)
 "fQO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -24306,21 +25147,29 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"fXb" = (
+"fWV" = (
 /obj/structure/cable/yellow{
-	icon_state = "0-4"
+	icon_state = "4-8"
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/tcommsat/storage";
-	dir = 1;
-	name = "Telecommunications Storage APC";
-	pixel_y = 23
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/space)
+"fXb" = (
+/obj/machinery/telecomms/server/presets/service,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "fXm" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -24378,14 +25227,15 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance";
-	req_access_txt = "65"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/airlock/hatch{
+	name = "Telecomms Tech Storage";
+	req_access_txt = "61"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "fYZ" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
@@ -24773,6 +25623,13 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/medical/virology)
+"gfw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/space)
 "gfL" = (
 /obj/machinery/door/airlock{
 	name = "Custodial Closet";
@@ -25003,17 +25860,33 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/machinery/door/airlock/highsecurity{
-	id_tag = "ai_core_airlock_interior";
-	name = "AI Core";
-	req_access_txt = "65"
-	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "aicoredoor";
 	name = "AI Chamber entrance shutters"
 	},
+/obj/machinery/door/airlock/public{
+	autoclose = 0;
+	frequency = 1449;
+	glass = 1;
+	id_tag = "telecomms_airlock_interior";
+	name = "Telecomms Server Room Access";
+	req_access_txt = "61"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower,
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/area/tcommsat/server)
+"gky" = (
+/obj/machinery/computer/teleporter{
+	dir = 1
+	},
+/turf/open/floor/circuit,
+/area/space)
 "gkA" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -25021,6 +25894,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"gkZ" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "gmo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -25103,6 +25989,15 @@
 /obj/machinery/atmospherics/miner/toxins,
 /turf/open/floor/engine/plasma,
 /area/engine/atmos/distro)
+"goP" = (
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/gloves/color/black,
+/turf/open/floor/plating,
+/area/space)
 "goW" = (
 /obj/machinery/light{
 	dir = 4
@@ -25132,6 +26027,13 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"gpL" = (
+/obj/machinery/computer/telecomms/server{
+	dir = 8;
+	network = "tcommsat"
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "gqn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -25232,14 +26134,12 @@
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
 "grq" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/obj/machinery/telecomms/hub/preset,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "gru" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -25286,6 +26186,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"gsD" = (
+/obj/item/radio/intercom{
+	dir = 1;
+	freerange = 1;
+	name = "Station Intercom (Telecomms)";
+	pixel_y = -26
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "gsK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -25438,14 +26351,13 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "guR" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 8;
+	external_pressure_bound = 120;
+	name = "server vent"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/turf/open/floor/circuit/telecomms/server,
+/area/ai_monitored/turret_protected/ai)
 "guV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -25607,6 +26519,17 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
+"gzc" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Telecomms Control Room";
+	req_access_txt = "70"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel,
+/area/space)
 "gzl" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
@@ -25628,6 +26551,16 @@
 /obj/item/pool/rubber_ring,
 /turf/open/indestructible/sound/pool,
 /area/crew_quarters/fitness)
+"gzL" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space)
 "gzP" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -25647,6 +26580,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"gzZ" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Telecomms Admin";
+	departmentType = 5;
+	name = "Telecomms RC";
+	pixel_y = 30
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "gAh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25730,7 +26676,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "gBZ" = (
 /obj/structure/table,
 /obj/structure/disposalpipe/segment,
@@ -25744,20 +26690,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "gCs" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/tcommsat/storage)
+/obj/effect/turf_decal/ramp_middle,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "gCF" = (
 /obj/machinery/camera{
 	c_tag = "Prison Yard";
@@ -25804,6 +26739,21 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"gEa" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/tcommsat/storage";
+	dir = 1;
+	name = "Telecommunications Storage APC";
+	pixel_y = 23
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "gEq" = (
 /obj/machinery/light{
 	dir = 1
@@ -25873,6 +26823,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"gFu" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 9
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/space)
 "gFF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -25973,6 +26932,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"gHc" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/space)
 "gHl" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -26090,6 +27053,25 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/wood,
 /area/vacant_room)
+"gIY" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Antechamber";
+	req_access_txt = "65"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "gJh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
@@ -26168,12 +27150,9 @@
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "gLt" = (
-/obj/machinery/pipedispenser,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/area/ai_monitored/turret_protected/aisat_interior)
 "gLN" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
@@ -26232,12 +27211,15 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "gNr" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
 	dir = 4
 	},
-/turf/open/floor/circuit/telecomms/server,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	external_pressure_bound = 120;
+	name = "server vent"
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "gNM" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
@@ -26265,16 +27247,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "gOE" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/tcommsat/computer";
-	name = "Telecomms Control Room APC";
-	pixel_y = -23
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "gOU" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable{
@@ -26346,14 +27326,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "gQa" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 9
+	},
 /obj/machinery/airalarm/tcomms{
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "gQb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -26471,6 +27452,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"gRS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "gRT" = (
 /obj/structure/table/wood,
 /obj/item/storage/briefcase{
@@ -26546,6 +27536,16 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"gSl" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/computer/monitor{
+	dir = 1;
+	name = "MiniSat power monitoring console"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "gSn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -26571,6 +27571,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"gSI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "gSO" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -26663,6 +27672,13 @@
 	},
 /turf/open/water/safe,
 /area/hydroponics/garden)
+"gTO" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/space)
 "gTU" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -26687,17 +27703,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gTY" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/doorButtons/access_button{
-	idDoor = "ai_core_airlock_interior";
-	idSelf = "ai_core_airlock_control";
-	pixel_x = -23;
-	pixel_y = 7
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "gUw" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -26749,6 +27758,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
+"gVu" = (
+/obj/structure/transit_tube/curved{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space)
 "gVA" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -26852,6 +27867,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"gXZ" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "gYb" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -26874,6 +27901,20 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"gYf" = (
+/obj/item/toy/talking/AI{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/structure/table,
+/obj/item/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/crowbar,
+/obj/item/mmi,
+/turf/open/floor/plating,
+/area/space)
 "gYj" = (
 /obj/machinery/light_switch{
 	pixel_x = -23;
@@ -27013,7 +28054,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/space/basic,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "hal" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -27140,6 +28181,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"hci" = (
+/obj/structure/table/wood,
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Captain's Desk";
+	departmentType = 5;
+	name = "Captain RC";
+	pixel_x = -30
+	},
+/obj/machinery/photocopier/faxmachine{
+	department = "Captain";
+	name = "Captain's Fax Machine"
+	},
+/turf/open/floor/wood,
+/area/space)
 "hcE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -27292,6 +28348,20 @@
 "hfy" = (
 /turf/template_noop,
 /area/maintenance/port)
+"hfD" = (
+/obj/machinery/telecomms/server/presets/science,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "hfJ" = (
 /obj/structure/closet/boxinggloves,
 /obj/machinery/light{
@@ -27503,16 +28573,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hjk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
-	dir = 4
+/turf/open/floor/plating,
+/area/space)
+"hjt" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/turf/open/space/basic,
+/area/space)
 "hjA" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -27721,17 +28793,11 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "hmx" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/space)
 "hmO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -27786,19 +28852,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"hoK" = (
-/obj/machinery/holopad,
+"hoF" = (
+/obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+/turf/open/space/basic,
+/area/space)
+"hoK" = (
+/obj/machinery/blackbox_recorder,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "hoR" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -27842,7 +28916,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "hqu" = (
 /obj/machinery/camera{
 	c_tag = "Security Checkpoint";
@@ -27999,18 +29073,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
 "hsq" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 1
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 1
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1"
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower,
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 4;
+	external_pressure_bound = 120;
+	name = "server vent"
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "hsA" = (
 /obj/machinery/computer/camera_advanced/base_construction{
 	dir = 1
@@ -28134,6 +29210,22 @@
 /obj/effect/spawner/lootdrop/costume,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"hvo" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/showcase/cyborg/old{
+	dir = 4;
+	pixel_x = -9;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "hvG" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
@@ -28281,6 +29373,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"hyr" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "hyG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
@@ -28377,6 +29483,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"hAC" = (
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 24;
+	pixel_y = -10
+	},
+/obj/machinery/camera/motion{
+	c_tag = "MiniSat Foyer";
+	dir = 8;
+	network = list("minisat","ss13")
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "hAJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -28539,6 +29662,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"hCt" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "MiniSat Exterior - Port Aft";
+	dir = 8;
+	network = list("minisat","ss13")
+	},
+/turf/open/space/basic,
+/area/space)
 "hCy" = (
 /turf/open/floor/plating/broken,
 /area/maintenance/port/fore)
@@ -28708,6 +29843,19 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/fore)
+"hFn" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "hFo" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/cardboard,
@@ -28981,6 +30129,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"hMW" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "hNs" = (
 /obj/effect/landmark/stationroom/maint/fivexthree,
 /turf/template_noop,
@@ -29070,6 +30225,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"hOS" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/computer/teleporter{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "hOU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -29232,6 +30394,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hRI" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "MiniSat Maintenance";
+	req_access_txt = "65"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "hRR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -29279,6 +30460,24 @@
 	},
 /turf/open/floor/plating,
 /area/security/warden)
+"hTd" = (
+/obj/machinery/camera{
+	c_tag = "MiniSat - Monitoring room";
+	dir = 8;
+	network = list("minisat","ss13")
+	},
+/obj/machinery/newscaster/security_unit{
+	pixel_x = 28
+	},
+/obj/machinery/computer/ai_resource_distribution{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
+"hTj" = (
+/obj/machinery/pipedispenser,
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "hTo" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -29393,22 +30592,17 @@
 /area/maintenance/aft)
 "hUA" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 8;
-	external_pressure_bound = 120;
-	name = "server vent"
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 4
+/obj/effect/turf_decal/trimline/green/filled/line/lower,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/area/space)
 "hUM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29538,11 +30732,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "hWd" = (
-/obj/machinery/telecomms/broadcaster/preset_left{
-	name = "subspace broadcaster A"
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/machinery/porta_turret/ai,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "hWe" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -29610,30 +30802,33 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
-"hXu" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
+"hXs" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/area/space)
+"hXu" = (
+/obj/machinery/teleport/hub,
+/turf/open/floor/circuit,
+/area/space)
 "hYy" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Telecomms Admin";
-	departmentType = 5;
-	name = "Telecomms RC";
-	pixel_y = 30
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/obj/structure/table,
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/ansible,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "hYM" = (
 /obj/machinery/bounty_board{
 	pixel_y = 32
@@ -29656,12 +30851,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/computer/monitor{
-	dir = 1;
-	name = "MiniSat power monitoring console"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
 	},
 /turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "hYY" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -29685,7 +30879,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "hZo" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
@@ -29850,6 +31044,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"ibK" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access_txt = "10;13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/space)
 "ibL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -29866,6 +31068,9 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"ibO" = (
+/turf/open/floor/plating,
+/area/space)
 "ibZ" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -29875,7 +31080,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "ica" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
@@ -30053,14 +31258,14 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Teleporter Room";
-	req_one_access_txt = "17;65"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/airlock/hatch{
+	name = "Telecomms Teleporter Room";
+	req_access_txt = "61;17"
+	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "ien" = (
 /obj/machinery/computer/security/telescreen/vault{
 	pixel_y = 30
@@ -30075,23 +31280,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "ieo" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 5
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/aisat_interior)
 "ier" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -30125,14 +31319,13 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "ieK" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/shoes/winterboots,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
+/obj/machinery/door/airlock/highsecurity{
+	id_tag = "ai_core_airlock_interior";
+	name = "AI Server Room 1";
+	req_access_txt = "65"
 	},
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ifh" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -30335,9 +31528,9 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/mix)
 "ikV" = (
-/obj/machinery/ai/server_cabinet/prefilled,
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "ilc" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /turf/open/floor/plasteel,
@@ -30357,6 +31550,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
+"ilq" = (
+/obj/machinery/telecomms/bus/preset_three,
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "ilr" = (
 /obj/machinery/door/airlock/security{
 	name = "Detective's Office";
@@ -30394,6 +31602,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/service)
+"ilL" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "ilQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -30424,6 +31641,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
+"imN" = (
+/obj/machinery/light_switch{
+	pixel_x = -20
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "imT" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -30487,6 +31710,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"inD" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "inN" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -30696,6 +31925,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"iqH" = (
+/obj/machinery/telecomms/processor/preset_four,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "iqU" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
@@ -30742,6 +31985,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"irs" = (
+/obj/structure/table,
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/item/book/manual/wiki/tcomms,
+/obj/item/paper_bin,
+/obj/item/radio{
+	pixel_x = -10
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "irC" = (
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
@@ -30862,6 +32119,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"isU" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 8
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
 "itm" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/structure/window/reinforced{
@@ -30974,7 +32237,7 @@
 	network = list("minisat","ss13")
 	},
 /turf/open/space/basic,
-/area/ai_monitored/turret_protected/ai)
+/area/tcommsat/server)
 "ixh" = (
 /obj/machinery/status_display/ai{
 	pixel_y = 32
@@ -31010,6 +32273,10 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"iyq" = (
+/obj/machinery/ai/server_cabinet/prefilled,
+/turf/open/floor/circuit/green/telecomms,
+/area/space)
 "iyt" = (
 /obj/structure/table/glass,
 /obj/machinery/door/window/northright{
@@ -31110,6 +32377,20 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"iAl" = (
+/obj/machinery/telecomms/server/presets/command,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "iAx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -31223,6 +32504,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"iCz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "iCG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -31271,8 +32561,25 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
+	dir = 8
+	},
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
+"iDK" = (
+/obj/machinery/telecomms/processor/preset_three,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "iDQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -31460,29 +32767,19 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "iHu" = (
-/obj/machinery/power/apc/tcomms{
-	areastring = "/area/tcommsat/server";
-	dir = 4;
-	name = "Telecomms Server APC";
-	pixel_x = 24
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
+/obj/machinery/telecomms/processor/preset_one,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/area/space)
 "iHI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -31529,25 +32826,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "iIj" = (
-/obj/machinery/ntnet_relay,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/turf/open/floor/plasteel,
+/area/space)
 "iII" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/obj/structure/lattice/catwalk,
+/turf/closed/wall/r_wall,
+/area/space)
 "iJa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -31570,6 +32854,15 @@
 /obj/effect/spawner/lootdrop/minor/kittyears_or_rabbitears,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"iJq" = (
+/obj/machinery/advanced_airlock_controller{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/space)
 "iJt" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -31594,7 +32887,7 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/gloves/color/black,
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "iJO" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/air_input{
 	dir = 4
@@ -31640,7 +32933,7 @@
 	dir = 4
 	},
 /turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "iKk" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -31679,6 +32972,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iLr" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "iLA" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/sign/warning/nosmoking{
@@ -31909,6 +33214,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"iOR" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	piping_layer = 1
+	},
+/turf/open/floor/plating,
+/area/space)
 "iOS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -32047,23 +33358,8 @@
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen{
-	dir = 1;
-	name = "Telecomms Camera Monitor";
-	network = list("tcomms");
-	pixel_x = 30;
-	pixel_y = -37
-	},
-/obj/item/radio/intercom{
-	dir = 1;
-	freerange = 1;
-	name = "Station Intercom (Telecomms)";
-	pixel_x = 28;
-	pixel_y = -26
-	},
-/obj/effect/landmark/start/yogs/network_admin,
 /turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/area/ai_monitored/storage/satellite)
 "iRY" = (
 /obj/structure/table,
 /obj/item/flashlight{
@@ -32119,6 +33415,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"iSD" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 26
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "iSH" = (
 /obj/structure/lattice,
 /turf/closed/wall,
@@ -32320,6 +33627,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"iWd" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/space)
 "iWw" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/mixing";
@@ -32411,6 +33727,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"iXR" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/space)
 "iYc" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -32426,6 +33748,23 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos/foyer)
+"iYH" = (
+/obj/machinery/light_switch{
+	pixel_y = -27
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/rack,
+/obj/item/multitool,
+/obj/item/radio/off{
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/toy/talking/AI,
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "iZf" = (
 /obj/structure/bed,
 /obj/structure/cloth_curtain{
@@ -32536,6 +33875,22 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"jaF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "jaI" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 1";
@@ -32568,6 +33923,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"jbG" = (
+/obj/machinery/telecomms/server/presets/supply,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "jbI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -32586,6 +33945,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"jbQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/turf/open/floor/circuit,
+/area/space)
 "jbY" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
@@ -32618,6 +33988,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"jcv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "jcz" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
@@ -32634,6 +34015,11 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
+"jcO" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "jda" = (
 /obj/machinery/shower{
 	dir = 4
@@ -32985,6 +34371,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"jkE" = (
+/obj/structure/table,
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/treatment,
+/obj/item/stock_parts/subspace/treatment,
+/obj/item/stock_parts/subspace/treatment,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "jkJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -33150,15 +34551,9 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "jnr" = (
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "AI Chamber - Aft";
-	dir = 4;
-	network = list("aicore")
-	},
-/obj/machinery/porta_turret/ai,
-/turf/open/floor/circuit/telecomms/server,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/space)
 "jnA" = (
 /obj/structure/grille,
 /turf/open/space/basic,
@@ -33280,7 +34675,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "jpy" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -33513,6 +34908,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"jsq" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "jst" = (
 /obj/structure/sink{
 	dir = 4;
@@ -33546,6 +34950,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"jtA" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/space)
 "jtJ" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -33588,6 +35002,13 @@
 	},
 /turf/closed/wall,
 /area/engine/atmos/distro)
+"juw" = (
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
+/obj/machinery/rack_creator,
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "juN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -33626,6 +35047,13 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"jwq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
 "jwH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -33714,11 +35142,12 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "jzm" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "jzo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -33816,6 +35245,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"jBK" = (
+/obj/machinery/telecomms/server/presets/medical,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "jCo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -33842,17 +35275,9 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "jCM" = (
-/obj/machinery/computer/message_monitor{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/machinery/camera{
-	c_tag = "Telecomms Maintenance";
-	dir = 1;
-	network = list("ss13","tcomms")
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/space)
 "jDa" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -33868,6 +35293,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"jDi" = (
+/obj/structure/table,
+/obj/item/stock_parts/subspace/analyzer,
+/obj/item/stock_parts/subspace/analyzer,
+/obj/item/stock_parts/subspace/analyzer,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "jDj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -33957,7 +35389,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "jEn" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall,
@@ -33974,6 +35406,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"jEF" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "MiniSat External Access";
+	req_access_txt = "65"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/space)
 "jEV" = (
 /obj/structure/closet/secure_closet/paramedic,
 /obj/effect/turf_decal/delivery,
@@ -34113,33 +35555,28 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "jHo" = (
-/obj/machinery/door/airlock/hatch{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "telecomms_airlock_exterior";
-	name = "Telecomms Server Room Access";
-	req_access_txt = "61"
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/highsecurity{
+	id_tag = "ai_core_airlock_interior";
+	name = "AI Core";
+	req_access_txt = "65"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/area/ai_monitored/turret_protected/aisat_interior)
 "jHq" = (
 /obj/machinery/camera{
 	c_tag = "AI Satellite Access"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"jHs" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/telecomms/processor/preset_four,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "jHx" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -34152,6 +35589,20 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jHM" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "jId" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -34193,6 +35644,26 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/library)
+"jIA" = (
+/obj/machinery/door/airlock/hatch{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "telecomms_airlock_exterior";
+	name = "Telecomms Server Room Access";
+	req_access_txt = "61"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "jIJ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -34240,12 +35711,17 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "jJK" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
-/obj/machinery/telecomms/processor/preset_two,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/machinery/door/airlock/external{
+	name = "MiniSat External Access";
+	req_access_txt = "65"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/space)
 "jJP" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/holopad,
@@ -34270,57 +35746,41 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
+"jKm" = (
+/obj/machinery/telecomms/bus/preset_three,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
+"jKC" = (
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 25;
+	pixel_y = 6
+	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "ai_core_airlock_interior";
+	idSelf = "ai_core_airlock_control";
+	pixel_x = 23;
+	pixel_y = -7
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "jKG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "jKN" = (
-/obj/machinery/ai/data_core/primary,
-/obj/machinery/power/apc/highcap{
-	dir = 8;
-	name = "AI Chamber APC";
-	pixel_x = -25
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/structure/cable/white{
-	icon_state = "0-4"
-	},
-/obj/item/radio/intercom{
-	anyai = 1;
-	freerange = 1;
-	listening = 0;
-	name = "Custom Channel";
-	pixel_y = -27
-	},
-/obj/item/radio/intercom{
-	anyai = 1;
-	broadcasting = 0;
-	freerange = 1;
-	frequency = 1447;
-	name = "Private Channel";
-	pixel_y = 20
-	},
-/obj/item/radio/intercom{
-	broadcasting = 0;
-	freerange = 1;
-	listening = 1;
-	name = "Common Channel";
-	pixel_y = -37
-	},
-/obj/machinery/turretid{
-	icon_state = "control_stun";
-	name = "AI Chamber turret control";
-	pixel_x = -1;
-	pixel_y = 38
-	},
-/obj/machinery/button/door{
-	id = "aicoredoor";
-	name = "AI Chamber entrance shutters control";
-	pixel_x = -23;
-	pixel_y = 21;
-	req_access_txt = "16"
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "jKZ" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/structure/chair/office/dark{
@@ -34356,6 +35816,13 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
+"jMq" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "jMv" = (
 /turf/closed/wall,
 /area/crew_quarters/theatre)
@@ -34565,6 +36032,16 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"jRb" = (
+/obj/effect/turf_decal/bot_white,
+/obj/item/storage/toolbox/mechanical,
+/obj/machinery/camera{
+	c_tag = "Telecomms Teleporter Room";
+	dir = 4;
+	network = list("ss13","minisat")
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "jRq" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
@@ -34584,6 +36061,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"jRO" = (
+/obj/machinery/telecomms/receiver/preset_right{
+	name = "subspace receiver B"
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "jSi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -34665,6 +36148,18 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"jTN" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "jTP" = (
 /obj/machinery/light/small,
 /obj/machinery/button/door{
@@ -34742,6 +36237,23 @@
 "jVe" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
+"jVz" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/machinery/button/door{
+	id = "tcomms_bridge";
+	name = "Telecommunications server shutters control";
+	pixel_x = 25;
+	pixel_y = 25;
+	req_one_access_txt = "19;61"
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "jVL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -34806,7 +36318,19 @@
 /obj/item/tank/internals/emergency_oxygen,
 /obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
+"jWs" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "jWx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -34858,7 +36382,7 @@
 	network = list("minisat","ss13")
 	},
 /turf/open/space/basic,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "jXv" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
@@ -34877,7 +36401,7 @@
 "jXD" = (
 /obj/structure/lattice/catwalk,
 /turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai)
+/area/tcommsat/server)
 "jXI" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -35000,6 +36524,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"kag" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "kaA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/table,
@@ -35040,14 +36571,19 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "kcr" = (
-/obj/machinery/status_display/ai{
-	pixel_y = -32
+/obj/machinery/telecomms/server/presets/common,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/circuit/telecomms/server,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "kcy" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
@@ -35131,6 +36667,15 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
+"kdN" = (
+/obj/machinery/telecomms/broadcaster/preset_left{
+	name = "subspace broadcaster A"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "kdZ" = (
 /obj/machinery/vending/fishing,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -35145,6 +36690,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"kep" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 10
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "ket" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -35180,7 +36731,7 @@
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "kgs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -35294,7 +36845,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "khY" = (
 /obj/effect/turf_decal/pool/corner{
 	dir = 8
@@ -35333,8 +36884,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
 /turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "kim" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /turf/open/floor/plasteel,
@@ -35377,24 +36931,17 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "kit" = (
-/obj/structure/table,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/capacitor,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/obj/machinery/firealarm{
+	pixel_y = 26
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "kiy" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
@@ -35503,6 +37050,36 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"kjX" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/space)
+"kks" = (
+/obj/machinery/status_display/ai{
+	pixel_x = -32
+	},
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/tcomms{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/paper_bin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/folder/blue,
+/obj/item/pen,
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "kkv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -35518,6 +37095,22 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"klm" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/camera{
+	c_tag = "MiniSat Maintenance";
+	dir = 8;
+	name = "ai camera";
+	network = list("minisat","ss13");
+	start_active = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/space)
 "klD" = (
 /obj/structure/sign/departments/minsky/medical/chemistry/chemical2,
 /turf/closed/wall,
@@ -35667,7 +37260,7 @@
 	network = list("minisat")
 	},
 /turf/open/space/basic,
-/area/ai_monitored/turret_protected/ai)
+/area/tcommsat/server)
 "kpp" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -35718,6 +37311,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"kqr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "kqw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -35737,22 +37344,13 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "kqB" = (
-/obj/structure/table,
-/obj/item/stock_parts/subspace/amplifier,
-/obj/item/stock_parts/subspace/amplifier,
-/obj/item/stock_parts/subspace/transmitter,
-/obj/item/stock_parts/subspace/transmitter,
-/obj/item/stock_parts/subspace/transmitter,
-/obj/machinery/camera{
-	c_tag = "Telecomms Tech Storage";
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 4;
-	network = list("ss13","telecomms")
+	external_pressure_bound = 120;
+	name = "server vent"
 	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "kqJ" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/virology{
@@ -35815,15 +37413,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "krI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/structure/chair/office/dark,
+/obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/space)
 "krO" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer_R";
@@ -35895,6 +37493,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ktI" = (
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "kua" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light,
@@ -35907,6 +37514,16 @@
 "kub" = (
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"kug" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/space/basic,
+/area/space)
 "kuB" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Prison Forestry"
@@ -35925,6 +37542,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"kuT" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
+/turf/closed/wall/r_wall,
+/area/space)
 "kuY" = (
 /obj/machinery/holopad,
 /obj/item/kirbyplants/random,
@@ -35959,6 +37583,15 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
+"kvY" = (
+/obj/machinery/camera{
+	c_tag = "Telecomms Control Room";
+	dir = 4;
+	network = list("ss13","tcomms")
+	},
+/obj/machinery/announcement_system,
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "kwm" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -36056,7 +37689,7 @@
 	pixel_y = -7
 	},
 /turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "kyM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -36234,6 +37867,14 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"kBF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "tcomms";
+	name = "Telecommunications server shutters"
+	},
+/turf/open/floor/plating,
+/area/space)
 "kBL" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -36436,6 +38077,12 @@
 /obj/structure/lattice/catwalk,
 /turf/closed/wall/r_wall,
 /area/engine/atmos/distro)
+"kGg" = (
+/obj/machinery/telecomms/broadcaster/preset_left{
+	name = "subspace broadcaster A"
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "kGn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -36600,6 +38247,33 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/secondarydatacore)
+"kJV" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
+"kKg" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "kKq" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -36610,6 +38284,20 @@
 /obj/item/toy/figure/curator,
 /turf/open/floor/engine/cult,
 /area/library)
+"kKy" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/trimline/green/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "kKK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -36715,11 +38403,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "kMi" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/area/ai_monitored/turret_protected/aisat_interior)
 "kMt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -36940,6 +38628,15 @@
 /obj/machinery/light,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
+"kPh" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "kPn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -37009,7 +38706,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "kRI" = (
 /obj/structure/closet/crate,
 /obj/item/assembly/infra,
@@ -37085,6 +38782,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"kST" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/plasteel,
+/area/space)
 "kTm" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/structure/window/reinforced{
@@ -37105,11 +38806,17 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "kTy" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 5
+/obj/machinery/computer/message_monitor{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/machinery/camera{
+	c_tag = "Telecomms Maintenance";
+	dir = 1;
+	network = list("ss13","tcomms")
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "kTM" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -37327,6 +39034,15 @@
 "kZF" = (
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
+"laa" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/machinery/door/airlock/external{
+	name = "MiniSat External Access";
+	req_access_txt = "65"
+	},
+/turf/open/floor/plating,
+/area/space)
 "lao" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -37368,29 +39084,11 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "laN" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	freerange = 1;
-	name = "Station Intercom (Telecomms)";
-	pixel_y = -28
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+/obj/effect/turf_decal/stripes/white/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/area/ai_monitored/turret_protected/ai)
 "laR" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
@@ -37454,7 +39152,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "lbH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -37473,14 +39171,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "lbX" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/closed/wall/r_wall,
-/area/tcommsat/storage)
+/turf/closed/wall,
+/area/space)
 "lcb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -37512,6 +39204,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
+"ldD" = (
+/obj/machinery/computer/security/telescreen{
+	dir = 8;
+	name = "MiniSat Camera Monitor";
+	network = list("minisat","aicore");
+	pixel_x = 26
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "ldU" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hop";
@@ -37541,6 +39245,29 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"lec" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/space)
+"lem" = (
+/obj/structure/table,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/filter,
+/obj/item/stock_parts/subspace/treatment,
+/obj/item/stock_parts/subspace/treatment,
+/obj/item/stock_parts/subspace/treatment,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "leo" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -37566,6 +39293,15 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
+"leM" = (
+/obj/structure/rack,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 35
+	},
+/turf/open/floor/plating,
+/area/space)
 "leO" = (
 /obj/machinery/modular_computer/console/preset/command,
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
@@ -37667,14 +39403,18 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "lfM" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 4
+/obj/machinery/status_display/ai{
+	pixel_y = -32
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
+"lfU" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/space)
 "lfW" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -37746,8 +39486,11 @@
 /turf/open/floor/wood,
 /area/library)
 "lhk" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/area/ai_monitored/storage/satellite)
 "lhG" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
@@ -38110,6 +39853,10 @@
 /obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/carpet,
 /area/library)
+"lma" = (
+/obj/machinery/teleport/station,
+/turf/open/floor/circuit,
+/area/space)
 "lmd" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
@@ -38354,6 +40101,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"lqZ" = (
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
 "lrb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -38544,7 +40294,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "lvP" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -38632,6 +40382,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"lxm" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 1
+	},
+/obj/machinery/telecomms/message_server/preset,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "lxz" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
@@ -38655,7 +40412,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "lxP" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow,
@@ -38703,7 +40460,7 @@
 /area/teleporter)
 "lyX" = (
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/area/ai_monitored/turret_protected/aisat_interior)
 "lza" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -38892,6 +40649,16 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"lDN" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "lDR" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Power Storage";
@@ -38924,6 +40691,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"lEd" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/satellite)
 "lEr" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -38969,14 +40740,24 @@
 /turf/template_noop,
 /area/maintenance/port/fore)
 "lFm" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/area/space)
 "lFG" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -39013,6 +40794,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"lGC" = (
+/obj/machinery/airalarm/tcomms{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
 "lGF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -39043,10 +40833,17 @@
 /turf/open/floor/plasteel/dark,
 /area/janitor)
 "lHO" = (
-/obj/item/stack/cable_coil,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "lIb" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -39315,8 +41112,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "lMT" = (
-/turf/closed/wall/r_wall,
-/area/tcommsat/storage)
+/obj/machinery/cell_charger,
+/obj/structure/table,
+/obj/item/stock_parts/cell/high{
+	pixel_x = 3;
+	pixel_y = 7
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space)
 "lMW" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -39337,6 +41143,20 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"lNm" = (
+/obj/machinery/telecomms/server/presets/medical,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "lNn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -39436,6 +41256,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"lQb" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "MiniSat Exterior - Port Fore";
+	dir = 8;
+	network = list("minisat")
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/space/basic,
+/area/space)
 "lQl" = (
 /obj/structure/table/reinforced,
 /obj/item/hfr_box/body/fuel_input,
@@ -39456,20 +41289,12 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "lQv" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "lQB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -39692,14 +41517,24 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "lWl" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
 	},
 /turf/open/floor/circuit/telecomms/server,
-/area/ai_monitored/turret_protected/ai)
+/area/tcommsat/server)
+"lWm" = (
+/obj/structure/table/wood,
+/obj/item/radio/off{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/folder{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/disk/holodisk/tutorial/AICore,
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "lWz" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -39719,6 +41554,14 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"lXd" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "lXo" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
@@ -39918,18 +41761,9 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "lZD" = (
-/obj/structure/table/wood,
-/obj/item/radio/off{
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/obj/item/folder{
-	pixel_x = 6;
-	pixel_y = 2
-	},
-/obj/item/disk/holodisk/tutorial/AICore,
+/obj/machinery/announcement_system,
 /turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "lZH" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light/small{
@@ -39960,6 +41794,18 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"maY" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access_txt = "10;13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/space)
 "mbf" = (
 /obj/machinery/vending/wallmed{
 	pixel_y = 29
@@ -40117,6 +41963,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"mdZ" = (
+/obj/structure/window/reinforced,
+/obj/structure/transit_tube/curved{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "mel" = (
 /obj/structure/table,
 /obj/machinery/photocopier/faxmachine{
@@ -40192,16 +42048,20 @@
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "mfG" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 1
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1"
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8;
+	external_pressure_bound = 140;
+	pressure_checks = 0
+	},
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "mfN" = (
 /obj/machinery/camera{
 	c_tag = "Aft Starboard Solar Access";
@@ -40490,6 +42350,12 @@
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"mkL" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "mkP" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Mix Tank";
@@ -40555,6 +42421,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"mlS" = (
+/obj/machinery/recharge_station,
+/obj/structure/sign/departments/minsky/command/charge{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/space)
 "mmb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -40620,6 +42493,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
+"mnJ" = (
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 9;
+	pixel_y = -10
+	},
+/turf/closed/wall/r_wall,
+/area/space)
 "mnR" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -40655,6 +42536,15 @@
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"mot" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/turf/open/floor/plating,
+/area/space)
 "moy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -40827,16 +42717,44 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
+"mqB" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "mqI" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "mqO" = (
-/obj/machinery/telecomms/receiver/preset_left{
-	name = "subspace receiver A"
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/hatch{
+	name = "Hardware Workshop";
+	req_access_txt = "61"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "mqR" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable{
@@ -40852,6 +42770,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"mqZ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plating,
+/area/space)
 "mrk" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
@@ -40896,14 +42824,11 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "mrS" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 1
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 5
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/closed/wall/r_wall,
-/area/tcommsat/server)
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "msb" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/meter,
@@ -40997,17 +42922,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "mtW" = (
-/obj/machinery/computer/security/telescreen{
+/obj/machinery/computer/telecomms/server{
 	dir = 8;
-	name = "MiniSat Camera Monitor";
-	network = list("minisat","aicore");
-	pixel_x = 26
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
+	network = "tcommsat"
 	},
 /turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "mtZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -41038,6 +42958,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"muL" = (
+/obj/item/kirbyplants/photosynthetic,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "muY" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 6
@@ -41129,6 +43056,17 @@
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
+"mxG" = (
+/obj/structure/window/reinforced,
+/obj/structure/transit_tube/curved{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "mxL" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -41164,7 +43102,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
+/area/tcommsat/server)
 "mxS" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = -32
@@ -41242,6 +43180,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"mAn" = (
+/obj/machinery/telecomms/receiver/preset_right,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "mAs" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -41536,13 +43488,13 @@
 	},
 /area/maintenance/starboard/fore)
 "mDO" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "tcomms";
-	name = "Telecommunications server shutters"
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
 	},
-/turf/open/floor/plating,
-/area/tcommsat/server)
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "mEa" = (
 /obj/machinery/door/window/brigdoor/eastright{
 	dir = 2;
@@ -41640,11 +43592,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "mFE" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 9
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/ai_monitored/turret_protected/ai)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space)
 "mFO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -41809,6 +43759,12 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"mIH" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/space)
 "mIS" = (
 /obj/effect/landmark/start/yogs/brigphsyician,
 /turf/open/floor/plasteel/white,
@@ -41852,6 +43808,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"mJE" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "mJV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -41868,6 +43834,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
+"mKm" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/camera{
+	c_tag = "MiniSat Exterior - Fore";
+	dir = 1;
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "mKD" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -41894,6 +43869,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"mLm" = (
+/obj/structure/table,
+/obj/item/stock_parts/subspace/amplifier,
+/obj/item/stock_parts/subspace/amplifier,
+/obj/item/stock_parts/subspace/transmitter,
+/obj/item/stock_parts/subspace/transmitter,
+/obj/item/stock_parts/subspace/transmitter,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "mLw" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -42290,6 +44274,18 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"mSd" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/doorButtons/airlock_controller{
+	idExterior = "telecomms_airlock_exterior";
+	idInterior = "telecomms_airlock_interior";
+	idSelf = "telecomms_airlock_control";
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "mSg" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/circuit/telecomms/server,
@@ -42410,20 +44406,12 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "mUg" = (
-/obj/machinery/power/terminal{
-	dir = 1
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/turf/open/space/basic,
+/area/space)
 "mUk" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -42470,6 +44458,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"mVn" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/transit_tube/curved/flipped,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "mVw" = (
 /obj/machinery/light{
 	dir = 8
@@ -42499,7 +44498,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "mVV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -42535,16 +44534,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "mWE" = (
-/obj/machinery/status_display/ai{
-	pixel_y = 32
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 8;
-	external_pressure_bound = 120;
-	name = "server vent"
+/obj/effect/decal/remains/robot,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/circuit/telecomms/server,
-/area/ai_monitored/turret_protected/ai)
+/obj/effect/mapping_helpers/teleport_anchor,
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/space)
 "mWH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -42574,6 +44574,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"mXq" = (
+/obj/item/storage/toolbox/mechanical,
+/obj/structure/rack,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "mXr" = (
 /obj/structure/grille,
 /obj/structure/window{
@@ -42693,6 +44701,29 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"mZM" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Telecomms Tech Storage";
+	req_access_txt = "61"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "mZO" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input{
 	dir = 8
@@ -42700,43 +44731,29 @@
 /turf/open/floor/engine/plasma,
 /area/engine/atmos/distro)
 "naj" = (
-/obj/machinery/doorButtons/access_button{
-	idDoor = "telecomms_airlock_exterior";
-	idSelf = "telecomms_airlock_control";
-	pixel_x = -7;
-	pixel_y = 23
-	},
-/obj/machinery/doorButtons/airlock_controller{
-	idExterior = "telecomms_airlock_exterior";
-	idInterior = "telecomms_airlock_interior";
-	idSelf = "telecomms_airlock_control";
-	pixel_x = 5;
-	pixel_y = 25
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/modular_computer/console/preset/tcomms,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
-"naq" = (
 /obj/structure/table,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/treatment,
-/obj/item/stock_parts/subspace/treatment,
-/obj/item/stock_parts/subspace/treatment,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser/high,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/manipulator,
+/obj/item/stock_parts/capacitor,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
 	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/area/space)
+"naq" = (
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plating,
+/area/space)
 "naz" = (
 /obj/effect/spawner/structure/solars/solar_96,
 /obj/structure/cable/yellow{
@@ -42787,6 +44804,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"nbc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "nbf" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -42864,6 +44887,24 @@
 /obj/item/pen,
 /turf/open/floor/plasteel,
 /area/security/main)
+"nbP" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/space)
+"nbX" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "nca" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio_l";
@@ -43127,15 +45168,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "nfC" = (
-/obj/structure/chair/office/dark,
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "nfK" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -43258,6 +45299,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"niD" = (
+/obj/machinery/telecomms/bus/preset_one,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "niK" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -43461,7 +45506,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "nnN" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff";
@@ -43509,16 +45554,9 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "npc" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = 8;
-	pixel_y = -23
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "npK" = (
 /obj/machinery/light{
 	dir = 8
@@ -43585,6 +45623,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"nrp" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "nrq" = (
 /obj/structure/grille,
 /obj/machinery/meter{
@@ -43639,6 +45683,10 @@
 	},
 /turf/open/floor/plating,
 /area/bridge/meeting_room)
+"nst" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
 "nsx" = (
 /obj/machinery/door/airlock/research{
 	name = "Robotics Lab";
@@ -43734,7 +45782,7 @@
 /obj/item/multitool,
 /obj/machinery/light/small,
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "ntL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -43865,6 +45913,12 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"nvG" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "nvR" = (
 /obj/machinery/suit_storage_unit/standard_unit{
 	suit_type = /obj/item/clothing/suit/space/paramedic
@@ -43927,6 +45981,53 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"nxc" = (
+/obj/machinery/ai/data_core/primary,
+/obj/machinery/power/apc/highcap{
+	dir = 8;
+	name = "AI Chamber APC";
+	pixel_x = -25
+	},
+/obj/structure/cable/white{
+	icon_state = "0-4"
+	},
+/obj/item/radio/intercom{
+	anyai = 1;
+	freerange = 1;
+	listening = 0;
+	name = "Custom Channel";
+	pixel_y = -27
+	},
+/obj/item/radio/intercom{
+	anyai = 1;
+	broadcasting = 0;
+	freerange = 1;
+	frequency = 1447;
+	name = "Private Channel";
+	pixel_y = 20
+	},
+/obj/item/radio/intercom{
+	broadcasting = 0;
+	freerange = 1;
+	listening = 1;
+	name = "Common Channel";
+	pixel_y = -37
+	},
+/obj/machinery/turretid{
+	icon_state = "control_stun";
+	name = "AI Chamber turret control";
+	pixel_x = -1;
+	pixel_y = 38
+	},
+/obj/machinery/button/door{
+	id = "aicoredoor";
+	name = "AI Chamber entrance shutters control";
+	pixel_x = -23;
+	pixel_y = 21;
+	req_access_txt = "16"
+	},
+/turf/open/floor/circuit/green/telecomms,
+/area/space)
 "nxp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -43962,13 +46063,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/area/ai_monitored/storage/satellite)
 "nyu" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -44050,7 +46146,7 @@
 	dir = 4
 	},
 /turf/open/space/basic,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "nzW" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "garbage";
@@ -44120,7 +46216,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "nCd" = (
 /obj/structure/chair{
 	dir = 4;
@@ -44190,6 +46286,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"nCJ" = (
+/obj/machinery/atmospherics/components/binary/valve/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/space)
 "nCL" = (
 /obj/machinery/vending/autodrobe/capdrobe,
 /turf/open/floor/wood,
@@ -44279,6 +46380,20 @@
 /obj/item/flashlight,
 /turf/open/floor/plating,
 /area/construction)
+"nEG" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/transit_tube/curved/flipped,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "nEH" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -44390,6 +46505,29 @@
 	},
 /turf/open/floor/grass,
 /area/medical/genetics)
+"nHt" = (
+/obj/machinery/doorButtons/access_button{
+	idDoor = "telecomms_airlock_exterior";
+	idSelf = "telecomms_airlock_control";
+	pixel_x = -7;
+	pixel_y = 23
+	},
+/obj/machinery/doorButtons/airlock_controller{
+	idExterior = "telecomms_airlock_exterior";
+	idInterior = "telecomms_airlock_interior";
+	idSelf = "telecomms_airlock_control";
+	pixel_x = 5;
+	pixel_y = 25
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/modular_computer/console/preset/tcomms,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "nHw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -44429,19 +46567,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "nHT" = (
-/obj/machinery/camera{
-	c_tag = "AI Chamber - Port";
-	dir = 8;
-	network = list("aicore")
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
 	},
-/obj/machinery/requests_console{
-	department = "AI";
-	departmentType = 5;
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "nHU" = (
 /obj/machinery/requests_console{
 	department = "Science";
@@ -44458,7 +46588,7 @@
 	piping_layer = 2
 	},
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "nIk" = (
 /obj/machinery/firealarm{
 	pixel_y = 26
@@ -44490,6 +46620,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"nII" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/space)
 "nJl" = (
 /obj/effect/turf_decal/pool{
 	dir = 8
@@ -44598,7 +46735,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
+/area/tcommsat/server)
 "nKP" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -44682,6 +46819,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"nNV" = (
+/obj/machinery/ntnet_relay,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "nNY" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -44699,16 +46840,45 @@
 	},
 /turf/open/floor/plating/airless,
 /area/security/prison)
+"nOm" = (
+/mob/living/simple_animal/pet/axolotl/bop,
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "nOu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"nOQ" = (
+/obj/machinery/camera{
+	c_tag = "Telecomms Control Room";
+	dir = 4;
+	network = list("ss13","minisat")
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "nPD" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
+"nPV" = (
+/obj/structure/table,
+/obj/item/stock_parts/subspace/amplifier,
+/obj/item/stock_parts/subspace/amplifier,
+/obj/item/stock_parts/subspace/transmitter,
+/obj/item/stock_parts/subspace/transmitter,
+/obj/item/stock_parts/subspace/transmitter,
+/obj/machinery/camera{
+	c_tag = "Telecomms Tech Storage";
+	dir = 4;
+	network = list("ss13","telecomms")
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "nQi" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -44743,18 +46913,20 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "nQP" = (
-/obj/machinery/button/door{
-	id = "tcomms";
-	name = "Telecommunications server shutters control";
-	pixel_y = -27;
-	req_access_txt = "61"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/area/ai_monitored/turret_protected/aisat_interior)
+"nRa" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
 "nRs" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Genetics Research";
@@ -44917,7 +47089,7 @@
 	},
 /obj/structure/table,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "nTb" = (
 /obj/machinery/door/airlock{
 	name = "Private Restroom";
@@ -45241,6 +47413,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"nZC" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "oaC" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -45348,12 +47531,28 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"odu" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "ody" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "odE" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -45475,6 +47674,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
+"ofx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/structure/chair/office/dark,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "ofy" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -45520,13 +47729,27 @@
 	network = list("minisat")
 	},
 /turf/open/space/basic,
-/area/ai_monitored/turret_protected/ai)
+/area/space/nearstation)
 "ogm" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"ogx" = (
+/obj/machinery/telecomms/hub/preset,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "ogV" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -45554,7 +47777,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "ohy" = (
 /obj/machinery/recharger/wallrecharger{
 	pixel_x = 5;
@@ -45567,6 +47790,18 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"ohF" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "ohL" = (
 /obj/structure/window/reinforced,
 /obj/structure/cable{
@@ -45574,6 +47809,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
+"ohP" = (
+/obj/machinery/status_display/ai{
+	pixel_x = 32
+	},
+/obj/machinery/recharge_station,
+/turf/open/floor/circuit,
+/area/space)
 "oif" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
@@ -45641,12 +47883,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ojM" = (
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 9
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 4;
+	external_pressure_bound = 120;
+	name = "server vent"
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/turf/open/floor/circuit/telecomms/server,
+/area/ai_monitored/turret_protected/ai)
 "oke" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Chief Engineer";
@@ -45939,18 +48182,14 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"opJ" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+"opr" = (
+/obj/machinery/rnd/production/circuit_imprinter/department/netmin,
 /turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/area/space)
+"opJ" = (
+/obj/machinery/telecomms/server/presets/science,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "oqf" = (
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine{
@@ -46085,6 +48324,13 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"otc" = (
+/obj/structure/lattice,
+/obj/structure/transit_tube/junction/flipped{
+	dir = 8
+	},
+/turf/open/space/basic,
+/area/space)
 "otj" = (
 /obj/structure/table/glass,
 /obj/item/stock_parts/manipulator,
@@ -46166,7 +48412,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "ous" = (
 /obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
@@ -46213,11 +48459,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/door/airlock/highsecurity{
-	id_tag = "ai_core_airlock_exterior";
-	name = "AI Core";
-	req_access_txt = "65"
-	},
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -46237,8 +48478,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/door/airlock/hatch{
+	autoclose = 0;
+	frequency = 1449;
+	id_tag = "telecomms_airlock_exterior";
+	name = "Telecomms Server Room Access";
+	req_access_txt = "61"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
 /turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
+/area/tcommsat/server)
 "ouF" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -46285,6 +48536,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ovk" = (
+/obj/machinery/camera{
+	c_tag = "MiniSat Teleporter Room";
+	dir = 4;
+	network = list("ss13","minisat")
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "ovw" = (
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
@@ -46415,6 +48679,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"oxs" = (
+/obj/machinery/power/port_gen/pacman,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
 "oxw" = (
 /obj/machinery/doorButtons/access_button{
 	idDoor = "virology_airlock_exterior";
@@ -46449,6 +48720,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"oxX" = (
+/obj/machinery/telecomms/bus/preset_four,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "oyd" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -46465,6 +48740,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
+"oyi" = (
+/obj/item/kirbyplants/photosynthetic,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "oyj" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/spawner/structure/window/reinforced,
@@ -46637,6 +48919,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"oAr" = (
+/obj/machinery/status_display/ai{
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 8;
+	external_pressure_bound = 120;
+	name = "server vent"
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
 "oAt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -46698,7 +48991,23 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
+"oBz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "Telecomms Access";
+	req_access_txt = "61"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "oBA" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -46897,6 +49206,18 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"oHF" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "oHK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -46924,6 +49245,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"oIu" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/suit_storage_unit/captain,
+/turf/open/floor/wood,
+/area/space)
 "oIJ" = (
 /obj/machinery/button/door{
 	id = "genedesk";
@@ -47098,6 +49426,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"oLj" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "oLx" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -47178,6 +49512,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"oMx" = (
+/obj/machinery/power/smes/fullycharged,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/space)
 "oME" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/matches,
@@ -47254,7 +49595,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "oND" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32
@@ -47380,6 +49721,21 @@
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel/dark,
 /area/security/prison/hallway)
+"oQz" = (
+/obj/machinery/camera{
+	c_tag = "AI Chamber - Port";
+	dir = 4;
+	network = list("aicore")
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "oQJ" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -47389,7 +49745,7 @@
 	dir = 5
 	},
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "oRb" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
@@ -47489,6 +49845,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
+"oSV" = (
+/obj/machinery/telecomms/receiver/preset_left{
+	name = "subspace receiver A"
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "oTa" = (
 /obj/structure/transit_tube/crossing,
 /obj/structure/lattice/catwalk,
@@ -47505,6 +49867,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"oTR" = (
+/turf/open/floor/circuit/green/telecomms,
+/area/space)
 "oTV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -47512,18 +49877,15 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "oUc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
+/obj/machinery/advanced_airlock_controller{
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/turf/open/floor/plating,
+/area/space)
 "oUl" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -47619,6 +49981,11 @@
 /obj/effect/spawner/wire_splicing/thirty,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"oWc" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/space/basic,
+/area/space)
 "oWf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -47795,6 +50162,13 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"oZA" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/space)
 "oZW" = (
 /obj/machinery/door/window/westleft{
 	base_state = "right";
@@ -47848,14 +50222,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "paH" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = -32
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
-/obj/machinery/vending/wardrobe/sig_wardrobe,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/turf/closed/wall/r_wall,
+/area/space)
 "paQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 4
@@ -47943,25 +50314,11 @@
 /area/security/detectives_office)
 "pen" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 4;
-	external_pressure_bound = 120;
-	name = "server vent"
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower,
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/obj/machinery/telecomms/processor/preset_two,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "pew" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -48142,11 +50499,12 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "phI" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -48213,19 +50571,12 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "phR" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	external_pressure_bound = 120;
-	name = "server vent"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plasteel/dark,
+/area/space)
 "pia" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4
@@ -48357,14 +50708,12 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "pkb" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
+/obj/machinery/telecomms/processor/preset_four,
 /obj/structure/cable/yellow{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "pkD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -48456,6 +50805,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"pmd" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/circuit/green/telecomms,
+/area/space)
 "pmx" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -48655,6 +51019,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"ppD" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "telecomms_airlock_interior";
+	idSelf = "telecomms_airlock_control";
+	pixel_x = -23;
+	pixel_y = -23
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "ppK" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -48706,7 +51086,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "pqG" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -48746,6 +51126,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
+"prn" = (
+/obj/structure/rack,
+/obj/item/circuitboard/machine/telecomms/broadcaster,
+/obj/item/circuitboard/machine/telecomms/bus,
+/obj/item/circuitboard/machine/telecomms/hub,
+/obj/item/circuitboard/machine/telecomms/processor,
+/obj/item/circuitboard/machine/telecomms/receiver,
+/obj/item/circuitboard/machine/telecomms/relay,
+/obj/item/circuitboard/machine/telecomms/server,
+/obj/item/circuitboard/machine/telecomms/server,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "prq" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/sign/warning/radiation/rad_area{
@@ -48766,12 +51158,13 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "prN" = (
-/obj/machinery/telecomms/server/presets/service,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = -22
 	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "prQ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -48794,9 +51187,6 @@
 /obj/machinery/door/airlock/hatch{
 	name = "Hardware Workshop";
 	req_access_txt = "61"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -48821,6 +51211,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
+"pss" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/camera{
+	c_tag = "MiniSat Exterior - Starboard";
+	dir = 4;
+	network = list("minisat","ss13")
+	},
+/turf/open/space/basic,
+/area/space)
 "pst" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -48860,7 +51259,7 @@
 	network = list("minisat","ss13")
 	},
 /turf/open/space/basic,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "ptr" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -48884,12 +51283,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "ptV" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 1
+/obj/structure/transit_tube/curved{
+	dir = 8
 	},
-/obj/machinery/telecomms/message_server/preset,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/turf/open/space/basic,
+/area/space)
 "put" = (
 /obj/machinery/door/airlock/external{
 	name = "Security Secure External Airlock";
@@ -48932,22 +51330,15 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "pvf" = (
-/obj/machinery/status_display/ai{
-	pixel_x = -32
+/obj/structure/rack,
+/obj/item/multitool,
+/obj/item/radio/off{
+	pixel_y = 4
 	},
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/tcomms{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/item/paper_bin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/folder/blue,
-/obj/item/pen,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/toy/talking/AI,
 /turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/area/ai_monitored/storage/satellite)
 "pvo" = (
 /obj/structure/sign/departments/minsky/engineering/telecommmunications{
 	pixel_y = 32
@@ -49166,7 +51557,7 @@
 	pixel_y = 1
 	},
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "pyJ" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
@@ -49213,7 +51604,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "pzg" = (
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre";
@@ -49237,6 +51628,52 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"pzi" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	freerange = 1;
+	name = "Station Intercom (Telecomms)";
+	pixel_y = -28
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
+"pzn" = (
+/obj/machinery/camera{
+	c_tag = "MiniSat  Antechamber";
+	dir = 8;
+	network = list("minisat","ss13")
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/doorButtons/airlock_controller{
+	idExterior = "ai_core_airlock_exterior";
+	idInterior = "ai_core_airlock_interior";
+	idSelf = "ai_core_airlock_control";
+	pixel_x = 25;
+	pixel_y = 7
+	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "ai_core_airlock_exterior";
+	idSelf = "ai_core_airlock_control";
+	pixel_x = 23;
+	pixel_y = -7
+	},
+/turf/open/floor/circuit,
+/area/space)
 "pzv" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -49390,13 +51827,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "pBl" = (
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = 9;
-	pixel_y = -10
-	},
-/turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai)
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/obj/structure/cable/yellow,
+/turf/open/floor/plating,
+/area/space)
 "pBm" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -49460,6 +51894,10 @@
 	},
 /turf/open/space,
 /area/solar/port/aft)
+"pCI" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/wood,
+/area/space)
 "pCR" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating{
@@ -49672,6 +52110,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"pFX" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "pGs" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/stripes/line{
@@ -49744,12 +52188,10 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "pJy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/tcommsat/storage)
+/obj/effect/turf_decal/ramp_middle,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "pJB" = (
 /turf/closed/wall,
 /area/tcommsat/computer)
@@ -49763,12 +52205,11 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "pJS" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/area/ai_monitored/turret_protected/aisat_interior)
 "pKl" = (
 /obj/structure/table/glass,
 /obj/machinery/door/window/northleft{
@@ -49788,6 +52229,17 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"pKt" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "pKz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -49809,6 +52261,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"pLe" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "pLj" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -49819,6 +52277,12 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"pLM" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/ai/server_cabinet/prefilled,
+/turf/open/floor/circuit/green/telecomms,
+/area/space)
 "pLQ" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
@@ -49826,6 +52290,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
+"pMf" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "pMs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -49871,6 +52347,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"pNs" = (
+/obj/machinery/status_display/ai{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 4;
+	external_pressure_bound = 120;
+	name = "server vent"
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
 "pOw" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/port)
@@ -49886,6 +52373,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"pOK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/space)
 "pOP" = (
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plating,
@@ -50028,6 +52521,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
+"pQN" = (
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/space)
 "pQS" = (
 /obj/structure/window/reinforced,
 /obj/structure/chair/stool{
@@ -50092,7 +52597,7 @@
 	},
 /obj/machinery/recharge_station,
 /turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "pRx" = (
 /obj/machinery/door/window/brigdoor/security/holding{
 	id = "Holding Cell";
@@ -50148,17 +52653,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "pSY" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
-/obj/machinery/light{
-	dir = 1
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/area/ai_monitored/storage/satellite)
 "pTb" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -50189,20 +52688,45 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"pTC" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/tcommsat/computer";
+	dir = 1;
+	name = "Telecomms Control APC";
+	pixel_y = 24
+	},
+/obj/machinery/space_heater,
+/turf/open/floor/plating,
+/area/space)
 "pTI" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "pTL" = (
-/obj/structure/sign/departments/minsky/engineering/telecommmunications{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "pTP" = (
 /obj/structure/holohoop{
 	dir = 8
@@ -50213,6 +52737,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"pUk" = (
+/obj/item/stack/cable_coil,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/circuit/green/telecomms,
+/area/space)
 "pUH" = (
 /obj/structure/table,
 /obj/item/hand_tele,
@@ -50541,19 +53070,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
 "pZI" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower,
+/obj/effect/turf_decal/stripes/white/line,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/area/ai_monitored/turret_protected/ai)
 "pZU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -50589,9 +53109,37 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"qaA" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/departments/minsky/command/charge{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 8
+	},
+/obj/item/kirbyplants/photosynthetic{
+	pixel_y = 10
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "qaO" = (
 /turf/closed/wall/r_wall,
 /area/security/interrogation)
+"qaQ" = (
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Sattelite Access";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "qbw" = (
 /obj/structure/sign/departments/minsky/medical/virology/virology2{
 	pixel_y = -32
@@ -50748,6 +53296,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"qex" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "qeC" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
@@ -50984,21 +53538,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
 "qjk" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/stripes/white/corner,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/area/ai_monitored/turret_protected/ai)
 "qjx" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -51145,7 +53687,7 @@
 "qlI" = (
 /obj/machinery/teleport/hub,
 /turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "qlJ" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable,
@@ -51341,18 +53883,11 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "qoQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower,
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/area/ai_monitored/turret_protected/ai)
 "qoX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -51414,6 +53949,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"qpA" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "qpF" = (
 /obj/machinery/door/airlock{
 	name = "Service Hall";
@@ -51452,6 +54006,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/interrogation)
+"qrZ" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "qsk" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -51761,15 +54322,36 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "qzd" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/computer/ai_control_console{
+/obj/machinery/computer/message_monitor{
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
+"qzr" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/highsecurity{
+	id_tag = "ai_core_airlock_interior";
+	name = "AI Core";
+	req_access_txt = "65"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "aicoredoor";
+	name = "AI Chamber entrance shutters"
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "qzt" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
@@ -51803,7 +54385,18 @@
 	network = list("minisat")
 	},
 /turf/open/space/basic,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
+"qAr" = (
+/obj/machinery/door/airlock/external{
+	name = "MiniSat External Access";
+	req_access_txt = "65"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/space)
 "qAt" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -51839,6 +54432,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"qBW" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/teleport/hub,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "qCq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -52012,6 +54610,25 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
+"qFi" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "qFC" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -52256,6 +54873,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"qId" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
+	dir = 1
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "qIr" = (
 /obj/structure/table,
 /obj/item/storage/lockbox/vialbox/virology{
@@ -52344,6 +54967,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"qJC" = (
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "qJI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -52353,22 +54980,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"qJJ" = (
+/obj/machinery/recharger/wallrecharger{
+	pixel_x = -21;
+	pixel_y = -3
+	},
+/obj/machinery/papershredder,
+/turf/open/floor/wood,
+/area/space)
 "qKi" = (
-/obj/item/stock_parts/subspace/crystal,
-/obj/item/stock_parts/subspace/crystal,
-/obj/item/stock_parts/subspace/crystal,
-/obj/item/stock_parts/subspace/ansible,
-/obj/item/stock_parts/subspace/ansible,
-/obj/item/stock_parts/subspace/ansible,
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "qKn" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry Lab";
@@ -52462,19 +55084,12 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "qLi" = (
-/obj/machinery/camera{
-	c_tag = "MiniSat - Monitoring room";
+/obj/machinery/computer/telecomms/traffic{
 	dir = 8;
-	network = list("minisat","ss13")
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 28
-	},
-/obj/machinery/computer/ai_resource_distribution{
-	dir = 8
+	network = "tcommsat"
 	},
 /turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "qLt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -52507,6 +55122,16 @@
 /obj/item/storage/belt/utility,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"qLN" = (
+/obj/machinery/computer/telecomms/server{
+	dir = 1;
+	network = "tcommsat"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "qLP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -52656,6 +55281,20 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"qOj" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/storage/satellite";
+	name = "MiniSat Maint APC";
+	pixel_y = -23
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
 "qOl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -52789,7 +55428,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "qQw" = (
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -52810,6 +55449,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"qQH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "Telecomms Teleporter Room";
+	req_access_txt = "61;17"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "qQV" = (
 /turf/template_noop,
 /area/template_noop)
@@ -52840,6 +55493,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/sleeper)
+"qRI" = (
+/obj/machinery/light,
+/obj/machinery/computer/ai_server_console{
+	dir = 1
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "qRK" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -52877,6 +55537,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"qSm" = (
+/obj/machinery/telecomms/receiver/preset_left{
+	name = "subspace receiver A"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "qSq" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
@@ -52904,9 +55573,11 @@
 /area/template_noop)
 "qTh" = (
 /obj/machinery/atmospherics/components/binary/valve/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "qTi" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -52987,6 +55658,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"qUE" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Monitoring Room";
+	req_access_txt = "65"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "qUL" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -53037,9 +55724,9 @@
 /turf/open/floor/wood,
 /area/library)
 "qVN" = (
-/obj/machinery/telecomms/bus/preset_four,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/structure/transit_tube/diagonal/topleft,
+/turf/open/space/basic,
+/area/space)
 "qVZ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -53140,6 +55827,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"qXr" = (
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/space)
 "qXB" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -53216,23 +55921,11 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "qZK" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/machinery/doorButtons/access_button{
-	idDoor = "telecomms_airlock_interior";
-	idSelf = "telecomms_airlock_control";
-	pixel_x = -23;
-	pixel_y = -23
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/area/ai_monitored/turret_protected/ai)
 "ras" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -53405,14 +56098,11 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "rdw" = (
-/obj/machinery/camera{
-	c_tag = "Telecomms Control Room";
-	dir = 4;
-	network = list("ss13","tcomms")
+/obj/machinery/computer/ai_overclocking{
+	dir = 1
 	},
-/obj/machinery/announcement_system,
 /turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/area/ai_monitored/storage/satellite)
 "rdx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -53451,11 +56141,8 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
 "rdR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
 /turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/area/ai_monitored/storage/satellite)
 "rfl" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -53492,6 +56179,18 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
+"rfv" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "ai_core_airlock_interior";
+	idSelf = "ai_core_airlock_control";
+	pixel_x = -23;
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "rfy" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -53509,12 +56208,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"rfJ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
+"rfA" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 9
 	},
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
+"rfJ" = (
 /turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/area/space)
 "rfK" = (
 /obj/machinery/light{
 	dir = 4
@@ -53807,14 +56509,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "rlo" = (
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/telecomms/processor/preset_two,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "rlx" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -53893,6 +56590,18 @@
 /mob/living/simple_animal/mouse/brown/Tom,
 /turf/open/floor/plating,
 /area/security/prison)
+"rnc" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "rnS" = (
 /turf/template_noop,
 /area/security/execution/transfer)
@@ -53929,7 +56638,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "ror" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -54256,7 +56965,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "ruZ" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
@@ -54434,14 +57143,11 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "rzx" = (
-/obj/machinery/light{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/sign/plaques/kiddie{
-	pixel_y = 32
-	},
 /turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/area/ai_monitored/storage/satellite)
 "rzz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -54529,6 +57235,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"rAM" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/tcommsat/entrance";
+	dir = 8;
+	name = "Telecomms Entrance APC";
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "rAP" = (
 /obj/structure/filingcabinet,
 /obj/machinery/airalarm{
@@ -54574,6 +57293,21 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/service)
+"rBN" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "rBY" = (
 /obj/machinery/camera{
 	c_tag = "Security Office";
@@ -54593,21 +57327,33 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "rCp" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow,
 /turf/open/space/basic,
 /area/solar/port/fore)
 "rCq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/machinery/doorButtons/access_button{
+	idDoor = "telecomms_airlock_interior";
+	idSelf = "telecomms_airlock_control";
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "rCr" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
@@ -55059,18 +57805,9 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
 "rJJ" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/space)
 "rKk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -55097,6 +57834,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"rKI" = (
+/obj/machinery/camera{
+	c_tag = "AI Chamber - Fore";
+	dir = 4;
+	network = list("aicore")
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/porta_turret/ai,
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
 "rKJ" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -55388,14 +58140,9 @@
 /turf/open/floor/plating,
 /area/vacant_room/commissary)
 "rPo" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/obj/machinery/status_display/ai_core,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/storage/satellite)
 "rPH" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -55478,21 +58225,9 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "rRA" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/vodka{
-	pixel_x = 8;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 8;
-	pixel_y = 1
-	},
-/obj/effect/spawner/lootdrop/donkpockets{
-	pixel_x = -6;
-	pixel_y = 1
-	},
+/obj/machinery/rnd/production/circuit_imprinter/department/netmin,
 /turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/area/ai_monitored/storage/satellite)
 "rRD" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -55540,6 +58275,12 @@
 /obj/effect/landmark/stationroom/maint/fivexthree,
 /turf/template_noop,
 /area/maintenance/port/aft)
+"rSF" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "rST" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/plating,
@@ -55642,7 +58383,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "rUn" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -55790,6 +58531,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"rWQ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
 "rXm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -55858,16 +58608,15 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
 "rYz" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -26
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "tcomms_bridge";
-	name = "Telecommunications server shutters"
+/obj/structure/sign/departments/minsky/engineering/telecommmunications{
+	pixel_x = 32
 	},
-/turf/open/floor/plating,
-/area/bridge)
+/turf/open/floor/plasteel,
+/area/space)
 "rYI" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -56060,7 +58809,7 @@
 "sdl" = (
 /obj/machinery/teleport/station,
 /turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "sdq" = (
 /obj/machinery/computer/secure_data{
 	dir = 1
@@ -56301,6 +59050,15 @@
 	dir = 4
 	},
 /area/security/prison)
+"sgw" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "sgz" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -56411,6 +59169,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/genetics)
+"sjc" = (
+/obj/machinery/doorButtons/access_button{
+	idDoor = "telecomms_airlock_exterior";
+	idSelf = "telecomms_airlock_control";
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/white,
+/area/space)
 "sjg" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -56537,6 +59303,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
+"slU" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space)
 "sma" = (
 /obj/structure/chair{
 	dir = 1
@@ -56544,6 +59319,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"smd" = (
+/obj/structure/sign/departments/minsky/engineering/telecommmunications{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "smk" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -56620,8 +59404,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "snF" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -56648,11 +59433,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "soe" = (
+/obj/machinery/telecomms/bus/preset_four,
 /obj/structure/cable/yellow{
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "soo" = (
 /turf/closed/wall,
 /area/engine/atmos/mix)
@@ -56693,6 +59479,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"spr" = (
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide2{
+	dir = 1
+	},
+/area/ai_monitored/turret_protected/ai)
 "sps" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -56719,17 +59513,9 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "sqj" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/area/ai_monitored/turret_protected/aisat_interior)
 "sqE" = (
 /obj/structure/sign/warning/fire{
 	pixel_y = -32
@@ -56756,6 +59542,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"sqS" = (
+/obj/machinery/meter{
+	pixel_x = -5;
+	pixel_y = -3;
+	target_layer = 2
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/space)
 "srB" = (
 /obj/effect/turf_decal/trimline/engiyellow/warning/lower{
 	dir = 1
@@ -56773,6 +59568,10 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"ssf" = (
+/obj/effect/landmark/start/cyborg,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "ssh" = (
 /obj/machinery/light,
 /obj/machinery/papershredder,
@@ -56903,7 +59702,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "sud" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -56932,11 +59731,9 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "suV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/aisat_interior)
 "svh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -57052,7 +59849,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "syi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -57148,10 +59945,20 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "sAr" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/end{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
-/area/tcommsat/storage)
+/area/space)
 "sAs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8;
@@ -57191,6 +59998,16 @@
 "sAV" = (
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
+"sBc" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "sBp" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -30
@@ -57491,6 +60308,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"sGz" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "sGA" = (
 /obj/machinery/status_display/evac{
 	layer = 4;
@@ -57502,6 +60330,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"sGU" = (
+/obj/machinery/telecomms/broadcaster/preset_right{
+	name = "subspace broadcaster B"
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "sGW" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 5
@@ -57863,6 +60697,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"sNq" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/space)
 "sNL" = (
 /obj/structure/closet/crate{
 	name = "solar pack crate"
@@ -57944,11 +60784,11 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "sPc" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 9
 	},
 /turf/open/floor/circuit/telecomms/server,
-/area/ai_monitored/turret_protected/ai)
+/area/tcommsat/server)
 "sQc" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -58024,6 +60864,13 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"sRE" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
+	name = "Waste Ejector"
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space)
 "sSb" = (
 /obj/machinery/disposal/bin,
 /obj/structure/sign/warning/deathsposal{
@@ -58308,6 +61155,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"sXt" = (
+/obj/machinery/airalarm/tcomms{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "sXv" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/fire/firefighter,
@@ -58691,6 +61552,20 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"tdJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "telecomms_airlock_interior";
+	idSelf = "telecomms_airlock_control";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/white,
+/area/space)
 "tdO" = (
 /obj/structure/window,
 /obj/structure/table,
@@ -58999,12 +61874,14 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "tiN" = (
-/obj/machinery/light,
-/obj/machinery/computer/ai_server_console{
-	dir = 1
+/obj/machinery/modular_computer/console/preset/tcomms{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "tjk" = (
 /obj/structure/closet,
 /obj/item/storage/box/donkpockets,
@@ -59049,19 +61926,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "tjY" = (
-/obj/machinery/power/smes/engineering{
-	charge = 5e+006;
-	input_level = 25000;
-	output_level = 20000
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "0-2"
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plasteel/dark,
+/area/space)
 "tkd" = (
 /obj/machinery/camera{
 	c_tag = "Engineering East";
@@ -59167,15 +62036,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "tmm" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/area/ai_monitored/turret_protected/aisat_interior)
 "tmp" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/requests_console{
@@ -59234,6 +62099,17 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"tmU" = (
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room";
+	network = list("ss13","tcomms");
+	pixel_x = 22
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "tnB" = (
 /turf/closed/wall,
 /area/bridge)
@@ -59362,6 +62238,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
+"tqj" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/computer/ai_control_console{
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "tqk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -59496,15 +62382,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "tto" = (
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/structure/rack,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/area/space)
 "ttQ" = (
 /obj/structure/rack,
 /obj/machinery/light{
@@ -60008,7 +62889,7 @@
 	amount = 35
 	},
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "tGe" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Incinerator Access";
@@ -60040,11 +62921,17 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "tGz" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "tGM" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -60144,7 +63031,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
+/area/tcommsat/server)
 "tHZ" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -60185,6 +63072,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"tJH" = (
+/obj/machinery/camera{
+	c_tag = "Telecomms Life Support";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/obj/machinery/meter{
+	target_layer = 1
+	},
+/turf/open/floor/plating,
+/area/space)
 "tJN" = (
 /obj/machinery/light{
 	dir = 1
@@ -60346,6 +63245,12 @@
 "tMi" = (
 /turf/open/floor/plating/airless,
 /area/maintenance/fore)
+"tMo" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	target_temperature = 80
+	},
+/turf/open/floor/plating,
+/area/space)
 "tMG" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -60421,16 +63326,14 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "tNs" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/structure/window/reinforced,
+/obj/machinery/camera{
+	c_tag = "MiniSat Exterior Access";
+	dir = 8;
+	network = list("minisat","ss13")
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/turf/open/space/basic,
+/area/space)
 "tNA" = (
 /obj/machinery/camera{
 	c_tag = "Dormitory South";
@@ -60498,6 +63401,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"tOs" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/space/basic,
+/area/space)
 "tOL" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -60590,6 +63504,13 @@
 /obj/item/book/manual/wiki/surgery,
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
+"tPN" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
+/turf/open/floor/plasteel/white,
+/area/space)
 "tPY" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -60820,6 +63741,20 @@
 /obj/machinery/porta_turret/ai,
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
+"tTW" = (
+/obj/machinery/telecomms/message_server/preset,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "tUe" = (
 /obj/machinery/keycard_auth{
 	pixel_x = 24;
@@ -60882,6 +63817,18 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/fore)
+"tUP" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "telecomms_airlock_exterior";
+	idSelf = "telecomms_airlock_control";
+	pixel_x = 24;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "tVa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -60913,6 +63860,23 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/science/research)
+"tVH" = (
+/obj/machinery/telecomms/bus/preset_one,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "tVL" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -60937,6 +63901,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"tWs" = (
+/obj/machinery/telecomms/broadcaster/preset_right,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "tWQ" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -60952,6 +63930,20 @@
 "tXb" = (
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/ai_monitored/secondarydatacore)
+"tXe" = (
+/obj/structure/showcase/cyborg/old{
+	dir = 4;
+	pixel_x = -9;
+	pixel_y = 2
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "tXk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -60979,6 +63971,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"tXT" = (
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "tYa" = (
 /obj/machinery/camera{
 	c_tag = "Aft Port Solar Access";
@@ -61009,6 +64010,18 @@
 "tYk" = (
 /turf/closed/wall,
 /area/security/prison/hallway)
+"tYq" = (
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "tYt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -61075,7 +64088,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "tZH" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -61227,6 +64240,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
 /area/library)
+"ucD" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "ucF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -61333,6 +64353,25 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
+"udW" = (
+/obj/machinery/doorButtons/access_button{
+	idDoor = "ai_core_airlock_exterior";
+	idSelf = "ai_core_airlock_control";
+	pixel_x = -23;
+	pixel_y = 7
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "ues" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -61395,6 +64434,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"ufy" = (
+/obj/effect/turf_decal/trimline/green/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "ufD" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -61591,6 +64641,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
+"ulw" = (
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/crystal,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/ansible,
+/obj/item/stock_parts/subspace/ansible,
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "ulL" = (
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -61603,14 +64669,19 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "ume" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	external_pressure_bound = 0;
+	frequency = 1441;
+	id_tag = "mix_out";
+	initialize_directions = 1;
+	internal_pressure_bound = 4000;
+	pressure_checks = 2;
+	pressure_resistance = 10;
+	pump_direction = 0
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/turf/open/floor/circuit/telecomms/server,
+/area/ai_monitored/turret_protected/ai)
 "ums" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff"
@@ -61881,6 +64952,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"urd" = (
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/tcommsat/computer";
+	name = "Telecomms Control Room APC";
+	pixel_y = -23
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "ure" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -62036,11 +65118,11 @@
 /turf/template_noop,
 /area/crew_quarters/dorms)
 "uuG" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/area/ai_monitored/turret_protected/aisat_interior)
 "uuW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -62050,7 +65132,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
+/area/tcommsat/server)
 "uvc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -62281,28 +65363,11 @@
 /turf/closed/wall,
 /area/medical/paramedic)
 "uAV" = (
-/obj/effect/turf_decal/stripes/end{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/doorButtons/access_button{
-	idDoor = "telecomms_airlock_exterior";
-	idSelf = "telecomms_airlock_control";
-	pixel_x = 7;
-	pixel_y = -23
-	},
-/obj/machinery/doorButtons/access_button{
-	idDoor = "telecomms_airlock_interior";
-	idSelf = "telecomms_airlock_control";
-	pixel_x = -23;
-	pixel_y = 6
-	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room Access";
-	dir = 4;
-	network = list("ss13","tcomms")
-	},
-/turf/open/floor/plasteel/white,
-/area/tcommsat/storage)
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "uAW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -62318,6 +65383,20 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"uBd" = (
+/obj/machinery/telecomms/bus/preset_four,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "uBe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -62599,38 +65678,31 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"uGb" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/public{
-	autoclose = 0;
-	frequency = 1449;
-	glass = 1;
-	id_tag = "telecomms_airlock_interior";
-	name = "Telecomms Server Room Access";
-	req_access_txt = "61"
+"uFX" = (
+/obj/structure/transit_tube/station{
+	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"uGb" = (
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_middle{
+	dir = 1
+	},
+/area/ai_monitored/turret_protected/ai)
+"uGc" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/storage)
-"uGc" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/area/ai_monitored/turret_protected/ai)
 "uGf" = (
 /obj/machinery/pipedispenser/disposal,
 /turf/open/floor/plating,
@@ -62786,11 +65858,10 @@
 	network = list("minisat","ss13");
 	start_active = 1
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "uIX" = (
 /obj/structure/filingcabinet,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -62849,6 +65920,10 @@
 /obj/item/stock_parts/micro_laser/high,
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
+"uKy" = (
+/obj/machinery/telecomms/server/presets/engineering,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "uKB" = (
 /obj/machinery/meter,
 /obj/structure/sign/warning/nosmoking{
@@ -62869,6 +65944,20 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"uKS" = (
+/obj/machinery/telecomms/broadcaster/preset_left,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "uLi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -62917,6 +66006,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"uLG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "Telecomms Life Support";
+	req_access_txt = "61"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/space)
 "uLO" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -62950,15 +66053,13 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "uMi" = (
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 8;
+	external_pressure_bound = 120;
+	name = "server vent"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "uMB" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -62994,6 +66095,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/interrogation)
+"uMP" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/space)
+"uMU" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/space)
 "uMW" = (
 /obj/structure/displaycase/trophy,
 /turf/open/floor/carpet,
@@ -63044,22 +66160,26 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "uNG" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+/obj/structure/chair/office/dark{
+	dir = 4
 	},
-/obj/machinery/button/door{
-	id = "tcomms_bridge";
-	name = "Telecommunications server shutters control";
-	pixel_x = 25;
-	pixel_y = 25;
-	req_one_access_txt = "19;61"
+/obj/machinery/computer/security/telescreen{
+	dir = 1;
+	name = "Telecomms Camera Monitor";
+	network = list("tcomms");
+	pixel_x = 30;
+	pixel_y = -37
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower,
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 1
+/obj/item/radio/intercom{
+	dir = 1;
+	freerange = 1;
+	name = "Station Intercom (Telecomms)";
+	pixel_x = 28;
+	pixel_y = -26
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/obj/effect/landmark/start/yogs/network_admin,
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "uNH" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -63079,6 +66199,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"uNT" = (
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/department/tcoms";
+	dir = 4;
+	name = "Telecommunications Maintenance APC";
+	pixel_x = 24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/space)
+"uNW" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/bluespace_beacon,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "uOe" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/security,
@@ -63236,6 +66373,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"uQK" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/light,
+/turf/open/floor/plating,
+/area/space)
 "uQR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -63261,6 +66406,17 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
+"uRo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "uRV" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway West";
@@ -63330,6 +66486,20 @@
 "uTh" = (
 /turf/closed/wall,
 /area/security/execution/transfer)
+"uTz" = (
+/obj/machinery/telecomms/server/presets/engineering,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "uUb" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -63388,6 +66558,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"uUE" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "uUY" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Biohazard";
@@ -63593,6 +66774,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"uXc" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/camera{
+	c_tag = "MiniSat Exterior - Aft Starboard";
+	network = list("minisat")
+	},
+/turf/open/space/basic,
+/area/space)
 "uXk" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
@@ -63648,8 +66837,11 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
+/area/tcommsat/server)
 "uYM" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -63660,6 +66852,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"uZo" = (
+/obj/structure/transit_tube/diagonal,
+/turf/open/space/basic,
+/area/space)
 "uZw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -63687,6 +66883,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"uZN" = (
+/obj/machinery/pipedispenser,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "uZU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -63702,6 +66905,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
+"uZV" = (
+/obj/structure/transit_tube/curved/flipped{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space)
 "vaq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -63777,7 +66986,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "vbx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -64016,6 +67225,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"vfm" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space)
 "vfr" = (
 /obj/machinery/power/smes,
 /obj/structure/cable/yellow{
@@ -64034,6 +67250,39 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
+"vgg" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/highsecurity{
+	id_tag = "ai_core_airlock_exterior";
+	name = "AI Core";
+	req_access_txt = "65"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/space)
 "vgq" = (
 /obj/machinery/status_display/evac{
 	pixel_y = -32
@@ -64051,6 +67300,14 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"vgr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
+	},
+/turf/open/floor/circuit/green/telecomms,
+/area/space)
 "vhz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -64113,6 +67370,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"viP" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 8;
+	external_pressure_bound = 120;
+	name = "server vent"
+	},
+/obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "viU" = (
 /obj/structure/table,
 /obj/structure/mirror{
@@ -64197,6 +67472,12 @@
 /obj/effect/turf_decal/trimline/white/arrow_ccw,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"vkj" = (
+/obj/machinery/computer/message_monitor{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "vkp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/computer/security/telescreen/turbine{
@@ -64311,7 +67592,7 @@
 /area/maintenance/fore)
 "vmm" = (
 /turf/closed/wall,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "vmo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -64514,6 +67795,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
+"vpq" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 4;
+	external_pressure_bound = 120;
+	name = "server vent"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower,
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "vpX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -64565,6 +67867,20 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"vqQ" = (
+/obj/machinery/telecomms/server/presets/security,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "vra" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -64664,7 +67980,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/space/basic,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "vtK" = (
 /obj/structure/closet/crate/bin,
 /obj/item/trash/sosjerky,
@@ -64739,6 +68055,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"vva" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 10
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
 "vvd" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -64773,7 +68098,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "vvV" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -64959,7 +68284,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "vyo" = (
 /obj/structure/chair/sofa/right,
 /obj/effect/decal/cleanable/dirt,
@@ -65000,6 +68325,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"vyH" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/porta_turret/ai,
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
 "vyL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -65051,15 +68383,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "vzc" = (
-/obj/machinery/computer/telecomms/server{
-	dir = 1;
-	network = "tcommsat"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
+/obj/machinery/door/airlock/highsecurity{
+	id_tag = "ai_core_airlock_interior";
+	name = "AI Server Room 2";
+	req_access_txt = "65"
 	},
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/area/ai_monitored/turret_protected/aisat_interior)
 "vzs" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -65135,9 +68465,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "vAP" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/tcommsat/server)
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
+	dir = 1
+	},
+/area/ai_monitored/turret_protected/ai)
 "vBj" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Access"
@@ -65472,6 +68806,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"vHu" = (
+/obj/structure/transit_tube/crossing/horizontal,
+/turf/open/space/basic,
+/area/space)
 "vHH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -65492,6 +68830,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"vHN" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "vHO" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -65690,19 +69044,26 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "vJJ" = (
-/obj/machinery/airalarm/tcomms{
-	dir = 4;
-	pixel_x = -24
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
-	dir = 4
+/turf/open/space/basic,
+/area/space)
+"vJW" = (
+/obj/machinery/camera{
+	c_tag = "AI Chamber - Port";
+	dir = 8;
+	network = list("aicore")
 	},
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 8
+/obj/machinery/requests_console{
+	department = "AI";
+	departmentType = 5;
+	pixel_x = 0;
+	pixel_y = -32
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
 "vKb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -65831,9 +69192,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/foyer)
 "vMR" = (
-/obj/structure/filingcabinet,
+/obj/machinery/vending/wardrobe/sig_wardrobe,
 /turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "vMZ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -65992,6 +69353,12 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/storage/tech)
+"vPw" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
 "vPF" = (
 /obj/machinery/light{
 	dir = 8;
@@ -66089,6 +69456,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"vRp" = (
+/obj/machinery/atmospherics/components/binary/pump/on/layer2{
+	dir = 4;
+	name = "AI Satellite Supply"
+	},
+/obj/effect/mapping_helpers/teleport_anchor,
+/turf/open/floor/plating,
+/area/space)
 "vRA" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -66120,6 +69495,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"vTA" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/closed/wall/r_wall,
+/area/space)
 "vTB" = (
 /obj/machinery/shower{
 	dir = 4
@@ -66197,7 +69581,7 @@
 	network = list("minisat","ss13")
 	},
 /turf/open/space/basic,
-/area/ai_monitored/turret_protected/ai)
+/area/tcommsat/server)
 "vUi" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/aft_starboard";
@@ -66285,8 +69669,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/ai)
+/area/tcommsat/server)
 "vVb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -66423,6 +69810,30 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"vYj" = (
+/obj/machinery/power/apc/tcomms{
+	areastring = "/area/tcommsat/server";
+	dir = 4;
+	name = "Telecomms Server APC";
+	pixel_x = 24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "vYs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -66653,7 +70064,7 @@
 "wbH" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/ai)
+/area/tcommsat/server)
 "wbI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -66753,13 +70164,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "wer" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
+/obj/machinery/airalarm{
+	pixel_y = 24
 	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "weD" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -67038,17 +70450,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "wkd" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8;
+	external_pressure_bound = 140;
+	pressure_checks = 0
 	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/turf/open/floor/circuit/telecomms/server,
+/area/ai_monitored/turret_protected/ai)
 "wkE" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -67131,6 +70539,19 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"wlO" = (
+/obj/machinery/button/door{
+	id = "tcomms";
+	name = "Telecommunications server shutters control";
+	pixel_y = -27;
+	req_access_txt = "61"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "wlT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -67151,7 +70572,20 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
+"wmA" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Telecomms Admin";
+	departmentType = 5;
+	name = "Telecomms RC";
+	pixel_y = 30
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "wmB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -67347,6 +70781,14 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"wpK" = (
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room Access";
+	dir = 4;
+	network = list("ss13","minisat")
+	},
+/turf/open/floor/plasteel/white,
+/area/space)
 "wpR" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/bot_white,
@@ -67435,15 +70877,11 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "wrK" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower,
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/turf/open/floor/plasteel/dark,
+/area/space)
 "wrN" = (
 /obj/structure/chair/comfy/beige,
 /turf/open/floor/plasteel/grimy,
@@ -67624,6 +71062,16 @@
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
+"wwq" = (
+/obj/machinery/light,
+/obj/machinery/camera{
+	c_tag = "AI Chamber - Aft";
+	dir = 4;
+	network = list("aicore")
+	},
+/obj/machinery/porta_turret/ai,
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
 "wwt" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 4
@@ -67781,6 +71229,15 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"wyJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 10
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/space)
 "wzr" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -67856,19 +71313,9 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "wBI" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/tcommsat/server)
+/obj/machinery/telecomms/bus/preset_two,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "wBN" = (
 /obj/effect/turf_decal/tile{
 	dir = 8
@@ -67929,6 +71376,12 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"wEd" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "wEe" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
 	dir = 1
@@ -68007,20 +71460,20 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "wEX" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -1;
-	pixel_y = 6
-	},
-/obj/item/pen,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/donkpockets{
+	pixel_x = -6;
+	pixel_y = 1
+	},
+/obj/item/reagent_containers/food/drinks/bottle/vodka{
+	pixel_x = 8;
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/computer)
 "wFh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -68054,7 +71507,7 @@
 	network = list("minisat")
 	},
 /turf/open/space/basic,
-/area/ai_monitored/turret_protected/ai)
+/area/space/nearstation)
 "wHf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -68157,12 +71610,15 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "wIB" = (
-/obj/machinery/blackbox_recorder,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "wJc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/reagent_dispensers/fueltank,
@@ -68188,7 +71644,16 @@
 "wJL" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
-/area/tcommsat/computer)
+/area/ai_monitored/storage/satellite)
+"wKd" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/space)
 "wKy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -68468,6 +71933,18 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"wPR" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "wPS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -68502,6 +71979,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"wRd" = (
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "wRg" = (
 /obj/machinery/flasher{
 	id = "AI";
@@ -68962,6 +72449,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"xaH" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Teleporter Room";
+	req_one_access_txt = "17;65"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/space)
+"xbi" = (
+/obj/machinery/telecomms/server/presets/supply,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "xbs" = (
 /obj/machinery/light{
 	dir = 8
@@ -69076,6 +72590,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
+"xdr" = (
+/obj/machinery/telecomms/bus/preset_two,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "xds" = (
 /obj/structure/chair{
 	dir = 1
@@ -69222,8 +72750,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "xhk" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -69270,6 +72799,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"xhM" = (
+/obj/machinery/telecomms/server/presets/security,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "xit" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/warden";
@@ -69462,8 +72995,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "xlV" = (
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/telecomms/server/presets/service,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "xmb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -69526,17 +73060,26 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "xnr" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+/turf/open/floor/circuit/telecomms/server,
+/area/space)
+"xnA" = (
+/obj/structure/table/wood,
+/obj/item/paper_bin{
+	pixel_x = -1;
+	pixel_y = 6
 	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
+/obj/item/pen,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/space)
 "xnF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -69560,7 +73103,7 @@
 	dir = 1
 	},
 /turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/tcommsat/entrance)
 "xoz" = (
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/stripes/corner{
@@ -69901,6 +73444,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"xvU" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/camera{
+	c_tag = "MiniSat Exterior - Fore Port";
+	dir = 1;
+	network = list("minisat")
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space)
 "xvY" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -69938,23 +73493,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "xwL" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp{
-	pixel_x = -4;
-	pixel_y = 7
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
 	},
-/obj/item/toy/figure/borg{
-	pixel_x = -4;
-	pixel_y = -2
-	},
-/obj/item/phone{
-	pixel_x = 7;
-	pixel_y = 1
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_y = -28
-	},
-/turf/open/floor/plasteel/grimy,
+/turf/open/floor/circuit/green/telecomms,
 /area/ai_monitored/turret_protected/aisat_interior)
 "xwU" = (
 /obj/structure/closet/secure_closet/atmospherics,
@@ -69985,11 +73528,13 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "xxd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/item/storage/toolbox/mechanical,
+/obj/item/flashlight,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/storage)
+/turf/open/floor/plating,
+/area/space)
 "xxr" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -70067,11 +73612,11 @@
 /turf/open/floor/plasteel/white,
 /area/engine/atmos/mix)
 "xyb" = (
-/obj/structure/chair/office/dark{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
+/area/space)
 "xyG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -70188,6 +73733,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"xBs" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/circuit/telecomms/mainframe,
+/area/space)
 "xBG" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot_red,
@@ -70369,6 +73923,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"xEB" = (
+/obj/structure/lattice/catwalk,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space)
 "xEH" = (
 /obj/machinery/computer/security,
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
@@ -70396,18 +73957,43 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"xFg" = (
-/obj/machinery/ai_slipper{
-	uses = 10
+"xEY" = (
+/obj/machinery/status_display/ai{
+	pixel_y = 32
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
+"xFf" = (
+/obj/structure/table,
+/obj/item/stock_parts/subspace/analyzer,
+/obj/item/stock_parts/subspace/analyzer,
+/obj/item/stock_parts/subspace/analyzer,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
+"xFg" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
 	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 1
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "xFk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -70688,10 +74274,28 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"xKk" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "xKE" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet,
 /area/library)
+"xLf" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/space)
 "xLu" = (
 /obj/machinery/computer/communications,
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
@@ -70714,6 +74318,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"xLT" = (
+/obj/machinery/computer/telecomms/traffic{
+	dir = 1;
+	network = "tcommsat"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/turf/open/floor/plasteel/dark,
+/area/space)
 "xLX" = (
 /obj/machinery/computer/atmos_alert,
 /obj/effect/turf_decal/tile/neutral{
@@ -70740,6 +74352,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"xMi" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
+"xMv" = (
+/obj/item/radio/intercom{
+	freerange = 1;
+	name = "Station Intercom (Telecomms)";
+	pixel_y = 26
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "xML" = (
 /turf/closed/wall,
 /area/hallway/primary/aft_starboard)
@@ -70877,6 +74503,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"xPv" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "xPE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -70884,12 +74522,8 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "xPL" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
-/turf/open/floor/plasteel/white,
-/area/tcommsat/storage)
+/turf/closed/wall/r_wall,
+/area/space)
 "xPQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -70917,6 +74551,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"xQw" = (
+/obj/machinery/vending/autodrobe/capdrobe,
+/turf/open/floor/wood,
+/area/space)
 "xQA" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -71099,6 +74737,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"xUb" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "xUd" = (
 /obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 4
@@ -71177,12 +74824,20 @@
 /turf/open/floor/plating,
 /area/security/main)
 "xUW" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
 	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/power/apc/tcomms{
+	areastring = "/area/tcommsat/server";
+	dir = 1;
+	name = "Telecomms Server APC";
+	pixel_y = 24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "xVm" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
@@ -71351,6 +75006,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"xZQ" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/line/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/space)
 "yab" = (
 /obj/machinery/computer/shuttle/mining,
 /obj/machinery/computer/security/telescreen{
@@ -71373,16 +75041,14 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "yap" = (
-/obj/machinery/status_display/ai{
-	pixel_y = -32
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 10
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 4;
-	external_pressure_bound = 120;
-	name = "server vent"
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 4
 	},
-/turf/open/floor/circuit/telecomms/server,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "yaq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment,
@@ -71444,11 +75110,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "ybM" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/space)
 "ycf" = (
 /obj/machinery/meter{
 	pixel_x = -5;
@@ -71457,7 +75126,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plating,
-/area/ai_monitored/storage/satellite)
+/area/tcommsat/computer)
 "ycl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -71505,6 +75174,15 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"ycM" = (
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/gloves/color/black,
+/obj/structure/closet,
+/turf/open/floor/plating,
+/area/space)
 "ydd" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Maintenance";
@@ -71517,6 +75195,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"ydM" = (
+/obj/machinery/status_display/ai{
+	pixel_x = 32
+	},
+/obj/structure/rack,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/turf/open/floor/circuit,
+/area/space)
 "yey" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -71627,6 +75318,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"yfJ" = (
+/obj/machinery/telecomms/server/presets/common,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/space)
 "yfL" = (
 /obj/item/book/manual/wiki/security_space_law,
 /obj/structure/table/wood,
@@ -71676,6 +75371,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"ygC" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access_txt = "10;13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/turf/open/floor/plating,
+/area/space)
 "yhc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -71805,6 +75511,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"yiK" = (
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
+	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "telecomms_airlock_exterior";
+	idSelf = "telecomms_airlock_control";
+	pixel_x = 7;
+	pixel_y = -23
+	},
+/obj/machinery/doorButtons/access_button{
+	idDoor = "telecomms_airlock_interior";
+	idSelf = "telecomms_airlock_control";
+	pixel_x = -23;
+	pixel_y = 6
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room Access";
+	dir = 4;
+	network = list("ss13","tcomms")
+	},
+/turf/open/floor/plasteel/white,
+/area/space)
 "yiM" = (
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Lab";
@@ -71967,6 +75696,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ylo" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/space/basic,
+/area/space)
 "ylx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -96386,24 +100122,24 @@ aaa
 aaa
 aaa
 aaa
+vfm
+aJt
 aaa
 aaa
+aJt
+otc
+aJt
 aaa
 aaa
+aJt
+mFE
+aJt
+fMm
+aJt
+aJt
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
 aaa
 aaa
 aaa
@@ -96643,24 +100379,24 @@ aaa
 aaa
 aaa
 aaa
+vfm
+aJt
+aaa
+aaa
+uZo
+aaa
+qVN
+aaa
+aaa
+aJt
+mFE
 aaa
 aaa
 aaa
+aJt
+aJt
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
 aaa
 aaa
 aaa
@@ -96900,24 +100636,24 @@ aaa
 aaa
 aaa
 aaa
+vfm
+aJt
+aaa
+uZV
 aaa
 aaa
 aaa
+gVu
+aaa
+aJt
+mFE
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aJt
+aJt
+aJt
+jCM
 aaa
 aaa
 aaa
@@ -97157,24 +100893,24 @@ aaa
 aaa
 aaa
 aaa
+vfm
+aJt
+aaa
+vHu
 aaa
 aaa
 aaa
+vHu
+aaa
+aJt
+mFE
 aaa
 aaa
 aaa
+aJt
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fMm
+jCM
 aaa
 aaa
 aaa
@@ -97414,21 +101150,21 @@ aaa
 aaa
 aaa
 aaa
+vfm
+aJt
+aaa
+ptV
+leo
+leo
+leo
+dLB
+aaa
+aJt
+mFE
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aJt
 aaa
 aaa
 aaa
@@ -97671,22 +101407,22 @@ aaa
 aaa
 aaa
 aaa
+vfm
+aJt
+aaa
+tNs
+nEG
+crS
+mxG
+akE
+aaa
+aJt
+mFE
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aJt
+jCM
 aaa
 aaa
 aaa
@@ -97928,22 +101664,22 @@ aaa
 aaa
 aaa
 aaa
+vfm
+xPL
+xPL
+xPL
+muL
+ssf
+oyi
+xPL
+xPL
+xPL
+mFE
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aJt
+aJt
+jCM
 aaa
 aaa
 aaa
@@ -98183,24 +101919,24 @@ aaa
 aaa
 aaa
 aaa
+mUg
+lQb
+hoF
+laa
+bhu
+jJK
+tto
+mJE
+tto
+jEF
+iJq
+qAr
+mFE
+hCt
+mFE
+aJt
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
 aaa
 aaa
 aaa
@@ -98440,25 +102176,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vfm
+xPL
+xPL
+xPL
+xPL
+xPL
+xEY
+cnX
+ddu
+xPL
+xPL
+xPL
+xPL
+xPL
+mFE
+aJt
+jCM
+jCM
+jCM
 aaa
 aaa
 aaa
@@ -98697,25 +102433,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vfm
+xPL
+dsI
+dxx
+fhe
+lbX
+wer
+pQN
+oLj
+lbX
+nbc
+ovk
+gky
+xPL
+mFE
+aJt
+jCM
+jCM
+jCM
 aaa
 aaa
 aaa
@@ -98954,25 +102690,25 @@ aaa
 aaa
 aaa
 aaa
+vfm
+xPL
+dsI
+sqS
+goP
+lbX
+hAC
+ucD
+jTN
+xaH
+gRS
+cDJ
+lma
+xPL
+mFE
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
 aaa
 aaa
 aaa
@@ -99209,27 +102945,27 @@ aaa
 aaa
 aaa
 aaa
+mUg
+oWc
+hoF
+xPL
+lMT
+vRp
+fbL
+lbX
+lbX
+gIY
+lbX
+lbX
+mXq
+iSD
+hXu
+xPL
+mFE
+mFE
+mFE
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
 aaa
 aaa
 aaa
@@ -99466,27 +103202,27 @@ aaa
 aaa
 aaa
 aaa
+xvU
+xPL
+xPL
+xPL
+gYf
+qOj
+lbX
+lbX
+tXe
+gSI
+hvo
+lbX
+lbX
+lbX
+lbX
+xPL
+xPL
+xPL
+bmg
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
 aaa
 aaa
 aaa
@@ -99722,28 +103458,28 @@ aaa
 aaa
 aaa
 aaa
+aMJ
+kug
+xPL
+leM
+mlS
+oxs
+slU
+lbX
+qaA
+kag
+nbP
+ybM
+phR
+lbX
+qJC
+xnA
+lWm
+eNA
+xPL
+mFE
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
 aaa
 aaa
 aaa
@@ -99979,28 +103715,28 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+sRE
+tOs
+djF
+wKd
+nCJ
+bxc
+kjX
+hRI
+lec
+lec
+jbQ
+uUE
+lec
+qUE
+aLy
+epV
+fME
+gSl
+pBl
+mFE
+aJt
+jCM
 aaa
 aaa
 aaa
@@ -100237,27 +103973,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+mFE
+xPL
+aVE
+mWE
+klm
+sNq
+lbX
+ohP
+pzn
+qXr
+fpD
+ydM
+lbX
+tqj
+hTd
+ldD
+qRI
+xPL
+mFE
+aJt
+jCM
 aaa
 aaa
 aaa
@@ -100391,19 +104127,19 @@ ngJ
 hRj
 stP
 yeC
-aZM
-aZM
-aZM
-aZM
-aZM
-aZM
-aZM
-aZM
-aZM
+cva
+cva
+cva
+cva
+cva
+cva
+cva
+cva
+gtB
 eTe
 qKi
 kqB
-lMT
+gtB
 gXs
 aaa
 gXs
@@ -100494,26 +104230,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+mFE
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+vgg
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+mFE
+aJt
 aaa
 aaa
 aaa
@@ -100647,24 +104383,24 @@ hRj
 hRj
 jTD
 lQX
-aPR
-fmC
+cva
+cva
 ojM
-lFm
+sAu
 fQt
-vJJ
+sAu
 ume
-hjk
-bjE
-mDO
-naq
+cva
+cva
+xwL
 lyX
-kit
-lMT
-bVJ
+lyX
+nQP
+gtB
+tgv
 wJL
 wJL
-pJB
+lmN
 aaa
 xJL
 qGt
@@ -100751,28 +104487,28 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+mFE
+mFE
+mFE
+mFE
+iII
+xPL
+xPL
+xPL
+oQz
+cwu
+udW
+xPL
+xPL
+xPL
+iII
+mFE
+mFE
+mFE
+mFE
+aJt
+aJt
+aJt
 aaa
 aaa
 aaa
@@ -100904,25 +104640,25 @@ exk
 hRj
 gqU
 gRs
-rYz
-iIj
-wrK
-aTs
-bcd
-fCV
-aTP
-hXu
-mqO
+cva
+iXp
+pyn
+nDA
+nDA
+nDA
+rjo
+tTK
+cva
 mDO
 gLt
 kMi
 uuG
 ieK
-bVJ
+rdR
 azq
 rRA
-pJB
-pJB
+lmN
+lmN
 aJw
 inP
 aJq
@@ -101009,25 +104745,25 @@ aaa
 aaa
 aaa
 aaa
+aJt
+aJt
+mFE
+mFE
+xPL
+xPL
+gHc
+jKC
+axV
+wIB
+gHc
+xPL
+xPL
+mFE
+mFE
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aJt
+aJt
 aaa
 aaa
 aaa
@@ -101161,23 +104897,23 @@ fJb
 lLe
 hRj
 pqr
-aPR
+cva
 hWd
 fiF
-bcc
-bdd
+cfh
+bPO
 cfh
 bfr
 qjk
-fmC
-fmC
-lMT
-fXb
+cva
+cva
+gtB
+ieo
 suV
-tto
-bVJ
-pSY
+gtB
 lhk
+pSY
+rdR
 rdw
 pvf
 aJw
@@ -101266,27 +105002,27 @@ aaa
 aaa
 aaa
 aaa
+aJt
+mFE
+mFE
+xPL
+xPL
+xPL
+xPL
+xPL
+qzr
+xPL
+xPL
+xPL
+xPL
+xPL
+mFE
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aJt
+aJt
+aJt
 aaa
 aaa
 aaa
@@ -101418,25 +105154,25 @@ lvm
 oXR
 hRj
 oeF
-aPR
-cuZ
-pen
-hmx
-hmx
+cva
+nDA
+nDA
+cva
+cva
 hsq
-kVh
+ilL
 qZK
 vAP
-uAV
-lMT
-cqT
-xxd
-paH
-bVJ
-pTL
-axV
+gCs
+gtB
+nQP
+lyX
+gtB
+lEd
+nyj
 rdR
-xyb
+rdR
+rdR
 aJw
 pvo
 sXZ
@@ -101524,24 +105260,24 @@ aaa
 aaa
 aaa
 aaa
+mFE
+xPL
+xPL
+xPL
+rKI
+lqZ
+uAV
+tYq
+rfv
+lqZ
+wwq
+xPL
+xPL
+mFE
+mFE
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aJt
 aaa
 aaa
 aaa
@@ -101675,25 +105411,25 @@ fJS
 hRj
 lja
 fFX
-aPR
+cva
 bVI
 eAU
-ptV
+cva
 erb
-afK
+jcz
 uGc
 pZI
 uGb
 pJy
 jHo
 sqj
-hoK
+lyX
 fJN
 aJy
 nyj
 rPo
-fkC
-opJ
+rdR
+rdR
 psj
 hsn
 sYk
@@ -101780,22 +105516,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aJt
+mFE
+xPL
+xPL
+xPL
+lGC
+qex
+inD
+bcz
+fCV
+fCV
+pNs
+xPL
+xPL
+xPL
+mFE
 aaa
 aaa
 aaa
@@ -101932,25 +105668,25 @@ iXt
 nvA
 hRj
 rMA
-aPR
-kTy
-hUA
-lfM
-lfM
+cva
+nDA
+nDA
+cva
+cva
 mfG
-loF
-rJJ
-vAP
+ilL
+qZK
+spr
 gCs
-lMT
-naj
-rCq
-jCM
-bVJ
-hYy
-lhk
-rfJ
-gOE
+gtB
+nQP
+lyX
+gtB
+fnl
+nyj
+rdR
+rdR
+iRV
 aJw
 hvG
 sYv
@@ -102038,24 +105774,24 @@ aaa
 aaa
 aaa
 aaa
+mFE
+xPL
+xPL
+pLM
+jwq
+bvC
+xPL
+xPL
+mnJ
+fCV
+xnr
+vgr
+xPL
+xPL
+mFE
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
+jCM
 aaa
 aaa
 aaa
@@ -102189,24 +105925,24 @@ vke
 dyd
 gFO
 jfG
-aPR
-mDn
+cva
+hWd
 qoQ
-jJK
+cfh
 prN
-wBI
-cOE
+cfh
+bfr
 laN
-mrS
-mrS
-lbX
+cva
+cva
+gtB
 ieo
-krI
-chg
-bVJ
+suV
+gtB
+aRB
 rzx
 iRV
-aSV
+hTj
 agz
 aJw
 qHo
@@ -102294,24 +106030,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jcO
+mKm
+xPL
+xPL
+pUk
+xnr
+mkL
+xPL
+nxc
+xPL
+fCV
+xnr
+oTR
+xPL
+xPL
+egy
+aJt
+jCM
 aaa
 aaa
 aaa
@@ -102446,25 +106182,25 @@ exk
 jTD
 gGc
 vrT
-rYz
-wIB
-uNG
-xzh
-qKK
-tNs
-qVN
-iII
-eKD
+cva
+iXp
+pyn
+nDA
+nDA
+nDA
+rjo
+tTK
+cva
 mDO
-sAr
+gLt
 tmm
 pJS
 vzc
-bVJ
+rdR
 dne
 bxL
-pJB
-pJB
+lmN
+lmN
 aJw
 inP
 aJq
@@ -102551,22 +106287,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aJt
+mFE
+xPL
+xPL
+byg
+bFi
+hXs
+pmd
+rWQ
+drk
+pFX
+nst
+iyq
+xPL
+xPL
+mFE
 aaa
 aaa
 aaa
@@ -102703,24 +106439,24 @@ hRj
 hRj
 hRj
 wVO
-aPR
-fmC
+cva
+cva
 guR
-aVE
+sAu
 cyY
-iHu
+sAu
 wkd
-oUc
-qQw
-mDO
-xPL
-xnr
+cva
+cva
+xwL
+lyX
+lyX
 nQP
-lMT
-bVJ
+gtB
+tgv
 wJL
 wJL
-pJB
+lmN
 aaa
 msD
 qGt
@@ -102806,27 +106542,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+dVn
+aJt
+aJt
+mFE
+xPL
+xPL
+xPL
+oAr
+vva
+pFX
+lXd
+sgw
+rfA
+lfM
+xPL
+xPL
+xPL
+mFE
+aJt
+aJt
+jCM
 aaa
 aaa
 aaa
@@ -102961,19 +106697,19 @@ fnb
 dwN
 kNr
 sTb
-aZV
-aZV
-aZV
-aZV
-aZV
-aZV
-aZV
-aZV
-aZV
-djF
-mUg
+cva
+cva
+cva
+cva
+cva
+cva
+cva
+cva
+gtB
+eTe
+qKi
 uMi
-lMT
+gtB
 gXs
 aoV
 gXs
@@ -103063,27 +106799,27 @@ aaa
 aaa
 aaa
 aaa
+dVn
 aaa
+aJt
+mFE
+iII
+xPL
+xPL
+vyH
+vPw
+dCa
+tXT
+nRa
+lqZ
+eRI
+xPL
+xPL
+xPL
+mFE
+aJt
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
 aaa
 aaa
 aaa
@@ -103320,27 +107056,27 @@ aaa
 aaa
 aaa
 aaa
+dVn
+aJt
+aJt
+mFE
+mFE
+xPL
+xPL
+xPL
+lqZ
+xnr
+bGo
+nRa
+vJW
+xPL
+xPL
+xPL
+mFE
+mFE
+aJt
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
 aaa
 aaa
 aaa
@@ -103577,27 +107313,27 @@ aaa
 aaa
 aaa
 aaa
+dVn
+aaa
+aJt
+aJt
+mFE
+cpN
+iII
+xPL
+xPL
+isU
+dQd
+ftO
+xPL
+xPL
+iII
+uXc
+mFE
+aJt
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
 aaa
 aaa
 aaa
@@ -103838,19 +107574,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aJt
+mFE
+mFE
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+mFE
+mFE
+aJt
 aaa
 aaa
 aaa
@@ -104093,23 +107829,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
+jCM
+jCM
+aJt
+mFE
+mFE
+xPL
+xPL
+xPL
+xPL
+xPL
+mFE
+mFE
+aJt
+jCM
+jCM
+jCM
 aaa
 aaa
 aaa
@@ -104354,16 +108090,16 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aJt
+mFE
+mFE
+xPL
+xPL
+xPL
+mFE
+mFE
+aJt
+aJt
 aaa
 aaa
 aaa
@@ -104609,19 +108345,19 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cuZ
+aJt
+aJt
+aJt
+mFE
+mFE
+pss
+mFE
+mFE
+aJt
+aJt
+aJt
+cuZ
 aaa
 aaa
 aaa
@@ -104868,22 +108604,22 @@ aaa
 aaa
 aaa
 aaa
+aJt
+aJt
+aJt
+aJt
+aJt
+aJt
+aJt
+aJt
+cuZ
+cuZ
 aaa
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cEB
 aaa
 aaa
 aaa
@@ -105124,15 +108860,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cuZ
+aJt
+cuZ
+aJt
+cuZ
+cuZ
+cuZ
+aJt
+cuZ
 aaa
 aaa
 aaa
@@ -105382,13 +109118,13 @@ aaa
 aaa
 aaa
 aaa
+cuZ
+aaa
+cuZ
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+cuZ
 aaa
 aaa
 aaa
@@ -108459,24 +112195,24 @@ aaa
 aaa
 aaa
 aaa
+mFE
+aJt
+aJt
+aJt
+aJt
+otc
+aJt
+aJt
+aJt
+aJt
+mFE
+aJt
+fMm
+aJt
+aJt
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
 aaa
 aaa
 aaa
@@ -108716,24 +112452,24 @@ aaa
 aaa
 aaa
 aaa
+mFE
+aJt
+aaa
+aaa
+uZo
+aaa
+qVN
+aaa
+aaa
+aJt
+mFE
 aaa
 aaa
 aaa
+aJt
+aJt
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
 aaa
 aaa
 aaa
@@ -108973,24 +112709,24 @@ aaa
 aaa
 aaa
 aaa
+mFE
+aJt
+aaa
+uZV
 aaa
 aaa
 aaa
+gVu
+aaa
+aJt
+mFE
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aJt
+aJt
+aJt
+jCM
 aaa
 aaa
 aaa
@@ -109230,24 +112966,24 @@ aaa
 aaa
 aaa
 aaa
+mFE
+aJt
+aaa
+vHu
 aaa
 aaa
 aaa
+vHu
+aaa
+aJt
+mFE
 aaa
 aaa
 aaa
+aJt
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fMm
+jCM
 aaa
 aaa
 aaa
@@ -109487,24 +113223,24 @@ aaa
 aaa
 aaa
 aaa
+mFE
+aJt
+aaa
+ptV
+leo
+leo
+leo
+dLB
+aaa
+aJt
+mFE
 aaa
 aaa
 aaa
+aJt
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoV
 aaa
 aaa
 aaa
@@ -109744,24 +113480,24 @@ aaa
 aaa
 aaa
 aaa
+mFE
+aJt
+aaa
+tZr
+mVn
+uFX
+mdZ
+akE
+aaa
+aJt
+mFE
+mFE
+mFE
+aaa
+aJt
+jCM
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoV
 aaa
 aaa
 aaa
@@ -110001,22 +113737,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+mFE
+xPL
+xPL
+xPL
+nrp
+iIj
+asG
+xPL
+xPL
+xPL
+mFE
+fMm
+mFE
+aJt
+aJt
+jCM
 aaa
 aaa
 aaa
@@ -110234,15 +113970,15 @@ aaa
 aaa
 aaa
 ucZ
-gtB
-gtB
-gtB
+cOE
+cOE
+cOE
 vbw
 fjN
 kRG
-gtB
-gtB
-gtB
+cOE
+cOE
+cOE
 pEf
 aaa
 aaa
@@ -110256,24 +113992,24 @@ aaa
 aaa
 aaa
 aaa
+ylo
+gzL
+aMJ
+maY
+oUc
+afK
+pLe
+rSF
+iIj
+ibK
+aTs
+ygC
+mFE
+xEB
+mFE
+aJt
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
 aaa
 aaa
 aaa
@@ -110513,26 +114249,26 @@ cEB
 aaa
 aaa
 aaa
+vJJ
+xPL
+xPL
+xPL
+xPL
+xPL
+qaQ
+uMP
+rYz
+xPL
+xPL
+xPL
+xPL
+xPL
+mFE
+aJt
+jCM
+jCM
+jCM
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoV
 aaa
 aaa
 aaa
@@ -110746,19 +114482,19 @@ aaa
 aaa
 aaa
 ucZ
-tgv
-tgv
-tgv
-tgv
-gtB
+bVJ
+bVJ
+cOE
+cOE
+cOE
 aDW
 sxE
 vvS
-gtB
-gtB
-gtB
-gtB
-gtB
+cOE
+cOE
+cOE
+cOE
+cOE
 pEf
 gXs
 aKN
@@ -110770,25 +114506,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vJJ
+xPL
+mLm
+hYy
+prn
+xPL
+xPL
+oBz
+xPL
+xPL
+rAM
+jRb
+hOS
+xPL
+mFE
+aJt
+jCM
+jCM
+jCM
 aaa
 aaa
 aaa
@@ -111003,11 +114739,11 @@ aaa
 aaa
 aaa
 ucZ
-tgv
+bVJ
 nIj
 oQJ
 ntH
-vmm
+pJB
 rCd
 iKg
 mVN
@@ -111015,7 +114751,7 @@ vmm
 ody
 kfG
 xnR
-gtB
+cOE
 pEf
 gXs
 aKN
@@ -111027,25 +114763,25 @@ aaa
 aaa
 aaa
 aaa
+vJJ
+xPL
+fqr
+aSA
+aSA
+cAw
+iIj
+xLf
+pLe
+qQH
+hMW
+uNW
+dvh
+xPL
+mFE
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
 aaa
 aaa
 aaa
@@ -111260,11 +114996,11 @@ aaa
 aaa
 aaa
 ucZ
-tgv
+bVJ
 nIj
 ycf
 iJL
-vmm
+pJB
 tZD
 ohh
 rUm
@@ -111272,7 +115008,7 @@ iek
 cZu
 cLg
 sdl
-gtB
+cOE
 pEf
 aaa
 aaa
@@ -111282,28 +115018,28 @@ aaa
 aaa
 aaa
 aaa
+ylo
+aMJ
+hjt
+xPL
+jDi
+lem
+bmX
+xPL
+iIj
+uMP
+jMq
+xPL
+fkC
+pKt
+qBW
+xPL
+mFE
+mFE
+mFE
 aaa
+jCM
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoV
 aaa
 aaa
 aaa
@@ -111517,19 +115253,19 @@ aaa
 bPq
 pkF
 sXV
-tgv
+bVJ
 oBt
 dgV
 pyG
-vmm
-vmm
+pJB
+pJB
 bSJ
-vmm
-vmm
+pJB
+pJB
 gBP
 vxS
 qlI
-gtB
+cOE
 pEf
 pEf
 pEf
@@ -111539,28 +115275,28 @@ aaa
 aaa
 aaa
 aaa
+vJJ
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+cqT
+gTO
+dZh
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+mFE
 aaa
+jCM
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aoV
 aaa
 aaa
 aaa
@@ -111772,23 +115508,23 @@ ufD
 aaa
 aaa
 nzG
-tgv
-tgv
-tgv
+bVJ
+bVJ
+bVJ
 eva
 oNw
-lmN
-vmm
+pJB
+pJB
 jEd
 qQs
 fnK
-vmm
-vmm
-vmm
-vmm
-gtB
-gtB
-gtB
+pJB
+pJB
+pJB
+pJB
+bVJ
+bVJ
+bVJ
 qAp
 aaa
 aKN
@@ -111796,27 +115532,27 @@ aaa
 aaa
 aaa
 aaa
+vJJ
+xPL
+mot
+bUO
+pOK
+mqZ
+pOK
+uLG
+mSd
+tUP
+iIj
+gzc
+imN
+iIj
+qrZ
+nOQ
+cVE
+xPL
+mFE
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
 aaa
 aaa
 aaa
@@ -112029,23 +115765,23 @@ sSk
 vUc
 vUc
 iwZ
-tgv
+bVJ
 tFW
 stR
 dgZ
 rur
-lmN
+pJB
 nSR
 otV
 nnx
 lxF
 lbE
-vmm
+pJB
 vMR
 wEX
 lZD
-xwL
-gtB
+aSV
+bVJ
 pEf
 aaa
 aKN
@@ -112053,27 +115789,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vJJ
+xPL
+pTC
+hjk
+iWd
+hjk
+uQK
+paH
+xPL
+jIA
+xPL
+xPL
+wmA
+iIj
+iIj
+kST
+irs
+xPL
+mFE
+aJt
+jCM
 aaa
 aaa
 aaa
@@ -112296,7 +116032,7 @@ snB
 snB
 cqk
 bhL
-snB
+ffl
 dEd
 pyZ
 dTb
@@ -112310,27 +116046,27 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vJJ
+lfU
+ycM
+ibO
+xxd
+ibO
+naq
+uMU
+sjc
+cJo
+wpK
+rJJ
+iIj
+iIj
+iIj
+iIj
+gsD
+xPL
+mFE
+fMm
+jCM
 aaa
 aaa
 aaa
@@ -112543,23 +116279,23 @@ aaa
 aaa
 aaa
 pEf
-tgv
+bVJ
 hZg
 cBP
 uIU
 xgS
-lmN
+pJB
 pRt
 kyA
 kik
 eEZ
 jWq
-vmm
+pJB
 qzd
 qLi
 mtW
 tiN
-gtB
+bVJ
 pEf
 gXs
 aKN
@@ -112567,26 +116303,26 @@ aaa
 aKN
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vJJ
+xPL
+iOR
+ibO
+uNT
+tJH
+tMo
+kuT
+tdJ
+iXR
+dqm
+rJJ
+aTP
+vkj
+gpL
+fHw
+bPG
+xPL
+mFE
+aJt
 aaa
 aaa
 aaa
@@ -112800,23 +116536,23 @@ aaa
 aaa
 aaa
 pEf
-tgv
-tgv
-tgv
-tgv
-tgv
-tgv
-cva
-cva
+bVJ
+bVJ
+bVJ
+bVJ
+bVJ
+bVJ
+fmC
+fmC
 ouB
-cva
-cva
-gtB
-gtB
-gtB
-gtB
-gtB
-gtB
+fmC
+fmC
+bVJ
+bVJ
+bVJ
+bVJ
+bVJ
+bVJ
 pEf
 gXs
 aaa
@@ -112824,28 +116560,28 @@ aaa
 aKN
 aaa
 aaa
+vJJ
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+mIH
+gfw
+dnq
+gfw
+rJJ
+rJJ
+xPL
+xPL
+xPL
+xPL
+xPL
+mFE
+aJt
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aJt
 aaa
 aaa
 aaa
@@ -113061,15 +116797,15 @@ pEf
 pEf
 pEf
 jXD
-cva
-cva
-cva
+fmC
+fmC
+fmC
 tHJ
 vUR
 nKN
-cva
-cva
-cva
+fmC
+fmC
+fmC
 jXD
 pEf
 pEf
@@ -113080,29 +116816,29 @@ gXs
 gXs
 aKN
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aMJ
+hjt
+mFE
+mFE
+mFE
+xPL
+xPL
+dvx
+rCq
+lFm
+hyr
+qFi
+hFn
+hFn
+xPL
+xPL
+mFE
+mFE
+mFE
+mFE
+aJt
+aJt
+aJt
 aaa
 aaa
 aaa
@@ -113318,15 +117054,15 @@ gXs
 gXs
 pEf
 pEf
-cva
-cva
+fmC
+fmC
 wbH
 mxQ
 uYw
 uuW
 wbH
-cva
-cva
+fmC
+fmC
 pEf
 pEf
 aaa
@@ -113341,23 +117077,23 @@ aaa
 aaa
 aaa
 aaa
+mFE
+xPL
+xPL
+hFn
+kcr
+qpA
+uBd
+qpA
+uTz
+hFn
+xPL
+xPL
+mFE
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aJt
 aaa
 aaa
 aaa
@@ -113574,17 +117310,17 @@ aaa
 gXs
 pEf
 pEf
-cva
-cva
-cva
-cva
-cva
+pEf
+fmC
+fmC
+fmC
+fmC
 gka
-cva
-cva
-cva
-cva
-cva
+fmC
+fmC
+fmC
+fmC
+pEf
 pEf
 aaa
 aaa
@@ -113598,25 +117334,25 @@ aaa
 aaa
 aaa
 aaa
+mFE
+xPL
+xPL
+lNm
+uKS
+xBs
+iqH
+xBs
+dHS
+vqQ
+xPL
+xPL
+mFE
 aaa
 aaa
+aJt
+aJt
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
 aaa
 aaa
 aaa
@@ -113830,18 +117566,18 @@ aaa
 aaa
 aaa
 pEf
-cva
-cva
-cva
-byg
-sAu
+pEf
+pEf
+fmC
+fmC
+kdN
 bRu
 xFg
 gTY
-sAu
-jnr
-cva
-cva
+qSm
+fmC
+fmC
+pEf
 pEf
 pEf
 aaa
@@ -113854,24 +117590,24 @@ aaa
 aaa
 aaa
 aaa
+aJt
+mFE
+xPL
+xPL
+kqr
+jnr
+ctL
+hFn
+fWV
+jnr
+jaF
+xPL
+xPL
+mFE
+aJt
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
+jCM
 aaa
 aaa
 aaa
@@ -114087,19 +117823,19 @@ aaa
 aaa
 gXs
 pEf
-cva
-cva
-cva
+pEf
+fmC
+fmC
 gQa
 jzm
-ybM
+cbd
 soe
-nDA
-nDA
+cbd
+gOE
 yap
-cva
-cva
-cva
+fmC
+fmC
+pEf
 pEf
 aaa
 aaa
@@ -114111,23 +117847,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aJt
+mFE
+xPL
+xPL
+tVH
+iHu
+qpA
+ogx
+qpA
+iDK
+ilq
+xPL
+xPL
+mFE
+aJt
+aJt
+jCM
 aaa
 aaa
 aaa
@@ -114344,19 +118080,19 @@ aaa
 aaa
 aaa
 pEf
-cva
-cva
-abx
+fmC
+fmC
+fmC
 gNr
 npc
-cva
-cva
-pBl
-nDA
-rjo
-wer
-cva
-cva
+cbd
+pkb
+cbd
+qId
+cxF
+fmC
+fmC
+fmC
 pEf
 aaa
 aKN
@@ -114368,21 +118104,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aJt
+mFE
+xPL
+xPL
+kqr
+jnr
+gFu
+hFn
+wyJ
+jnr
+jaF
+xPL
+xPL
+mFE
+aJt
 aaa
 aaa
 aaa
@@ -114601,19 +118337,19 @@ aaa
 aaa
 tgE
 koy
-cva
-cva
-lHO
-rjo
-dnj
-cva
+fmC
+fmC
+bjE
+qQw
+lWl
+cbd
 jKN
-cva
-nDA
-rjo
+cbd
+lWl
+loF
 xlV
-cva
-cva
+fmC
+fmC
 vUh
 gXs
 aKN
@@ -114622,27 +118358,27 @@ aaa
 aaa
 aaa
 aaa
+jCM
+aJt
 aaa
+aJt
+mFE
+xPL
+xPL
+hfD
+mAn
+hmx
+btR
+hmx
+tWs
+iAl
+xPL
+xPL
+mFE
+aJt
+aJt
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
 aaa
 aaa
 aaa
@@ -114858,19 +118594,19 @@ aaa
 aaa
 gXs
 pEf
-cva
-cva
+fmC
+fmC
 xUW
-jcz
+xPv
 cWY
 lQv
 grq
-phR
+nHT
 tGz
-pyn
+xKk
 ikV
-cva
-cva
+fmC
+fmC
 pEf
 aaa
 aaa
@@ -114879,27 +118615,27 @@ aaa
 aaa
 aaa
 aaa
+jCM
+aJt
+aJt
 aaa
+mFE
+xPL
+xPL
+xPL
+xbi
+kKg
+xdr
+kKg
+fXb
+xPL
+xPL
+xPL
+mFE
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aJt
+aJt
+jCM
 aaa
 aaa
 aaa
@@ -115115,19 +118851,19 @@ jXY
 gXs
 gXs
 pEf
-cva
-cva
-cva
-mWE
+fmC
+fmC
+kVh
+qKK
 lWl
-tGz
+cbd
 car
-dOp
-mFE
-kcr
-cva
-cva
-cva
+cbd
+lWl
+bdd
+bcd
+fmC
+fmC
 pEf
 gXs
 gXs
@@ -115136,27 +118872,27 @@ aaa
 aaa
 aaa
 aaa
+jCM
+aaa
+aJt
+aaa
+mFE
+mFE
+xPL
+xPL
+xMv
+dFP
+fvy
+vHN
+nNV
+xPL
+xPL
+mFE
+mFE
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
 aaa
 aaa
 aaa
@@ -115373,18 +119109,18 @@ aaa
 gXs
 pEf
 jXD
-cva
-cva
+fmC
+fmC
 dOn
 sPc
-fMm
+cbd
 rlo
 cbd
-sAu
-tTK
-cva
-cva
-cva
+kep
+dYN
+fmC
+fmC
+fmC
 pEf
 gXs
 aaa
@@ -115393,27 +119129,27 @@ aaa
 aaa
 aaa
 aaa
+jCM
+aJt
+aJt
+aaa
+aJt
+mFE
+xPL
+xPL
+xPL
+tTW
+dnj
+hoK
+xPL
+xPL
+xPL
+mFE
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
 aaa
 aaa
 aaa
@@ -115630,17 +119366,17 @@ gXs
 gXs
 pEf
 pEf
-cva
-cva
-cva
-sAu
-rjo
-pkb
+fmC
+fmC
+xUb
+ikV
+cbd
+xzh
 cbd
 nHT
-cva
-cva
-cva
+dfA
+fmC
+fmC
 pEf
 pEf
 gXs
@@ -115650,27 +119386,27 @@ aaa
 aaa
 aaa
 aaa
+jCM
+aaa
+aJt
+aJt
+aJt
+mFE
+mFE
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+mFE
+mFE
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
 aaa
 aaa
 aaa
@@ -115889,13 +119625,13 @@ gXs
 pEf
 ogh
 jXD
-cva
-cva
-iXp
-tjY
+fmC
+mDn
+bkZ
+car
 dTU
-cva
-cva
+eKD
+fmC
 jXD
 wGq
 pEf
@@ -115911,18 +119647,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aJt
+aJt
+mFE
+mFE
+xPL
+xPL
+xPL
+xPL
+xPL
+mFE
+mFE
+aJt
 aaa
 aaa
 aaa
@@ -116146,13 +119882,13 @@ aaa
 gXs
 pEf
 pEf
-cva
-cva
-cva
-cva
-cva
-cva
-cva
+fmC
+fmC
+fmC
+fmC
+fmC
+fmC
+fmC
 pEf
 pEf
 gXs
@@ -116166,23 +119902,23 @@ aaa
 aaa
 aaa
 aaa
+jCM
+jCM
+jCM
+aJt
 aaa
+mFE
+mFE
+mFE
+mFE
+mFE
+mFE
+mFE
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aJt
+jCM
+jCM
+jCM
 aaa
 aaa
 aaa
@@ -116404,11 +120140,11 @@ aKN
 gXs
 pEf
 pEf
-cva
-cva
-cva
-cva
-cva
+fmC
+fmC
+fmC
+fmC
+fmC
 pEf
 pEf
 gXs
@@ -116428,13 +120164,13 @@ aaa
 aaa
 aaa
 aaa
+jCM
+jCM
+jCM
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jCM
+jCM
+jCM
 aaa
 aaa
 aaa
@@ -116662,9 +120398,9 @@ aaa
 gXs
 pEf
 pEf
-cva
-cva
-cva
+fmC
+fmC
+fmC
 pEf
 pEf
 gXs
@@ -116687,9 +120423,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+jCM
+jCM
+jCM
 aaa
 aaa
 aaa
@@ -119235,25 +122971,25 @@ aaa
 aaa
 aaa
 aaa
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+xFf
+ulw
+nPV
+xPL
+aJt
 aaa
+aJt
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aJt
+diU
 aaa
 aaa
 aaa
@@ -119492,25 +123228,25 @@ aaa
 aaa
 aaa
 aaa
+xPL
+ePD
+clN
+iLr
+sXt
+jsq
+jcv
+jBK
+kBF
+jkE
+aSA
+naj
+xPL
+xPL
+lfU
+lfU
+lbX
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+krI
 aaa
 aaa
 aaa
@@ -119749,25 +123485,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fKE
+lDN
+jKm
+xhM
+esq
+niD
+kJV
+oSV
+kBF
+uZN
+xMi
+tjY
+aNW
+xPL
+bOL
+fJa
+lbX
+lbX
+lbX
 aaa
 aaa
 aaa
@@ -120006,25 +123742,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+kGg
+nZC
+dOp
+cfn
+wRd
+bcc
+odu
+xPL
+xPL
+xPL
+gEa
+nbc
+eui
+xPL
+kit
+rfJ
+kvY
+kks
+lbX
 aaa
 aaa
 aaa
@@ -120263,25 +123999,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+tmU
+vpq
+ohF
+ohF
+gkZ
+opJ
+ppD
+rJJ
+yiK
+xPL
+gXZ
+wrK
+fvW
+xPL
+smd
+nOm
+wEd
+nvG
+lbX
 aaa
 aaa
 aaa
@@ -120520,25 +124256,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cUN
+sBc
+lxm
+dBM
+flJ
+rBN
+jHM
+eOa
+nII
+fPW
+eNX
+eJD
+lHO
+mZM
+uRo
+bDr
+wPR
+jWs
+mqO
 aaa
 aaa
 aaa
@@ -120777,25 +124513,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+mrS
+viP
+ktI
+ktI
+ufy
+uKy
+aeC
+rJJ
+sAr
+xPL
+nHt
+iCz
+kTy
+xPL
+gzZ
+rfJ
+xyb
+urd
+lbX
 aaa
 aaa
 aaa
@@ -121034,25 +124770,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jRO
+hUA
+pen
+fCL
+kKy
+jHs
+pzi
+vTA
+vTA
+vTA
+pTL
+ofx
+xLT
+xPL
+chg
+uNG
+ekV
+iYH
+lbX
 aaa
 aaa
 aaa
@@ -121291,25 +125027,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+elv
+jVz
+wBI
+jbG
+sGz
+oxX
+xZQ
+sGU
+kBF
+bRF
+nbX
+ecb
+qLN
+xPL
+juw
+opr
+lbX
+lbX
+lbX
 aaa
 aaa
 aaa
@@ -121548,25 +125284,25 @@ aaa
 aaa
 aaa
 aaa
+xPL
+kPh
+mqB
+pMf
+vYj
+rnc
+eBf
+yfJ
+kBF
+tPN
+oHF
+wlO
+xPL
+xPL
+lfU
+lfU
+lbX
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+jtA
 aaa
 aaa
 aaa
@@ -121805,25 +125541,25 @@ aaa
 aaa
 aaa
 aaa
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+oMx
+abx
+fvb
+xPL
+aJt
+aoV
+aJt
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aJt
+oZA
 aaa
 aaa
 aaa
@@ -122062,25 +125798,25 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+xPL
+cMK
+pCI
+xQw
+oIu
+hci
+qJJ
+cfN
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
+xPL
 aaa
 aaa
 aaa

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -295,21 +295,6 @@
 /obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"abx" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "aby" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -755,19 +740,6 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
-"aeC" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "aeI" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -857,18 +829,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "afK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = 22
 	},
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_access_txt = "10;13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "afL" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -2518,10 +2485,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
-"asG" = (
-/obj/machinery/light/small,
-/turf/open/floor/plasteel,
-/area/space)
 "asM" = (
 /obj/effect/turf_decal/pool/corner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -3216,23 +3179,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "axV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "ayd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -5240,14 +5188,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/security/processing)
-"aLy" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "aLz" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/dark,
@@ -5453,13 +5393,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
-"aMJ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/space/basic,
-/area/space)
 "aML" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
@@ -5619,15 +5552,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
-"aNW" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/shoes/winterboots,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "aNZ" = (
 /obj/machinery/camera{
 	c_tag = "Escape Podbay"
@@ -6172,12 +6096,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"aRB" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "aRJ" = (
 /obj/machinery/door/airlock/mining{
 	req_access_txt = "48"
@@ -6354,9 +6272,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"aSA" = (
-/turf/open/floor/plasteel/dark,
-/area/space)
 "aSG" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
@@ -6427,13 +6342,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port)
-"aTs" = (
-/obj/machinery/advanced_airlock_controller{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plating,
-/area/space)
 "aTw" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -6524,10 +6432,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
-"aTP" = (
-/obj/machinery/vending/wardrobe/sig_wardrobe,
-/turf/open/floor/plasteel,
-/area/space)
 "aTQ" = (
 /obj/machinery/light{
 	dir = 1
@@ -6689,17 +6593,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
-"aVE" = (
-/obj/machinery/power/smes/engineering{
-	charge = 5e+006;
-	input_level = 40000;
-	output_level = 30000
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/space)
 "aVX" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/dark,
@@ -7352,10 +7245,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"bcc" = (
-/obj/machinery/telecomms/processor/preset_one,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "bcd" = (
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -7421,12 +7310,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"bcz" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "bcA" = (
 /obj/machinery/light{
 	dir = 4
@@ -7780,9 +7663,14 @@
 /turf/open/floor/plasteel,
 /area/bridge/meeting_room)
 "bfr" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/telecomms/broadcaster/preset_left{
+	name = "subspace broadcaster A"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "bfv" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -8053,17 +7941,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"bhu" = (
-/obj/machinery/advanced_airlock_controller{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/space)
 "bhy" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 8
@@ -8517,10 +8394,6 @@
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"bkZ" = (
-/obj/machinery/telecomms/message_server/preset,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "blb" = (
 /obj/effect/landmark/stationroom/maint/tenxfive,
 /turf/template_noop,
@@ -8635,14 +8508,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"bmg" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Aft Port";
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space)
 "bmi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
@@ -8680,10 +8545,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bmX" = (
-/obj/machinery/pipedispenser,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "bnc" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/mechbay)
@@ -9493,20 +9354,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"btR" = (
-/obj/machinery/telecomms/processor/preset_two,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "btT" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
@@ -9738,17 +9585,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"bvC" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = 8;
-	pixel_y = -23
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "bvD" = (
 /obj/item/chair,
 /obj/effect/decal/cleanable/blood,
@@ -9888,15 +9724,6 @@
 "bwZ" = (
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"bxc" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/space)
 "bxd" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -10003,12 +9830,14 @@
 /turf/closed/wall/r_wall,
 /area/science/server)
 "byg" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/circuit/green/telecomms,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "byi" = (
 /turf/closed/wall,
 /area/security/checkpoint/science)
@@ -10813,15 +10642,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"bDr" = (
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "bDx" = (
 /obj/structure/table/wood,
 /obj/item/canvas/twentythreeXtwentythree{
@@ -10993,12 +10813,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"bFi" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	dir = 1
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
 "bFr" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -11074,15 +10888,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/quartermaster/miningdock)
-"bGo" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "bGq" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -11987,13 +11792,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"bOL" = (
-/obj/structure/table/wood,
-/obj/machinery/microwave{
-	pixel_y = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "bOQ" = (
 /obj/structure/table,
 /obj/item/t_scanner,
@@ -12178,17 +11976,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"bPG" = (
-/obj/machinery/announcement_system,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "bPH" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "atmos";
@@ -12201,14 +11988,6 @@
 "bPN" = (
 /turf/closed/wall,
 /area/science/misc_lab)
-"bPO" = (
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = 22
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "bPT" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -12442,11 +12221,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/foyer)
-"bRF" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/atmospherics/components/unary/portables_connector,
-/turf/open/floor/plasteel/white,
-/area/space)
 "bRG" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -12670,15 +12444,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
-"bUO" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/space)
 "bUV" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/machinery/light,
@@ -13058,9 +12823,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/prison)
-"car" = (
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "caI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -13098,9 +12860,6 @@
 /obj/item/beacon,
 /turf/open/floor/engine,
 /area/science/misc_lab)
-"cbd" = (
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
 "cbe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -13407,18 +13166,19 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cfh" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "cfm" = (
 /obj/item/c_tube,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"cfn" = (
-/obj/machinery/telecomms/server/presets/command,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "cfo" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -13473,16 +13233,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"cfN" = (
-/obj/item/radio/intercom{
-	dir = 8;
-	freerange = 1;
-	name = "Station Intercom (Command)";
-	pixel_x = -28
-	},
-/obj/structure/filingcabinet,
-/turf/open/floor/wood,
-/area/space)
 "cfY" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating{
@@ -13549,15 +13299,6 @@
 /obj/item/stack/rods/fifty,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"chg" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/plaques/kiddie{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "chq" = (
 /obj/machinery/processor/slime,
 /obj/item/radio/intercom{
@@ -13966,15 +13707,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"clN" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "cmb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -14171,15 +13903,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"cnX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "cob" = (
 /obj/machinery/camera{
 	c_tag = "Research Division South";
@@ -14306,15 +14029,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
-"cpN" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Fore Starboard";
-	dir = 1;
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space)
 "cpO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -14396,15 +14110,11 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "cqT" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
 	},
-/obj/machinery/camera/motion{
-	c_tag = "Telecomms Foyer";
-	network = list("ss13","minisat")
-	},
-/turf/open/floor/plasteel,
-/area/space)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "cqW" = (
 /obj/effect/decal/cleanable/xenoblood,
 /turf/open/floor/engine,
@@ -14517,15 +14227,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"crS" = (
-/obj/structure/transit_tube/station{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "csl" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/dark,
@@ -14636,13 +14337,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ctL" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/space)
 "ctR" = (
 /turf/open/floor/engine/n2,
 /area/engine/atmos/distro)
@@ -14735,10 +14429,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"cuZ" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
 "cva" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
@@ -14815,25 +14505,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"cwu" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "cwH" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -14889,15 +14560,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"cxF" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "cxI" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/hydroponicsplants{
@@ -15020,17 +14682,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"cAw" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Telecomms Tech Storage";
-	req_access_txt = "61"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "cAA" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/AI,
@@ -15300,11 +14951,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/lawoffice)
-"cDJ" = (
-/obj/machinery/bluespace_beacon,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "cDK" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -15610,9 +15256,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"cJo" = (
-/turf/open/floor/plasteel/white,
-/area/space)
 "cJu" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 30
@@ -15853,13 +15496,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
-"cMK" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/space)
 "cMO" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -16021,8 +15657,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
 "cOE" = (
-/turf/closed/wall/r_wall,
-/area/tcommsat/entrance)
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "cOJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -16403,15 +16040,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"cUN" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "cUP" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L7"
@@ -16456,20 +16084,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"cVE" = (
-/obj/structure/table,
-/obj/item/folder/blue,
-/obj/item/pen,
-/obj/item/multitool,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "cVS" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -16825,16 +16439,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ddu" = (
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "ddA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -16920,15 +16524,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"dfA" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "dfD" = (
 /obj/structure/sink{
 	dir = 4;
@@ -17083,13 +16678,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
-"diU" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/space)
 "dja" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -17124,15 +16712,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"djF" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/space)
 "dkq" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -17320,23 +16899,12 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
 "dnj" = (
+/obj/machinery/telecomms/processor/preset_four,
 /obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc/tcomms{
-	areastring = "/area/tcommsat/server";
-	dir = 4;
-	name = "Telecomms Server APC";
-	pixel_x = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
+	icon_state = "4-8"
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
+/area/tcommsat/server)
 "dno" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -17359,27 +16927,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
-"dnq" = (
-/obj/machinery/door/airlock/public{
-	autoclose = 0;
-	frequency = 1449;
-	glass = 1;
-	id_tag = "telecomms_airlock_interior";
-	name = "Telecomms Server Room Access";
-	req_access_txt = "61"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/space)
 "doM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -17498,12 +17045,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"dqm" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/white,
-/area/space)
 "dqM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -17539,20 +17080,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"drk" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	external_pressure_bound = 120;
-	name = "server vent"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/space)
 "drF" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -17601,12 +17128,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"dsI" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	piping_layer = 2
-	},
-/turf/open/floor/plating,
-/area/space)
 "dsQ" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable{
@@ -17721,11 +17242,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
-"dvh" = (
-/obj/effect/turf_decal/bot_white,
-/obj/machinery/teleport/station,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "dvj" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
@@ -17738,23 +17254,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"dvx" = (
-/obj/machinery/airalarm/tcomms{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "dvB" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -17879,16 +17378,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"dxx" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/space)
 "dxE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -18145,26 +17634,10 @@
 /obj/machinery/meter,
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/secondarydatacore)
-"dBM" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 1
-	},
-/obj/machinery/telecomms/hub/preset,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "dBV" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
-"dCa" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
 "dCj" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L4"
@@ -18372,22 +17845,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"dFP" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "dGd" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -18492,20 +17949,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"dHS" = (
-/obj/machinery/telecomms/receiver/preset_left,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "dId" = (
 /obj/machinery/light,
 /obj/structure/tank_dispenser,
@@ -18662,12 +18105,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"dLB" = (
-/obj/structure/transit_tube/curved/flipped{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space)
 "dLK" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/white,
@@ -18796,10 +18233,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
-"dOp" = (
-/obj/machinery/telecomms/processor/preset_three,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "dOt" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /obj/machinery/light,
@@ -18897,20 +18330,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"dQd" = (
-/obj/machinery/power/smes/engineering{
-	charge = 5e+006;
-	input_level = 25000;
-	output_level = 20000
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "0-2"
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
 "dQj" = (
 /obj/item/reagent_containers/glass/bucket,
 /obj/effect/decal/cleanable/dirt,
@@ -19184,11 +18603,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dVn" = (
-/obj/structure/grille,
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/space)
 "dVy" = (
 /obj/machinery/light_switch{
 	pixel_x = 27
@@ -19361,15 +18775,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
-"dYN" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "dZg" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/sleeper";
@@ -19389,10 +18794,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"dZh" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/space)
 "dZi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -19502,13 +18903,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"ecb" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "ecl" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
@@ -19728,14 +19122,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"egy" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Aft";
-	network = list("minisat","ss13")
-	},
-/turf/open/space/basic,
-/area/space)
 "egY" = (
 /obj/structure/closet/secure_closet/security,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -19927,12 +19313,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
-"ekV" = (
-/obj/machinery/computer/ai_overclocking{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "ekZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -19985,13 +19365,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"elv" = (
-/obj/machinery/blackbox_recorder,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "elK" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -20190,20 +19563,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"epV" = (
-/obj/machinery/holopad,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "eqA" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/power/apc{
@@ -20345,13 +19704,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/security/prison)
-"esq" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "esu" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -20485,16 +19837,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/interrogation)
-"eui" = (
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/structure/rack,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "eum" = (
 /obj/effect/landmark/start/assistant,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -20953,19 +20295,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"eBf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "eBC" = (
 /obj/machinery/requests_console{
 	department = "Hydroponics";
@@ -21434,19 +20763,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"eJD" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "eJE" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/cmo";
@@ -21692,54 +21008,6 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/medical/psych)
-"eNA" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp{
-	pixel_x = -4;
-	pixel_y = 7
-	},
-/obj/item/toy/figure/borg{
-	pixel_x = -4;
-	pixel_y = -2
-	},
-/obj/item/phone{
-	pixel_x = 7;
-	pixel_y = 1
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_y = -28
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
-"eNX" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
-"eOa" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/public{
-	autoclose = 0;
-	frequency = 1449;
-	glass = 1;
-	id_tag = "telecomms_airlock_interior";
-	name = "Telecomms Server Room Access";
-	req_access_txt = "61"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "eOj" = (
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/dark,
@@ -21804,13 +21072,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"ePD" = (
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "ePH" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/start/detective,
@@ -21929,10 +21190,6 @@
 /obj/effect/turf_decal/bot_red,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"eRI" = (
-/obj/machinery/porta_turret/ai,
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
 "eRZ" = (
 /obj/machinery/light{
 	dir = 1;
@@ -22474,18 +21731,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
-"fbL" = (
-/obj/structure/table,
-/obj/item/assembly/flash/handheld{
-	pixel_x = -8;
-	pixel_y = 2
-	},
-/obj/item/aicard{
-	pixel_x = 6;
-	pixel_y = 1
-	},
-/turf/open/floor/plating,
-/area/space)
 "fca" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -22630,14 +21875,6 @@
 "ffb" = (
 /turf/closed/wall,
 /area/maintenance/solars/port/aft)
-"ffl" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "ffo" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
@@ -22710,17 +21947,6 @@
 /obj/effect/turf_decal/arrows/white,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
-"fhe" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/multitool,
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/space)
 "fhF" = (
 /obj/structure/closet/crate,
 /obj/item/stack/license_plates/empty/fifty,
@@ -22905,10 +22131,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"fkC" = (
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "fkH" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/structure/cable{
@@ -22967,20 +22189,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"flJ" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "flL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -23063,16 +22271,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"fnl" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	dir = 1;
-	name = "AI Antechamber APC";
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
 "fnr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23236,26 +22434,6 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"fpD" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	dir = 4;
-	name = "MiniSat Antechamber APC";
-	pixel_x = 24
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/rack,
-/obj/item/clothing/shoes/winterboots,
-/obj/item/clothing/shoes/winterboots,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/space)
 "fpR" = (
 /obj/machinery/computer/shuttle/labor,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -23263,24 +22441,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"fqr" = (
-/obj/structure/table,
-/obj/machinery/camera{
-	c_tag = "Telecomms Tech Storage";
-	network = list("ss13","minisat")
-	},
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/capacitor,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "fqv" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -23458,15 +22618,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"ftO" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	dir = 8
-	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
 "ftR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -23502,16 +22653,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"fvb" = (
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "fvc" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -23560,25 +22701,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"fvy" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "fvz" = (
 /obj/machinery/light_switch{
 	pixel_x = 15;
@@ -23666,15 +22788,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"fvW" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = -32
-	},
-/obj/machinery/vending/wardrobe/sig_wardrobe,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "fwa" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/structure/cable{
@@ -24029,16 +23142,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/lawoffice)
-"fCL" = (
-/obj/machinery/telecomms/server/presets/service,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
-"fCV" = (
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "fDx" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -24272,13 +23375,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"fHw" = (
-/obj/machinery/computer/telecomms/traffic{
-	dir = 8;
-	network = "tcommsat"
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "fHC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -24370,22 +23466,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
-"fJa" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/bottle/vodka{
-	pixel_x = 8;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass{
-	pixel_x = 8;
-	pixel_y = 1
-	},
-/obj/effect/spawner/lootdrop/donkpockets{
-	pixel_x = -6;
-	pixel_y = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "fJb" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
@@ -24529,13 +23609,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"fKE" = (
-/obj/machinery/ntnet_relay,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "fKM" = (
 /obj/machinery/door/airlock/command/glass{
 	id_tag = "secondary_aicore_interior";
@@ -24679,8 +23752,8 @@
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "fMm" = (
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "fMp" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall,
@@ -24713,16 +23786,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"fME" = (
-/obj/structure/chair/office/dark,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "fMR" = (
 /obj/machinery/power/smes,
 /obj/structure/cable/yellow{
@@ -24856,28 +23919,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"fPW" = (
-/obj/machinery/door/airlock/hatch{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "telecomms_airlock_exterior";
-	name = "Telecomms Server Room Access";
-	req_access_txt = "61"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "fQt" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -25147,29 +24188,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"fWV" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
-	dir = 1
-	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/space)
-"fXb" = (
-/obj/machinery/telecomms/server/presets/service,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "fXm" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -25623,13 +24641,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/medical/virology)
-"gfw" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/space)
 "gfL" = (
 /obj/machinery/door/airlock{
 	name = "Custodial Closet";
@@ -25881,12 +24892,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"gky" = (
-/obj/machinery/computer/teleporter{
-	dir = 1
-	},
-/turf/open/floor/circuit,
-/area/space)
 "gkA" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -25894,19 +24899,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"gkZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower,
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "gmo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -25989,15 +24981,6 @@
 /obj/machinery/atmospherics/miner/toxins,
 /turf/open/floor/engine/plasma,
 /area/engine/atmos/distro)
-"goP" = (
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/gloves/color/black,
-/turf/open/floor/plating,
-/area/space)
 "goW" = (
 /obj/machinery/light{
 	dir = 4
@@ -26027,13 +25010,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"gpL" = (
-/obj/machinery/computer/telecomms/server{
-	dir = 8;
-	network = "tcommsat"
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "gqn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -26186,19 +25162,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"gsD" = (
-/obj/item/radio/intercom{
-	dir = 1;
-	freerange = 1;
-	name = "Station Intercom (Telecomms)";
-	pixel_y = -26
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "gsK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -26519,17 +25482,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
-"gzc" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Telecomms Control Room";
-	req_access_txt = "70"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
-/area/space)
 "gzl" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
@@ -26551,16 +25503,6 @@
 /obj/item/pool/rubber_ring,
 /turf/open/indestructible/sound/pool,
 /area/crew_quarters/fitness)
-"gzL" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space)
 "gzP" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -26580,19 +25522,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"gzZ" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Telecomms Admin";
-	departmentType = 5;
-	name = "Telecomms RC";
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "gAh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26689,10 +25618,6 @@
 /obj/item/latexballon,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"gCs" = (
-/obj/effect/turf_decal/ramp_middle,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "gCF" = (
 /obj/machinery/camera{
 	c_tag = "Prison Yard";
@@ -26739,21 +25664,6 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
-"gEa" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/tcommsat/storage";
-	dir = 1;
-	name = "Telecommunications Storage APC";
-	pixel_y = 23
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "gEq" = (
 /obj/machinery/light{
 	dir = 1
@@ -26823,15 +25733,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"gFu" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 9
-	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/space)
 "gFF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -26932,10 +25833,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"gHc" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/space)
 "gHl" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -27053,25 +25950,6 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/wood,
 /area/vacant_room)
-"gIY" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Antechamber";
-	req_access_txt = "65"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "gJh" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
@@ -27149,10 +26027,6 @@
 "gLo" = (
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
-"gLt" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "gLN" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
@@ -27247,13 +26121,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "gOE" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "gOU" = (
 /obj/effect/landmark/event_spawn,
@@ -27452,15 +26323,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"gRS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "gRT" = (
 /obj/structure/table/wood,
 /obj/item/storage/briefcase{
@@ -27536,16 +26398,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"gSl" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/computer/monitor{
-	dir = 1;
-	name = "MiniSat power monitoring console"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "gSn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -27571,15 +26423,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"gSI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "gSO" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -27672,13 +26515,6 @@
 	},
 /turf/open/water/safe,
 /area/hydroponics/garden)
-"gTO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/holopad,
-/turf/open/floor/plasteel,
-/area/space)
 "gTU" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -27758,12 +26594,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
-"gVu" = (
-/obj/structure/transit_tube/curved{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space)
 "gVA" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -27867,18 +26697,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"gXZ" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "gYb" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -27901,20 +26719,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
-"gYf" = (
-/obj/item/toy/talking/AI{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/structure/table,
-/obj/item/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/crowbar,
-/obj/item/mmi,
-/turf/open/floor/plating,
-/area/space)
 "gYj" = (
 /obj/machinery/light_switch{
 	pixel_x = -23;
@@ -28181,21 +26985,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"hci" = (
-/obj/structure/table/wood,
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Captain's Desk";
-	departmentType = 5;
-	name = "Captain RC";
-	pixel_x = -30
-	},
-/obj/machinery/photocopier/faxmachine{
-	department = "Captain";
-	name = "Captain's Fax Machine"
-	},
-/turf/open/floor/wood,
-/area/space)
 "hcE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -28348,20 +27137,6 @@
 "hfy" = (
 /turf/template_noop,
 /area/maintenance/port)
-"hfD" = (
-/obj/machinery/telecomms/server/presets/science,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "hfJ" = (
 /obj/structure/closet/boxinggloves,
 /obj/machinery/light{
@@ -28572,19 +27347,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hjk" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/space)
-"hjt" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/space/basic,
-/area/space)
 "hjA" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -28793,11 +27555,13 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "hmx" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
 	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/space)
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide2{
+	dir = 1
+	},
+/area/ai_monitored/turret_protected/ai)
 "hmO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -28852,27 +27616,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"hoF" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/space/basic,
-/area/space)
-"hoK" = (
-/obj/machinery/blackbox_recorder,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "hoR" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -29210,22 +27953,6 @@
 /obj/effect/spawner/lootdrop/costume,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"hvo" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/showcase/cyborg/old{
-	dir = 4;
-	pixel_x = -9;
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "hvG" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
@@ -29373,20 +28100,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"hyr" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "hyG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
@@ -29483,23 +28196,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"hAC" = (
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = 24;
-	pixel_y = -10
-	},
-/obj/machinery/camera/motion{
-	c_tag = "MiniSat Foyer";
-	dir = 8;
-	network = list("minisat","ss13")
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "hAJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -29662,18 +28358,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"hCt" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Port Aft";
-	dir = 8;
-	network = list("minisat","ss13")
-	},
-/turf/open/space/basic,
-/area/space)
 "hCy" = (
 /turf/open/floor/plating/broken,
 /area/maintenance/port/fore)
@@ -29843,19 +28527,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/fore)
-"hFn" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "hFo" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/cardboard,
@@ -30129,13 +28800,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"hMW" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "hNs" = (
 /obj/effect/landmark/stationroom/maint/fivexthree,
 /turf/template_noop,
@@ -30225,13 +28889,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"hOS" = (
-/obj/effect/turf_decal/bot_white,
-/obj/machinery/computer/teleporter{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "hOU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -30394,25 +29051,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hRI" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "MiniSat Maintenance";
-	req_access_txt = "65"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "hRR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -30460,24 +29098,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/warden)
-"hTd" = (
-/obj/machinery/camera{
-	c_tag = "MiniSat - Monitoring room";
-	dir = 8;
-	network = list("minisat","ss13")
-	},
-/obj/machinery/newscaster/security_unit{
-	pixel_x = 28
-	},
-/obj/machinery/computer/ai_resource_distribution{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
-"hTj" = (
-/obj/machinery/pipedispenser,
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "hTo" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -30590,19 +29210,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"hUA" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower,
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "hUM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30802,33 +29409,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
-"hXs" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+"hXu" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
-"hXu" = (
-/obj/machinery/teleport/hub,
-/turf/open/floor/circuit,
-/area/space)
-"hYy" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/structure/table,
-/obj/item/stock_parts/subspace/crystal,
-/obj/item/stock_parts/subspace/crystal,
-/obj/item/stock_parts/subspace/crystal,
-/obj/item/stock_parts/subspace/ansible,
-/obj/item/stock_parts/subspace/ansible,
-/obj/item/stock_parts/subspace/ansible,
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/tcommsat/server)
 "hYM" = (
 /obj/machinery/bounty_board{
 	pixel_y = 32
@@ -31044,14 +29633,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"ibK" = (
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_access_txt = "10;13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/space)
 "ibL" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -31068,9 +29649,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"ibO" = (
-/turf/open/floor/plating,
-/area/space)
 "ibZ" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -31550,21 +30128,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
-"ilq" = (
-/obj/machinery/telecomms/bus/preset_three,
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "ilr" = (
 /obj/machinery/door/airlock/security{
 	name = "Detective's Office";
@@ -31602,15 +30165,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/service)
-"ilL" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "ilQ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -31641,12 +30195,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
-"imN" = (
-/obj/machinery/light_switch{
-	pixel_x = -20
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "imT" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -31710,12 +30258,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"inD" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "inN" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -31925,20 +30467,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"iqH" = (
-/obj/machinery/telecomms/processor/preset_four,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "iqU" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
@@ -31985,20 +30513,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"irs" = (
-/obj/structure/table,
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/item/book/manual/wiki/tcomms,
-/obj/item/paper_bin,
-/obj/item/radio{
-	pixel_x = -10
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "irC" = (
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
@@ -32119,12 +30633,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"isU" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	dir = 8
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
 "itm" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/structure/window/reinforced{
@@ -32273,10 +30781,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
-"iyq" = (
-/obj/machinery/ai/server_cabinet/prefilled,
-/turf/open/floor/circuit/green/telecomms,
-/area/space)
 "iyt" = (
 /obj/structure/table/glass,
 /obj/machinery/door/window/northright{
@@ -32377,20 +30881,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"iAl" = (
-/obj/machinery/telecomms/server/presets/command,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "iAx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -32504,15 +30994,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"iCz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "iCG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -32566,20 +31047,6 @@
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
-"iDK" = (
-/obj/machinery/telecomms/processor/preset_three,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "iDQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -32766,20 +31233,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
-"iHu" = (
-/obj/machinery/telecomms/processor/preset_one,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "iHI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -32826,12 +31279,14 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "iIj" = (
-/turf/open/floor/plasteel,
-/area/space)
-"iII" = (
-/obj/structure/lattice/catwalk,
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "iJa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -32854,15 +31309,6 @@
 /obj/effect/spawner/lootdrop/minor/kittyears_or_rabbitears,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"iJq" = (
-/obj/machinery/advanced_airlock_controller{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/space)
 "iJt" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -32972,18 +31418,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"iLr" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "iLA" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/sign/warning/nosmoking{
@@ -33214,12 +31648,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"iOR" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	piping_layer = 1
-	},
-/turf/open/floor/plating,
-/area/space)
 "iOS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -33415,17 +31843,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"iSD" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 26
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "iSH" = (
 /obj/structure/lattice,
 /turf/closed/wall,
@@ -33627,15 +32044,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"iWd" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/space)
 "iWw" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/mixing";
@@ -33727,12 +32135,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
-"iXR" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/space)
 "iYc" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -33748,23 +32150,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos/foyer)
-"iYH" = (
-/obj/machinery/light_switch{
-	pixel_y = -27
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/rack,
-/obj/item/multitool,
-/obj/item/radio/off{
-	pixel_y = 4
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/toy/talking/AI,
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "iZf" = (
 /obj/structure/bed,
 /obj/structure/cloth_curtain{
@@ -33875,22 +32260,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"jaF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "jaI" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 1";
@@ -33923,10 +32292,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jbG" = (
-/obj/machinery/telecomms/server/presets/supply,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "jbI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/reinforced,
@@ -33945,17 +32310,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"jbQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/circuit,
-/area/space)
 "jbY" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
@@ -33988,17 +32342,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"jcv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "jcz" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
@@ -34015,11 +32358,6 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
-"jcO" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "jda" = (
 /obj/machinery/shower{
 	dir = 4
@@ -34371,21 +32709,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"jkE" = (
-/obj/structure/table,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/treatment,
-/obj/item/stock_parts/subspace/treatment,
-/obj/item/stock_parts/subspace/treatment,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "jkJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -34551,9 +32874,14 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "jnr" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/space)
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "jnA" = (
 /obj/structure/grille,
 /turf/open/space/basic,
@@ -34908,15 +33236,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"jsq" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "jst" = (
 /obj/structure/sink{
 	dir = 4;
@@ -34950,16 +33269,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"jtA" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/space)
 "jtJ" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -35002,13 +33311,6 @@
 	},
 /turf/closed/wall,
 /area/engine/atmos/distro)
-"juw" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
-/obj/machinery/rack_creator,
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "juN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -35047,13 +33349,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"jwq" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
 "jwH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -35245,10 +33540,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"jBK" = (
-/obj/machinery/telecomms/server/presets/medical,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "jCo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -35274,10 +33565,6 @@
 /obj/effect/turf_decal/box/corners,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"jCM" = (
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/space)
 "jDa" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -35293,13 +33580,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"jDi" = (
-/obj/structure/table,
-/obj/item/stock_parts/subspace/analyzer,
-/obj/item/stock_parts/subspace/analyzer,
-/obj/item/stock_parts/subspace/analyzer,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "jDj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -35406,16 +33686,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"jEF" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "MiniSat External Access";
-	req_access_txt = "65"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/space)
 "jEV" = (
 /obj/structure/closet/secure_closet/paramedic,
 /obj/effect/turf_decal/delivery,
@@ -35570,13 +33840,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"jHs" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/telecomms/processor/preset_four,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "jHx" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -35589,20 +33852,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"jHM" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "jId" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -35644,26 +33893,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/library)
-"jIA" = (
-/obj/machinery/door/airlock/hatch{
-	autoclose = 0;
-	frequency = 1449;
-	id_tag = "telecomms_airlock_exterior";
-	name = "Telecomms Server Room Access";
-	req_access_txt = "61"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "jIJ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -35711,17 +33940,9 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "jJK" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external{
-	name = "MiniSat External Access";
-	req_access_txt = "65"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "jJP" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/holopad,
@@ -35746,31 +33967,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
-"jKm" = (
-/obj/machinery/telecomms/bus/preset_three,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
-"jKC" = (
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = 25;
-	pixel_y = 6
-	},
-/obj/machinery/doorButtons/access_button{
-	idDoor = "ai_core_airlock_interior";
-	idSelf = "ai_core_airlock_control";
-	pixel_x = 23;
-	pixel_y = -7
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "jKG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
@@ -35816,13 +34012,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
-"jMq" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "jMv" = (
 /turf/closed/wall,
 /area/crew_quarters/theatre)
@@ -36032,16 +34221,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"jRb" = (
-/obj/effect/turf_decal/bot_white,
-/obj/item/storage/toolbox/mechanical,
-/obj/machinery/camera{
-	c_tag = "Telecomms Teleporter Room";
-	dir = 4;
-	network = list("ss13","minisat")
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "jRq" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 6
@@ -36061,12 +34240,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"jRO" = (
-/obj/machinery/telecomms/receiver/preset_right{
-	name = "subspace receiver B"
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "jSi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -36148,18 +34321,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"jTN" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "jTP" = (
 /obj/machinery/light/small,
 /obj/machinery/button/door{
@@ -36237,23 +34398,6 @@
 "jVe" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"jVz" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/machinery/button/door{
-	id = "tcomms_bridge";
-	name = "Telecommunications server shutters control";
-	pixel_x = 25;
-	pixel_y = 25;
-	req_one_access_txt = "19;61"
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower,
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "jVL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -36319,18 +34463,6 @@
 /obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/circuit,
 /area/tcommsat/computer)
-"jWs" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "jWx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -36524,13 +34656,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"kag" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "kaA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/table,
@@ -36570,20 +34695,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/security/prison)
-"kcr" = (
-/obj/machinery/telecomms/server/presets/common,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "kcy" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
@@ -36667,15 +34778,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
-"kdN" = (
-/obj/machinery/telecomms/broadcaster/preset_left{
-	name = "subspace broadcaster A"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "kdZ" = (
 /obj/machinery/vending/fishing,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -36690,12 +34792,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"kep" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 10
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
 "ket" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -36931,17 +35027,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "kit" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	pixel_y = 26
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
+/obj/machinery/telecomms/message_server/preset,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "kiy" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
@@ -37050,36 +35138,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"kjX" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/space)
-"kks" = (
-/obj/machinery/status_display/ai{
-	pixel_x = -32
-	},
-/obj/structure/table/wood,
-/obj/item/book/manual/wiki/tcomms{
-	pixel_x = -4;
-	pixel_y = 5
-	},
-/obj/item/paper_bin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/folder/blue,
-/obj/item/pen,
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "kkv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -37095,22 +35153,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"klm" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "MiniSat Maintenance";
-	dir = 8;
-	name = "ai camera";
-	network = list("minisat","ss13");
-	start_active = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/space)
 "klD" = (
 /obj/structure/sign/departments/minsky/medical/chemistry/chemical2,
 /turf/closed/wall,
@@ -37311,20 +35353,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"kqr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "kqw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -37413,15 +35441,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "krI" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/space)
+/area/ai_monitored/turret_protected/aisat_interior)
 "krO" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer_R";
@@ -37493,15 +35515,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"ktI" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "kua" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light,
@@ -37514,16 +35527,6 @@
 "kub" = (
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"kug" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/space/basic,
-/area/space)
 "kuB" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Prison Forestry"
@@ -37542,13 +35545,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"kuT" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
-/turf/closed/wall/r_wall,
-/area/space)
 "kuY" = (
 /obj/machinery/holopad,
 /obj/item/kirbyplants/random,
@@ -37583,15 +35579,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
-"kvY" = (
-/obj/machinery/camera{
-	c_tag = "Telecomms Control Room";
-	dir = 4;
-	network = list("ss13","tcomms")
-	},
-/obj/machinery/announcement_system,
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "kwm" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -37867,14 +35854,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"kBF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "tcomms";
-	name = "Telecommunications server shutters"
-	},
-/turf/open/floor/plating,
-/area/space)
 "kBL" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -38077,12 +36056,6 @@
 /obj/structure/lattice/catwalk,
 /turf/closed/wall/r_wall,
 /area/engine/atmos/distro)
-"kGg" = (
-/obj/machinery/telecomms/broadcaster/preset_left{
-	name = "subspace broadcaster A"
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "kGn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -38247,33 +36220,6 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/secondarydatacore)
-"kJV" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
-"kKg" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "kKq" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -38284,20 +36230,6 @@
 /obj/item/toy/figure/curator,
 /turf/open/floor/engine/cult,
 /area/library)
-"kKy" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "kKK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -38628,15 +36560,6 @@
 /obj/machinery/light,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
-"kPh" = (
-/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "kPn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -38782,10 +36705,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"kST" = (
-/obj/structure/chair/office/dark,
-/turf/open/floor/plasteel,
-/area/space)
 "kTm" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/structure/window/reinforced{
@@ -38805,18 +36724,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"kTy" = (
-/obj/machinery/computer/message_monitor{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/machinery/camera{
-	c_tag = "Telecomms Maintenance";
-	dir = 1;
-	network = list("ss13","tcomms")
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "kTM" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -39034,15 +36941,6 @@
 "kZF" = (
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
-"laa" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/door/airlock/external{
-	name = "MiniSat External Access";
-	req_access_txt = "65"
-	},
-/turf/open/floor/plating,
-/area/space)
 "lao" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/dirt,
@@ -39170,9 +37068,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"lbX" = (
-/turf/closed/wall,
-/area/space)
 "lcb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -39204,18 +37099,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
-"ldD" = (
-/obj/machinery/computer/security/telescreen{
-	dir = 8;
-	name = "MiniSat Camera Monitor";
-	network = list("minisat","aicore");
-	pixel_x = 26
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "ldU" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hop";
@@ -39245,29 +37128,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"lec" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/space)
-"lem" = (
-/obj/structure/table,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/filter,
-/obj/item/stock_parts/subspace/treatment,
-/obj/item/stock_parts/subspace/treatment,
-/obj/item/stock_parts/subspace/treatment,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "leo" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -39293,15 +37153,6 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
-"leM" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 35
-	},
-/turf/open/floor/plating,
-/area/space)
 "leO" = (
 /obj/machinery/modular_computer/console/preset/command,
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
@@ -39402,19 +37253,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"lfM" = (
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
-"lfU" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/space)
 "lfW" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -39486,9 +37324,7 @@
 /turf/open/floor/wood,
 /area/library)
 "lhk" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
 "lhG" = (
@@ -39853,10 +37689,6 @@
 /obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/carpet,
 /area/library)
-"lma" = (
-/obj/machinery/teleport/station,
-/turf/open/floor/circuit,
-/area/space)
 "lmd" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
@@ -40101,9 +37933,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"lqZ" = (
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
 "lrb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -40382,13 +38211,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"lxm" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 1
-	},
-/obj/machinery/telecomms/message_server/preset,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "lxz" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/decal/cleanable/dirt,
@@ -40459,8 +38281,15 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "lyX" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
+	dir = 1;
+	name = "AI Antechamber APC";
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/ai_monitored/storage/satellite)
 "lza" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -40649,16 +38478,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"lDN" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower,
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "lDR" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Power Storage";
@@ -40691,10 +38510,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"lEd" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
 "lEr" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -40739,25 +38554,6 @@
 "lFj" = (
 /turf/template_noop,
 /area/maintenance/port/fore)
-"lFm" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "lFG" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -40794,15 +38590,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"lGC" = (
-/obj/machinery/airalarm/tcomms{
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
 "lGF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -40832,18 +38619,6 @@
 /obj/item/mop,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
-"lHO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "lIb" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -41111,18 +38886,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"lMT" = (
-/obj/machinery/cell_charger,
-/obj/structure/table,
-/obj/item/stock_parts/cell/high{
-	pixel_x = 3;
-	pixel_y = 7
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/space)
 "lMW" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -41143,20 +38906,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"lNm" = (
-/obj/machinery/telecomms/server/presets/medical,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "lNn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -41256,19 +39005,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"lQb" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Port Fore";
-	dir = 8;
-	network = list("minisat")
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/space/basic,
-/area/space)
 "lQl" = (
 /obj/structure/table/reinforced,
 /obj/item/hfr_box/body/fuel_input,
@@ -41522,19 +39258,6 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
-"lWm" = (
-/obj/structure/table/wood,
-/obj/item/radio/off{
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/obj/item/folder{
-	pixel_x = 6;
-	pixel_y = 2
-	},
-/obj/item/disk/holodisk/tutorial/AICore,
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "lWz" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -41554,14 +39277,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"lXd" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "lXo" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
@@ -41794,18 +39509,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"maY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_access_txt = "10;13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/space)
 "mbf" = (
 /obj/machinery/vending/wallmed{
 	pixel_y = 29
@@ -41963,16 +39666,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"mdZ" = (
-/obj/structure/window/reinforced,
-/obj/structure/transit_tube/curved{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "mel" = (
 /obj/structure/table,
 /obj/machinery/photocopier/faxmachine{
@@ -42350,12 +40043,6 @@
 /obj/structure/lattice,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"mkL" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "mkP" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Mix Tank";
@@ -42421,13 +40108,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"mlS" = (
-/obj/machinery/recharge_station,
-/obj/structure/sign/departments/minsky/command/charge{
-	pixel_x = -32
-	},
-/turf/open/floor/plating,
-/area/space)
 "mmb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -42493,14 +40173,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"mnJ" = (
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = 9;
-	pixel_y = -10
-	},
-/turf/closed/wall/r_wall,
-/area/space)
 "mnR" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -42536,15 +40208,6 @@
 /obj/effect/turf_decal/tile/brown/opposingcorners,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"mot" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/smes{
-	charge = 5e+006
-	},
-/turf/open/floor/plating,
-/area/space)
 "moy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -42717,44 +40380,10 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
-"mqB" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "mqI" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
-"mqO" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/hatch{
-	name = "Hardware Workshop";
-	req_access_txt = "61"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "mqR" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable{
@@ -42770,16 +40399,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"mqZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plating,
-/area/space)
 "mrk" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
@@ -42823,12 +40442,6 @@
 /obj/structure/transit_tube_pod,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"mrS" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "msb" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/meter,
@@ -42958,13 +40571,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"muL" = (
-/obj/item/kirbyplants/photosynthetic,
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "muY" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 6
@@ -43056,17 +40662,6 @@
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
-"mxG" = (
-/obj/structure/window/reinforced,
-/obj/structure/transit_tube/curved{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "mxL" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -43180,20 +40775,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"mAn" = (
-/obj/machinery/telecomms/receiver/preset_right,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "mAs" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
@@ -43492,7 +41073,6 @@
 	anchored = 1;
 	state = 2
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/circuit/green/telecomms,
 /area/ai_monitored/turret_protected/aisat_interior)
 "mEa" = (
@@ -43591,10 +41171,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"mFE" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space)
 "mFO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -43759,12 +41335,6 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
-"mIH" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/space)
 "mIS" = (
 /obj/effect/landmark/start/yogs/brigphsyician,
 /turf/open/floor/plasteel/white,
@@ -43808,16 +41378,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"mJE" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "mJV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -43834,15 +41394,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"mKm" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Fore";
-	dir = 1;
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space)
 "mKD" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -43869,15 +41420,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"mLm" = (
-/obj/structure/table,
-/obj/item/stock_parts/subspace/amplifier,
-/obj/item/stock_parts/subspace/amplifier,
-/obj/item/stock_parts/subspace/transmitter,
-/obj/item/stock_parts/subspace/transmitter,
-/obj/item/stock_parts/subspace/transmitter,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "mLw" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -44274,18 +41816,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"mSd" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/doorButtons/airlock_controller{
-	idExterior = "telecomms_airlock_exterior";
-	idInterior = "telecomms_airlock_interior";
-	idSelf = "telecomms_airlock_control";
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "mSg" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/circuit/telecomms/server,
@@ -44405,13 +41935,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
-"mUg" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/space/basic,
-/area/space)
 "mUk" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -44458,17 +41981,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mVn" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/transit_tube/curved/flipped,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "mVw" = (
 /obj/machinery/light{
 	dir = 8
@@ -44533,18 +42045,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"mWE" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/remains/robot,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/teleport_anchor,
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/space)
 "mWH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -44574,14 +42074,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"mXq" = (
-/obj/item/storage/toolbox/mechanical,
-/obj/structure/rack,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "mXr" = (
 /obj/structure/grille,
 /obj/structure/window{
@@ -44701,59 +42193,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
-"mZM" = (
-/obj/machinery/door/airlock/hatch{
-	name = "Telecomms Tech Storage";
-	req_access_txt = "61"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "mZO" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxin_input{
 	dir = 8
 	},
 /turf/open/floor/engine/plasma,
 /area/engine/atmos/distro)
-"naj" = (
-/obj/structure/table,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser/high,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/manipulator,
-/obj/item/stock_parts/capacitor,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel/dark,
-/area/space)
-"naq" = (
-/obj/machinery/atmospherics/components/unary/portables_connector,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/plating,
-/area/space)
 "naz" = (
 /obj/effect/spawner/structure/solars/solar_96,
 /obj/structure/cable/yellow{
@@ -44804,12 +42249,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"nbc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "nbf" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -44887,24 +42326,6 @@
 /obj/item/pen,
 /turf/open/floor/plasteel,
 /area/security/main)
-"nbP" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/space)
-"nbX" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "nca" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio_l";
@@ -45299,10 +42720,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"niD" = (
-/obj/machinery/telecomms/bus/preset_one,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "niK" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -45623,12 +43040,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"nrp" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "nrq" = (
 /obj/structure/grille,
 /obj/machinery/meter{
@@ -45683,10 +43094,6 @@
 	},
 /turf/open/floor/plating,
 /area/bridge/meeting_room)
-"nst" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
 "nsx" = (
 /obj/machinery/door/airlock/research{
 	name = "Robotics Lab";
@@ -45913,12 +43320,6 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"nvG" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "nvR" = (
 /obj/machinery/suit_storage_unit/standard_unit{
 	suit_type = /obj/item/clothing/suit/space/paramedic
@@ -45981,53 +43382,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"nxc" = (
-/obj/machinery/ai/data_core/primary,
-/obj/machinery/power/apc/highcap{
-	dir = 8;
-	name = "AI Chamber APC";
-	pixel_x = -25
-	},
-/obj/structure/cable/white{
-	icon_state = "0-4"
-	},
-/obj/item/radio/intercom{
-	anyai = 1;
-	freerange = 1;
-	listening = 0;
-	name = "Custom Channel";
-	pixel_y = -27
-	},
-/obj/item/radio/intercom{
-	anyai = 1;
-	broadcasting = 0;
-	freerange = 1;
-	frequency = 1447;
-	name = "Private Channel";
-	pixel_y = 20
-	},
-/obj/item/radio/intercom{
-	broadcasting = 0;
-	freerange = 1;
-	listening = 1;
-	name = "Common Channel";
-	pixel_y = -37
-	},
-/obj/machinery/turretid{
-	icon_state = "control_stun";
-	name = "AI Chamber turret control";
-	pixel_x = -1;
-	pixel_y = 38
-	},
-/obj/machinery/button/door{
-	id = "aicoredoor";
-	name = "AI Chamber entrance shutters control";
-	pixel_x = -23;
-	pixel_y = 21;
-	req_access_txt = "16"
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/space)
 "nxp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -46059,12 +43413,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"nyj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "nyu" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -46286,11 +43634,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
-"nCJ" = (
-/obj/machinery/atmospherics/components/binary/valve/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/space)
 "nCL" = (
 /obj/machinery/vending/autodrobe/capdrobe,
 /turf/open/floor/wood,
@@ -46380,20 +43723,6 @@
 /obj/item/flashlight,
 /turf/open/floor/plating,
 /area/construction)
-"nEG" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	layer = 2.9
-	},
-/obj/structure/transit_tube/curved/flipped,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "nEH" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -46505,29 +43834,6 @@
 	},
 /turf/open/floor/grass,
 /area/medical/genetics)
-"nHt" = (
-/obj/machinery/doorButtons/access_button{
-	idDoor = "telecomms_airlock_exterior";
-	idSelf = "telecomms_airlock_control";
-	pixel_x = -7;
-	pixel_y = 23
-	},
-/obj/machinery/doorButtons/airlock_controller{
-	idExterior = "telecomms_airlock_exterior";
-	idInterior = "telecomms_airlock_interior";
-	idSelf = "telecomms_airlock_control";
-	pixel_x = 5;
-	pixel_y = 25
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/modular_computer/console/preset/tcomms,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "nHw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -46620,13 +43926,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"nII" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/white,
-/area/space)
 "nJl" = (
 /obj/effect/turf_decal/pool{
 	dir = 8
@@ -46819,10 +44118,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"nNV" = (
-/obj/machinery/ntnet_relay,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "nNY" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -46840,45 +44135,16 @@
 	},
 /turf/open/floor/plating/airless,
 /area/security/prison)
-"nOm" = (
-/mob/living/simple_animal/pet/axolotl/bop,
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "nOu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"nOQ" = (
-/obj/machinery/camera{
-	c_tag = "Telecomms Control Room";
-	dir = 4;
-	network = list("ss13","minisat")
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "nPD" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
-"nPV" = (
-/obj/structure/table,
-/obj/item/stock_parts/subspace/amplifier,
-/obj/item/stock_parts/subspace/amplifier,
-/obj/item/stock_parts/subspace/transmitter,
-/obj/item/stock_parts/subspace/transmitter,
-/obj/item/stock_parts/subspace/transmitter,
-/obj/machinery/camera{
-	c_tag = "Telecomms Tech Storage";
-	dir = 4;
-	network = list("ss13","telecomms")
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "nQi" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -46913,20 +44179,17 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "nQP" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
-"nRa" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
+/area/tcommsat/server)
 "nRs" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Genetics Research";
@@ -47413,17 +44676,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"nZC" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "oaC" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -47531,22 +44783,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"odu" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "ody" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -47674,16 +44910,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/prison)
-"ofx" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/structure/chair/office/dark,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "ofy" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -47736,20 +44962,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"ogx" = (
-/obj/machinery/telecomms/hub/preset,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "ogV" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -47790,18 +45002,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"ohF" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "ohL" = (
 /obj/structure/window/reinforced,
 /obj/structure/cable{
@@ -47809,13 +45009,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
-"ohP" = (
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
-/obj/machinery/recharge_station,
-/turf/open/floor/circuit,
-/area/space)
 "oif" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
@@ -48182,14 +45375,15 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"opr" = (
-/obj/machinery/rnd/production/circuit_imprinter/department/netmin,
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "opJ" = (
-/obj/machinery/telecomms/server/presets/science,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "oqf" = (
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine{
@@ -48324,13 +45518,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"otc" = (
-/obj/structure/lattice,
-/obj/structure/transit_tube/junction/flipped{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space)
 "otj" = (
 /obj/structure/table/glass,
 /obj/item/stock_parts/manipulator,
@@ -48536,19 +45723,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ovk" = (
-/obj/machinery/camera{
-	c_tag = "MiniSat Teleporter Room";
-	dir = 4;
-	network = list("ss13","minisat")
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "ovw" = (
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
@@ -48679,13 +45853,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"oxs" = (
-/obj/machinery/power/port_gen/pacman,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/space)
 "oxw" = (
 /obj/machinery/doorButtons/access_button{
 	idDoor = "virology_airlock_exterior";
@@ -48720,10 +45887,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"oxX" = (
-/obj/machinery/telecomms/bus/preset_four,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "oyd" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -48740,13 +45903,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
-"oyi" = (
-/obj/item/kirbyplants/photosynthetic,
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "oyj" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/spawner/structure/window/reinforced,
@@ -48919,17 +46075,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"oAr" = (
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 8;
-	external_pressure_bound = 120;
-	name = "server vent"
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
 "oAt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -48992,22 +46137,6 @@
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
-"oBz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "Telecomms Access";
-	req_access_txt = "61"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "oBA" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -49206,18 +46335,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"oHF" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 9
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "oHK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -49245,13 +46362,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"oIu" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/suit_storage_unit/captain,
-/turf/open/floor/wood,
-/area/space)
 "oIJ" = (
 /obj/machinery/button/door{
 	id = "genedesk";
@@ -49426,12 +46536,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"oLj" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "oLx" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -49512,13 +46616,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"oMx" = (
-/obj/machinery/power/smes/fullycharged,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/white,
-/area/space)
 "oME" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/matches,
@@ -49721,21 +46818,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel/dark,
 /area/security/prison/hallway)
-"oQz" = (
-/obj/machinery/camera{
-	c_tag = "AI Chamber - Port";
-	dir = 4;
-	network = list("aicore")
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "oQJ" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -49845,12 +46927,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
-"oSV" = (
-/obj/machinery/telecomms/receiver/preset_left{
-	name = "subspace receiver A"
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "oTa" = (
 /obj/structure/transit_tube/crossing,
 /obj/structure/lattice/catwalk,
@@ -49867,25 +46943,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"oTR" = (
-/turf/open/floor/circuit/green/telecomms,
-/area/space)
 "oTV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"oUc" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/advanced_airlock_controller{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plating,
-/area/space)
 "oUl" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -49981,11 +47044,6 @@
 /obj/effect/spawner/wire_splicing/thirty,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"oWc" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/space/basic,
-/area/space)
 "oWf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -50162,13 +47220,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
-"oZA" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/space)
 "oZW" = (
 /obj/machinery/door/window/westleft{
 	base_state = "right";
@@ -50221,12 +47272,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"paH" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/closed/wall/r_wall,
-/area/space)
 "paQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 4
@@ -50312,13 +47357,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"pen" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/telecomms/processor/preset_two,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "pew" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -50570,13 +47608,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"phR" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "pia" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4
@@ -50707,13 +47738,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"pkb" = (
-/obj/machinery/telecomms/processor/preset_four,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "pkD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -50805,21 +47829,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"pmd" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/space)
 "pmx" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -51019,22 +48028,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"ppD" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/machinery/doorButtons/access_button{
-	idDoor = "telecomms_airlock_interior";
-	idSelf = "telecomms_airlock_control";
-	pixel_x = -23;
-	pixel_y = -23
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "ppK" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -51126,18 +48119,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
-"prn" = (
-/obj/structure/rack,
-/obj/item/circuitboard/machine/telecomms/broadcaster,
-/obj/item/circuitboard/machine/telecomms/bus,
-/obj/item/circuitboard/machine/telecomms/hub,
-/obj/item/circuitboard/machine/telecomms/processor,
-/obj/item/circuitboard/machine/telecomms/receiver,
-/obj/item/circuitboard/machine/telecomms/relay,
-/obj/item/circuitboard/machine/telecomms/server,
-/obj/item/circuitboard/machine/telecomms/server,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "prq" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/sign/warning/radiation/rad_area{
@@ -51211,15 +48192,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/nanite)
-"pss" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Starboard";
-	dir = 4;
-	network = list("minisat","ss13")
-	},
-/turf/open/space/basic,
-/area/space)
 "pst" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -51282,12 +48254,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"ptV" = (
-/obj/structure/transit_tube/curved{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space)
 "put" = (
 /obj/machinery/door/airlock/external{
 	name = "Security Secure External Airlock";
@@ -51628,52 +48594,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"pzi" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	freerange = 1;
-	name = "Station Intercom (Telecomms)";
-	pixel_y = -28
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
-"pzn" = (
-/obj/machinery/camera{
-	c_tag = "MiniSat  Antechamber";
-	dir = 8;
-	network = list("minisat","ss13")
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/doorButtons/airlock_controller{
-	idExterior = "ai_core_airlock_exterior";
-	idInterior = "ai_core_airlock_interior";
-	idSelf = "ai_core_airlock_control";
-	pixel_x = 25;
-	pixel_y = 7
-	},
-/obj/machinery/doorButtons/access_button{
-	idDoor = "ai_core_airlock_exterior";
-	idSelf = "ai_core_airlock_control";
-	pixel_x = 23;
-	pixel_y = -7
-	},
-/turf/open/floor/circuit,
-/area/space)
 "pzv" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -51826,11 +48746,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"pBl" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/structure/cable/yellow,
-/turf/open/floor/plating,
-/area/space)
 "pBm" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -51894,10 +48809,6 @@
 	},
 /turf/open/space,
 /area/solar/port/aft)
-"pCI" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/wood,
-/area/space)
 "pCR" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating{
@@ -52110,12 +49021,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"pFX" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "pGs" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/turf_decal/stripes/line{
@@ -52229,17 +49134,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"pKt" = (
-/obj/effect/turf_decal/bot_white,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "pKz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -52261,12 +49155,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"pLe" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "pLj" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -52277,12 +49165,6 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"pLM" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/machinery/ai/server_cabinet/prefilled,
-/turf/open/floor/circuit/green/telecomms,
-/area/space)
 "pLQ" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
@@ -52290,18 +49172,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
-"pMf" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "pMs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -52347,17 +49217,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"pNs" = (
-/obj/machinery/status_display/ai{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 4;
-	external_pressure_bound = 120;
-	name = "server vent"
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
 "pOw" = (
 /turf/closed/wall/r_wall,
 /area/hallway/primary/port)
@@ -52373,12 +49232,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"pOK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/space)
 "pOP" = (
 /obj/effect/turf_decal/stripes/end,
 /turf/open/floor/plating,
@@ -52521,18 +49374,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"pQN" = (
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/space)
 "pQS" = (
 /obj/structure/window/reinforced,
 /obj/structure/chair/stool{
@@ -52688,45 +49529,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"pTC" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/tcommsat/computer";
-	dir = 1;
-	name = "Telecomms Control APC";
-	pixel_y = 24
-	},
-/obj/machinery/space_heater,
-/turf/open/floor/plating,
-/area/space)
 "pTI" = (
 /obj/structure/grille/broken,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "pTL" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 5
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/space)
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "pTP" = (
 /obj/structure/holohoop{
 	dir = 8
@@ -52737,11 +49550,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"pUk" = (
-/obj/item/stack/cable_coil,
-/obj/effect/decal/cleanable/dirt/dust,
-/turf/open/floor/circuit/green/telecomms,
-/area/space)
 "pUH" = (
 /obj/structure/table,
 /obj/item/hand_tele,
@@ -53109,37 +49917,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"qaA" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/departments/minsky/command/charge{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 8
-	},
-/obj/item/kirbyplants/photosynthetic{
-	pixel_y = 10
-	},
-/obj/structure/table,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "qaO" = (
 /turf/closed/wall/r_wall,
 /area/security/interrogation)
-"qaQ" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Sattelite Access";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "qbw" = (
 /obj/structure/sign/departments/minsky/medical/virology/virology2{
 	pixel_y = -32
@@ -53296,12 +50076,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"qex" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "qeC" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
@@ -53949,25 +50723,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"qpA" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "qpF" = (
 /obj/machinery/door/airlock{
 	name = "Service Hall";
@@ -54006,13 +50761,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/interrogation)
-"qrZ" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "qsk" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -54327,31 +51075,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"qzr" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/airlock/highsecurity{
-	id_tag = "ai_core_airlock_interior";
-	name = "AI Core";
-	req_access_txt = "65"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "aicoredoor";
-	name = "AI Chamber entrance shutters"
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "qzt" = (
 /obj/machinery/door/airlock/external{
 	name = "Engineering External Access";
@@ -54386,17 +51109,6 @@
 	},
 /turf/open/space/basic,
 /area/tcommsat/computer)
-"qAr" = (
-/obj/machinery/door/airlock/external{
-	name = "MiniSat External Access";
-	req_access_txt = "65"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/space)
 "qAt" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -54432,11 +51144,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"qBW" = (
-/obj/effect/turf_decal/bot_white,
-/obj/machinery/teleport/hub,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "qCq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -54610,25 +51317,6 @@
 /obj/structure/rack,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"qFi" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "qFC" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -54873,12 +51561,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"qId" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
-	dir = 1
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
 "qIr" = (
 /obj/structure/table,
 /obj/item/storage/lockbox/vialbox/virology{
@@ -54967,10 +51649,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"qJC" = (
-/obj/structure/filingcabinet,
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "qJI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -54980,14 +51658,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"qJJ" = (
-/obj/machinery/recharger/wallrecharger{
-	pixel_x = -21;
-	pixel_y = -3
-	},
-/obj/machinery/papershredder,
-/turf/open/floor/wood,
-/area/space)
 "qKi" = (
 /turf/open/floor/circuit/green/telecomms,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -55122,16 +51792,6 @@
 /obj/item/storage/belt/utility,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"qLN" = (
-/obj/machinery/computer/telecomms/server{
-	dir = 1;
-	network = "tcommsat"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "qLP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -55281,20 +51941,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"qOj" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/storage/satellite";
-	name = "MiniSat Maint APC";
-	pixel_y = -23
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/space)
 "qOl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -55449,20 +52095,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"qQH" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "Telecomms Teleporter Room";
-	req_access_txt = "61;17"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "qQV" = (
 /turf/template_noop,
 /area/template_noop)
@@ -55493,13 +52125,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/sleeper)
-"qRI" = (
-/obj/machinery/light,
-/obj/machinery/computer/ai_server_console{
-	dir = 1
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "qRK" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -55537,15 +52162,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"qSm" = (
-/obj/machinery/telecomms/receiver/preset_left{
-	name = "subspace receiver A"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 5
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "qSq" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
@@ -55658,22 +52274,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"qUE" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Monitoring Room";
-	req_access_txt = "65"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "qUL" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -55724,9 +52324,11 @@
 /turf/open/floor/wood,
 /area/library)
 "qVN" = (
-/obj/structure/transit_tube/diagonal/topleft,
-/turf/open/space/basic,
-/area/space)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "qVZ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -55827,24 +52429,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"qXr" = (
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/space)
 "qXB" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -56140,9 +52724,6 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
-"rdR" = (
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "rfl" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -56179,18 +52760,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
-"rfv" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/doorButtons/access_button{
-	idDoor = "ai_core_airlock_interior";
-	idSelf = "ai_core_airlock_control";
-	pixel_x = -23;
-	pixel_y = 7
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "rfy" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -56208,15 +52777,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"rfA" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 9
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
-"rfJ" = (
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "rfK" = (
 /obj/machinery/light{
 	dir = 4
@@ -56590,18 +53150,6 @@
 /mob/living/simple_animal/mouse/brown/Tom,
 /turf/open/floor/plating,
 /area/security/prison)
-"rnc" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "rnS" = (
 /turf/template_noop,
 /area/security/execution/transfer)
@@ -57235,19 +53783,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"rAM" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/tcommsat/entrance";
-	dir = 8;
-	name = "Telecomms Entrance APC";
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "rAP" = (
 /obj/structure/filingcabinet,
 /obj/machinery/airalarm{
@@ -57293,21 +53828,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/service)
-"rBN" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "rBY" = (
 /obj/machinery/camera{
 	c_tag = "Security Office";
@@ -57334,26 +53854,14 @@
 /turf/open/space/basic,
 /area/solar/port/fore)
 "rCq" = (
-/obj/machinery/doorButtons/access_button{
-	idDoor = "telecomms_airlock_interior";
-	idSelf = "telecomms_airlock_control";
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 10
-	},
 /turf/open/floor/plasteel/dark/telecomms,
-/area/space)
+/area/ai_monitored/turret_protected/ai)
 "rCr" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
@@ -57805,9 +54313,8 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
 "rJJ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/space)
+/turf/closed/wall/r_wall,
+/area/tcommsat/entrance)
 "rKk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -57834,21 +54341,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"rKI" = (
-/obj/machinery/camera{
-	c_tag = "AI Chamber - Fore";
-	dir = 4;
-	network = list("aicore")
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/porta_turret/ai,
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
 "rKJ" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -58275,12 +54767,6 @@
 /obj/effect/landmark/stationroom/maint/fivexthree,
 /turf/template_noop,
 /area/maintenance/port/aft)
-"rSF" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "rST" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /turf/open/floor/plating,
@@ -58531,15 +55017,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"rWQ" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
 "rXm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -58607,16 +55084,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
-"rYz" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -26
-	},
-/obj/structure/sign/departments/minsky/engineering/telecommmunications{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "rYI" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -59050,15 +55517,6 @@
 	dir = 4
 	},
 /area/security/prison)
-"sgw" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	dir = 8
-	},
-/obj/structure/cable/white{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "sgz" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -59169,14 +55627,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/genetics)
-"sjc" = (
-/obj/machinery/doorButtons/access_button{
-	idDoor = "telecomms_airlock_exterior";
-	idSelf = "telecomms_airlock_control";
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/white,
-/area/space)
 "sjg" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -59303,15 +55753,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
-"slU" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/space)
 "sma" = (
 /obj/structure/chair{
 	dir = 1
@@ -59319,15 +55760,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"smd" = (
-/obj/structure/sign/departments/minsky/engineering/telecommmunications{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "smk" = (
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -59404,7 +55836,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "snF" = (
@@ -59479,14 +55910,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"spr" = (
-/obj/effect/turf_decal/ramp_middle{
-	dir = 1
-	},
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide2{
-	dir = 1
-	},
-/area/ai_monitored/turret_protected/ai)
 "sps" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -59542,15 +55965,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"sqS" = (
-/obj/machinery/meter{
-	pixel_x = -5;
-	pixel_y = -3;
-	target_layer = 2
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/space)
 "srB" = (
 /obj/effect/turf_decal/trimline/engiyellow/warning/lower{
 	dir = 1
@@ -59568,10 +55982,6 @@
 /obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"ssf" = (
-/obj/effect/landmark/start/cyborg,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "ssh" = (
 /obj/machinery/light,
 /obj/machinery/papershredder,
@@ -59730,10 +56140,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"suV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
 "svh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -59945,20 +56351,9 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
 "sAr" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "sAs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8;
@@ -59998,16 +56393,6 @@
 "sAV" = (
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
-"sBc" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "sBp" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -30
@@ -60308,17 +56693,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"sGz" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "sGA" = (
 /obj/machinery/status_display/evac{
 	layer = 4;
@@ -60330,12 +56704,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"sGU" = (
-/obj/machinery/telecomms/broadcaster/preset_right{
-	name = "subspace broadcaster B"
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "sGW" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 5
@@ -60697,12 +57065,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"sNq" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/space)
 "sNL" = (
 /obj/structure/closet/crate{
 	name = "solar pack crate"
@@ -60864,13 +57226,6 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"sRE" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on/layer4{
-	name = "Waste Ejector"
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space)
 "sSb" = (
 /obj/machinery/disposal/bin,
 /obj/structure/sign/warning/deathsposal{
@@ -61155,20 +57510,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"sXt" = (
-/obj/machinery/airalarm/tcomms{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower,
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "sXv" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/fire/firefighter,
@@ -61552,20 +57893,6 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"tdJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/doorButtons/access_button{
-	idDoor = "telecomms_airlock_interior";
-	idSelf = "telecomms_airlock_control";
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/white,
-/area/space)
 "tdO" = (
 /obj/structure/window,
 /obj/structure/table,
@@ -61926,11 +58253,8 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "tjY" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "tkd" = (
 /obj/machinery/camera{
 	c_tag = "Engineering East";
@@ -62099,17 +58423,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"tmU" = (
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room";
-	network = list("ss13","tcomms");
-	pixel_x = 22
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "tnB" = (
 /turf/closed/wall,
 /area/bridge)
@@ -62238,16 +58551,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
-"tqj" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/computer/ai_control_console{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "tqk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -62382,10 +58685,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "tto" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/space)
+/obj/machinery/pipedispenser,
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "ttQ" = (
 /obj/structure/rack,
 /obj/machinery/light{
@@ -63072,18 +59374,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"tJH" = (
-/obj/machinery/camera{
-	c_tag = "Telecomms Life Support";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
-	},
-/obj/machinery/meter{
-	target_layer = 1
-	},
-/turf/open/floor/plating,
-/area/space)
 "tJN" = (
 /obj/machinery/light{
 	dir = 1
@@ -63245,12 +59535,6 @@
 "tMi" = (
 /turf/open/floor/plating/airless,
 /area/maintenance/fore)
-"tMo" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	target_temperature = 80
-	},
-/turf/open/floor/plating,
-/area/space)
 "tMG" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 1
@@ -63326,14 +59610,13 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "tNs" = (
-/obj/structure/window/reinforced,
-/obj/machinery/camera{
-	c_tag = "MiniSat Exterior Access";
-	dir = 8;
-	network = list("minisat","ss13")
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
 	},
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "tNA" = (
 /obj/machinery/camera{
 	c_tag = "Dormitory South";
@@ -63401,17 +59684,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"tOs" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/space/basic,
-/area/space)
 "tOL" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -63504,13 +59776,6 @@
 /obj/item/book/manual/wiki/surgery,
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
-"tPN" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
-/turf/open/floor/plasteel/white,
-/area/space)
 "tPY" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -63741,20 +60006,6 @@
 /obj/machinery/porta_turret/ai,
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
-"tTW" = (
-/obj/machinery/telecomms/message_server/preset,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "tUe" = (
 /obj/machinery/keycard_auth{
 	pixel_x = 24;
@@ -63817,18 +60068,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/fore)
-"tUP" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/doorButtons/access_button{
-	idDoor = "telecomms_airlock_exterior";
-	idSelf = "telecomms_airlock_control";
-	pixel_x = 24;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "tVa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -63860,23 +60099,6 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/science/research)
-"tVH" = (
-/obj/machinery/telecomms/bus/preset_one,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "tVL" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -63901,20 +60123,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"tWs" = (
-/obj/machinery/telecomms/broadcaster/preset_right,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "tWQ" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -63930,20 +60138,6 @@
 "tXb" = (
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/ai_monitored/secondarydatacore)
-"tXe" = (
-/obj/structure/showcase/cyborg/old{
-	dir = 4;
-	pixel_x = -9;
-	pixel_y = 2
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "tXk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -63971,15 +60165,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"tXT" = (
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "tYa" = (
 /obj/machinery/camera{
 	c_tag = "Aft Port Solar Access";
@@ -64010,18 +60195,6 @@
 "tYk" = (
 /turf/closed/wall,
 /area/security/prison/hallway)
-"tYq" = (
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "tYt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -64240,13 +60413,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
 /area/library)
-"ucD" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "ucF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -64353,25 +60519,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"udW" = (
-/obj/machinery/doorButtons/access_button{
-	idDoor = "ai_core_airlock_exterior";
-	idSelf = "ai_core_airlock_control";
-	pixel_x = -23;
-	pixel_y = 7
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "ues" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -64434,17 +60581,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"ufy" = (
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "ufD" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -64641,22 +60777,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"ulw" = (
-/obj/item/stock_parts/subspace/crystal,
-/obj/item/stock_parts/subspace/crystal,
-/obj/item/stock_parts/subspace/crystal,
-/obj/item/stock_parts/subspace/ansible,
-/obj/item/stock_parts/subspace/ansible,
-/obj/item/stock_parts/subspace/ansible,
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "ulL" = (
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
@@ -64952,17 +61072,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"urd" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/tcommsat/computer";
-	name = "Telecomms Control Room APC";
-	pixel_y = -23
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "ure" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -65363,11 +61472,9 @@
 /turf/closed/wall,
 /area/medical/paramedic)
 "uAV" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/plasteel/dark/telecomms,
-/area/space)
+/area/ai_monitored/turret_protected/ai)
 "uAW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -65383,20 +61490,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"uBd" = (
-/obj/machinery/telecomms/bus/preset_four,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "uBe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -65678,15 +61771,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"uFX" = (
-/obj/structure/transit_tube/station{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "uGb" = (
 /obj/effect/turf_decal/ramp_middle{
 	dir = 1
@@ -65920,10 +62004,6 @@
 /obj/item/stock_parts/micro_laser/high,
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
-"uKy" = (
-/obj/machinery/telecomms/server/presets/engineering,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "uKB" = (
 /obj/machinery/meter,
 /obj/structure/sign/warning/nosmoking{
@@ -65944,20 +62024,6 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"uKS" = (
-/obj/machinery/telecomms/broadcaster/preset_left,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "uLi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -66006,20 +62072,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"uLG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "Telecomms Life Support";
-	req_access_txt = "61"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plating,
-/area/space)
 "uLO" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -66095,21 +62147,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/interrogation)
-"uMP" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/space)
-"uMU" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/space)
 "uMW" = (
 /obj/structure/displaycase/trophy,
 /turf/open/floor/carpet,
@@ -66159,27 +62196,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"uNG" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/machinery/computer/security/telescreen{
-	dir = 1;
-	name = "Telecomms Camera Monitor";
-	network = list("tcomms");
-	pixel_x = 30;
-	pixel_y = -37
-	},
-/obj/item/radio/intercom{
-	dir = 1;
-	freerange = 1;
-	name = "Station Intercom (Telecomms)";
-	pixel_x = 28;
-	pixel_y = -26
-	},
-/obj/effect/landmark/start/yogs/network_admin,
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "uNH" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -66199,23 +62215,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"uNT" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/department/tcoms";
-	dir = 4;
-	name = "Telecommunications Maintenance APC";
-	pixel_x = 24
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/space)
-"uNW" = (
-/obj/effect/turf_decal/bot_white,
-/obj/machinery/bluespace_beacon,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "uOe" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/security,
@@ -66373,14 +62372,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"uQK" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/light,
-/turf/open/floor/plating,
-/area/space)
 "uQR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -66406,17 +62397,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
-"uRo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "uRV" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway West";
@@ -66486,20 +62466,6 @@
 "uTh" = (
 /turf/closed/wall,
 /area/security/execution/transfer)
-"uTz" = (
-/obj/machinery/telecomms/server/presets/engineering,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "uUb" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -66558,17 +62524,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"uUE" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "uUY" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Biohazard";
@@ -66774,14 +62729,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"uXc" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Aft Starboard";
-	network = list("minisat")
-	},
-/turf/open/space/basic,
-/area/space)
 "uXk" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/color/latex,
@@ -66852,10 +62799,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"uZo" = (
-/obj/structure/transit_tube/diagonal,
-/turf/open/space/basic,
-/area/space)
 "uZw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -66883,13 +62826,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"uZN" = (
-/obj/machinery/pipedispenser,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "uZU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -66905,12 +62841,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
-"uZV" = (
-/obj/structure/transit_tube/curved/flipped{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space)
 "vaq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -67225,13 +63155,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"vfm" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space)
 "vfr" = (
 /obj/machinery/power/smes,
 /obj/structure/cable/yellow{
@@ -67250,39 +63173,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"vgg" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/highsecurity{
-	id_tag = "ai_core_airlock_exterior";
-	name = "AI Core";
-	req_access_txt = "65"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/space)
 "vgq" = (
 /obj/machinery/status_display/evac{
 	pixel_y = -32
@@ -67300,14 +63190,6 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"vgr" = (
-/obj/effect/decal/cleanable/dirt/dust,
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/space)
 "vhz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -67370,24 +63252,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"viP" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 8;
-	external_pressure_bound = 120;
-	name = "server vent"
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower,
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "viU" = (
 /obj/structure/table,
 /obj/structure/mirror{
@@ -67472,12 +63336,6 @@
 /obj/effect/turf_decal/trimline/white/arrow_ccw,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"vkj" = (
-/obj/machinery/computer/message_monitor{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "vkp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/computer/security/telescreen/turbine{
@@ -67795,27 +63653,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
-"vpq" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 4;
-	external_pressure_bound = 120;
-	name = "server vent"
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower,
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "vpX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -67867,20 +63704,6 @@
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"vqQ" = (
-/obj/machinery/telecomms/server/presets/security,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "vra" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -68055,15 +63878,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"vva" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 10
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
 "vvd" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -68325,13 +64139,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"vyH" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/porta_turret/ai,
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
 "vyL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -68806,10 +64613,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"vHu" = (
-/obj/structure/transit_tube/crossing/horizontal,
-/turf/open/space/basic,
-/area/space)
 "vHH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -68830,22 +64633,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"vHN" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "vHO" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -69043,27 +64830,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"vJJ" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/space/basic,
-/area/space)
-"vJW" = (
-/obj/machinery/camera{
-	c_tag = "AI Chamber - Port";
-	dir = 8;
-	network = list("aicore")
-	},
-/obj/machinery/requests_console{
-	department = "AI";
-	departmentType = 5;
-	pixel_x = 0;
-	pixel_y = -32
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
 "vKb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -69353,12 +65119,6 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
 /area/storage/tech)
-"vPw" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
 "vPF" = (
 /obj/machinery/light{
 	dir = 8;
@@ -69456,14 +65216,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"vRp" = (
-/obj/machinery/atmospherics/components/binary/pump/on/layer2{
-	dir = 4;
-	name = "AI Satellite Supply"
-	},
-/obj/effect/mapping_helpers/teleport_anchor,
-/turf/open/floor/plating,
-/area/space)
 "vRA" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -69495,15 +65247,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"vTA" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/closed/wall/r_wall,
-/area/space)
 "vTB" = (
 /obj/machinery/shower{
 	dir = 4
@@ -69810,30 +65553,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"vYj" = (
-/obj/machinery/power/apc/tcomms{
-	areastring = "/area/tcommsat/server";
-	dir = 4;
-	name = "Telecomms Server APC";
-	pixel_x = 24
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "vYs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -70164,14 +65883,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "wer" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "weD" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -70539,19 +66255,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"wlO" = (
-/obj/machinery/button/door{
-	id = "tcomms";
-	name = "Telecommunications server shutters control";
-	pixel_y = -27;
-	req_access_txt = "61"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "wlT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -70573,19 +66276,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/tcommsat/entrance)
-"wmA" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Telecomms Admin";
-	departmentType = 5;
-	name = "Telecomms RC";
-	pixel_y = 30
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "wmB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -70781,14 +66471,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
-"wpK" = (
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room Access";
-	dir = 4;
-	network = list("ss13","minisat")
-	},
-/turf/open/floor/plasteel/white,
-/area/space)
 "wpR" = (
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/bot_white,
@@ -70877,11 +66559,14 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "wrK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/machinery/telecomms/receiver/preset_left{
+	name = "subspace receiver A"
 	},
-/turf/open/floor/plasteel/dark,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "wrN" = (
 /obj/structure/chair/comfy/beige,
 /turf/open/floor/plasteel/grimy,
@@ -71062,16 +66747,6 @@
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
-"wwq" = (
-/obj/machinery/light,
-/obj/machinery/camera{
-	c_tag = "AI Chamber - Aft";
-	dir = 4;
-	network = list("aicore")
-	},
-/obj/machinery/porta_turret/ai,
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
 "wwt" = (
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
 	dir = 4
@@ -71229,15 +66904,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"wyJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 10
-	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/space)
 "wzr" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -71312,10 +66978,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"wBI" = (
-/obj/machinery/telecomms/bus/preset_two,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "wBN" = (
 /obj/effect/turf_decal/tile{
 	dir = 8
@@ -71376,12 +67038,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"wEd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "wEe" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
 	dir = 1
@@ -71610,15 +67266,14 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "wIB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 8
 	},
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
-/area/space)
+/area/tcommsat/server)
 "wJc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/reagent_dispensers/fueltank,
@@ -71645,15 +67300,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
-"wKd" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/space)
 "wKy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -71933,18 +67579,6 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
-"wPR" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "wPS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -71979,16 +67613,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"wRd" = (
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "wRg" = (
 /obj/machinery/flasher{
 	id = "AI";
@@ -72449,33 +68073,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"xaH" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Teleporter Room";
-	req_one_access_txt = "17;65"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/space)
-"xbi" = (
-/obj/machinery/telecomms/server/presets/supply,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "xbs" = (
 /obj/machinery/light{
 	dir = 8
@@ -72590,20 +68187,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
-"xdr" = (
-/obj/machinery/telecomms/bus/preset_two,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "xds" = (
 /obj/structure/chair{
 	dir = 1
@@ -72799,10 +68382,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"xhM" = (
-/obj/machinery/telecomms/server/presets/security,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "xit" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/warden";
@@ -73059,27 +68638,6 @@
 /obj/structure/closet/secure_closet/warden,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"xnr" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/space)
-"xnA" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -1;
-	pixel_y = 6
-	},
-/obj/item/pen,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "xnF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -73444,18 +69002,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"xvU" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/camera{
-	c_tag = "MiniSat Exterior - Fore Port";
-	dir = 1;
-	network = list("minisat")
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space)
 "xvY" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -73493,12 +69039,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "xwL" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/satellite)
 "xwU" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/machinery/light{
@@ -73528,13 +69071,8 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "xxd" = (
-/obj/item/storage/toolbox/mechanical,
-/obj/item/flashlight,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/space)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "xxr" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -73611,12 +69149,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/white,
 /area/engine/atmos/mix)
-"xyb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
-/area/space)
 "xyG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -73733,15 +69265,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"xBs" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/circuit/telecomms/mainframe,
-/area/space)
 "xBG" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot_red,
@@ -73923,13 +69446,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"xEB" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space)
 "xEH" = (
 /obj/machinery/computer/security,
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
@@ -73957,25 +69473,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"xEY" = (
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
-"xFf" = (
-/obj/structure/table,
-/obj/item/stock_parts/subspace/analyzer,
-/obj/item/stock_parts/subspace/analyzer,
-/obj/item/stock_parts/subspace/analyzer,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "xFg" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
@@ -74274,28 +69771,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"xKk" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "xKE" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet,
 /area/library)
-"xLf" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/space)
 "xLu" = (
 /obj/machinery/computer/communications,
 /obj/effect/turf_decal/trimline/darkblue/filled/line/lower{
@@ -74318,14 +69797,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"xLT" = (
-/obj/machinery/computer/telecomms/traffic{
-	dir = 1;
-	network = "tcommsat"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel/dark,
-/area/space)
 "xLX" = (
 /obj/machinery/computer/atmos_alert,
 /obj/effect/turf_decal/tile/neutral{
@@ -74352,20 +69823,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"xMi" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
-"xMv" = (
-/obj/item/radio/intercom{
-	freerange = 1;
-	name = "Station Intercom (Telecomms)";
-	pixel_y = 26
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "xML" = (
 /turf/closed/wall,
 /area/hallway/primary/aft_starboard)
@@ -74503,18 +69960,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"xPv" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "xPE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -74522,8 +69967,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "xPL" = (
-/turf/closed/wall/r_wall,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 10
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "xPQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -74551,10 +69999,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
-"xQw" = (
-/obj/machinery/vending/autodrobe/capdrobe,
-/turf/open/floor/wood,
-/area/space)
 "xQA" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -74737,15 +70181,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"xUb" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "xUd" = (
 /obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 4
@@ -75006,19 +70441,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"xZQ" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/space)
 "yab" = (
 /obj/machinery/computer/shuttle/mining,
 /obj/machinery/computer/security/telescreen{
@@ -75109,15 +70531,6 @@
 /obj/effect/turf_decal/trimline/chemorange/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"ybM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/space)
 "ycf" = (
 /obj/machinery/meter{
 	pixel_x = -5;
@@ -75174,15 +70587,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"ycM" = (
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/gloves/color/black,
-/obj/structure/closet,
-/turf/open/floor/plating,
-/area/space)
 "ydd" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Maintenance";
@@ -75195,19 +70599,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"ydM" = (
-/obj/machinery/status_display/ai{
-	pixel_x = 32
-	},
-/obj/structure/rack,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/turf/open/floor/circuit,
-/area/space)
 "yey" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -75318,10 +70709,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"yfJ" = (
-/obj/machinery/telecomms/server/presets/common,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/space)
 "yfL" = (
 /obj/item/book/manual/wiki/security_space_law,
 /obj/structure/table/wood,
@@ -75371,17 +70758,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
-"ygC" = (
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_access_txt = "10;13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/space)
 "yhc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 1
@@ -75511,29 +70887,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"yiK" = (
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/obj/machinery/doorButtons/access_button{
-	idDoor = "telecomms_airlock_exterior";
-	idSelf = "telecomms_airlock_control";
-	pixel_x = 7;
-	pixel_y = -23
-	},
-/obj/machinery/doorButtons/access_button{
-	idDoor = "telecomms_airlock_interior";
-	idSelf = "telecomms_airlock_control";
-	pixel_x = -23;
-	pixel_y = 6
-	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room Access";
-	dir = 4;
-	network = list("ss13","tcomms")
-	},
-/turf/open/floor/plasteel/white,
-/area/space)
 "yiM" = (
 /obj/machinery/door/airlock/research{
 	name = "Xenobiology Lab";
@@ -75696,13 +71049,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ylo" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/space/basic,
-/area/space)
 "ylx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -100122,24 +95468,24 @@ aaa
 aaa
 aaa
 aaa
-vfm
-aJt
 aaa
 aaa
-aJt
-otc
-aJt
 aaa
 aaa
-aJt
-mFE
-aJt
-fMm
-aJt
-aJt
 aaa
 aaa
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -100379,24 +95725,24 @@ aaa
 aaa
 aaa
 aaa
-vfm
-aJt
-aaa
-aaa
-uZo
-aaa
-qVN
-aaa
-aaa
-aJt
-mFE
 aaa
 aaa
 aaa
-aJt
-aJt
 aaa
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -100636,24 +95982,24 @@ aaa
 aaa
 aaa
 aaa
-vfm
-aJt
-aaa
-uZV
 aaa
 aaa
 aaa
-gVu
-aaa
-aJt
-mFE
 aaa
 aaa
 aaa
-aJt
-aJt
-aJt
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -100893,24 +96239,24 @@ aaa
 aaa
 aaa
 aaa
-vfm
-aJt
-aaa
-vHu
 aaa
 aaa
 aaa
-vHu
-aaa
-aJt
-mFE
 aaa
 aaa
 aaa
-aJt
 aaa
-fMm
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -101150,21 +96496,21 @@ aaa
 aaa
 aaa
 aaa
-vfm
-aJt
-aaa
-ptV
-leo
-leo
-leo
-dLB
-aaa
-aJt
-mFE
 aaa
 aaa
 aaa
-aJt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -101407,22 +96753,22 @@ aaa
 aaa
 aaa
 aaa
-vfm
-aJt
-aaa
-tNs
-nEG
-crS
-mxG
-akE
-aaa
-aJt
-mFE
 aaa
 aaa
 aaa
-aJt
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -101664,22 +97010,22 @@ aaa
 aaa
 aaa
 aaa
-vfm
-xPL
-xPL
-xPL
-muL
-ssf
-oyi
-xPL
-xPL
-xPL
-mFE
 aaa
 aaa
-aJt
-aJt
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -101919,24 +97265,24 @@ aaa
 aaa
 aaa
 aaa
-mUg
-lQb
-hoF
-laa
-bhu
-jJK
-tto
-mJE
-tto
-jEF
-iJq
-qAr
-mFE
-hCt
-mFE
-aJt
 aaa
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -102176,25 +97522,25 @@ aaa
 aaa
 aaa
 aaa
-vfm
-xPL
-xPL
-xPL
-xPL
-xPL
-xEY
-cnX
-ddu
-xPL
-xPL
-xPL
-xPL
-xPL
-mFE
-aJt
-jCM
-jCM
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -102433,25 +97779,25 @@ aaa
 aaa
 aaa
 aaa
-vfm
-xPL
-dsI
-dxx
-fhe
-lbX
-wer
-pQN
-oLj
-lbX
-nbc
-ovk
-gky
-xPL
-mFE
-aJt
-jCM
-jCM
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -102690,25 +98036,25 @@ aaa
 aaa
 aaa
 aaa
-vfm
-xPL
-dsI
-sqS
-goP
-lbX
-hAC
-ucD
-jTN
-xaH
-gRS
-cDJ
-lma
-xPL
-mFE
 aaa
 aaa
 aaa
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -102945,27 +98291,27 @@ aaa
 aaa
 aaa
 aaa
-mUg
-oWc
-hoF
-xPL
-lMT
-vRp
-fbL
-lbX
-lbX
-gIY
-lbX
-lbX
-mXq
-iSD
-hXu
-xPL
-mFE
-mFE
-mFE
 aaa
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -103202,27 +98548,27 @@ aaa
 aaa
 aaa
 aaa
-xvU
-xPL
-xPL
-xPL
-gYf
-qOj
-lbX
-lbX
-tXe
-gSI
-hvo
-lbX
-lbX
-lbX
-lbX
-xPL
-xPL
-xPL
-bmg
 aaa
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -103458,28 +98804,28 @@ aaa
 aaa
 aaa
 aaa
-aMJ
-kug
-xPL
-leM
-mlS
-oxs
-slU
-lbX
-qaA
-kag
-nbP
-ybM
-phR
-lbX
-qJC
-xnA
-lWm
-eNA
-xPL
-mFE
 aaa
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -103715,28 +99061,28 @@ aaa
 aaa
 aaa
 aaa
-sRE
-tOs
-djF
-wKd
-nCJ
-bxc
-kjX
-hRI
-lec
-lec
-jbQ
-uUE
-lec
-qUE
-aLy
-epV
-fME
-gSl
-pBl
-mFE
-aJt
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -103973,27 +99319,27 @@ aaa
 aaa
 aaa
 aaa
-mFE
-xPL
-aVE
-mWE
-klm
-sNq
-lbX
-ohP
-pzn
-qXr
-fpD
-ydM
-lbX
-tqj
-hTd
-ldD
-qRI
-xPL
-mFE
-aJt
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -104230,26 +99576,26 @@ aaa
 aaa
 aaa
 aaa
-mFE
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-vgg
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-mFE
-aJt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -104392,10 +99738,10 @@ sAu
 ume
 cva
 cva
-xwL
-lyX
-lyX
-nQP
+mDO
+xxd
+xxd
+cqT
 gtB
 tgv
 wJL
@@ -104487,28 +99833,28 @@ aaa
 aaa
 aaa
 aaa
-mFE
-mFE
-mFE
-mFE
-iII
-xPL
-xPL
-xPL
-oQz
-cwu
-udW
-xPL
-xPL
-xPL
-iII
-mFE
-mFE
-mFE
-mFE
-aJt
-aJt
-aJt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -104649,12 +99995,12 @@ nDA
 rjo
 tTK
 cva
-mDO
-gLt
+tNs
+sAr
 kMi
 uuG
 ieK
-rdR
+axV
 azq
 rRA
 lmN
@@ -104745,25 +100091,25 @@ aaa
 aaa
 aaa
 aaa
-aJt
-aJt
-mFE
-mFE
-xPL
-xPL
-gHc
-jKC
-axV
-wIB
-gHc
-xPL
-xPL
-mFE
-mFE
 aaa
 aaa
-aJt
-aJt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -104900,20 +100246,20 @@ pqr
 cva
 hWd
 fiF
-cfh
-bPO
-cfh
-bfr
+jJK
+afK
+jJK
+cOE
 qjk
 cva
 cva
 gtB
 ieo
-suV
+krI
 gtB
-lhk
+qVN
 pSY
-rdR
+lhk
 rdw
 pvf
 aJw
@@ -105002,27 +100348,27 @@ aaa
 aaa
 aaa
 aaa
-aJt
-mFE
-mFE
-xPL
-xPL
-xPL
-xPL
-xPL
-qzr
-xPL
-xPL
-xPL
-xPL
-xPL
-mFE
 aaa
 aaa
 aaa
-aJt
-aJt
-aJt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -105160,19 +100506,19 @@ nDA
 cva
 cva
 hsq
-ilL
+rCq
 qZK
 vAP
-gCs
+uAV
 gtB
-nQP
-lyX
+cqT
+xxd
 gtB
-lEd
-nyj
-rdR
-rdR
-rdR
+xwL
+pTL
+axV
+axV
+axV
 aJw
 pvo
 sXZ
@@ -105260,24 +100606,24 @@ aaa
 aaa
 aaa
 aaa
-mFE
-xPL
-xPL
-xPL
-rKI
-lqZ
-uAV
-tYq
-rfv
-lqZ
-wwq
-xPL
-xPL
-mFE
-mFE
 aaa
 aaa
-aJt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -105423,13 +100769,13 @@ uGb
 pJy
 jHo
 sqj
-lyX
+xxd
 fJN
 aJy
-nyj
+pTL
 rPo
-rdR
-rdR
+axV
+axV
 psj
 hsn
 sYk
@@ -105516,22 +100862,22 @@ aaa
 aaa
 aaa
 aaa
-aJt
-mFE
-xPL
-xPL
-xPL
-lGC
-qex
-inD
-bcz
-fCV
-fCV
-pNs
-xPL
-xPL
-xPL
-mFE
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -105674,18 +101020,18 @@ nDA
 cva
 cva
 mfG
-ilL
+rCq
 qZK
-spr
-gCs
+hmx
+uAV
 gtB
-nQP
+cqT
+xxd
+gtB
 lyX
-gtB
-fnl
-nyj
-rdR
-rdR
+pTL
+axV
+axV
 iRV
 aJw
 hvG
@@ -105774,24 +101120,24 @@ aaa
 aaa
 aaa
 aaa
-mFE
-xPL
-xPL
-pLM
-jwq
-bvC
-xPL
-xPL
-mnJ
-fCV
-xnr
-vgr
-xPL
-xPL
-mFE
 aaa
-jCM
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -105928,21 +101274,21 @@ jfG
 cva
 hWd
 qoQ
-cfh
+jJK
 prN
-cfh
-bfr
+jJK
+cOE
 laN
 cva
 cva
 gtB
 ieo
-suV
+krI
 gtB
-aRB
+wer
 rzx
 iRV
-hTj
+tto
 agz
 aJw
 qHo
@@ -106030,24 +101376,24 @@ aaa
 aaa
 aaa
 aaa
-jcO
-mKm
-xPL
-xPL
-pUk
-xnr
-mkL
-xPL
-nxc
-xPL
-fCV
-xnr
-oTR
-xPL
-xPL
-egy
-aJt
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -106191,12 +101537,12 @@ nDA
 rjo
 tTK
 cva
-mDO
-gLt
+tNs
+sAr
 tmm
 pJS
 vzc
-rdR
+axV
 dne
 bxL
 lmN
@@ -106287,22 +101633,22 @@ aaa
 aaa
 aaa
 aaa
-aJt
-mFE
-xPL
-xPL
-byg
-bFi
-hXs
-pmd
-rWQ
-drk
-pFX
-nst
-iyq
-xPL
-xPL
-mFE
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -106448,10 +101794,10 @@ sAu
 wkd
 cva
 cva
-xwL
-lyX
-lyX
-nQP
+mDO
+xxd
+xxd
+cqT
 gtB
 tgv
 wJL
@@ -106542,27 +101888,27 @@ aaa
 aaa
 aaa
 aaa
-dVn
-aJt
-aJt
-mFE
-xPL
-xPL
-xPL
-oAr
-vva
-pFX
-lXd
-sgw
-rfA
-lfM
-xPL
-xPL
-xPL
-mFE
-aJt
-aJt
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -106799,27 +102145,27 @@ aaa
 aaa
 aaa
 aaa
-dVn
 aaa
-aJt
-mFE
-iII
-xPL
-xPL
-vyH
-vPw
-dCa
-tXT
-nRa
-lqZ
-eRI
-xPL
-xPL
-xPL
-mFE
-aJt
 aaa
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -107056,27 +102402,27 @@ aaa
 aaa
 aaa
 aaa
-dVn
-aJt
-aJt
-mFE
-mFE
-xPL
-xPL
-xPL
-lqZ
-xnr
-bGo
-nRa
-vJW
-xPL
-xPL
-xPL
-mFE
-mFE
-aJt
 aaa
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -107313,27 +102659,27 @@ aaa
 aaa
 aaa
 aaa
-dVn
-aaa
-aJt
-aJt
-mFE
-cpN
-iII
-xPL
-xPL
-isU
-dQd
-ftO
-xPL
-xPL
-iII
-uXc
-mFE
-aJt
 aaa
 aaa
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -107574,19 +102920,19 @@ aaa
 aaa
 aaa
 aaa
-aJt
-mFE
-mFE
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-mFE
-mFE
-aJt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -107829,23 +103175,23 @@ aaa
 aaa
 aaa
 aaa
-jCM
-jCM
-jCM
-aJt
-mFE
-mFE
-xPL
-xPL
-xPL
-xPL
-xPL
-mFE
-mFE
-aJt
-jCM
-jCM
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -108090,16 +103436,16 @@ aaa
 aaa
 aaa
 aaa
-aJt
-mFE
-mFE
-xPL
-xPL
-xPL
-mFE
-mFE
-aJt
-aJt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -108345,19 +103691,19 @@ aaa
 aaa
 aaa
 aaa
-cuZ
-aJt
-aJt
-aJt
-mFE
-mFE
-pss
-mFE
-mFE
-aJt
-aJt
-aJt
-cuZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -108604,22 +103950,22 @@ aaa
 aaa
 aaa
 aaa
-aJt
-aJt
-aJt
-aJt
-aJt
-aJt
-aJt
-aJt
-cuZ
-cuZ
 aaa
 aaa
 aaa
 aaa
 aaa
-cEB
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -108860,15 +104206,15 @@ aaa
 aaa
 aaa
 aaa
-cuZ
-aJt
-cuZ
-aJt
-cuZ
-cuZ
-cuZ
-aJt
-cuZ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -109118,13 +104464,13 @@ aaa
 aaa
 aaa
 aaa
-cuZ
-aaa
-cuZ
 aaa
 aaa
 aaa
-cuZ
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -112195,24 +107541,24 @@ aaa
 aaa
 aaa
 aaa
-mFE
-aJt
-aJt
-aJt
-aJt
-otc
-aJt
-aJt
-aJt
-aJt
-mFE
-aJt
-fMm
-aJt
-aJt
 aaa
 aaa
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -112452,24 +107798,24 @@ aaa
 aaa
 aaa
 aaa
-mFE
-aJt
-aaa
-aaa
-uZo
-aaa
-qVN
-aaa
-aaa
-aJt
-mFE
 aaa
 aaa
 aaa
-aJt
-aJt
 aaa
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -112709,24 +108055,24 @@ aaa
 aaa
 aaa
 aaa
-mFE
-aJt
-aaa
-uZV
 aaa
 aaa
 aaa
-gVu
-aaa
-aJt
-mFE
 aaa
 aaa
 aaa
-aJt
-aJt
-aJt
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -112966,24 +108312,24 @@ aaa
 aaa
 aaa
 aaa
-mFE
-aJt
-aaa
-vHu
 aaa
 aaa
 aaa
-vHu
-aaa
-aJt
-mFE
 aaa
 aaa
 aaa
-aJt
 aaa
-fMm
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -113223,21 +108569,21 @@ aaa
 aaa
 aaa
 aaa
-mFE
-aJt
-aaa
-ptV
-leo
-leo
-leo
-dLB
-aaa
-aJt
-mFE
 aaa
 aaa
 aaa
-aJt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -113480,22 +108826,22 @@ aaa
 aaa
 aaa
 aaa
-mFE
-aJt
 aaa
-tZr
-mVn
-uFX
-mdZ
-akE
 aaa
-aJt
-mFE
-mFE
-mFE
 aaa
-aJt
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -113737,22 +109083,22 @@ aaa
 aaa
 aaa
 aaa
-mFE
-xPL
-xPL
-xPL
-nrp
-iIj
-asG
-xPL
-xPL
-xPL
-mFE
-fMm
-mFE
-aJt
-aJt
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -113970,15 +109316,15 @@ aaa
 aaa
 aaa
 ucZ
-cOE
-cOE
-cOE
+rJJ
+rJJ
+rJJ
 vbw
 fjN
 kRG
-cOE
-cOE
-cOE
+rJJ
+rJJ
+rJJ
 pEf
 aaa
 aaa
@@ -113992,24 +109338,24 @@ aaa
 aaa
 aaa
 aaa
-ylo
-gzL
-aMJ
-maY
-oUc
-afK
-pLe
-rSF
-iIj
-ibK
-aTs
-ygC
-mFE
-xEB
-mFE
-aJt
 aaa
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -114249,25 +109595,25 @@ cEB
 aaa
 aaa
 aaa
-vJJ
-xPL
-xPL
-xPL
-xPL
-xPL
-qaQ
-uMP
-rYz
-xPL
-xPL
-xPL
-xPL
-xPL
-mFE
-aJt
-jCM
-jCM
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -114484,17 +109830,17 @@ aaa
 ucZ
 bVJ
 bVJ
-cOE
-cOE
-cOE
+rJJ
+rJJ
+rJJ
 aDW
 sxE
 vvS
-cOE
-cOE
-cOE
-cOE
-cOE
+rJJ
+rJJ
+rJJ
+rJJ
+rJJ
 pEf
 gXs
 aKN
@@ -114506,25 +109852,25 @@ aaa
 aaa
 aaa
 aaa
-vJJ
-xPL
-mLm
-hYy
-prn
-xPL
-xPL
-oBz
-xPL
-xPL
-rAM
-jRb
-hOS
-xPL
-mFE
-aJt
-jCM
-jCM
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -114751,7 +110097,7 @@ vmm
 ody
 kfG
 xnR
-cOE
+rJJ
 pEf
 gXs
 aKN
@@ -114763,25 +110109,25 @@ aaa
 aaa
 aaa
 aaa
-vJJ
-xPL
-fqr
-aSA
-aSA
-cAw
-iIj
-xLf
-pLe
-qQH
-hMW
-uNW
-dvh
-xPL
-mFE
 aaa
 aaa
 aaa
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -115008,7 +110354,7 @@ iek
 cZu
 cLg
 sdl
-cOE
+rJJ
 pEf
 aaa
 aaa
@@ -115018,27 +110364,27 @@ aaa
 aaa
 aaa
 aaa
-ylo
-aMJ
-hjt
-xPL
-jDi
-lem
-bmX
-xPL
-iIj
-uMP
-jMq
-xPL
-fkC
-pKt
-qBW
-xPL
-mFE
-mFE
-mFE
 aaa
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -115265,7 +110611,7 @@ pJB
 gBP
 vxS
 qlI
-cOE
+rJJ
 pEf
 pEf
 pEf
@@ -115275,27 +110621,27 @@ aaa
 aaa
 aaa
 aaa
-vJJ
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-cqT
-gTO
-dZh
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-mFE
 aaa
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -115532,27 +110878,27 @@ aaa
 aaa
 aaa
 aaa
-vJJ
-xPL
-mot
-bUO
-pOK
-mqZ
-pOK
-uLG
-mSd
-tUP
-iIj
-gzc
-imN
-iIj
-qrZ
-nOQ
-cVE
-xPL
-mFE
 aaa
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -115789,27 +111135,27 @@ aaa
 aaa
 aaa
 aaa
-vJJ
-xPL
-pTC
-hjk
-iWd
-hjk
-uQK
-paH
-xPL
-jIA
-xPL
-xPL
-wmA
-iIj
-iIj
-kST
-irs
-xPL
-mFE
-aJt
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -116028,11 +111374,11 @@ qTh
 phH
 iDE
 fYE
-snB
-snB
+byg
+byg
 cqk
 bhL
-ffl
+snB
 dEd
 pyZ
 dTb
@@ -116046,27 +111392,27 @@ aaa
 aaa
 aaa
 aaa
-vJJ
-lfU
-ycM
-ibO
-xxd
-ibO
-naq
-uMU
-sjc
-cJo
-wpK
-rJJ
-iIj
-iIj
-iIj
-iIj
-gsD
-xPL
-mFE
-fMm
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -116303,26 +111649,26 @@ aaa
 aKN
 aaa
 aaa
-vJJ
-xPL
-iOR
-ibO
-uNT
-tJH
-tMo
-kuT
-tdJ
-iXR
-dqm
-rJJ
-aTP
-vkj
-gpL
-fHw
-bPG
-xPL
-mFE
-aJt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -116560,28 +111906,28 @@ aaa
 aKN
 aaa
 aaa
-vJJ
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-mIH
-gfw
-dnq
-gfw
-rJJ
-rJJ
-xPL
-xPL
-xPL
-xPL
-xPL
-mFE
-aJt
 aaa
-aJt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -116816,29 +112162,29 @@ gXs
 gXs
 aKN
 aaa
-aMJ
-hjt
-mFE
-mFE
-mFE
-xPL
-xPL
-dvx
-rCq
-lFm
-hyr
-qFi
-hFn
-hFn
-xPL
-xPL
-mFE
-mFE
-mFE
-mFE
-aJt
-aJt
-aJt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -117077,23 +112423,23 @@ aaa
 aaa
 aaa
 aaa
-mFE
-xPL
-xPL
-hFn
-kcr
-qpA
-uBd
-qpA
-uTz
-hFn
-xPL
-xPL
-mFE
 aaa
 aaa
 aaa
-aJt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -117334,25 +112680,25 @@ aaa
 aaa
 aaa
 aaa
-mFE
-xPL
-xPL
-lNm
-uKS
-xBs
-iqH
-xBs
-dHS
-vqQ
-xPL
-xPL
-mFE
 aaa
 aaa
-aJt
-aJt
 aaa
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -117570,11 +112916,11 @@ pEf
 pEf
 fmC
 fmC
-kdN
+bfr
 bRu
 xFg
 gTY
-qSm
+wrK
 fmC
 fmC
 pEf
@@ -117590,24 +112936,24 @@ aaa
 aaa
 aaa
 aaa
-aJt
-mFE
-xPL
-xPL
-kqr
-jnr
-ctL
-hFn
-fWV
-jnr
-jaF
-xPL
-xPL
-mFE
-aJt
 aaa
-jCM
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -117828,10 +113174,10 @@ fmC
 fmC
 gQa
 jzm
-cbd
+fMm
 soe
-cbd
-gOE
+fMm
+cfh
 yap
 fmC
 fmC
@@ -117847,23 +113193,23 @@ aaa
 aaa
 aaa
 aaa
-aJt
-mFE
-xPL
-xPL
-tVH
-iHu
-qpA
-ogx
-qpA
-iDK
-ilq
-xPL
-xPL
-mFE
-aJt
-aJt
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -118085,11 +113431,11 @@ fmC
 fmC
 gNr
 npc
-cbd
-pkb
-cbd
-qId
-cxF
+fMm
+dnj
+fMm
+gOE
+iIj
 fmC
 fmC
 fmC
@@ -118104,21 +113450,21 @@ aaa
 aaa
 aaa
 aaa
-aJt
-mFE
-xPL
-xPL
-kqr
-jnr
-gFu
-hFn
-wyJ
-jnr
-jaF
-xPL
-xPL
-mFE
-aJt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -118342,9 +113688,9 @@ fmC
 bjE
 qQw
 lWl
-cbd
+fMm
 jKN
-cbd
+fMm
 lWl
 loF
 xlV
@@ -118358,27 +113704,27 @@ aaa
 aaa
 aaa
 aaa
-jCM
-aJt
 aaa
-aJt
-mFE
-xPL
-xPL
-hfD
-mAn
-hmx
-btR
-hmx
-tWs
-iAl
-xPL
-xPL
-mFE
-aJt
-aJt
 aaa
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -118597,13 +113943,13 @@ pEf
 fmC
 fmC
 xUW
-xPv
+nQP
 cWY
 lQv
 grq
 nHT
 tGz
-xKk
+opJ
 ikV
 fmC
 fmC
@@ -118615,27 +113961,27 @@ aaa
 aaa
 aaa
 aaa
-jCM
-aJt
-aJt
 aaa
-mFE
-xPL
-xPL
-xPL
-xbi
-kKg
-xdr
-kKg
-fXb
-xPL
-xPL
-xPL
-mFE
 aaa
-aJt
-aJt
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -118856,9 +114202,9 @@ fmC
 kVh
 qKK
 lWl
-cbd
-car
-cbd
+fMm
+tjY
+fMm
 lWl
 bdd
 bcd
@@ -118872,27 +114218,27 @@ aaa
 aaa
 aaa
 aaa
-jCM
-aaa
-aJt
-aaa
-mFE
-mFE
-xPL
-xPL
-xMv
-dFP
-fvy
-vHN
-nNV
-xPL
-xPL
-mFE
-mFE
 aaa
 aaa
 aaa
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -119113,11 +114459,11 @@ fmC
 fmC
 dOn
 sPc
-cbd
+fMm
 rlo
-cbd
-kep
-dYN
+fMm
+xPL
+hXu
 fmC
 fmC
 fmC
@@ -119129,27 +114475,27 @@ aaa
 aaa
 aaa
 aaa
-jCM
-aJt
-aJt
-aaa
-aJt
-mFE
-xPL
-xPL
-xPL
-tTW
-dnj
-hoK
-xPL
-xPL
-xPL
-mFE
 aaa
 aaa
 aaa
 aaa
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -119368,13 +114714,13 @@ pEf
 pEf
 fmC
 fmC
-xUb
+wIB
 ikV
-cbd
+fMm
 xzh
-cbd
+fMm
 nHT
-dfA
+jnr
 fmC
 fmC
 pEf
@@ -119386,27 +114732,27 @@ aaa
 aaa
 aaa
 aaa
-jCM
-aaa
-aJt
-aJt
-aJt
-mFE
-mFE
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-mFE
-mFE
 aaa
 aaa
 aaa
 aaa
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -119627,8 +114973,8 @@ ogh
 jXD
 fmC
 mDn
-bkZ
-car
+kit
+tjY
 dTU
 eKD
 fmC
@@ -119647,18 +114993,18 @@ aaa
 aaa
 aaa
 aaa
-aJt
-aJt
-mFE
-mFE
-xPL
-xPL
-xPL
-xPL
-xPL
-mFE
-mFE
-aJt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -119902,23 +115248,23 @@ aaa
 aaa
 aaa
 aaa
-jCM
-jCM
-jCM
-aJt
 aaa
-mFE
-mFE
-mFE
-mFE
-mFE
-mFE
-mFE
 aaa
-aJt
-jCM
-jCM
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -120164,13 +115510,13 @@ aaa
 aaa
 aaa
 aaa
-jCM
-jCM
-jCM
 aaa
-jCM
-jCM
-jCM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -120423,9 +115769,9 @@ aaa
 aaa
 aaa
 aaa
-jCM
-jCM
-jCM
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -122971,25 +118317,25 @@ aaa
 aaa
 aaa
 aaa
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-xFf
-ulw
-nPV
-xPL
-aJt
 aaa
-aJt
 aaa
-aJt
-diU
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -123228,25 +118574,25 @@ aaa
 aaa
 aaa
 aaa
-xPL
-ePD
-clN
-iLr
-sXt
-jsq
-jcv
-jBK
-kBF
-jkE
-aSA
-naj
-xPL
-xPL
-lfU
-lfU
-lbX
 aaa
-krI
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -123485,25 +118831,25 @@ aaa
 aaa
 aaa
 aaa
-fKE
-lDN
-jKm
-xhM
-esq
-niD
-kJV
-oSV
-kBF
-uZN
-xMi
-tjY
-aNW
-xPL
-bOL
-fJa
-lbX
-lbX
-lbX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -123742,25 +119088,25 @@ aaa
 aaa
 aaa
 aaa
-kGg
-nZC
-dOp
-cfn
-wRd
-bcc
-odu
-xPL
-xPL
-xPL
-gEa
-nbc
-eui
-xPL
-kit
-rfJ
-kvY
-kks
-lbX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -123999,25 +119345,25 @@ aaa
 aaa
 aaa
 aaa
-tmU
-vpq
-ohF
-ohF
-gkZ
-opJ
-ppD
-rJJ
-yiK
-xPL
-gXZ
-wrK
-fvW
-xPL
-smd
-nOm
-wEd
-nvG
-lbX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -124256,25 +119602,25 @@ aaa
 aaa
 aaa
 aaa
-cUN
-sBc
-lxm
-dBM
-flJ
-rBN
-jHM
-eOa
-nII
-fPW
-eNX
-eJD
-lHO
-mZM
-uRo
-bDr
-wPR
-jWs
-mqO
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -124513,25 +119859,25 @@ aaa
 aaa
 aaa
 aaa
-mrS
-viP
-ktI
-ktI
-ufy
-uKy
-aeC
-rJJ
-sAr
-xPL
-nHt
-iCz
-kTy
-xPL
-gzZ
-rfJ
-xyb
-urd
-lbX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -124770,25 +120116,25 @@ aaa
 aaa
 aaa
 aaa
-jRO
-hUA
-pen
-fCL
-kKy
-jHs
-pzi
-vTA
-vTA
-vTA
-pTL
-ofx
-xLT
-xPL
-chg
-uNG
-ekV
-iYH
-lbX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -125027,25 +120373,25 @@ aaa
 aaa
 aaa
 aaa
-elv
-jVz
-wBI
-jbG
-sGz
-oxX
-xZQ
-sGU
-kBF
-bRF
-nbX
-ecb
-qLN
-xPL
-juw
-opr
-lbX
-lbX
-lbX
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -125284,25 +120630,25 @@ aaa
 aaa
 aaa
 aaa
-xPL
-kPh
-mqB
-pMf
-vYj
-rnc
-eBf
-yfJ
-kBF
-tPN
-oHF
-wlO
-xPL
-xPL
-lfU
-lfU
-lbX
 aaa
-jtA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -125541,25 +120887,25 @@ aaa
 aaa
 aaa
 aaa
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-oMx
-abx
-fvb
-xPL
-aJt
-aoV
-aJt
 aaa
-aJt
-oZA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -125798,25 +121144,25 @@ aaa
 aaa
 aaa
 aaa
-xPL
-cMK
-pCI
-xQw
-oIu
-hci
-qJJ
-cfN
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
-xPL
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -295,6 +295,15 @@
 /obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"abx" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "aby" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -828,6 +837,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"afK" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "afL" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -3171,8 +3189,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "axV" = (
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "ayd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -6339,15 +6360,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port)
-"aTs" = (
-/obj/machinery/telecomms/receiver/preset_left{
-	name = "subspace receiver A"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 5
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "aTw" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -6438,6 +6450,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
+"aTP" = (
+/obj/machinery/telecomms/receiver/preset_left{
+	name = "subspace receiver A"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "aTQ" = (
 /obj/machinery/light{
 	dir = 1
@@ -7257,6 +7278,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"bcc" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
+	dir = 1
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "bcd" = (
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -9837,24 +9864,18 @@
 /turf/closed/wall/r_wall,
 /area/science/server)
 "byg" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/light/small{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room South";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/obj/machinery/telecomms/bus/preset_one,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
+/obj/machinery/light_switch{
+	pixel_x = 7;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "byi" = (
 /turf/closed/wall,
 /area/security/checkpoint/science)
@@ -12880,10 +12901,6 @@
 /obj/item/beacon,
 /turf/open/floor/engine,
 /area/science/misc_lab)
-"cbd" = (
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/circuit,
-/area/ai_monitored/storage/satellite)
 "cbe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -13318,16 +13335,6 @@
 /obj/item/stack/rods/fifty,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"chg" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
-	},
-/obj/machinery/camera{
-	c_tag = "East AI Server"
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
 "chq" = (
 /obj/machinery/processor/slime,
 /obj/item/radio/intercom{
@@ -14139,19 +14146,8 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "cqT" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/obj/structure/rack,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/suit/hooded/wintercoat,
-/obj/item/clothing/shoes/winterboots,
-/obj/item/clothing/shoes/winterboots,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/open/floor/circuit,
-/area/ai_monitored/storage/satellite)
+/area/ai_monitored/turret_protected/ai)
 "cqW" = (
 /obj/effect/decal/cleanable/xenoblood,
 /turf/open/floor/engine,
@@ -16758,15 +16754,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"djF" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "dkq" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -18287,12 +18274,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
-"dOp" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "dOt" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /obj/machinery/light,
@@ -23229,9 +23210,15 @@
 /turf/open/floor/plating,
 /area/lawoffice)
 "fCV" = (
-/obj/machinery/telecomms/message_server/preset,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
+	dir = 1;
+	name = "AI Antechamber APC";
+	pixel_y = 24
+	},
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/circuit,
+/area/ai_monitored/storage/satellite)
 "fDx" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -23626,7 +23613,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
+/area/ai_monitored/turret_protected/ai)
 "fJS" = (
 /obj/machinery/button/door{
 	id = "bridge blast";
@@ -23850,15 +23837,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"fMm" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "fMp" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall,
@@ -25720,8 +25698,20 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "gCs" = (
-/obj/effect/turf_decal/ramp_middle,
-/turf/open/floor/plasteel/dark/telecomms,
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 25;
+	pixel_y = 6
+	},
+/obj/machinery/light_switch{
+	pixel_x = 7;
+	pixel_y = 28
+	},
+/obj/machinery/camera{
+	c_tag = "AI Access"
+	},
+/obj/machinery/porta_turret/ai,
+/turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
 "gCF" = (
 /obj/machinery/camera{
@@ -27752,8 +27742,11 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/cyborg,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
 /turf/open/floor/circuit,
-/area/ai_monitored/storage/satellite)
+/area/ai_monitored/turret_protected/ai)
 "hoR" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -27953,13 +27946,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
-"hsq" = (
-/obj/machinery/pipedispenser,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "hsA" = (
 /obj/machinery/computer/camera_advanced/base_construction{
 	dir = 1
@@ -29550,13 +29536,24 @@
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
 "hXu" = (
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = 22
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room South";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/obj/machinery/telecomms/processor/preset_three,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "hYy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -30005,17 +30002,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"ieo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "aiserverdoor";
-	name = "AI Server Shutters"
-	},
-/turf/open/floor/circuit/green,
-/area/ai_monitored/storage/satellite)
 "ier" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -31396,6 +31382,15 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
+"iHu" = (
+/obj/machinery/telecomms/broadcaster/preset_left{
+	name = "subspace broadcaster A"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "iHI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -31442,17 +31437,15 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "iIj" = (
-/obj/effect/turf_decal/ramp_middle{
-	dir = 1
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
 	},
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = -22
+/obj/machinery/camera{
+	c_tag = "West AI Server"
 	},
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
-	dir = 1
-	},
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "iJa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -33046,14 +33039,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"jnr" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
 "jnA" = (
 /obj/structure/grille,
 /turf/open/space/basic,
@@ -33997,26 +33982,20 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "jHo" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/highsecurity{
-	id_tag = "ai_core_airlock_interior";
-	name = "AI Core";
-	req_access_txt = "65"
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 25;
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "aicoredoor";
-	name = "AI Chamber entrance shutters"
+/obj/machinery/ai_slipper{
+	uses = 10
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "jHq" = (
 /obj/machinery/camera{
 	c_tag = "Telecomms Satellite Access"
@@ -35213,11 +35192,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "kit" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/telecomms/message_server/preset,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "kiy" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/cmo)
@@ -35637,8 +35614,11 @@
 	id = "aiserverdoor";
 	name = "AI Server Shutters"
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
 /turf/open/floor/circuit/green,
-/area/ai_monitored/storage/satellite)
+/area/ai_monitored/turret_protected/ai)
 "krO" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer_R";
@@ -36530,12 +36510,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "kMi" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "kMt" = (
@@ -36923,9 +36901,11 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "kTy" = (
-/obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
@@ -37276,6 +37256,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"lbX" = (
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/circuit,
+/area/ai_monitored/storage/satellite)
 "lcb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -38500,8 +38484,8 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "lyX" = (
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/closed/wall/r_wall,
+/area/tcommsat/entrance)
 "lza" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -38766,6 +38750,25 @@
 "lFj" = (
 /turf/template_noop,
 /area/maintenance/port/fore)
+"lFm" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room South";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/obj/machinery/telecomms/bus/preset_one,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "lFG" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -38831,15 +38834,6 @@
 /obj/item/mop,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
-"lHO" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "lIb" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -39107,6 +39101,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"lMT" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/porta_turret/ai,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "lMW" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -39475,7 +39476,7 @@
 /area/maintenance/fore)
 "lWl" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
+	dir = 10
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
@@ -39961,25 +39962,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"mfG" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room South";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
-	},
-/obj/machinery/telecomms/processor/preset_three,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "mfN" = (
 /obj/machinery/camera{
 	c_tag = "Aft Starboard Solar Access";
@@ -40609,6 +40591,13 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
+"mqO" = (
+/obj/machinery/telecomms/processor/preset_four,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "mqR" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable{
@@ -40667,6 +40656,15 @@
 /obj/structure/transit_tube_pod,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"mrS" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "msb" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/meter,
@@ -41299,7 +41297,7 @@
 	state = 2
 	},
 /obj/machinery/camera{
-	c_tag = "West AI Server"
+	c_tag = "East AI Server"
 	},
 /turf/open/floor/circuit/green/telecomms,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -41401,7 +41399,7 @@
 /area/engine/engineering)
 "mFE" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 10
+	dir = 4
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
@@ -42285,15 +42283,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"mWE" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "mWH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -42448,40 +42437,9 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/engine/atmos/distro)
-"naj" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = 25;
-	pixel_y = 6
-	},
-/obj/structure/rack,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = 28
-	},
-/obj/machinery/camera{
-	c_tag = "AI Access"
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/storage/satellite)
 "naq" = (
-/obj/machinery/telecomms/broadcaster/preset_left{
-	name = "subspace broadcaster A"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "naz" = (
 /obj/effect/spawner/structure/solars/solar_96,
 /obj/structure/cable/yellow{
@@ -44174,6 +44132,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"nHT" = (
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
+	dir = 1
+	},
+/area/ai_monitored/turret_protected/ai)
 "nHU" = (
 /obj/machinery/requests_console{
 	department = "Science";
@@ -44474,6 +44444,12 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"nQP" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "nRs" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Genetics Research";
@@ -47232,9 +47208,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"oUc" = (
-/turf/closed/wall/r_wall,
-/area/tcommsat/entrance)
 "oUl" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -48037,6 +48010,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"pkb" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "pkD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -49056,14 +49037,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "pBl" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "pBm" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -49411,12 +49386,26 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "pJy" = (
-/obj/effect/turf_decal/ramp_middle,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/highsecurity{
+	id_tag = "ai_core_airlock_interior";
+	name = "AI Core";
+	req_access_txt = "65"
+	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "aicoredoor";
+	name = "AI Chamber entrance shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark/telecomms,
+/obj/effect/turf_decal/ramp_middle,
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "pJB" = (
 /turf/closed/wall,
@@ -49431,9 +49420,7 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "pJS" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "pKl" = (
@@ -52668,12 +52655,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"qVN" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
-	dir = 1
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
 "qVZ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -53077,6 +53058,9 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
+"rdR" = (
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "rfl" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -53130,6 +53114,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"rfJ" = (
+/obj/machinery/gulag_item_reclaimer,
+/turf/open/space/basic,
+/area/space)
 "rfK" = (
 /obj/machinery/light{
 	dir = 4
@@ -54213,8 +54201,18 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
+/obj/structure/rack,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
 /turf/open/floor/circuit,
-/area/ai_monitored/storage/satellite)
+/area/ai_monitored/turret_protected/ai)
 "rCr" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
@@ -55446,19 +55444,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
-"rYz" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "rYI" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -56211,6 +56196,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "snF" = (
@@ -56311,20 +56297,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "sqj" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = 25;
-	pixel_y = 24
-	},
-/obj/machinery/ai_slipper{
-	uses = 10
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/circuit,
-/area/ai_monitored/storage/satellite)
+/area/ai_monitored/turret_protected/ai)
 "sqE" = (
 /obj/structure/sign/warning/fire{
 	pixel_y = -32
@@ -58643,14 +58621,11 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "tjY" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	dir = 1;
-	name = "AI Antechamber APC";
-	pixel_y = 24
+/obj/machinery/pipedispenser,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/circuit,
+/turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
 "tkd" = (
 /obj/machinery/camera{
@@ -58757,9 +58732,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "tmm" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "tmp" = (
@@ -59082,11 +59055,11 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "tto" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
@@ -61622,12 +61595,10 @@
 /turf/template_noop,
 /area/crew_quarters/dorms)
 "uuG" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "uuW" = (
@@ -61870,14 +61841,12 @@
 /turf/closed/wall,
 /area/medical/paramedic)
 "uAV" = (
-/obj/effect/turf_decal/ramp_middle,
-/obj/machinery/camera/motion{
-	c_tag = "AI Chamber South";
-	dir = 1;
-	network = list("RD")
+/obj/structure/cable{
+	icon_state = "1-4";
+	tag = ""
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "uAW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -62195,7 +62164,6 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
 	},
-/obj/machinery/porta_turret/ai,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "uGf" = (
@@ -62604,11 +62572,13 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "uNG" = (
-/obj/machinery/telecomms/processor/preset_four,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
 	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "uNH" = (
 /obj/structure/rack,
@@ -66314,14 +66284,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "wer" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 8
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "weD" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -69471,9 +69440,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "xwL" = (
-/obj/machinery/gulag_item_reclaimer,
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "xwU" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/machinery/light{
@@ -69506,8 +69479,16 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
+/obj/structure/rack,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
 /turf/open/floor/circuit,
-/area/ai_monitored/storage/satellite)
+/area/ai_monitored/turret_protected/ai)
 "xxr" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -70964,9 +70945,6 @@
 /obj/effect/turf_decal/trimline/chemorange/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"ybM" = (
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
 "ycf" = (
 /obj/machinery/meter{
 	pixel_x = -5;
@@ -100174,10 +100152,10 @@ vJJ
 ume
 cva
 cva
-mDO
-lyX
-lyX
-kit
+iIj
+naq
+naq
+nQP
 gtB
 tgv
 wJL
@@ -100431,12 +100409,12 @@ nDA
 rjo
 tTK
 cva
-jnr
+wer
 gLt
 kMi
 uuG
 ieK
-kTy
+uAV
 azq
 rRA
 lmN
@@ -100683,17 +100661,17 @@ cva
 hWd
 fiF
 cfh
-hXu
+xwL
 cfh
 bfr
 qjk
 cva
 cva
-tgv
-ieo
+cva
+cva
 krI
-tgv
-rYz
+cva
+byg
 pSY
 lhk
 rdw
@@ -100942,19 +100920,19 @@ pen
 hmx
 cva
 cva
-dOp
+axV
 qZK
-iIj
-uAV
-tgv
+nHT
+cva
+lMT
 cqT
 xxd
-tgv
-cbd
+cva
+lbX
 pTL
-axV
-axV
-axV
+rdR
+rdR
+rdR
 aJw
 pvo
 sXZ
@@ -101456,18 +101434,18 @@ hUA
 lfM
 cva
 cva
-dOp
+axV
 rJJ
 vAP
+cva
 gCs
-tgv
-naj
+cqT
 rCq
-tgv
-tjY
+cva
+fCV
 hYy
-axV
-axV
+rdR
+rdR
 gOE
 aJw
 hvG
@@ -101717,14 +101695,14 @@ cOE
 laN
 cva
 cva
-tgv
-ieo
+cva
+cva
 krI
-tgv
-lHO
+cva
+kTy
 rzx
 iRV
-hsq
+tjY
 agz
 aJw
 qHo
@@ -101968,17 +101946,17 @@ cva
 iXp
 pyn
 dnj
-mWE
+mrS
 nDA
 rjo
 tTK
 cva
-jnr
+wer
 sAr
 tmm
 pJS
 vzc
-axV
+rdR
 dne
 bxL
 lmN
@@ -102230,10 +102208,10 @@ cva
 wkd
 cva
 cva
-chg
-lyX
-lyX
-kit
+mDO
+naq
+naq
+nQP
 gtB
 tgv
 wJL
@@ -108473,7 +108451,7 @@ aaa
 xrX
 aaa
 slA
-xwL
+rfJ
 aaa
 gXs
 pEf
@@ -109752,15 +109730,15 @@ aaa
 aaa
 aaa
 ucZ
-oUc
-oUc
-oUc
+lyX
+lyX
+lyX
 vbw
 fjN
 kRG
-oUc
-oUc
-oUc
+lyX
+lyX
+lyX
 pEf
 aaa
 aaa
@@ -110266,17 +110244,17 @@ aaa
 ucZ
 bVJ
 bVJ
-oUc
-oUc
-oUc
+lyX
+lyX
+lyX
 aDW
 sxE
 vvS
-oUc
-oUc
-oUc
-oUc
-oUc
+lyX
+lyX
+lyX
+lyX
+lyX
 pEf
 gXs
 aKN
@@ -110533,7 +110511,7 @@ vmm
 ody
 kfG
 xnR
-oUc
+lyX
 pEf
 gXs
 aKN
@@ -110790,7 +110768,7 @@ iek
 cZu
 cLg
 sdl
-oUc
+lyX
 pEf
 aaa
 aaa
@@ -111047,7 +111025,7 @@ pJB
 gBP
 vxS
 qlI
-oUc
+lyX
 pEf
 pEf
 pEf
@@ -111810,11 +111788,11 @@ qTh
 phH
 iDE
 fYE
-pBl
-pBl
+snB
+snB
 cqk
 bhL
-snB
+pkb
 dEd
 pyZ
 dTb
@@ -113352,11 +113330,11 @@ pEf
 pEf
 fmC
 fmC
-naq
+iHu
 bRu
 xFg
 gTY
-aTs
+aTP
 fmC
 fmC
 pEf
@@ -113610,10 +113588,10 @@ fmC
 fmC
 gQa
 jzm
-ybM
+pBl
 soe
-ybM
-fMm
+pBl
+tto
 yap
 fmC
 fmC
@@ -113867,11 +113845,11 @@ fmC
 fmC
 gNr
 npc
-ybM
-uNG
-ybM
-qVN
-djF
+pBl
+mqO
+pBl
+bcc
+abx
 fmC
 fmC
 fmC
@@ -114123,11 +114101,11 @@ fmC
 fmC
 bjE
 qQw
-lWl
-ybM
+mFE
+pBl
 jKN
-ybM
-lWl
+pBl
+mFE
 loF
 xlV
 fmC
@@ -114385,7 +114363,7 @@ lQv
 grq
 phR
 tGz
-tto
+uNG
 ikV
 fmC
 fmC
@@ -114637,11 +114615,11 @@ fmC
 fmC
 kVh
 qKK
-lWl
-ybM
+mFE
+pBl
 car
-ybM
-lWl
+pBl
+mFE
 bdd
 bcd
 fmC
@@ -114895,11 +114873,11 @@ fmC
 fmC
 dOn
 sPc
-ybM
+pBl
 rlo
-ybM
-mFE
-wer
+pBl
+lWl
+afK
 fmC
 fmC
 fmC
@@ -115150,13 +115128,13 @@ pEf
 pEf
 fmC
 fmC
-mfG
+hXu
 ikV
-ybM
+pBl
 xzh
-ybM
+pBl
 phR
-byg
+lFm
 fmC
 fmC
 pEf
@@ -115409,7 +115387,7 @@ ogh
 jXD
 fmC
 mDn
-fCV
+kit
 fmC
 dTU
 eKD

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -295,14 +295,6 @@
 /obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"abx" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "aby" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -836,14 +828,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"afK" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
 "afL" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -3186,6 +3170,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"axV" = (
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "ayd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -6352,6 +6339,15 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port)
+"aTs" = (
+/obj/machinery/telecomms/receiver/preset_left{
+	name = "subspace receiver A"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "aTw" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -6442,15 +6438,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
-"aTP" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "aTQ" = (
 /obj/machinery/light{
 	dir = 1
@@ -7270,10 +7257,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"bcc" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "bcd" = (
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -9854,13 +9837,23 @@
 /turf/closed/wall/r_wall,
 /area/science/server)
 "byg" = (
-/obj/machinery/telecomms/broadcaster/preset_left{
-	name = "subspace broadcaster A"
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 6
 	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room South";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/obj/machinery/telecomms/bus/preset_one,
+/turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "byi" = (
 /turf/closed/wall,
@@ -12888,12 +12881,9 @@
 /turf/open/floor/engine,
 /area/science/misc_lab)
 "cbd" = (
-/obj/machinery/telecomms/processor/preset_four,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/circuit,
+/area/ai_monitored/storage/satellite)
 "cbe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -13199,6 +13189,10 @@
 /obj/machinery/power/emitter,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cfh" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "cfm" = (
 /obj/item/c_tube,
 /obj/structure/disposalpipe/segment,
@@ -13324,6 +13318,16 @@
 /obj/item/stack/rods/fifty,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"chg" = (
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
+	},
+/obj/machinery/camera{
+	c_tag = "East AI Server"
+	},
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "chq" = (
 /obj/machinery/processor/slime,
 /obj/item/radio/intercom{
@@ -16755,9 +16759,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "djF" = (
-/obj/machinery/ai/server_cabinet/prefilled,
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "dkq" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -18278,6 +18287,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
+"dOp" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "dOt" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /obj/machinery/light,
@@ -19651,6 +19666,10 @@
 /area/science/robotics/lab)
 "erb" = (
 /obj/machinery/ai/data_core/primary,
+/obj/machinery/power/apc/highcap{
+	name = "AI Chamber APC";
+	pixel_y = -24
+	},
 /obj/item/radio/intercom{
 	anyai = 1;
 	freerange = 1;
@@ -19695,6 +19714,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/circuit/green/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "erf" = (
@@ -20337,6 +20357,9 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
@@ -21286,14 +21309,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "eTe" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
+/obj/machinery/ai/server_cabinet/prefilled,
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "eTh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -23211,14 +23229,9 @@
 /turf/open/floor/plating,
 /area/lawoffice)
 "fCV" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
+/obj/machinery/telecomms/message_server/preset,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "fDx" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -23837,6 +23850,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"fMm" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "fMp" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall,
@@ -24271,10 +24293,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"fXb" = (
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/circuit,
-/area/ai_monitored/storage/satellite)
 "fXm" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -27451,12 +27469,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hjk" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 10
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
 "hjA" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -27942,14 +27954,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
 "hsq" = (
-/obj/machinery/telecomms/receiver/preset_left{
-	name = "subspace receiver A"
+/obj/machinery/pipedispenser,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 5
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "hsA" = (
 /obj/machinery/computer/camera_advanced/base_construction{
 	dir = 1
@@ -29336,7 +29346,7 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
@@ -29540,15 +29550,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
 "hXu" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	dir = 1;
-	name = "AI Antechamber APC";
-	pixel_y = 24
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = 22
 	},
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/circuit,
-/area/ai_monitored/storage/satellite)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "hYy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -31388,25 +31396,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
-"iHu" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room South";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
-	},
-/obj/machinery/telecomms/processor/preset_three,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "iHI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -31452,6 +31441,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"iIj" = (
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
+	dir = 1
+	},
+/area/ai_monitored/turret_protected/ai)
 "iJa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -33045,6 +33046,14 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"jnr" = (
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "jnA" = (
 /obj/structure/grille,
 /turf/open/space/basic,
@@ -36914,16 +36923,12 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "kTy" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
+/obj/structure/cable{
+	icon_state = "1-4";
+	tag = ""
 	},
-/obj/machinery/power/apc/highcap{
-	dir = 1;
-	name = "AI Chamber APC";
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "kTM" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -37271,15 +37276,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"lbX" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "lcb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -37547,6 +37543,7 @@
 /turf/open/floor/wood,
 /area/library)
 "lhk" = (
+/obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
 "lhG" = (
@@ -38835,13 +38832,14 @@
 /turf/open/floor/plasteel/dark,
 /area/janitor)
 "lHO" = (
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = 22
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "lIb" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -39109,10 +39107,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"lMT" = (
-/obj/structure/chair/office/dark,
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "lMW" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -39969,10 +39963,10 @@
 /area/engine/foyer)
 "mfG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 1
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 6
+	dir = 5
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -39983,7 +39977,7 @@
 	network = list("ss13","minisat");
 	pixel_y = -22
 	},
-/obj/machinery/telecomms/bus/preset_one,
+/obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "mfN" = (
@@ -40615,13 +40609,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
-"mqO" = (
-/obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "mqR" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable{
@@ -40680,9 +40667,6 @@
 /obj/structure/transit_tube_pod,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"mrS" = (
-/turf/closed/wall/r_wall,
-/area/tcommsat/entrance)
 "msb" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/meter,
@@ -41416,8 +41400,8 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "mFE" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 10
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
@@ -42302,8 +42286,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "mWE" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+/obj/machinery/power/terminal{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
@@ -42486,6 +42473,15 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/storage/satellite)
+"naq" = (
+/obj/machinery/telecomms/broadcaster/preset_left{
+	name = "subspace broadcaster A"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "naz" = (
 /obj/effect/spawner/structure/solars/solar_96,
 /obj/structure/cable/yellow{
@@ -44178,10 +44174,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"nHT" = (
-/obj/machinery/telecomms/message_server/preset,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "nHU" = (
 /obj/machinery/requests_console{
 	department = "Science";
@@ -44482,17 +44474,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
-"nQP" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = 8;
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "nRs" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Genetics Research";
@@ -47252,9 +47233,8 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "oUc" = (
-/obj/machinery/gulag_item_reclaimer,
-/turf/open/space/basic,
-/area/space)
+/turf/closed/wall/r_wall,
+/area/tcommsat/entrance)
 "oUl" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -48577,12 +48557,12 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "ptV" = (
-/obj/machinery/pipedispenser,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
+/turf/open/floor/circuit/telecomms/server,
+/area/ai_monitored/turret_protected/ai)
 "put" = (
 /obj/machinery/door/airlock/external{
 	name = "Security Secure External Airlock";
@@ -49075,6 +49055,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"pBl" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "pBm" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -52679,6 +52668,12 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"qVN" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
+	dir = 1
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "qVZ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -53082,18 +53077,6 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
-"rdR" = (
-/obj/effect/turf_decal/ramp_middle{
-	dir = 1
-	},
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = -22
-	},
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
-	dir = 1
-	},
-/area/ai_monitored/turret_protected/ai)
 "rfl" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -55463,6 +55446,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
+"rYz" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 7;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "rYI" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -56215,7 +56211,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "snF" = (
@@ -56531,16 +56526,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"suV" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
-	},
-/obj/machinery/camera{
-	c_tag = "East AI Server"
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
 "svh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -58657,6 +58642,16 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"tjY" = (
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
+	dir = 1;
+	name = "AI Antechamber APC";
+	pixel_y = 24
+	},
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/circuit,
+/area/ai_monitored/storage/satellite)
 "tkd" = (
 /obj/machinery/camera{
 	c_tag = "Engineering East";
@@ -59086,6 +59081,15 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"tto" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "ttQ" = (
 /obj/structure/rack,
 /obj/machinery/light{
@@ -60007,15 +60011,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"tNs" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "tNA" = (
 /obj/machinery/camera{
 	c_tag = "Dormitory South";
@@ -62192,6 +62187,11 @@
 	},
 /area/ai_monitored/turret_protected/ai)
 "uGc" = (
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 8;
+	pixel_y = 23
+	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
 	},
@@ -62603,6 +62603,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"uNG" = (
+/obj/machinery/telecomms/processor/preset_four,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "uNH" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -66306,6 +66313,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"wer" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "weD" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -67690,19 +67706,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"wIB" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "wJc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/reagent_dispensers/fueltank,
@@ -69468,14 +69471,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "xwL" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
+/obj/machinery/gulag_item_reclaimer,
+/turf/open/space/basic,
+/area/space)
 "xwU" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/machinery/light{
@@ -99920,7 +99918,7 @@ cva
 cva
 cva
 gtB
-djF
+eTe
 qKi
 kqB
 gtB
@@ -100433,12 +100431,12 @@ nDA
 rjo
 tTK
 cva
-afK
+jnr
 gLt
 kMi
 uuG
 ieK
-mqO
+kTy
 azq
 rRA
 lmN
@@ -100684,9 +100682,9 @@ pqr
 cva
 hWd
 fiF
-bcc
-lHO
-bcc
+cfh
+hXu
+cfh
 bfr
 qjk
 cva
@@ -100695,9 +100693,9 @@ tgv
 ieo
 krI
 tgv
-wIB
+rYz
 pSY
-lMT
+lhk
 rdw
 pvf
 aJw
@@ -100944,19 +100942,19 @@ pen
 hmx
 cva
 cva
-nQP
+dOp
 qZK
-rdR
+iIj
 uAV
 tgv
 cqT
 xxd
 tgv
-fXb
+cbd
 pTL
-lhk
-lhk
-lhk
+axV
+axV
+axV
 aJw
 pvo
 sXZ
@@ -101198,7 +101196,7 @@ fFX
 cva
 bVI
 eAU
-pyn
+ptV
 erb
 cva
 uGc
@@ -101453,12 +101451,12 @@ nvA
 hRj
 rMA
 cva
-kTy
+nDA
 hUA
 lfM
 cva
 cva
-mWE
+dOp
 rJJ
 vAP
 gCs
@@ -101466,10 +101464,10 @@ tgv
 naj
 rCq
 tgv
-hXu
+tjY
 hYy
-lhk
-lhk
+axV
+axV
 gOE
 aJw
 hvG
@@ -101723,10 +101721,10 @@ tgv
 ieo
 krI
 tgv
-fCV
+lHO
 rzx
 iRV
-ptV
+hsq
 agz
 aJw
 qHo
@@ -101970,17 +101968,17 @@ cva
 iXp
 pyn
 dnj
-aTP
+mWE
 nDA
 rjo
 tTK
 cva
-afK
+jnr
 sAr
 tmm
 pJS
 vzc
-lhk
+axV
 dne
 bxL
 lmN
@@ -102232,7 +102230,7 @@ cva
 wkd
 cva
 cva
-suV
+chg
 lyX
 lyX
 kit
@@ -102490,7 +102488,7 @@ cva
 cva
 cva
 gtB
-djF
+eTe
 mUg
 uMi
 gtB
@@ -108475,7 +108473,7 @@ aaa
 xrX
 aaa
 slA
-oUc
+xwL
 aaa
 gXs
 pEf
@@ -109754,15 +109752,15 @@ aaa
 aaa
 aaa
 ucZ
-mrS
-mrS
-mrS
+oUc
+oUc
+oUc
 vbw
 fjN
 kRG
-mrS
-mrS
-mrS
+oUc
+oUc
+oUc
 pEf
 aaa
 aaa
@@ -110268,17 +110266,17 @@ aaa
 ucZ
 bVJ
 bVJ
-mrS
-mrS
-mrS
+oUc
+oUc
+oUc
 aDW
 sxE
 vvS
-mrS
-mrS
-mrS
-mrS
-mrS
+oUc
+oUc
+oUc
+oUc
+oUc
 pEf
 gXs
 aKN
@@ -110535,7 +110533,7 @@ vmm
 ody
 kfG
 xnR
-mrS
+oUc
 pEf
 gXs
 aKN
@@ -110792,7 +110790,7 @@ iek
 cZu
 cLg
 sdl
-mrS
+oUc
 pEf
 aaa
 aaa
@@ -111049,7 +111047,7 @@ pJB
 gBP
 vxS
 qlI
-mrS
+oUc
 pEf
 pEf
 pEf
@@ -111812,11 +111810,11 @@ qTh
 phH
 iDE
 fYE
-snB
-snB
+pBl
+pBl
 cqk
 bhL
-abx
+snB
 dEd
 pyZ
 dTb
@@ -113354,11 +113352,11 @@ pEf
 pEf
 fmC
 fmC
-byg
+naq
 bRu
 xFg
 gTY
-hsq
+aTs
 fmC
 fmC
 pEf
@@ -113615,7 +113613,7 @@ jzm
 ybM
 soe
 ybM
-lbX
+fMm
 yap
 fmC
 fmC
@@ -113870,10 +113868,10 @@ fmC
 gNr
 npc
 ybM
-cbd
+uNG
 ybM
-mFE
-xwL
+qVN
+djF
 fmC
 fmC
 fmC
@@ -114387,7 +114385,7 @@ lQv
 grq
 phR
 tGz
-eTe
+tto
 ikV
 fmC
 fmC
@@ -114900,8 +114898,8 @@ sPc
 ybM
 rlo
 ybM
-hjk
-tNs
+mFE
+wer
 fmC
 fmC
 fmC
@@ -115152,13 +115150,13 @@ pEf
 pEf
 fmC
 fmC
-iHu
+mfG
 ikV
 ybM
 xzh
 ybM
 phR
-mfG
+byg
 fmC
 fmC
 pEf
@@ -115411,7 +115409,7 @@ ogh
 jXD
 fmC
 mDn
-nHT
+fCV
 fmC
 dTU
 eKD

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -828,15 +828,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"afK" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/ai_monitored/turret_protected/ai)
 "afL" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -3179,6 +3170,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"axV" = (
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "ayd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -6345,12 +6339,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port)
-"aTs" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
-	dir = 1
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
 "aTw" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -6602,15 +6590,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
-"aVE" = (
-/obj/machinery/telecomms/broadcaster/preset_left{
-	name = "subspace broadcaster A"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "aVX" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/dark,
@@ -9840,10 +9819,14 @@
 /area/science/server)
 "byg" = (
 /obj/structure/window/reinforced{
-	dir = 8
+	dir = 4
 	},
-/obj/machinery/airalarm{
-	pixel_y = 24
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 7;
+	pixel_y = 28
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
@@ -12872,13 +12855,6 @@
 /obj/item/beacon,
 /turf/open/floor/engine,
 /area/science/misc_lab)
-"cbd" = (
-/obj/machinery/pipedispenser,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "cbe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -13313,13 +13289,6 @@
 /obj/item/stack/rods/fifty,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"chg" = (
-/obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "chq" = (
 /obj/machinery/processor/slime,
 /obj/item/radio/intercom{
@@ -15694,7 +15663,6 @@
 /area/engine/atmos/mix)
 "cOE" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
-/obj/machinery/porta_turret/ai,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "cOJ" = (
@@ -16749,6 +16717,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"djF" = (
+/obj/machinery/ai/server_cabinet/prefilled,
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "dkq" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -16935,12 +16907,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
-"dnj" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
 "dno" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -18268,6 +18234,12 @@
 	name = "server vent"
 	},
 /turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
+"dOp" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
+	dir = 1
+	},
+/turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "dOt" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
@@ -19643,9 +19615,8 @@
 "erb" = (
 /obj/machinery/ai/data_core/primary,
 /obj/machinery/power/apc/highcap{
-	dir = 1;
 	name = "AI Chamber APC";
-	pixel_y = 24
+	pixel_y = -24
 	},
 /obj/item/radio/intercom{
 	anyai = 1;
@@ -19678,14 +19649,14 @@
 	id = "aiserverdoor";
 	name = "AI Server entrance shutters control";
 	pixel_x = 20;
-	pixel_y = 21;
+	pixel_y = -21;
 	req_access_txt = "16"
 	},
 /obj/machinery/button/door{
 	id = "aicoredoor";
 	name = "AI Chamber entrance shutters control";
 	pixel_x = -23;
-	pixel_y = 21;
+	pixel_y = -21;
 	req_access_txt = "16"
 	},
 /obj/structure/cable{
@@ -20329,10 +20300,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "eAU" = (
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = 8;
-	pixel_y = -23
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
@@ -21282,9 +21253,14 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "eTe" = (
-/obj/machinery/ai/server_cabinet/prefilled,
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/telecomms/receiver/preset_left{
+	name = "subspace receiver A"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "eTh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -22098,8 +22074,8 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "fiF" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
@@ -23819,9 +23795,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"fMm" = (
-/turf/closed/wall/r_wall,
-/area/tcommsat/entrance)
 "fMp" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall,
@@ -24257,15 +24230,16 @@
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
 "fXb" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "West AI Server"
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "aiserverdoor";
+	name = "AI Server Shutters"
 	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/circuit/green,
+/area/ai_monitored/storage/satellite)
 "fXm" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -27442,16 +27416,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hjk" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
-	},
-/obj/machinery/camera{
-	c_tag = "East AI Server"
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
 "hjA" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -27660,9 +27624,16 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "hmx" = (
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 4;
+	external_pressure_bound = 120;
+	name = "server vent"
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/ai_monitored/turret_protected/ai)
 "hmO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -27929,21 +27900,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
-"hsq" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
-	dir = 4;
-	external_pressure_bound = 120;
-	name = "server vent"
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "hsA" = (
 /obj/machinery/computer/camera_advanced/base_construction{
 	dir = 1
@@ -29324,6 +29280,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"hUA" = (
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "hUM" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29523,6 +29486,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
+"hXu" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "hYy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -29972,16 +29944,15 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "ieo" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "aiserverdoor";
-	name = "AI Server Shutters"
+/obj/machinery/camera{
+	c_tag = "West AI Server"
 	},
-/turf/open/floor/circuit/green,
-/area/ai_monitored/storage/satellite)
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "ier" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -31407,6 +31378,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"iIj" = (
+/obj/machinery/telecomms/broadcaster/preset_left{
+	name = "subspace broadcaster A"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "iII" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 10
@@ -33006,6 +32986,13 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"jnr" = (
+/obj/structure/cable{
+	icon_state = "1-4";
+	tag = ""
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "jnA" = (
 /obj/structure/grille,
 /turf/open/space/basic,
@@ -33689,6 +33676,13 @@
 /obj/effect/turf_decal/box/corners,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"jCM" = (
+/obj/machinery/pipedispenser,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "jDa" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -34074,14 +34068,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/science/research)
-"jJK" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/machinery/airalarm/tcomms{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "jJP" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/machinery/holopad,
@@ -34835,14 +34821,9 @@
 /turf/open/floor/plating,
 /area/security/prison)
 "kcr" = (
-/obj/machinery/telecomms/receiver/preset_left{
-	name = "subspace receiver A"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 5
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/machinery/gulag_item_reclaimer,
+/turf/open/space/basic,
+/area/space)
 "kcy" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
@@ -35594,9 +35575,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "krI" = (
-/obj/machinery/telecomms/message_server/preset,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "aiserverdoor";
+	name = "AI Server Shutters"
+	},
+/turf/open/floor/circuit/green,
+/area/ai_monitored/storage/satellite)
 "krO" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer_R";
@@ -36880,15 +36865,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"kTy" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "kTM" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -37418,6 +37394,17 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"lfM" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8;
+	external_pressure_bound = 140;
+	pressure_checks = 0
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/ai_monitored/turret_protected/ai)
 "lfW" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -38445,6 +38432,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
+"lyX" = (
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "lza" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -38774,25 +38764,6 @@
 /obj/item/mop,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
-"lHO" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room South";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
-	},
-/obj/machinery/telecomms/bus/preset_one,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "lIb" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -39060,6 +39031,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"lMT" = (
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/circuit,
+/area/ai_monitored/storage/satellite)
 "lMW" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -39426,6 +39401,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"lWl" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "lWz" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -39908,21 +39889,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"mfG" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8;
-	external_pressure_bound = 140;
-	pressure_checks = 0
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "mfN" = (
 /obj/machinery/camera{
 	c_tag = "Aft Starboard Solar Access";
@@ -40553,13 +40519,14 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "mqO" = (
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = 22
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "mqR" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable{
@@ -40618,6 +40585,15 @@
 /obj/structure/transit_tube_pod,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"mrS" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "msb" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/meter,
@@ -41348,6 +41324,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"mFE" = (
+/obj/machinery/telecomms/processor/preset_four,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "mFO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -42228,6 +42211,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"mWE" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "mWH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -42408,7 +42400,14 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/storage/satellite)
 "naq" = (
-/turf/open/floor/plasteel/dark,
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
+	},
+/obj/machinery/camera{
+	c_tag = "East AI Server"
+	},
+/turf/open/floor/circuit/green/telecomms,
 /area/ai_monitored/turret_protected/aisat_interior)
 "naz" = (
 /obj/effect/spawner/structure/solars/solar_96,
@@ -44403,16 +44402,14 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "nQP" = (
-/obj/effect/turf_decal/ramp_middle{
-	dir = 1
-	},
-/obj/machinery/light/small{
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 4
 	},
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide2{
-	dir = 1
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 8
 	},
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "nRs" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Genetics Research";
@@ -47172,13 +47169,17 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "oUc" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
+	dir = 1
+	},
+/area/ai_monitored/turret_protected/ai)
 "oUl" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -47587,19 +47588,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"pen" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "pew" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -48504,14 +48492,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "ptV" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "put" = (
 /obj/machinery/door/airlock/external{
 	name = "Security Secure External Airlock";
@@ -49004,6 +48989,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"pBl" = (
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "pBm" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -50935,12 +50923,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"qoQ" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "qoX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -52605,6 +52587,25 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"qVN" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room South";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/obj/machinery/telecomms/processor/preset_three,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "qVZ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -52782,6 +52783,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/entrance)
+"qZK" = (
+/obj/effect/turf_decal/stripes/white/line,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "ras" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -53004,25 +53009,6 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
-"rdR" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room South";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
-	},
-/obj/machinery/telecomms/processor/preset_three,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "rfl" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -53076,16 +53062,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"rfJ" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	dir = 1;
-	name = "AI Antechamber APC";
-	pixel_y = 24
-	},
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
 "rfK" = (
 /obj/machinery/light{
 	dir = 4
@@ -54621,10 +54597,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
-"rJJ" = (
-/obj/effect/turf_decal/stripes/white/line,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "rKk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -56151,7 +56123,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "snF" = (
@@ -56467,14 +56438,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"suV" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "aiserverdoor";
-	name = "AI Server Shutters"
-	},
-/turf/open/floor/circuit/green,
-/area/ai_monitored/storage/satellite)
 "svh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -58591,6 +58554,25 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"tjY" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room South";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/obj/machinery/telecomms/bus/preset_one,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "tkd" = (
 /obj/machinery/camera{
 	c_tag = "Engineering East";
@@ -59020,6 +59002,9 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"tto" = (
+/turf/closed/wall/r_wall,
+/area/tcommsat/entrance)
 "ttQ" = (
 /obj/structure/rack,
 /obj/machinery/light{
@@ -60327,14 +60312,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "tTK" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
+/obj/machinery/porta_turret/ai,
+/turf/open/floor/circuit/telecomms/server,
+/area/ai_monitored/turret_protected/ai)
 "tUe" = (
 /obj/machinery/keycard_auth{
 	pixel_x = 24;
@@ -62122,14 +62102,18 @@
 	},
 /area/ai_monitored/turret_protected/ai)
 "uGc" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/holopad,
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 8;
+	pixel_y = 23
+	},
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	dir = 1
+	},
+/obj/machinery/porta_turret/ai,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "uGf" = (
@@ -62537,6 +62521,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"uNG" = (
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "uNH" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/hooded/wintercoat,
@@ -64624,11 +64616,10 @@
 /obj/effect/turf_decal/ramp_middle{
 	dir = 1
 	},
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = -22
+/obj/machinery/light/small{
+	dir = 4
 	},
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide2{
 	dir = 1
 	},
 /area/ai_monitored/turret_protected/ai)
@@ -67323,11 +67314,10 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "wBI" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/airalarm/tcomms{
+	dir = 4;
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
@@ -67623,6 +67613,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"wIB" = (
+/obj/machinery/telecomms/message_server/preset,
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "wJc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/reagent_dispensers/fueltank,
@@ -68988,12 +68982,15 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "xnr" = (
-/obj/machinery/telecomms/processor/preset_four,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
+	dir = 1;
+	name = "AI Antechamber APC";
+	pixel_y = 24
 	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/circuit,
+/area/ai_monitored/storage/satellite)
 "xnF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -69504,9 +69501,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/white,
 /area/engine/atmos/mix)
-"xyb" = (
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "xyG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -70324,15 +70318,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"xPL" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "xPQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -70897,7 +70882,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "ybM" = (
-/turf/open/floor/circuit/telecomms/server,
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "ycf" = (
 /obj/machinery/meter{
@@ -99850,7 +99841,7 @@ cva
 cva
 cva
 gtB
-eTe
+djF
 qKi
 kqB
 gtB
@@ -100106,9 +100097,9 @@ vJJ
 ume
 cva
 cva
-fXb
-naq
-naq
+ieo
+lyX
+lyX
 kit
 gtB
 tgv
@@ -100361,14 +100352,14 @@ nDA
 nDA
 nDA
 rjo
-sAu
+tTK
 cva
 mDO
 gLt
 kMi
 uuG
 ieK
-chg
+jnr
 azq
 rRA
 lmN
@@ -100615,17 +100606,17 @@ cva
 hWd
 fiF
 cfh
-mqO
+uNG
 cfh
 cOE
 qjk
 cva
 cva
 tgv
-ieo
-suV
+fXb
+krI
 tgv
-pen
+byg
 pSY
 lhk
 rdw
@@ -100870,23 +100861,23 @@ hRj
 oeF
 cva
 cuZ
-nDA
+hUA
+hmx
 cva
 cva
-hsq
-wBI
-rJJ
-vAP
+ptV
+qZK
+oUc
 uAV
 tgv
 cqT
 xxd
 tgv
-hmx
+lMT
 pTL
-xyb
-xyb
-xyb
+axV
+axV
+axV
 aJw
 pvo
 sXZ
@@ -101128,9 +101119,9 @@ fFX
 cva
 bVI
 eAU
-cva
+pyn
 erb
-afK
+cva
 uGc
 pZI
 uGb
@@ -101384,22 +101375,22 @@ hRj
 rMA
 cva
 nDA
-nDA
+hUA
+lfM
 cva
 cva
-mfG
-wBI
-rJJ
-nQP
+ptV
+qZK
+vAP
 gCs
 tgv
 naj
 rCq
 tgv
-rfJ
+xnr
 hYy
-xyb
-xyb
+axV
+axV
 gOE
 aJw
 hvG
@@ -101641,22 +101632,22 @@ gFO
 jfG
 cva
 hWd
-qoQ
-jJK
-prN
+fiF
 cfh
+prN
+wBI
 cOE
 laN
 cva
 cva
 tgv
-ieo
-suV
+fXb
+krI
 tgv
-byg
+mWE
 rzx
 iRV
-cbd
+jCM
 agz
 aJw
 qHo
@@ -101903,14 +101894,14 @@ nDA
 nDA
 nDA
 rjo
-sAu
+tTK
 cva
 mDO
 sAr
 tmm
 pJS
 vzc
-xyb
+axV
 dne
 bxL
 lmN
@@ -102162,9 +102153,9 @@ sAu
 wkd
 cva
 cva
-hjk
 naq
-naq
+lyX
+lyX
 kit
 gtB
 tgv
@@ -102420,7 +102411,7 @@ cva
 cva
 cva
 gtB
-eTe
+djF
 mUg
 uMi
 gtB
@@ -108405,7 +108396,7 @@ aaa
 xrX
 aaa
 slA
-aaa
+kcr
 aaa
 gXs
 pEf
@@ -109684,15 +109675,15 @@ aaa
 aaa
 aaa
 ucZ
-fMm
-fMm
-fMm
+tto
+tto
+tto
 vbw
 fjN
 kRG
-fMm
-fMm
-fMm
+tto
+tto
+tto
 pEf
 aaa
 aaa
@@ -110198,17 +110189,17 @@ aaa
 ucZ
 bVJ
 bVJ
-fMm
-fMm
-fMm
+tto
+tto
+tto
 aDW
 sxE
 vvS
-fMm
-fMm
-fMm
-fMm
-fMm
+tto
+tto
+tto
+tto
+tto
 pEf
 gXs
 aKN
@@ -110465,7 +110456,7 @@ vmm
 ody
 kfG
 xnR
-fMm
+tto
 pEf
 gXs
 aKN
@@ -110722,7 +110713,7 @@ iek
 cZu
 cLg
 sdl
-fMm
+tto
 pEf
 aaa
 aaa
@@ -110979,7 +110970,7 @@ pJB
 gBP
 vxS
 qlI
-fMm
+tto
 pEf
 pEf
 pEf
@@ -111742,11 +111733,11 @@ qTh
 phH
 iDE
 fYE
-snB
-snB
+hXu
+hXu
 cqk
 bhL
-oUc
+snB
 dEd
 pyZ
 dTb
@@ -113284,11 +113275,11 @@ pEf
 pEf
 fmC
 fmC
-aVE
+iIj
 bRu
 xFg
 gTY
-kcr
+eTe
 fmC
 fmC
 pEf
@@ -113542,10 +113533,10 @@ fmC
 fmC
 gQa
 jzm
-ybM
+pBl
 soe
-ybM
-kTy
+pBl
+mqO
 yap
 fmC
 fmC
@@ -113799,11 +113790,11 @@ fmC
 fmC
 gNr
 npc
-ybM
-xnr
-ybM
-aTs
-xPL
+pBl
+mFE
+pBl
+dOp
+mrS
 fmC
 fmC
 fmC
@@ -114055,11 +114046,11 @@ fmC
 fmC
 bjE
 qQw
-dnj
-ybM
+lWl
+pBl
 jKN
-ybM
-dnj
+pBl
+lWl
 loF
 xlV
 fmC
@@ -114317,7 +114308,7 @@ lQv
 grq
 phR
 tGz
-ptV
+nQP
 ikV
 fmC
 fmC
@@ -114569,11 +114560,11 @@ fmC
 fmC
 kVh
 qKK
-dnj
-ybM
+lWl
+pBl
 car
-ybM
-dnj
+pBl
+lWl
 bdd
 bcd
 fmC
@@ -114827,11 +114818,11 @@ fmC
 fmC
 dOn
 sPc
-ybM
+pBl
 rlo
-ybM
+pBl
 iII
-tTK
+ybM
 fmC
 fmC
 fmC
@@ -115082,13 +115073,13 @@ pEf
 pEf
 fmC
 fmC
-rdR
+qVN
 ikV
-ybM
+pBl
 xzh
-ybM
+pBl
 phR
-lHO
+tjY
 fmC
 fmC
 pEf
@@ -115341,7 +115332,7 @@ ogh
 jXD
 fmC
 mDn
-krI
+wIB
 fmC
 dTU
 eKD

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -296,10 +296,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "abx" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/circuit/telecomms/server,
+/turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "aby" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -834,6 +837,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"afK" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "afL" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -3176,6 +3188,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"axV" = (
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "ayd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -6342,6 +6362,15 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port)
+"aTs" = (
+/obj/machinery/telecomms/receiver/preset_left{
+	name = "subspace receiver A"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "aTw" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -6432,6 +6461,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
+"aTP" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
 "aTQ" = (
 /obj/machinery/light{
 	dir = 1
@@ -7252,9 +7287,14 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bcc" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "bcd" = (
 /obj/machinery/telecomms/server/presets/security,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -9835,15 +9875,9 @@
 /turf/closed/wall/r_wall,
 /area/science/server)
 "byg" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
-	},
-/obj/machinery/camera{
-	c_tag = "West AI Server"
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/circuit,
+/area/ai_monitored/storage/satellite)
 "byi" = (
 /turf/closed/wall,
 /area/security/checkpoint/science)
@@ -12870,9 +12904,11 @@
 /turf/open/floor/engine,
 /area/science/misc_lab)
 "cbd" = (
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/circuit,
-/area/ai_monitored/storage/satellite)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "cbe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -13179,14 +13215,9 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cfh" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "cfm" = (
 /obj/item/c_tube,
 /obj/structure/disposalpipe/segment,
@@ -18252,6 +18283,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
+"dOp" = (
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "dOt" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /obj/machinery/light,
@@ -21268,12 +21302,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "eTe" = (
-/obj/machinery/telecomms/processor/preset_four,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
+/obj/machinery/gulag_item_reclaimer,
+/turf/open/space/basic,
+/area/space)
 "eTh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -23190,16 +23221,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/lawoffice)
-"fCV" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	dir = 1;
-	name = "AI Antechamber APC";
-	pixel_y = 24
-	},
-/obj/item/kirbyplants/photosynthetic,
-/turf/open/floor/circuit,
-/area/ai_monitored/storage/satellite)
 "fDx" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -24252,6 +24273,13 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"fXb" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/porta_turret/ai,
+/turf/open/floor/circuit,
+/area/ai_monitored/turret_protected/ai)
 "fXm" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -25678,15 +25706,6 @@
 /obj/item/latexballon,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"gCs" = (
-/obj/machinery/telecomms/broadcaster/preset_left{
-	name = "subspace broadcaster A"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "gCF" = (
 /obj/machinery/camera{
 	c_tag = "Prison Yard";
@@ -29509,14 +29528,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
-"hXu" = (
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = 22
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "hYy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -29965,6 +29976,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"ieo" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 10
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "ier" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -31346,13 +31363,13 @@
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
 "iHu" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 4
+/obj/machinery/telecomms/broadcaster/preset_left{
+	name = "subspace broadcaster A"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "iHI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -31399,6 +31416,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"iII" = (
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
+	},
+/obj/machinery/camera{
+	c_tag = "West AI Server"
+	},
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "iJa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 1
@@ -32992,6 +33019,12 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"jnr" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
+	dir = 1
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "jnA" = (
 /obj/structure/grille,
 /turf/open/space/basic,
@@ -35564,16 +35597,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "krI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "aiserverdoor";
-	name = "AI Server Shutters"
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
+	dir = 1;
+	name = "AI Antechamber APC";
+	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/circuit/green,
-/area/ai_monitored/turret_protected/ai)
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/circuit,
+/area/ai_monitored/storage/satellite)
 "krO" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer_R";
@@ -36856,11 +36888,14 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "kTy" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "kTM" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -37475,7 +37510,6 @@
 /turf/open/floor/wood,
 /area/library)
 "lhk" = (
-/obj/structure/chair/office/dark,
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
 "lhG" = (
@@ -38431,15 +38465,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/teleporter)
-"lyX" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "lza" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -38705,14 +38730,13 @@
 /turf/template_noop,
 /area/maintenance/port/fore)
 "lFm" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
+/area/tcommsat/computer)
 "lFG" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -38778,25 +38802,6 @@
 /obj/item/mop,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
-"lHO" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Telecomms Server Room South";
-	dir = 8;
-	network = list("ss13","minisat");
-	pixel_y = -22
-	},
-/obj/machinery/telecomms/processor/preset_three,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "lIb" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -39065,8 +39070,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "lMT" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 25;
+	pixel_y = 6
+	},
+/obj/machinery/light_switch{
+	pixel_x = 7;
+	pixel_y = 28
+	},
+/obj/machinery/camera{
+	c_tag = "AI Access"
 	},
 /obj/machinery/porta_turret/ai,
 /turf/open/floor/circuit,
@@ -39438,12 +39452,11 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "lWl" = (
-/obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "lWz" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -39926,22 +39939,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"mfG" = (
-/obj/machinery/flasher{
-	id = "AI";
-	pixel_x = 25;
-	pixel_y = 6
-	},
-/obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = 28
-	},
-/obj/machinery/camera{
-	c_tag = "AI Access"
-	},
-/obj/machinery/porta_turret/ai,
-/turf/open/floor/circuit,
-/area/ai_monitored/turret_protected/ai)
 "mfN" = (
 /obj/machinery/camera{
 	c_tag = "Aft Starboard Solar Access";
@@ -40572,14 +40569,24 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "mqO" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Telecomms Server Room South";
+	dir = 8;
+	network = list("ss13","minisat");
+	pixel_y = -22
+	},
+/obj/machinery/telecomms/processor/preset_three,
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "mqR" = (
 /obj/effect/spawner/structure/window,
 /obj/structure/cable{
@@ -40638,13 +40645,6 @@
 /obj/structure/transit_tube_pod,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"mrS" = (
-/obj/machinery/pipedispenser,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "msb" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/meter,
@@ -41276,7 +41276,9 @@
 	anchored = 1;
 	state = 2
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/camera{
+	c_tag = "East AI Server"
+	},
 /turf/open/floor/circuit/green/telecomms,
 /area/ai_monitored/turret_protected/aisat_interior)
 "mEa" = (
@@ -41376,10 +41378,13 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "mFE" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden{
 	dir = 4
 	},
-/turf/open/floor/circuit/telecomms/server,
+/turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
 "mFO" = (
 /obj/effect/turf_decal/stripes/line{
@@ -42262,10 +42267,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "mWE" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 10
+/obj/machinery/telecomms/processor/preset_four,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/circuit/telecomms/server,
+/turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "mWH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -42424,6 +42430,13 @@
 "naj" = (
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
+"naq" = (
+/obj/structure/cable{
+	icon_state = "1-4";
+	tag = ""
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "naz" = (
 /obj/effect/spawner/structure/solars/solar_96,
 /obj/structure/cable/yellow{
@@ -44116,12 +44129,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"nHT" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "nHU" = (
 /obj/machinery/requests_console{
 	department = "Science";
@@ -47181,14 +47188,8 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "oUc" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/turf/closed/wall/r_wall,
+/area/tcommsat/entrance)
 "oUl" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -47512,6 +47513,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"paH" = (
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "paQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 4
@@ -47856,18 +47865,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "phR" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 7;
-	pixel_y = 28
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "pia" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4
@@ -49017,8 +49019,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "pBl" = (
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
+/obj/structure/chair/office/dark,
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "pBm" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -52635,10 +52638,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"qVN" = (
-/obj/machinery/telecomms/message_server/preset,
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "qVZ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -53042,6 +53041,19 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/fore)
+"rdR" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 7;
+	pixel_y = 28
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "rfl" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -53095,9 +53107,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"rfJ" = (
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "rfK" = (
 /obj/machinery/light{
 	dir = 4
@@ -55424,9 +55433,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
-"rYz" = (
-/turf/closed/wall/r_wall,
-/area/tcommsat/entrance)
 "rYI" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -56179,6 +56185,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "snF" = (
@@ -56487,15 +56494,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "suV" = (
-/obj/effect/turf_decal/ramp_middle{
-	dir = 1
-	},
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide2{
-	dir = 1
-	},
+/turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
 "svh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -58613,6 +58615,17 @@
 /obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"tjY" = (
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide2{
+	dir = 1
+	},
+/area/ai_monitored/turret_protected/ai)
 "tkd" = (
 /obj/machinery/camera{
 	c_tag = "Engineering East";
@@ -59961,15 +59974,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"tNs" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "tNA" = (
 /obj/machinery/camera{
 	c_tag = "Dormitory South";
@@ -64641,6 +64645,11 @@
 	id = "Cell 2";
 	pixel_x = -22
 	},
+/obj/machinery/camera/motion{
+	c_tag = "AI Chamber South";
+	dir = 1;
+	network = list("RD")
+	},
 /turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
 	dir = 1
 	},
@@ -67638,12 +67647,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"wIB" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
 "wJc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/structure/reagent_dispensers/fueltank,
@@ -69428,12 +69431,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "xwL" = (
-/obj/machinery/telecomms/receiver/preset_left{
-	name = "subspace receiver A"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 5
-	},
+/obj/machinery/telecomms/message_server/preset,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "xwU" = (
@@ -69555,15 +69553,12 @@
 /turf/open/floor/plasteel/white,
 /area/engine/atmos/mix)
 "xyb" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
+/obj/machinery/pipedispenser,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "East AI Server"
-	},
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "xyG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -70948,9 +70943,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "ybM" = (
-/obj/machinery/gulag_item_reclaimer,
-/turf/open/space/basic,
-/area/space)
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "ycf" = (
 /obj/machinery/meter{
 	pixel_x = -5;
@@ -100158,7 +100158,7 @@ vJJ
 ume
 cva
 cva
-byg
+iII
 xPL
 xPL
 kit
@@ -100415,12 +100415,12 @@ nDA
 rjo
 tTK
 cva
-mDO
+paH
 gLt
 kMi
 uuG
 ieK
-lWl
+naq
 azq
 rRA
 lmN
@@ -100666,20 +100666,20 @@ pqr
 cva
 hWd
 fiF
-bcc
-hXu
-bcc
+cfh
+axV
+cfh
 bfr
 qjk
 cva
 cva
 cva
 cva
-krI
+suV
 cva
-phR
+rdR
 pSY
-lhk
+pBl
 rdw
 pvf
 aJw
@@ -100926,19 +100926,19 @@ pen
 hmx
 cva
 cva
-kTy
+cbd
 qZK
 vAP
 cva
-lMT
+fXb
 naj
 xxd
 cva
-cbd
+byg
 pTL
-rfJ
-rfJ
-rfJ
+lhk
+lhk
+lhk
 aJw
 pvo
 sXZ
@@ -101440,18 +101440,18 @@ hUA
 lfM
 cva
 cva
-kTy
+cbd
 rJJ
-suV
+tjY
 cva
-mfG
+lMT
 naj
 rCq
 cva
-fCV
+krI
 hYy
-rfJ
-rfJ
+lhk
+lhk
 gOE
 aJw
 hvG
@@ -101703,12 +101703,12 @@ cva
 cva
 cva
 cva
-krI
+suV
 cva
-cfh
+kTy
 rzx
 iRV
-mrS
+xyb
 agz
 aJw
 qHo
@@ -101952,17 +101952,17 @@ cva
 iXp
 pyn
 dnj
-oUc
+ybM
 nDA
 rjo
 tTK
 cva
-mDO
+paH
 sAr
 tmm
 pJS
 vzc
-rfJ
+lhk
 dne
 bxL
 lmN
@@ -102214,7 +102214,7 @@ cva
 wkd
 cva
 cva
-xyb
+mDO
 xPL
 xPL
 kit
@@ -102980,7 +102980,7 @@ xxK
 qNB
 kVQ
 bbw
-wIB
+aTP
 pUK
 sZn
 gtE
@@ -108457,7 +108457,7 @@ aaa
 xrX
 aaa
 slA
-ybM
+eTe
 aaa
 gXs
 pEf
@@ -109736,15 +109736,15 @@ aaa
 aaa
 aaa
 ucZ
-rYz
-rYz
-rYz
+oUc
+oUc
+oUc
 vbw
 fjN
 kRG
-rYz
-rYz
-rYz
+oUc
+oUc
+oUc
 pEf
 aaa
 aaa
@@ -110250,17 +110250,17 @@ aaa
 ucZ
 bVJ
 bVJ
-rYz
-rYz
-rYz
+oUc
+oUc
+oUc
 aDW
 sxE
 vvS
-rYz
-rYz
-rYz
-rYz
-rYz
+oUc
+oUc
+oUc
+oUc
+oUc
 pEf
 gXs
 aKN
@@ -110517,7 +110517,7 @@ vmm
 ody
 kfG
 xnR
-rYz
+oUc
 pEf
 gXs
 aKN
@@ -110774,7 +110774,7 @@ iek
 cZu
 cLg
 sdl
-rYz
+oUc
 pEf
 aaa
 aaa
@@ -111031,7 +111031,7 @@ pJB
 gBP
 vxS
 qlI
-rYz
+oUc
 pEf
 pEf
 pEf
@@ -111794,11 +111794,11 @@ qTh
 phH
 iDE
 fYE
-mqO
-mqO
+snB
+snB
 cqk
 bhL
-snB
+lFm
 dEd
 pyZ
 dTb
@@ -113336,11 +113336,11 @@ pEf
 pEf
 fmC
 fmC
-gCs
+iHu
 bRu
 xFg
 gTY
-xwL
+aTs
 fmC
 fmC
 pEf
@@ -113594,10 +113594,10 @@ fmC
 fmC
 gQa
 jzm
-pBl
+dOp
 soe
-pBl
-tNs
+dOp
+mFE
 yap
 fmC
 fmC
@@ -113851,11 +113851,11 @@ fmC
 fmC
 gNr
 npc
-pBl
-eTe
-pBl
-abx
-iHu
+dOp
+mWE
+dOp
+jnr
+bcc
 fmC
 fmC
 fmC
@@ -114107,11 +114107,11 @@ fmC
 fmC
 bjE
 qQw
-mFE
-pBl
+lWl
+dOp
 jKN
-pBl
-mFE
+dOp
+lWl
 loF
 xlV
 fmC
@@ -114367,9 +114367,9 @@ jcz
 cWY
 lQv
 grq
-nHT
+phR
 tGz
-lFm
+afK
 ikV
 fmC
 fmC
@@ -114621,11 +114621,11 @@ fmC
 fmC
 kVh
 qKK
-mFE
-pBl
+lWl
+dOp
 car
-pBl
-mFE
+dOp
+lWl
 bdd
 bcd
 fmC
@@ -114879,11 +114879,11 @@ fmC
 fmC
 dOn
 sPc
-pBl
+dOp
 rlo
-pBl
-mWE
-lyX
+dOp
+ieo
+abx
 fmC
 fmC
 fmC
@@ -115134,12 +115134,12 @@ pEf
 pEf
 fmC
 fmC
-lHO
+mqO
 ikV
-pBl
+dOp
 xzh
-pBl
-nHT
+dOp
+phR
 xnr
 fmC
 fmC
@@ -115393,7 +115393,7 @@ ogh
 jXD
 fmC
 mDn
-qVN
+xwL
 fmC
 dTU
 eKD

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -295,6 +295,13 @@
 /obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"abx" = (
+/obj/structure/frame/machine{
+	anchored = 1;
+	state = 2
+	},
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "aby" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
@@ -829,12 +836,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "afK" = (
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = 22
+/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/dark/telecomms,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
 "afL" = (
 /obj/item/radio/intercom{
@@ -3179,8 +3187,11 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "axV" = (
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
+/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
+	dir = 1
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "ayd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -4867,6 +4878,11 @@
 /turf/closed/wall,
 /area/hallway/primary/central)
 "aJy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "aJz" = (
@@ -6342,6 +6358,15 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/port)
+"aTs" = (
+/obj/machinery/telecomms/receiver/preset_left{
+	name = "subspace receiver A"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 5
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "aTw" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -6593,6 +6618,15 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
+"aVE" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "aVX" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel/dark,
@@ -7662,15 +7696,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/bridge/meeting_room)
-"bfr" = (
-/obj/machinery/telecomms/broadcaster/preset_left{
-	name = "subspace broadcaster A"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 6
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "bfv" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -9830,14 +9855,14 @@
 /turf/closed/wall/r_wall,
 /area/science/server)
 "byg" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
+/area/tcommsat/server)
 "byi" = (
 /turf/closed/wall,
 /area/security/checkpoint/science)
@@ -12823,6 +12848,15 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/prison)
+"car" = (
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "caI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -13166,14 +13200,9 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cfh" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "cfm" = (
 /obj/item/c_tube,
 /obj/structure/disposalpipe/segment,
@@ -14113,8 +14142,13 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/structure/rack,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/suit/hooded/wintercoat,
+/obj/item/clothing/shoes/winterboots,
+/obj/item/clothing/shoes/winterboots,
+/turf/open/floor/circuit,
+/area/ai_monitored/storage/satellite)
 "cqW" = (
 /obj/effect/decal/cleanable/xenoblood,
 /turf/open/floor/engine,
@@ -16712,6 +16746,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"djF" = (
+/obj/machinery/ai/server_cabinet/prefilled,
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "dkq" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -16899,10 +16937,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
 "dnj" = (
-/obj/machinery/telecomms/processor/preset_four,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
+/obj/machinery/telecomms/message_server/preset,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "dno" = (
@@ -18232,6 +18267,9 @@
 	name = "server vent"
 	},
 /turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
+"dOp" = (
+/turf/open/floor/circuit/telecomms/server,
 /area/tcommsat/server)
 "dOt" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
@@ -19638,11 +19676,21 @@
 	pixel_y = -4
 	},
 /obj/machinery/button/door{
+	id = "aiserverdoor";
+	name = "AI Server entrance shutters control";
+	pixel_x = 20;
+	pixel_y = 21;
+	req_access_txt = "16"
+	},
+/obj/machinery/button/door{
 	id = "aicoredoor";
 	name = "AI Chamber entrance shutters control";
 	pixel_x = -23;
 	pixel_y = 21;
 	req_access_txt = "16"
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/circuit/green/telecomms,
 /area/ai_monitored/turret_protected/ai)
@@ -21230,10 +21278,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"eTe" = (
-/obj/machinery/ai/server_cabinet/prefilled,
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
 "eTh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -23526,8 +23570,17 @@
 	name = "AI Core";
 	req_access_txt = "65"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/ai_monitored/storage/satellite)
 "fJS" = (
 /obj/machinery/button/door{
 	id = "bridge blast";
@@ -23751,9 +23804,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"fMm" = (
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
 "fMp" = (
 /obj/machinery/smartfridge,
 /turf/closed/wall,
@@ -24188,6 +24238,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"fXb" = (
+/obj/machinery/pipedispenser,
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "fXm" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -24870,10 +24924,6 @@
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "aicoredoor";
-	name = "AI Chamber entrance shutters"
 	},
 /obj/machinery/door/airlock/public{
 	autoclose = 0;
@@ -25618,6 +25668,10 @@
 /obj/item/latexballon,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"gCs" = (
+/obj/effect/turf_decal/ramp_middle,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "gCF" = (
 /obj/machinery/camera{
 	c_tag = "Prison Yard";
@@ -26027,6 +26081,19 @@
 "gLo" = (
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
+"gLt" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
+	dir = 4;
+	name = "AI Server APC";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "gLN" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
@@ -26121,11 +26188,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "gOE" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/hidden{
-	dir = 1
+/obj/structure/chair/office/dark{
+	dir = 4
 	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "gOU" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable{
@@ -27554,14 +27621,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
-"hmx" = (
-/obj/effect/turf_decal/ramp_middle{
-	dir = 1
-	},
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide2{
-	dir = 1
-	},
-/area/ai_monitored/turret_protected/ai)
 "hmO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -27616,6 +27675,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"hoK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/storage/satellite)
 "hoR" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -29409,15 +29480,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
-"hXu" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+"hYy" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "hYM" = (
 /obj/machinery/bounty_board{
 	pixel_y = 32
@@ -29862,8 +29933,12 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "aiserverdoor";
+	name = "AI Server Shutters"
+	},
+/turf/open/floor/circuit/green,
+/area/ai_monitored/storage/satellite)
 "ier" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -29901,6 +29976,17 @@
 	id_tag = "ai_core_airlock_interior";
 	name = "AI Server Room 1";
 	req_access_txt = "65"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "aiserverdoor";
+	name = "AI Server Shutters"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -31233,6 +31319,15 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/hop)
+"iHu" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "iHI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -31279,8 +31374,17 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "iIj" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
+"iII" = (
 /obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -31782,12 +31886,6 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"iRV" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "iRY" = (
 /obj/structure/table,
 /obj/item/flashlight{
@@ -32343,11 +32441,17 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "jcz" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
-	dir = 1
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 4
 	},
-/turf/open/floor/circuit/telecomms/server,
-/area/ai_monitored/turret_protected/ai)
+/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "jcF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -32873,15 +32977,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"jnr" = (
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "jnA" = (
 /obj/structure/grille,
 /turf/open/space/basic,
@@ -33832,8 +33927,19 @@
 	req_access_txt = "65"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "aicoredoor";
+	name = "AI Chamber entrance shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/ai_monitored/storage/satellite)
 "jHq" = (
 /obj/machinery/camera{
 	c_tag = "AI Satellite Access"
@@ -33941,6 +34047,10 @@
 /area/science/research)
 "jJK" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/airalarm/tcomms{
+	dir = 4;
+	pixel_x = -24
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "jJP" = (
@@ -35027,7 +35137,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "kit" = (
-/obj/machinery/telecomms/message_server/preset,
+/obj/machinery/telecomms/broadcaster/preset_left{
+	name = "subspace broadcaster A"
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 6
+	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
 "kiy" = (
@@ -35441,9 +35556,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "krI" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/telecomms/processor/preset_four,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/circuit/green/telecomms/mainframe,
+/area/tcommsat/server)
 "krO" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer_R";
@@ -36338,6 +36456,9 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "kMt" = (
@@ -36724,6 +36845,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"kTy" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
+	dir = 10
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/tcommsat/server)
 "kTM" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -38281,15 +38408,14 @@
 /turf/open/floor/plasteel,
 /area/teleporter)
 "lyX" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
-	dir = 1;
-	name = "AI Antechamber APC";
-	pixel_y = 24
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "lza" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
@@ -38619,6 +38745,18 @@
 /obj/item/mop,
 /turf/open/floor/plasteel/dark,
 /area/janitor)
+"lHO" = (
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
+	dir = 1
+	},
+/area/ai_monitored/turret_protected/ai)
 "lIb" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = 32
@@ -41073,6 +41211,7 @@
 	anchored = 1;
 	state = 2
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/circuit/green/telecomms,
 /area/ai_monitored/turret_protected/aisat_interior)
 "mEa" = (
@@ -41171,6 +41310,9 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"mFE" = (
+/turf/closed/wall/r_wall,
+/area/tcommsat/entrance)
 "mFO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -41935,6 +42077,9 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"mUg" = (
+/turf/open/floor/circuit/green/telecomms,
+/area/ai_monitored/turret_protected/aisat_interior)
 "mUk" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -42199,6 +42344,24 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/engine/atmos/distro)
+"naj" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 25;
+	pixel_y = 6
+	},
+/obj/structure/rack,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/gloves/color/black,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/turf/open/floor/circuit,
+/area/ai_monitored/storage/satellite)
 "naz" = (
 /obj/effect/spawner/structure/solars/solar_96,
 /obj/structure/cable/yellow{
@@ -43413,6 +43576,24 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"nyj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "nyu" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -43872,12 +44053,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"nHT" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
 "nHU" = (
 /obj/machinery/requests_console{
 	department = "Science";
@@ -44179,17 +44354,11 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "nQP" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
+/area/ai_monitored/turret_protected/aisat_interior)
 "nRs" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Genetics Research";
@@ -45376,14 +45545,13 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "opJ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/server)
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "oqf" = (
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine{
@@ -47272,6 +47440,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"paH" = (
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/satellite)
 "paQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/visible{
 	dir = 4
@@ -47608,6 +47780,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"phR" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "pia" = (
 /obj/effect/turf_decal/stripes{
 	dir = 4
@@ -48254,6 +48432,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"ptV" = (
+/obj/structure/cable{
+	icon_state = "1-4";
+	tag = ""
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "put" = (
 /obj/machinery/door/airlock/external{
 	name = "Security Secure External Airlock";
@@ -49095,6 +49280,9 @@
 "pJy" = (
 /obj/effect/turf_decal/ramp_middle,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "pJB" = (
@@ -49497,6 +49685,12 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
 "pTb" = (
@@ -49537,6 +49731,12 @@
 "pTL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
@@ -49880,6 +50080,12 @@
 "pZI" = (
 /obj/effect/turf_decal/stripes/white/line,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "pZU" = (
@@ -51658,9 +51864,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"qKi" = (
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
 "qKn" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry Lab";
@@ -52323,12 +52526,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"qVN" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "qVZ" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -52777,6 +52974,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"rfJ" = (
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/storage/satellite)
 "rfK" = (
 /obj/machinery/light{
 	dir = 4
@@ -53694,6 +53894,9 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/storage/satellite)
 "rzz" = (
@@ -53854,14 +54057,11 @@
 /turf/open/space/basic,
 /area/solar/port/fore)
 "rCq" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
+/turf/open/floor/circuit,
+/area/ai_monitored/storage/satellite)
 "rCr" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
@@ -54313,8 +54513,15 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
 "rJJ" = (
-/turf/closed/wall/r_wall,
-/area/tcommsat/entrance)
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
+	dir = 1;
+	name = "AI Antechamber APC";
+	pixel_y = 24
+	},
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/satellite)
 "rKk" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -54633,6 +54840,11 @@
 /area/vacant_room/commissary)
 "rPo" = (
 /obj/machinery/status_display/ai_core,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/storage/satellite)
 "rPH" = (
@@ -55084,6 +55296,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
+"rYz" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/server)
 "rYI" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -55937,8 +56158,19 @@
 /area/crew_quarters/fitness)
 "sqj" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/flasher{
+	id = "AI";
+	pixel_x = 25;
+	pixel_y = 24
+	},
+/obj/machinery/ai_slipper{
+	uses = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/storage/satellite)
 "sqE" = (
 /obj/structure/sign/warning/fire{
 	pixel_y = -32
@@ -56140,6 +56372,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"suV" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "aiserverdoor";
+	name = "AI Server Shutters"
+	},
+/turf/open/floor/circuit/green,
+/area/ai_monitored/storage/satellite)
 "svh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -56352,6 +56592,10 @@
 /area/maintenance/solars/starboard/fore)
 "sAr" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/machinery/airalarm/tcomms{
+	dir = 4;
+	pixel_x = -24
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "sAs" = (
@@ -58684,10 +58928,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"tto" = (
-/obj/machinery/pipedispenser,
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "ttQ" = (
 /obj/structure/rack,
 /obj/machinery/light{
@@ -59610,13 +59850,14 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "tNs" = (
-/obj/structure/frame/machine{
-	anchored = 1;
-	state = 2
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/circuit/green/telecomms,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/yellow/hidden,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "tNA" = (
 /obj/machinery/camera{
 	c_tag = "Dormitory South";
@@ -61230,6 +61471,9 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 9
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "uuW" = (
@@ -61471,10 +61715,6 @@
 /obj/structure/sign/departments/minsky/medical/medical1,
 /turf/closed/wall,
 /area/medical/paramedic)
-"uAV" = (
-/obj/effect/turf_decal/ramp_middle,
-/turf/open/floor/plasteel/dark/telecomms,
-/area/ai_monitored/turret_protected/ai)
 "uAW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -61776,6 +62016,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/stairs/goon/dark_stairs_middle{
 	dir = 1
 	},
@@ -61785,6 +62028,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/cyan/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
 "uGf" = (
@@ -64195,6 +64441,14 @@
 	name = "AI Server Room 2";
 	req_access_txt = "65"
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "aiserverdoor";
+	name = "AI Server Shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "vzs" = (
@@ -64275,7 +64529,7 @@
 /obj/effect/turf_decal/ramp_middle{
 	dir = 1
 	},
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide{
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_wide2{
 	dir = 1
 	},
 /area/ai_monitored/turret_protected/ai)
@@ -64830,6 +65084,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"vJJ" = (
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/turf/open/floor/plasteel/dark/telecomms,
+/area/ai_monitored/turret_protected/ai)
 "vKb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -65882,12 +66144,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"wer" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/storage/satellite)
 "weD" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
@@ -66558,15 +66814,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"wrK" = (
-/obj/machinery/telecomms/receiver/preset_left{
-	name = "subspace receiver A"
-	},
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 5
-	},
-/turf/open/floor/circuit/green/telecomms/mainframe,
-/area/tcommsat/server)
 "wrN" = (
 /obj/structure/chair/comfy/beige,
 /turf/open/floor/plasteel/grimy,
@@ -67267,10 +67514,10 @@
 /area/maintenance/fore)
 "wIB" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 8
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower{
-	dir = 5
+	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
@@ -68638,6 +68885,9 @@
 /obj/structure/closet/secure_closet/warden,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"xnr" = (
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "xnF" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -69038,10 +69288,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"xwL" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
 "xwU" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/machinery/light{
@@ -69071,8 +69317,12 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "xxd" = (
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/machinery/recharge_station,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/storage/satellite)
 "xxr" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -69966,12 +70216,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"xPL" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/hidden{
-	dir = 10
-	},
-/turf/open/floor/circuit/telecomms/server,
-/area/tcommsat/server)
 "xPQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -99482,8 +99726,8 @@ cva
 cva
 cva
 gtB
-eTe
-qKi
+djF
+mUg
 kqB
 gtB
 gXs
@@ -99738,10 +99982,10 @@ sAu
 ume
 cva
 cva
-mDO
-xxd
-xxd
-cqT
+abx
+xnr
+xnr
+nQP
 gtB
 tgv
 wJL
@@ -99995,12 +100239,12 @@ nDA
 rjo
 tTK
 cva
-tNs
-sAr
+mDO
+gLt
 kMi
 uuG
 ieK
-axV
+ptV
 azq
 rRA
 lmN
@@ -100246,18 +100490,18 @@ pqr
 cva
 hWd
 fiF
-jJK
-afK
-jJK
+cfh
+vJJ
+cfh
 cOE
 qjk
 cva
 cva
-gtB
+tgv
 ieo
-krI
-gtB
-qVN
+suV
+tgv
+aVE
 pSY
 lhk
 rdw
@@ -100506,19 +100750,19 @@ nDA
 cva
 cva
 hsq
-rCq
+lyX
 qZK
-vAP
-uAV
-gtB
+lHO
+gCs
+tgv
 cqT
 xxd
-gtB
-xwL
+tgv
+paH
 pTL
-axV
-axV
-axV
+rfJ
+rfJ
+rfJ
 aJw
 pvo
 sXZ
@@ -100762,20 +101006,20 @@ bVI
 eAU
 cva
 erb
-jcz
+afK
 uGc
 pZI
 uGb
 pJy
 jHo
 sqj
-xxd
+hoK
 fJN
 aJy
-pTL
+nyj
 rPo
-axV
-axV
+opJ
+opJ
 psj
 hsn
 sYk
@@ -101020,19 +101264,19 @@ nDA
 cva
 cva
 mfG
-rCq
-qZK
-hmx
-uAV
-gtB
-cqT
-xxd
-gtB
 lyX
-pTL
-axV
-axV
-iRV
+qZK
+vAP
+gCs
+tgv
+naj
+rCq
+tgv
+rJJ
+hYy
+rfJ
+rfJ
+gOE
 aJw
 hvG
 sYv
@@ -101276,19 +101520,19 @@ hWd
 qoQ
 jJK
 prN
-jJK
+cfh
 cOE
 laN
 cva
 cva
-gtB
+tgv
 ieo
-krI
-gtB
-wer
+suV
+tgv
+iIj
 rzx
-iRV
-tto
+gOE
+fXb
 agz
 aJw
 qHo
@@ -101537,12 +101781,12 @@ nDA
 rjo
 tTK
 cva
-tNs
+mDO
 sAr
 tmm
 pJS
 vzc
-axV
+rfJ
 dne
 bxL
 lmN
@@ -101794,10 +102038,10 @@ sAu
 wkd
 cva
 cva
-mDO
-xxd
-xxd
-cqT
+abx
+xnr
+xnr
+nQP
 gtB
 tgv
 wJL
@@ -102052,8 +102296,8 @@ cva
 cva
 cva
 gtB
-eTe
-qKi
+djF
+mUg
 uMi
 gtB
 gXs
@@ -109316,15 +109560,15 @@ aaa
 aaa
 aaa
 ucZ
-rJJ
-rJJ
-rJJ
+mFE
+mFE
+mFE
 vbw
 fjN
 kRG
-rJJ
-rJJ
-rJJ
+mFE
+mFE
+mFE
 pEf
 aaa
 aaa
@@ -109830,17 +110074,17 @@ aaa
 ucZ
 bVJ
 bVJ
-rJJ
-rJJ
-rJJ
+mFE
+mFE
+mFE
 aDW
 sxE
 vvS
-rJJ
-rJJ
-rJJ
-rJJ
-rJJ
+mFE
+mFE
+mFE
+mFE
+mFE
 pEf
 gXs
 aKN
@@ -110097,7 +110341,7 @@ vmm
 ody
 kfG
 xnR
-rJJ
+mFE
 pEf
 gXs
 aKN
@@ -110354,7 +110598,7 @@ iek
 cZu
 cLg
 sdl
-rJJ
+mFE
 pEf
 aaa
 aaa
@@ -110611,7 +110855,7 @@ pJB
 gBP
 vxS
 qlI
-rJJ
+mFE
 pEf
 pEf
 pEf
@@ -111374,8 +111618,8 @@ qTh
 phH
 iDE
 fYE
-byg
-byg
+tNs
+tNs
 cqk
 bhL
 snB
@@ -112916,11 +113160,11 @@ pEf
 pEf
 fmC
 fmC
-bfr
+kit
 bRu
 xFg
 gTY
-wrK
+aTs
 fmC
 fmC
 pEf
@@ -113174,10 +113418,10 @@ fmC
 fmC
 gQa
 jzm
-fMm
+dOp
 soe
-fMm
-cfh
+dOp
+iHu
 yap
 fmC
 fmC
@@ -113431,11 +113675,11 @@ fmC
 fmC
 gNr
 npc
-fMm
-dnj
-fMm
-gOE
-iIj
+dOp
+krI
+dOp
+axV
+rYz
 fmC
 fmC
 fmC
@@ -113688,9 +113932,9 @@ fmC
 bjE
 qQw
 lWl
-fMm
+dOp
 jKN
-fMm
+dOp
 lWl
 loF
 xlV
@@ -113943,13 +114187,13 @@ pEf
 fmC
 fmC
 xUW
-nQP
+jcz
 cWY
 lQv
 grq
-nHT
+phR
 tGz
-opJ
+byg
 ikV
 fmC
 fmC
@@ -114202,9 +114446,9 @@ fmC
 kVh
 qKK
 lWl
-fMm
+dOp
 tjY
-fMm
+dOp
 lWl
 bdd
 bcd
@@ -114459,11 +114703,11 @@ fmC
 fmC
 dOn
 sPc
-fMm
+dOp
 rlo
-fMm
-xPL
-hXu
+dOp
+kTy
+iII
 fmC
 fmC
 fmC
@@ -114714,13 +114958,13 @@ pEf
 pEf
 fmC
 fmC
-wIB
+car
 ikV
-fMm
+dOp
 xzh
-fMm
-nHT
-jnr
+dOp
+phR
+wIB
 fmC
 fmC
 pEf
@@ -114973,7 +115217,7 @@ ogh
 jXD
 fmC
 mDn
-kit
+dnj
 tjY
 dTU
 eKD


### PR DESCRIPTION
# Document the changes in your pull request
I always prefered this, it made box unique to other maps. It gave it some character.
We sapped that character away like it was nothing, spitting on its grave.
This adds it back.

![image](https://github.com/yogstation13/Yogstation/assets/42524344/8f51123b-d082-49cd-b306-70a6de0b9110)

![image](https://github.com/yogstation13/Yogstation/assets/42524344/25303a16-97ac-424e-9432-6edf765cf565)

# Why is this good for the game?
For a multitude of reasons, I think in our current code, this is a better position for AI.

1. Sigtech can more easily access it.
2. Allows for more server storage space, moves the servers to a more accessible area that AI's will be more likely to allow sigtechs to use.
3. Its prettier and more unique, provides more interesting gameplay.

# Testing
All comms channels work, ai chamber doesnt overheat, servers dont overheat.

# Changelog
:cl:  
mapping: Returns the AI to its primordial form on Boxstation, in the center of the station.
/:cl:
