### PR TITLE
Adds new grind_results to some items for Ghetto Chem.

### DIFF
--- a/code/game/objects/items/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/circuitboards/circuitboard.dm
@@ -12,7 +12,7 @@
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	materials = list(/datum/material/glass=1000)
 	w_class = WEIGHT_CLASS_SMALL
-	grind_results = list(/datum/reagent/silicon = 20)
+	grind_results = list(/datum/reagent/silicon = 20, /datum/reagent/gold = 10)
 	var/build_path = null
 
 /obj/item/circuitboard/proc/apply_default_parts(obj/machinery/M)

--- a/code/game/objects/items/cosmetics.dm
+++ b/code/game/objects/items/cosmetics.dm
@@ -4,6 +4,7 @@
 	desc = "A generic brand of lipstick."
 	icon = 'icons/obj/cosmetics.dmi'
 	icon_state = "lipstick"
+	grind_results = list(/datum/reagent/phenol = 5)
 	w_class = WEIGHT_CLASS_TINY
 	var/colour = "red"
 	var/open = FALSE
@@ -236,6 +237,7 @@
 /obj/item/dyespray
 	name = "hair dye spray"
 	desc = "A spray to dye your hair any gradients you'd like."
+	grind_results = list(/datum/reagent/phenol = 10, /datum/reagent/hair_dye = 5)
 	icon = 'icons/obj/cosmetics.dmi'
 	icon_state = "dyespray"
 

--- a/code/game/objects/items/devices/geiger_counter.dm
+++ b/code/game/objects/items/devices/geiger_counter.dm
@@ -16,6 +16,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	item_flags = NOBLUDGEON
 	materials = list(/datum/material/iron = 150, /datum/material/glass = 150)
+	grind_results = list(/datum/reagent/uranium/radium = 5)
 
 	var/grace = RAD_GEIGER_GRACE_PERIOD
 	var/datum/looping_sound/geiger/soundloop

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -23,7 +23,7 @@ GLOBAL_LIST_INIT(glass_recipes, list ( \
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 100)
 	resistance_flags = ACID_PROOF
 	merge_type = /obj/item/stack/sheet/glass
-	grind_results = list(/datum/reagent/silicon = 20, datum/reagent/sodium = 10)
+	grind_results = list(/datum/reagent/silicon = 20, /datum/reagent/sodium = 10)
 	point_value = 5
 	tableVariant = /obj/structure/table/glass
 	matter_amount = 4

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -23,7 +23,7 @@ GLOBAL_LIST_INIT(glass_recipes, list ( \
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 50, ACID = 100)
 	resistance_flags = ACID_PROOF
 	merge_type = /obj/item/stack/sheet/glass
-	grind_results = list(/datum/reagent/silicon = 20)
+	grind_results = list(/datum/reagent/silicon = 20, datum/reagent/sodium = 10)
 	point_value = 5
 	tableVariant = /obj/structure/table/glass
 	matter_amount = 4


### PR DESCRIPTION
# Document the changes in your pull request

You can now get gold from all circuitboards, 10u
You can now get phenol from lipstick, 5u
You can now get phenol (10u) and quantum hair dye (5u) from hair spray dye
You can now get radium from geiger counters, 5u
You can now get sodium from glass, 10u

# Why is this good for the game?
ghetto chem is cool and needs more love

# Wiki Documentation

https://wiki.yogstation.net/wiki/Guide_to_Ghetto_Chemistry needs to be updated

# Changelog

:cl:  cark
rscadd: certain items now give chems they did not before
/:cl:
