### PR TITLE
Cark Has 0 Clue What He Is Doing: Adds Stone To The Game Edition

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -67,7 +67,6 @@ GLOBAL_LIST_INIT(sandstone_recipes, list ( \
 	item_state = "sheet-stone"
 	throw_speed = 3
 	throw_range = 5
-	materials = list(/datum/material/stone=MINERAL_MATERIAL_AMOUNT)
 	sheettype = "stone"
 	merge_type = /obj/item/stack/sheet/mineral/stone
 

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -68,6 +68,7 @@ GLOBAL_LIST_INIT(sandstone_recipes, list ( \
 	throw_speed = 3
 	throw_range = 5
 	sheettype = "stone"
+	grind_results = list(/datum/reagent/oxygen = 5, /datum/reagent/silicon = 15)
 	merge_type = /obj/item/stack/sheet/mineral/stone
 
 GLOBAL_LIST_INIT(stone_recipes, list ( \

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -59,6 +59,18 @@ GLOBAL_LIST_INIT(sandstone_recipes, list ( \
  * Stone
  */
 
+/obj/item/stack/sheet/mineral/stone
+	name = "stone brick"
+	desc = "A stone brick."
+	singular_name = "stone brick"
+	icon_state = "sheet-stone"
+	item_state = "sheet-stone"
+	throw_speed = 3
+	throw_range = 5
+	materials = list(/datum/material/stone=MINERAL_MATERIAL_AMOUNT)
+	sheettype = "stone"
+	merge_type = /obj/item/stack/sheet/mineral/stone
+
 GLOBAL_LIST_INIT(stone_recipes, list ( \
 	new/datum/stack_recipe("stone brick tile", /obj/item/stack/tile/stone, 1, 4, 20), \
 ))

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -56,6 +56,14 @@ GLOBAL_LIST_INIT(sandstone_recipes, list ( \
 	amount = 30
 
 /*
+ * Stone
+ */
+
+GLOBAL_LIST_INIT(stone_recipes, list ( \
+	new/datum/stack_recipe("stone brick tile", /obj/item/stack/tile/stone, 1, 4, 20), \
+))
+
+/*
  * Sandbags
  */
 

--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -190,6 +190,15 @@
 	item_state = "tile-basalt"
 	turf_type = /turf/open/floor/grass/fakebasalt
 
+//Stone
+/obj/item/stack/tile/stone
+	name = "stone brick tile"
+	singular_name = "stone brick tile"
+	desc = "How rustic."
+	icon_state = "tile_stone"
+	item_state = "tile_stone"
+	turf_type = /turf/open/floor/stone
+
 //Carpets
 /obj/item/stack/tile/carpet
 	name = "carpet"

--- a/code/game/objects/structures/false_walls.dm
+++ b/code/game/objects/structures/false_walls.dm
@@ -290,6 +290,15 @@
 	walltype = /turf/closed/wall/mineral/sandstone
 	canSmoothWith = list(/obj/structure/falsewall/sandstone, /turf/closed/wall/mineral/sandstone)
 
+/obj/structure/falsewall/stone
+	name = "stone wall"
+	desc = "A wall with stone plating. Smooth."
+	icon = 'icons/turf/walls/stone_wall.dmi'
+	icon_state = "stone"
+	mineral = /obj/item/stack/sheet/mineral/stone
+	walltype = /turf/closed/wall/mineral/stone
+	canSmoothWith = list(/obj/structure/falsewall/stone, /turf/closed/wall/mineral/stone)
+
 /obj/structure/falsewall/wood
 	name = "wooden wall"
 	desc = "A wall with wooden plating. Stiff."

--- a/code/game/turfs/simulated/floor/misc_floor.dm
+++ b/code/game/turfs/simulated/floor/misc_floor.dm
@@ -323,4 +323,4 @@
 	name = "stone brick floor"
 	desc = "Some stone brick tiles, how rustic."
 	icon_state = "stone_floor"
-	floor_tile = /obj/item/stack/tile/plasteel
+	floor_tile = /obj/item/stack/tile/stone

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -29,7 +29,7 @@
 
 /turf/open/floor/plating/asteroid/proc/getDug()
 	new digResult(src, 5)
-	prob(20)
+	if(prob(20))
 		new /obj/item/stack/sheet/mineral/stone(src, rand(1,3))
 	if(postdig_icon_change)
 		if(!postdig_icon)

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -29,8 +29,8 @@
 
 /turf/open/floor/plating/asteroid/proc/getDug()
 	new digResult(src, 5)
-	if(prob(20))
-		new /obj/item/stack/sheet/mineral/stone(src, rand(1,3))
+	if(prob(50))
+		new /obj/item/stack/sheet/mineral/stone(src, rand(5))
 	if(postdig_icon_change)
 		if(!postdig_icon)
 			icon_plating = "[environment_type]_dug"

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -17,7 +17,7 @@
 	var/turf_type = /turf/open/floor/plating/asteroid //Because caves do whacky shit to revert to normal
 	var/floor_variance = 20 //probability floor has a different icon state
 	attachment_holes = FALSE
-	var/obj/item/stack/digResult = /obj/item/stack/ore/glass/basalt, /obj/item/stack/sheet/stone
+	var/obj/item/stack/digResult = /obj/item/stack/ore/glass/basalt
 	var/dug
 
 /turf/open/floor/plating/asteroid/Initialize(mapload)
@@ -29,6 +29,8 @@
 
 /turf/open/floor/plating/asteroid/proc/getDug()
 	new digResult(src, 5)
+	prob(20)
+		new /obj/item/stack/sheet/mineral/stone(src, rand(1,3))
 	if(postdig_icon_change)
 		if(!postdig_icon)
 			icon_plating = "[environment_type]_dug"

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -17,7 +17,7 @@
 	var/turf_type = /turf/open/floor/plating/asteroid //Because caves do whacky shit to revert to normal
 	var/floor_variance = 20 //probability floor has a different icon state
 	attachment_holes = FALSE
-	var/obj/item/stack/digResult = /obj/item/stack/ore/glass/basalt
+	var/obj/item/stack/digResult = /obj/item/stack/ore/glass/basalt, /obj/item/stack/sheet/stone
 	var/dug
 
 /turf/open/floor/plating/asteroid/Initialize(mapload)

--- a/code/game/turfs/simulated/wall/mineral_walls.dm
+++ b/code/game/turfs/simulated/wall/mineral_walls.dm
@@ -54,6 +54,15 @@
 	explosion_block = 0
 	canSmoothWith = list(/turf/closed/wall/mineral/sandstone, /obj/structure/falsewall/sandstone)
 
+/turf/closed/wall/mineral/stone
+	name = "stone wall"
+	desc = "A wall with stone plating. Smooth."
+	icon = 'icons/turf/walls/stone_wall.dmi'
+	icon_state = "stone"
+	sheet_type = /obj/item/stack/sheet/mineral/stone
+	explosion_block = 0
+	canSmoothWith = list(/turf/closed/wall/mineral/stone, /obj/structure/falsewall/stone)
+
 /turf/closed/wall/mineral/uranium
 	article = "a"
 	name = "uranium wall"

--- a/code/game/turfs/simulated/wall/mineral_walls.dm
+++ b/code/game/turfs/simulated/wall/mineral_walls.dm
@@ -60,7 +60,7 @@
 	icon = 'icons/turf/walls/stone_wall.dmi'
 	icon_state = "stone"
 	sheet_type = /obj/item/stack/sheet/mineral/stone
-	explosion_block = 0
+	explosion_block = 1
 	canSmoothWith = list(/turf/closed/wall/mineral/stone, /obj/structure/falsewall/stone)
 
 /turf/closed/wall/mineral/uranium


### PR DESCRIPTION
# Document the changes in your pull request

i add stone as a thing, acquired by digging ground on lavaland liek glas :)

i cant code i cant code i cant code i cant code i cant code i cant code 

- [ ] add sprites

# Why is this good for the game?

this allows us to have cool things like stone tiles be craftable + allows me to suck at coding in future when i port primitive cooking stuff like stone griddles and ovens from skyrat :)

# Testing
once its done

# Spriting
tbd

# Wiki Documentation

if there is a guide to mining this should go there

# Changelog

:cl:  Cark, Chubbygummibear
rscadd: Adds stone which you can mine stone by digging up lavaland turfs.  Stone can be used to craft stone tiles and walls.
imageadd: Adds an object sprite for stone tiles, and stone walls.
/:cl:
