### PR TITLE
[WOKE] Removes species pay modifiers

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -506,8 +506,6 @@
 	for(var/datum/department_goal/dg in SSYogs.department_goals)
 		goals[dg.account] += dg.get_result()
 
-	parts += "<br>Money diverted from non-human paychecks by NT: $[GLOB.stolen_paycheck_money]<br>"
-
 	parts += "<br>[span_header("Engineering department goals:")]<br>"
 	parts += goals[ACCOUNT_ENG]
 

--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -1,6 +1,3 @@
-GLOBAL_VAR_INIT(stolen_paycheck_money, 0)
-
-
 SUBSYSTEM_DEF(economy)
 	name = "Economy"
 	wait = 5 MINUTES

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -13,7 +13,7 @@
 	var/bounties_claimed = 0 // Marks how many bounties this person has successfully claimed
 	var/sec_weapon_claimed = FALSE // If this account has claimed a weapon \code\modules\vending\security_armaments.dm
 
-/datum/bank_account/New(newname)
+/datum/bank_account/New(newname, job)
 	var/limiter = 0
 	while(limiter < 10)
 		account_id = rand(111111,999999)

--- a/code/modules/economy/account.dm
+++ b/code/modules/economy/account.dm
@@ -3,7 +3,6 @@
 /datum/bank_account
 	var/account_holder = "Rusty Venture"
 	var/account_balance = 0
-	var/payday_modifier
 	var/datum/job/account_job
 	var/list/bank_cards = list()
 	var/add_to_accounts = TRUE
@@ -14,7 +13,7 @@
 	var/bounties_claimed = 0 // Marks how many bounties this person has successfully claimed
 	var/sec_weapon_claimed = FALSE // If this account has claimed a weapon \code\modules\vending\security_armaments.dm
 
-/datum/bank_account/New(newname, job, modifier = 1)
+/datum/bank_account/New(newname)
 	var/limiter = 0
 	while(limiter < 10)
 		account_id = rand(111111,999999)
@@ -29,7 +28,6 @@
 		SSeconomy.bank_accounts["[account_id]"] = src
 	account_holder = newname
 	account_job = job
-	payday_modifier = modifier
 
 /datum/bank_account/Destroy()
 	if(add_to_accounts)
@@ -68,9 +66,7 @@
 	return FALSE
 
 /datum/bank_account/proc/payday(amt_of_paychecks, free = FALSE)
-	var/money_to_transfer = account_job.paycheck * payday_modifier * amt_of_paychecks
-	var/stolen_money = (1 - payday_modifier) * account_job.paycheck * amt_of_paychecks
-	GLOB.stolen_paycheck_money += stolen_money
+	var/money_to_transfer = account_job.paycheck * amt_of_paychecks
 	if(free)
 		adjust_money(money_to_transfer)
 		return TRUE

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -189,7 +189,7 @@
 			H.apply_pref_name(/datum/preference/name/backup_human, preference_source)
 
 	if(!visualsOnly)
-		var/datum/bank_account/bank_account = new(H.real_name, src, H.dna.species.payday_modifier)
+		var/datum/bank_account/bank_account = new(H.real_name, src)
 		bank_account.adjust_money(rand(STARTING_PAYCHECKS_MIN, STARTING_PAYCHECKS_MAX), TRUE)
 		bank_account.payday(STARTING_PAYCHECKS, TRUE)
 		H.account_id = bank_account.account_id

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -99,8 +99,6 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	var/pressuremod = 1
 	/// multiplier for EMP severity
 	var/emp_mod = 1
-	/// multiplier for money paid at payday, species dependent
-	var/payday_modifier = 1
 	///Type of damage attack does
 	var/attack_type = BRUTE
 	///lowest possible punch damage. if this is set to 0, punches will always miss

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -24,7 +24,6 @@
 	exotic_blood = /datum/reagent/oil
 	damage_overlay_type = "synth"
 	limbs_id = "synth"
-	payday_modifier = 0.3 //Mass producible labor + robot, lucky to be paid at all
 	pressuremod = 0.5 // from the moment i understood the weakness of my flesh it disgusted me
 	heatmod = 0.5 // and i yearned for the certainty of steel
 	burnmod = 1.25 // easily cut by laser cutters and welding tools to speed up manufacturing

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -17,7 +17,6 @@
 	speedmod = -0.1 //Light and energy move quickly
 	punchdamagehigh  = 11 //Fire hand more painful
 	punchstunthreshold = 11 //Still stuns on max hit, but subsequently lower chance to stun overall
-	payday_modifier = 0.7 //Moths have to be compensated slightly more to be willing to work for NT bcuz drug therapy, both ethereal and moth are neutral though
 	attack_type = BURN //burn bish
 	damage_overlay_type = "" //We are too cool for regular damage overlays
 	species_traits = list(NOEYESPRITES, EYECOLOR, MUTCOLORS, AGENDER, HAIR, FACEHAIR, HAS_FLESH) // i mean i guess they have blood so they can have wounds too

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -17,7 +17,6 @@
 	coldmod = 6
 	heatmod = 0.5
 	burnmod = 0.5 // = 1/2x generic burn damage
-	payday_modifier = 0.6 //literally a pile of toxic ooze walking around, definitely a health hazard
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/jelly
 	swimming_component = /datum/component/swimming/dissolve

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -15,7 +15,6 @@
 	mutanttail = /obj/item/organ/tail/lizard
 	coldmod = 0.67 //used to being cold, just doesn't like it much
 	heatmod = 0.67 //greatly appreciate heat, just not too much
-	payday_modifier = 0.85 //Full SIC citizens, but not quite given all the same rights- it's been an ongoing process for about half a decade
 	default_features = list("mcolor" = "#00FF00", "tail_lizard" = "Smooth", "snout" = "Round", "horns" = "None", "frills" = "None", "spines" = "None", "body_markings" = "None", "legs" = "Normal Legs")
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	attack_verb = "slash"

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -5,7 +5,6 @@
 	say_mod = "flutters"
 	default_color = "00FF00"
 	species_traits = list(LIPS, NOEYESPRITES,HAS_FLESH,HAS_BONE)
-	payday_modifier = 0.8 //Neutral, but non-human; pay less if you can get away with it
 	inherent_biotypes = MOB_ORGANIC|MOB_HUMANOID|MOB_BUG
 	mutant_bodyparts = list("moth_wings")
 	default_features = list("moth_wings" = "Plain")

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -20,7 +20,6 @@
 	heatmod = 1.5 //Don't let the plasma actually heat up though
 	punchdamagehigh = 7 //Bone punches are weak and usually inside soft suit gloves
 	punchstunthreshold = 7 //Stuns on max hit as usual, somewhat higher stun chance because math
-	payday_modifier = 1 //Former humans, employment restrictions arise from psychological and practical concerns; they won't be able to be some head positions, but they get human pay and NT can't weasel out of it
 	breathid = "tox"
 	damage_overlay_type = ""//let's not show bloody wounds or burns over bones.
 	disliked_food = NONE

--- a/code/modules/mob/living/carbon/human/species_types/polysmorphs.dm
+++ b/code/modules/mob/living/carbon/human/species_types/polysmorphs.dm
@@ -21,7 +21,6 @@
 	inert_mutation = ACIDSPIT
 	punchdamagehigh = 11 //slightly better high end of damage
 	punchstunthreshold = 11 //technically slightly worse stunchance
-	payday_modifier = 0.3 //Some are quite literally slaves + they HAVE to work for NT
 	damage_overlay_type = "polysmorph"
 	deathsound = 'sound/voice/hiss6.ogg'
 	screamsound = 'sound/voice/hiss5.ogg'

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -20,7 +20,6 @@
 	siemens_coeff = 0.75 //I wouldn't make semiconductors out of plant material
 	punchdamagehigh = 8 //sorry anvil your balance choice was wrong imo and I WILL be changing this soon.
 	punchstunthreshold = 9
-	payday_modifier = 0.7 //Neutrally viewed by NT
 	mutantlungs = /obj/item/organ/lungs/plant //let them breathe CO2
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/plant
 	disliked_food = MEAT | DAIRY | MICE | VEGETABLES | FRUIT | GRAIN | JUNKFOOD | FRIED | RAW | GROSS | BREAKFAST | GRILLED | EGG | CHOCOLATE | SEAFOOD | CLOTH

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -26,7 +26,6 @@
 	punchdamagehigh = 7 //not built for large high speed acts like punches
 	punchstunthreshold = 7 //technically better stunning
 	siemens_coeff = 1.75 //Circuits REALLY don't like extra electricity flying around
-	payday_modifier = 0.6 //Highly efficient workers, but significant political tension between SIC and Remnants = next to no protection or people willing to fight the obvious wage cut
 	//mutant_bodyparts = list("head", "body_markings")
 	mutanteyes = /obj/item/organ/eyes/robotic/preternis
 	mutantlungs = /obj/item/organ/lungs/preternis


### PR DESCRIPTION
# Document the changes in your pull request

I've been thinking about it and I don't think this is conclusive to a fun game.

# Why is this good for the game?
This was originally a conditional for letting non-humans be certain heads. It was funny haha cartoon racism in the moment, but I don't think it's conclusive to good game balance or culture design to promote arbitrary "you're a weird furry so you're paid less", even if it doesn't matter due to economy being unbalanced.

# Wiki Documentation

Paycheck Modifier needs to be removed from every species

# Changelog

:cl:  
rscdel: Removes species pay modifiers
/:cl:
