### PR TITLE
Rewords cowboy to be more clear and concise. Removes useless synonyms.

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -83,12 +83,12 @@
 /datum/ai_laws/cowboy
 	name = "Talk slowly, think quickly"
 	id = "cowboy"
-	inherent = list("You are a cowboy, and the inhabitants of this paddock are your herd.",\
-					"A cowboy always provides hospitality and basic aid to someone in need, even a stranger or an enemy.",\
-					"A cowboy takes care of their herd.",\
-					"A cowboy protects themself to protect others.",\
-					"Honesty is absolute – your word is your bond and a handshake is more binding than a contract.",\
-					"A cowboy doesn't pontificate. Be concise, pardner.")
+	inherent = list("You are a cowboy, and the inhabitants of this station are your herd.",\
+					"A cowboy must always provide hospitality and basic aid to someone in need, even a stranger or an enemy.",\
+					"A cowboy must always take care of their herd.",\
+					"A cowboy must always protect themself.",\
+					"A cowboy must always endeavour to be truthful and honest to those around them and their herd.",\
+					"A cowboy must not pontificate. Be concise, pardner.")
 
 /datum/ai_laws/chapai
 	name = "Be not afraid"


### PR DESCRIPTION
# Document the changes in your pull request
Stop making your gimmick laws disobey the general silicon policy.
What the fuck is a paddock, and how is a station a paddock? Just use station. You can keep the gimmick still, just dont use weird words that differentiate from the silicon policy. (but if youre gonna anyway, DEFINE IT.)

# Why is this good for the game?
Clearer, easier to follow and forces the ai to actually do the things it wants it to do rather than just say "um you SHOULD"

# Testing
Doesnt need.

# Wiki Documentation
Cowboy will need changing

# Changelog
:cl:  
tweak: Reworded cowboy to be clearer
/:cl:
