### PR TITLE
Mech melee weapon name tweaks

### DIFF
--- a/code/game/mecha/equipment/weapons/melee_weapons.dm
+++ b/code/game/mecha/equipment/weapons/melee_weapons.dm
@@ -273,7 +273,7 @@
 	set_light_on(FALSE)	
 
 /obj/item/mecha_parts/mecha_equipment/melee_weapon/sword/katana	//Anime mech sword
-	name = "\improper OWM-5 \"Ronin\" katana"
+	name = "\improper HR-2 \"Ronin\" katana"
 	desc = "An oversized, light-weight replica of an ancient style of blade. Still woefully underpowered in D&D."
 	icon_state = "mecha_katana"
 	energy_drain = 15
@@ -363,7 +363,7 @@
 		playsound(L, 'sound/items/welder.ogg', 50, 1)
 
 /obj/item/mecha_parts/mecha_equipment/melee_weapon/sword/maul
-	name = "\improper CX-22 \"Barbatos\" heavy maul"
+	name = "\improper ASW-8 \"Barbatos\" heavy maul"
 	desc = "A massive, unwieldy, mace-like weapon, this thing really looks like something you don't want to be hit by if you're not a fan of being concave."
 	icon_state = "mecha_maul"
 	energy_drain = 40
@@ -385,7 +385,7 @@
 		do_item_attack_animation(L, hit_effect)
 
 /obj/item/mecha_parts/mecha_equipment/melee_weapon/sword/rapier
-	name = "\improper E9-V \"Sigrun\" rapier"
+	name = "\improper MS-15 \"Gyan\" rapier"
 	desc = "A remarkably thin blade for a weapon wielded by an exosuit, this rapier is the favorite of syndicate pilots that perfer finesse over brute force."
 	icon_state = "mecha_rapier"
 	energy_drain = 40
@@ -459,7 +459,7 @@
 
 
 /obj/item/mecha_parts/mecha_equipment/melee_weapon/rocket_fist	//Passive upgrade weapon when selected, makes your mech punch harder AND faster
-	name = "\improper DD-2 \"Atom Smasher\" rocket fist"
+	name = "\improper RS-77 \"Atom Smasher\" rocket fist"
 	desc = "A large metal fist fitted to the arm of an exosuit, it uses repurposed maneuvering thrusters from a Raven battlecruiser to give a little more oomph to every punch. Also helps increase the speed at which the mech is able to return to a ready stance after each swing."
 	icon_state = "mecha_rocket_fist"
 	weapon_damage = 20

--- a/code/modules/research/designs/mecha_designs.dm
+++ b/code/modules/research/designs/mecha_designs.dm
@@ -555,7 +555,7 @@
 	category = list("Exosuit Equipment")
 
 /datum/design/mech_rocket_fist
-	name = "Exosuit Weapon (DD-2 \"Atom Smasher\" Rocket Fist)"
+	name = "Exosuit Weapon (RS-77 \"Atom Smasher\" Rocket Fist)"
 	id = "mech_rocket_fist"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/melee_weapon/rocket_fist
@@ -575,7 +575,7 @@
 	combat_design = TRUE
 
 /datum/design/mech_katana
-	name = "Exosuit Weapon (OWM-5 \"Ronin\" katana)"
+	name = "Exosuit Weapon (HR-2 \"Ronin\" katana)"
 	id = "mech_katana"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/melee_weapon/sword/katana
@@ -605,7 +605,7 @@
 	combat_design = TRUE
 
 /datum/design/mech_maul
-	name = "Exosuit Weapon (CX-22 \"Barbatos\" heavy maul)"
+	name = "Exosuit Weapon (ASW-8 \"Barbatos\" heavy maul)"
 	id = "mech_maul"
 	build_type = MECHFAB
 	build_path = /obj/item/mecha_parts/mecha_equipment/melee_weapon/sword/maul

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -974,7 +974,7 @@
 
 /datum/techweb_node/mech_rocket_fist
 	id = "mech_rocket_fist"
-	display_name = "Exosuit Weapon (DD-2 \"Atom Smasher\" Rocket Fist)"
+	display_name = "Exosuit Weapon (RS-77 \"Atom Smasher\" Rocket Fist)"
 	description = "An advanced piece of mech weaponry"
 	prereq_ids = list("adv_mecha","weaponry")
 	design_ids = list("mech_rocket_fist")
@@ -990,7 +990,7 @@
 
 /datum/techweb_node/mech_katana
 	id = "mech_katana"
-	display_name = "Exosuit Weapon (OWM-5 \"Ronin\" katana)"
+	display_name = "Exosuit Weapon (HR-2 \"Ronin\" katana)"
 	description = "An advanced piece of mech weaponry"
 	prereq_ids = list("adv_mecha","mech_shortsword")
 	design_ids = list("mech_katana")
@@ -1014,7 +1014,7 @@
 
 /datum/techweb_node/mech_maul
 	id = "mech_maul"
-	display_name = "Exosuit Weapon (CX-22 \"Barbatos\" heavy maul)"
+	display_name = "Exosuit Weapon (ASW-8 \"Barbatos\" heavy maul)"
 	description = "An advanced piece of mech weaponry"
 	prereq_ids = list("adv_mecha","mech_shortsword")
 	design_ids = list("mech_maul")


### PR DESCRIPTION
# Document the changes in your pull request

# For the record, this PR does not make any additional references or change pre-existing ones.
I changed the Sigrun into the Gyan (both from Gundam) because the Sigrun has more of a Lance while the Gyan has more of a rapier.

Otherwise, changes the model numbers of some mech weapons to be more fitting/not random

OWM-5 Ronin changed to HR-2 Ronin (Hammond Robotics (Titanfall) 2)

CX-22 Barbatos changed to ASW-8 Barbatos (CX-22 was a random model number, the model number of Gundam Barbatos is ASW-G-08)

DD-2 Atom Smasher changed to RS-77 Atom Smasher (Real Steel + (Cyberpunk) 2077)

Also Mqiib signed off on me doing this

# Why is this good for the game?
<!-- Describe why you think this change is good for the game. This section is not required for bugfixes. -->

Better model numbers = more fun

# Testing
<!-- Describe what testing you did with this PR. Try to be thorough, especially if this is a larger project. -->

Lol

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

None

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

Gotta change names on the wiki

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Tweaked the names of a few mech melee weapons
/:cl:
