### PR TITLE
Gives every syndicate ghost role an evil survival box

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -540,9 +540,11 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	shoes = /obj/item/clothing/shoes/combat
 	gloves = /obj/item/clothing/gloves/combat
 	ears = /obj/item/radio/headset/syndicate/alt
-	back = /obj/item/storage/backpack
 	implants = list(/obj/item/implant/weapons_auth)
 	id = /obj/item/card/id/syndicate
+	backpack_contents = list(
+		/obj/item/storage/box/syndie
+		)
 
 /datum/outfit/syndicate_empty/post_equip(mob/living/carbon/human/H)
 	H.faction |= ROLE_SYNDICATE
@@ -559,6 +561,9 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	l_pocket = /obj/item/gun/ballistic/automatic/pistol
 	r_pocket = /obj/item/kitchen/knife/combat/survival
 	belt = /obj/item/storage/belt/military/assault
+	backpack_contents = list(
+		/obj/item/storage/box/syndie
+		)
 
 /obj/effect/mob_spawn/human/syndicate/battlecruiser/assault
 	name = "Syndicate Battlecruiser Assault Operative"
@@ -577,6 +582,9 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	suit_store = /obj/item/gun/ballistic/automatic/pistol
 	back = /obj/item/storage/backpack/security
 	mask = /obj/item/clothing/mask/gas/syndicate
+	backpack_contents = list(
+		/obj/item/storage/box/syndie
+		)
 
 /obj/effect/mob_spawn/human/syndicate/battlecruiser/captain
 	name = "Syndicate Battlecruiser Captain"
@@ -596,6 +604,9 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	head = /obj/item/clothing/head/HoS/syndicate
 	mask = /obj/item/clothing/mask/cigarette/cigar/havana
 	glasses = /obj/item/clothing/glasses/thermal/eyepatch
+	backpack_contents = list(
+		/obj/item/storage/box/syndie
+		)
 
 //Icemoon Syndicate. Players become research agents working under a Syndicate research station.
 /obj/effect/mob_spawn/human/syndicate/icemoon_syndicate //generic version
@@ -614,6 +625,9 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	r_pocket = /obj/item/tank/internals/emergency_oxygen/double
 	mask = /obj/item/clothing/mask/gas/syndicate
 	id = /obj/item/card/id/syndicate/anyone
+	backpack_contents = list(
+		/obj/item/storage/box/syndie
+		)
 
 /obj/effect/mob_spawn/human/syndicate/icemoon_syndicate/security
 	name = "Syndicate Outpost Security Officer"
@@ -629,6 +643,9 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	mask = /obj/item/clothing/mask/gas //i want them to look like the generic operative NPC
 	belt = /obj/item/storage/belt/security/full //take like one guy alive
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses //identify the job of whoever the fuck is breaking in at a glance
+	backpack_contents = list(
+		/obj/item/storage/box/syndie
+		)
 
 /obj/effect/mob_spawn/human/syndicate/icemoon_syndicate/sci
 	name = "Syndicate Outpost Researcher"
@@ -643,6 +660,9 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	suit = /obj/item/clothing/suit/toggle/labcoat/science
 	accessory = /obj/item/clothing/accessory/armband/science
 	glasses = /obj/item/clothing/glasses/hud/diagnostic/sunglasses/rd //it's a syndicate nerd
+	backpack_contents = list(
+		/obj/item/storage/box/syndie
+		)
 
 /obj/effect/mob_spawn/human/syndicate/icemoon_syndicate/engineer
 	name = "Syndicate Outpost Engineer"
@@ -658,6 +678,9 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	head = /obj/item/clothing/head/hardhat
 	accessory = /obj/item/clothing/accessory/armband/engine
 	glasses = /obj/item/clothing/glasses/meson/sunglasses/ce
+	backpack_contents = list(
+		/obj/item/storage/box/syndie
+		)
 
 /obj/effect/mob_spawn/human/syndicate/icemoon_syndicate/medic
 	name = "Syndicate Outpost Doctor"
@@ -672,6 +695,9 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	suit = /obj/item/clothing/suit/toggle/labcoat/md //I AM A SURGEON!!
 	glasses = /obj/item/clothing/glasses/hud/health/sunglasses/cmo //rapid hurt and chemical identification
 	accessory = /obj/item/clothing/accessory/armband/medblue
+	backpack_contents = list(
+		/obj/item/storage/box/syndie
+		)
 
 /obj/effect/mob_spawn/human/syndicate/icemoon_syndicate/commander
 	name = "Syndicate Outpost Commander"
@@ -693,7 +719,12 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	back = /obj/item/storage/backpack/satchel/leather //LUXURY AT ITS FINEST
 	suit_store = /obj/item/gun/ballistic/revolver
 	belt = /obj/item/storage/belt/sabre //ceremonial shamnk
-	backpack_contents = list(/obj/item/modular_computer/tablet/preset/syndicate=1, /obj/item/ammo_box/a357=2, /obj/item/melee/classic_baton/telescopic=1)
+	backpack_contents = list(
+		/obj/item/storage/box/syndie,
+		/obj/item/modular_computer/tablet/preset/syndicate=1,
+		/obj/item/ammo_box/a357=2,
+		/obj/item/melee/classic_baton/telescopic=1
+		)
 
 //Icemoon Hermit. Player becomes a individual who sook out shelter from society by running away.
 
@@ -898,6 +929,9 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	l_pocket = /obj/item/flashlight
 	r_pocket = /obj/item/kitchen/knife/combat/survival
 	implants = list(/obj/item/implant/weapons_auth)
+	backpack_contents = list(
+		/obj/item/storage/box/syndie
+		)
 
 /datum/outfit/syndicate_derelict_engi/post_equip(mob/living/carbon/human/H)
 	H.faction |= ROLE_SYNDICATE

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -542,6 +542,7 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	ears = /obj/item/radio/headset/syndicate/alt
 	implants = list(/obj/item/implant/weapons_auth)
 	id = /obj/item/card/id/syndicate
+	back = /obj/item/storage/backpack
 	backpack_contents = list(
 		/obj/item/storage/box/syndie
 		)
@@ -561,6 +562,7 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	l_pocket = /obj/item/gun/ballistic/automatic/pistol
 	r_pocket = /obj/item/kitchen/knife/combat/survival
 	belt = /obj/item/storage/belt/military/assault
+	back = /obj/item/storage/backpack
 	backpack_contents = list(
 		/obj/item/storage/box/syndie
 		)
@@ -625,6 +627,7 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	r_pocket = /obj/item/tank/internals/emergency_oxygen/double
 	mask = /obj/item/clothing/mask/gas/syndicate
 	id = /obj/item/card/id/syndicate/anyone
+	back = /obj/item/storage/backpack
 	backpack_contents = list(
 		/obj/item/storage/box/syndie
 		)
@@ -643,6 +646,7 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	mask = /obj/item/clothing/mask/gas //i want them to look like the generic operative NPC
 	belt = /obj/item/storage/belt/security/full //take like one guy alive
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses //identify the job of whoever the fuck is breaking in at a glance
+	back = /obj/item/storage/backpack
 	backpack_contents = list(
 		/obj/item/storage/box/syndie
 		)
@@ -660,6 +664,7 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	suit = /obj/item/clothing/suit/toggle/labcoat/science
 	accessory = /obj/item/clothing/accessory/armband/science
 	glasses = /obj/item/clothing/glasses/hud/diagnostic/sunglasses/rd //it's a syndicate nerd
+	back = /obj/item/storage/backpack
 	backpack_contents = list(
 		/obj/item/storage/box/syndie
 		)
@@ -678,6 +683,7 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	head = /obj/item/clothing/head/hardhat
 	accessory = /obj/item/clothing/accessory/armband/engine
 	glasses = /obj/item/clothing/glasses/meson/sunglasses/ce
+	back = /obj/item/storage/backpack
 	backpack_contents = list(
 		/obj/item/storage/box/syndie
 		)
@@ -695,6 +701,7 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	suit = /obj/item/clothing/suit/toggle/labcoat/md //I AM A SURGEON!!
 	glasses = /obj/item/clothing/glasses/hud/health/sunglasses/cmo //rapid hurt and chemical identification
 	accessory = /obj/item/clothing/accessory/armband/medblue
+	back = /obj/item/storage/backpack
 	backpack_contents = list(
 		/obj/item/storage/box/syndie
 		)

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -166,14 +166,16 @@
 	r_hand = /obj/item/melee/transforming/energy/sword/saber
 	mask = /obj/item/clothing/mask/chameleon/gps
 	suit = /obj/item/clothing/suit/armor/vest
+	back = /obj/item/storage/backpack
 	backpack_contents = list(
-		/obj/item/modular_computer/tablet/preset/syndicate=1,
-		/obj/item/storage/box/syndie
+		/obj/item/storage/box/syndie,
+		/obj/item/modular_computer/tablet/preset/syndicate=1
 		)
 
 /datum/outfit/lavaland_syndicate/comms/subordinate
 	name = "Space Syndicate Comms Agent"
 	r_hand = /obj/item/kitchen/knife/combat
+	back = /obj/item/storage/backpack
 	backpack_contents = list(
 		/obj/item/storage/box/syndie
 		)
@@ -183,6 +185,7 @@
 	r_hand = /obj/item/melee/transforming/energy/sword/saber
 	head = /obj/item/clothing/head/HoS/syndicate
 	r_pocket = null
+	back = /obj/item/storage/backpack
 	backpack_contents = list(
 		/obj/item/storage/box/syndie,
 		/obj/item/modular_computer/tablet/preset/syndicate=1,

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -133,6 +133,9 @@
 	r_pocket = /obj/item/gun/ballistic/automatic/pistol
 	id = /obj/item/card/id/syndicate/anyone
 	implants = list(/obj/item/implant/weapons_auth)
+	backpack_contents = list(
+		/obj/item/storage/box/syndie
+		)
 
 /datum/outfit/lavaland_syndicate/post_equip(mob/living/carbon/human/H)
 	H.faction |= ROLE_SYNDICATE
@@ -163,11 +166,17 @@
 	r_hand = /obj/item/melee/transforming/energy/sword/saber
 	mask = /obj/item/clothing/mask/chameleon/gps
 	suit = /obj/item/clothing/suit/armor/vest
-	backpack_contents = list(/obj/item/modular_computer/tablet/preset/syndicate=1)
+	backpack_contents = list(
+		/obj/item/modular_computer/tablet/preset/syndicate=1,
+		/obj/item/storage/box/syndie
+		)
 
 /datum/outfit/lavaland_syndicate/comms/subordinate
 	name = "Space Syndicate Comms Agent"
 	r_hand = /obj/item/kitchen/knife/combat
+	backpack_contents = list(
+		/obj/item/storage/box/syndie
+		)
 
 /datum/outfit/lavaland_syndicate/comms/lieutenant
 	name = "Space Syndicate Comms Agent Lieutenant"
@@ -175,8 +184,9 @@
 	head = /obj/item/clothing/head/HoS/syndicate
 	r_pocket = null
 	backpack_contents = list(
+		/obj/item/storage/box/syndie,
 		/obj/item/modular_computer/tablet/preset/syndicate=1,
-		/obj/item/gun/ballistic/revolver/ultrasecure=1,
+		/obj/item/gun/ballistic/revolver/ultrasecure=1
 		)
 
 /obj/item/clothing/mask/chameleon/gps/Initialize(mapload)


### PR DESCRIPTION
# Document the changes in your pull request
Adds a standard issue survival box to every ghost role working for the syndicate.

# Why is this good for the game?
Always bugged me that they never start with a survival box, and it makes sense that they should have one. And of course it has to be the evil variant.

# Testing
Not tested yet, I'll do it soon when I can.

# Wiki Documentation
I don't think this kinda stuff is documented anywhere.

# Changelog
:cl:  
tweak: Syndicate ghost roles now have a survival box
/:cl:
