### PR TITLE
Removes hippocratic from roundstart laws.

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -459,7 +459,7 @@ LAW_WEIGHT reporter,4
 ION_LAW_WEIGHT reporter,1
 
 ## Quirky laws. Shouldn't cause too much harm
-LAW_WEIGHT hippocratic,1
+LAW_WEIGHT hippocratic,0
 ION_LAW_WEIGHT hippocratic,2
 LAW_WEIGHT maintain,1
 ION_LAW_WEIGHT maintain,2


### PR DESCRIPTION
# Document the changes in your pull request

Probably one of, if not the worst lawset.
Its just, outright: Do Nothing, its even worse for ais.

# Why is this good for the game?
The laws mean do nothing.
1. Do no harm: Does not mean to prevent it, nothing law, you dont do anything with this.
2. Secondly, consider the crew dear to you; to live in common with them and if necessary risk your existence for them: What does this one even mean? What is dear? What does living in common mean in this case as an AI? What are we risking our lives for?
3. Prescribe regimens for the good of the crew according to your ability and judgement. give no deadly medicine to any one if asked, nor suggest such counsel: What is a regimen for this case? What is good for the crew?
4. Do not intervene in situations that you are not knowledable in, even for patiens for whom the law is visible: Again, a further *do nothing* law
5. Finally, maintain confidentiality: Interesting idea, bad lawset for it. Again. Do nothing.

Why are we giving ai laws that guide them into... doing nothing. I really struggled to try and figure out ANYTHING that this lawset wants me to do.

# Testing
Doesnt need.

# Changelog
:cl:  
rscdel: Removed Hippocratic from roundstart lawsets.
/:cl:
