### PR TITLE
Allows the Captain to unlock their gun's display case on Gamma alert or higher

### DIFF
--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -235,11 +235,11 @@
 	start_showpiece_type = /obj/item/gun/energy/laser/captain
 	req_access = list(ACCESS_CENT_SPECOPS) // This is intentional, presumably to make it slightly harder for caps to grab their gun roundstart.
 
-/obj/structure/displaycase/attackby(obj/item/W, mob/user, params) // Unless things are really fucked.
-	if(seclevel2num(get_security_level()) >= SEC_LEVEL_DELTA) // Everything higher than red.
+/obj/structure/displaycase/captain/attackby(obj/item/W, mob/user, params) // Unless shit has really hit the fan.
+	if(seclevel2num(get_security_level()) >= SEC_LEVEL_GAMMA) // Everything higher than red.
 		req_access = list(ACCESS_CAPTAIN)
 	else
-		to_chat(user, "The display case can only be unlocked above RED alert!")
+		to_chat(user, span_warning("The display case's access locks can only be lifted above red alert!"))
 		req_access = list(ACCESS_CENT_SPECOPS)
 		return
 	. = ..()

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -233,7 +233,16 @@
 //The lab cage and captain's display case do not spawn with electronics, which is why req_access is needed.
 /obj/structure/displaycase/captain
 	start_showpiece_type = /obj/item/gun/energy/laser/captain
-	req_access = list(ACCESS_CENT_SPECOPS) //this was intentional, presumably to make it slightly harder for caps to grab their gun roundstart
+	req_access = list(ACCESS_CENT_SPECOPS) // This is intentional, presumably to make it slightly harder for caps to grab their gun roundstart.
+
+/obj/structure/displaycase/attackby(obj/item/W, mob/user, params) // Unless things are really fucked.
+	if(seclevel2num(get_security_level()) >= SEC_LEVEL_DELTA) // Everything higher than red.
+		req_access = list(ACCESS_CAPTAIN)
+	else
+		to_chat(user, "The display case can only be unlocked above RED alert!"
+		req_access = list(ACCESS_CENT_SPECOPS)
+		return
+	. = ..()
 
 /obj/structure/displaycase/labcage
 	name = "lab cage"

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -239,7 +239,7 @@
 	if(seclevel2num(get_security_level()) >= SEC_LEVEL_DELTA) // Everything higher than red.
 		req_access = list(ACCESS_CAPTAIN)
 	else
-		to_chat(user, "The display case can only be unlocked above RED alert!"
+		to_chat(user, "The display case can only be unlocked above RED alert!")
 		req_access = list(ACCESS_CENT_SPECOPS)
 		return
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request
Lets the Captain swipe their ID card to unlock the antique display case on alert levels higher than red. Currently they have no way to access their personal gun without destroying the case and triggering the burglar alarm, even if a war has been declared.

# Why is this good for the game?
Not important, but I thought it would make sense for the captain to be able to access their gun in emergencies.
I agree that they shouldn't be able to access it normally, but when nukies/clockies declare war, or some other horrible catastrophe strikes, captains tend to go for their gun anyways, despite the case. This would only save them a bit of time.
Since powergaming is no longer barred on gamma alert and higher, I see no issue with this.

# Testing
Everything works as intended:
![image](https://github.com/yogstation13/Yogstation/assets/143908044/01bccce9-77c7-40f7-bfc4-fc2faea4c5b7)

# Wiki Documentation
Worth mentioning on the Captain's page.

# Changelog
:cl:  
tweak: Captains can now access their antique gun display case on Gamma alert or higher
/:cl: