### PR TITLE
Allows all colors to be used on canvases again

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -77,8 +77,8 @@
 	user.add_atom_colour(paint_color, ADMIN_COLOUR_PRIORITY)
 	return (BRUTELOSS|OXYLOSS)
 
-/obj/item/toy/crayon/proc/min_value() // Makes the paint color brighter if it is below quarter bright (V < 64)
-	var/list/read = ReadRGB(paint_color) // Converts the RGB string into a list
+/obj/item/toy/crayon/proc/min_value(color = "#000000") // Makes the paint color brighter if it is below quarter bright (V < 64)
+	var/list/read = ReadRGB(color) // Converts the RGB string into a list
 	var/value = max(read) // Reads the V from HSV, essentially the brightness
 
 	if(value >= 64) // Min V is 64, 3 quarters to black from white
@@ -94,7 +94,7 @@
 		read[2] = 64
 		read[3] = 64
 
-	paint_color = rgb(read[1], read[2], read[3])
+	return rgb(read[1], read[2], read[3])
 
 /obj/item/toy/crayon/Initialize(mapload)
 	. = ..()
@@ -254,7 +254,6 @@
 		if("select_colour")
 			if(can_change_colour)
 				paint_color = input(usr,"","Choose Color",paint_color) as color|null
-				min_value()
 				. = TRUE
 		if("enter_text")
 			var/txt = stripped_input(usr,"Choose what to write.",
@@ -393,7 +392,7 @@
 	if(actually_paints)
 		switch(paint_mode)
 			if(PAINT_NORMAL)
-				var/obj/effect/decal/cleanable/crayon/C = new(target, paint_color, drawing, temp, graf_rot)
+				var/obj/effect/decal/cleanable/crayon/C = new(target, min_value(paint_color), drawing, temp, graf_rot)
 				C.add_hiddenprint(user)
 				C.pixel_x = clickx
 				C.pixel_y = clicky
@@ -402,7 +401,7 @@
 				var/turf/left = locate(target.x-1,target.y,target.z)
 				var/turf/right = locate(target.x+1,target.y,target.z)
 				if(isValidSurface(left) && isValidSurface(right))
-					var/obj/effect/decal/cleanable/crayon/C = new(left, paint_color, drawing, temp, graf_rot, PAINT_LARGE_HORIZONTAL_ICON)
+					var/obj/effect/decal/cleanable/crayon/C = new(left, min_value(paint_color), drawing, temp, graf_rot, PAINT_LARGE_HORIZONTAL_ICON)
 					C.add_hiddenprint(user)
 					affected_turfs += left
 					affected_turfs += right
@@ -523,7 +522,6 @@
 
 /obj/item/toy/crayon/rainbow/afterattack(atom/target, mob/user, proximity, params)
 	paint_color = rgb(rand(0,255), rand(0,255), rand(0,255))
-	min_value()
 	. = ..()
 
 /*
@@ -682,7 +680,7 @@
 		if(ishuman(C) && actually_paints)
 			var/mob/living/carbon/human/H = C
 			H.lip_style = "spray_face"
-			H.lip_color = paint_color
+			H.lip_color = min_value(paint_color)
 			H.update_body()
 
 		. = use_charges(user, 10, FALSE)
@@ -693,9 +691,9 @@
 
 	if(isobj(target))
 		if(actually_paints)
-			target.add_atom_colour(paint_color, WASHABLE_COLOUR_PRIORITY)
+			target.add_atom_colour(min_value(paint_color), WASHABLE_COLOUR_PRIORITY)
 			if(istype(target, /obj/structure/window))
-				if(color_hex2num(paint_color) < 255)
+				if(color_hex2num(min_value(paint_color)) < 255)
 					target.set_opacity(255)
 				else
 					target.set_opacity(initial(target.opacity))


### PR DESCRIPTION
This is JUST paintings, not stuff you make on the floor or items you color. You can still select darker colors but they will show up as lighter unless used specifically on a canvas. Last person to fix the issue of vantablack cargo did it half-assed and screwed over our lovely artists. Credit to Crazy_Drakkon for bringing this to my attention.


### Testing:

![image](https://github.com/yogstation13/Yogstation/assets/43766432/9b033365-42e2-4b5f-a6f1-689c8ec71903)



# Changelog

:cl:  

bugfix: You can now use darker colors on canvases.


/:cl:
