### PR TITLE
Adds Impressa Coffee Machine to the bar on boxtstation + supplies to bartender's closet

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -43118,7 +43118,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar,
-/obj/item/reagent_containers/food/drinks/shaker,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -43132,6 +43131,8 @@
 	id = "barcounter";
 	name = "bar shutters"
 	},
+/obj/machinery/coffeemaker/impressa,
+/obj/item/reagent_containers/food/drinks/bottle/coffeepot,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "mKD" = (
@@ -59189,6 +59190,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar,
+/obj/item/reagent_containers/food/drinks/bottle/coffeepot,
+/obj/item/seeds/coffee/robusta,
+/obj/item/seeds/coffee,
+/obj/item/storage/box/coffee_condi_display,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "sFl" = (
@@ -72723,6 +72728,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"xHs" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barcounter";
+	name = "bar shutters"
+	},
+/obj/item/reagent_containers/food/drinks/shaker,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "xHA" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/disposalpipe/segment,
@@ -109809,7 +109831,7 @@ sGs
 sGs
 sGs
 mJZ
-sTA
+xHs
 oXZ
 aFd
 hRB


### PR DESCRIPTION
# Document the changes in your pull request

I would like people to partake in coffee, so the Impressa coffee machine + coffee pot has been added to the new bar

Additionally, a spare coffee pot & packs of beans + condiments for drinks have been added to the bartender's back room.

# Why is this good for the game?

Cawfee vs gween tea

# Testing

![image](https://github.com/yogstation13/Yogstation/assets/75333826/691a897e-5b55-4a38-9edc-d3e86387e7f9)

# Wiki Documentation

cark can do this :)

# Changelog

:cl:  
rscadd: Adds coffee machine to the new bar
mapping: Maps it duh
/:cl:
