### PR TITLE
[GAX] Removes Arrival Shuttle and replaces it with cryogenics, adds experimentor room

### DIFF
--- a/_maps/gaxstation.json
+++ b/_maps/gaxstation.json
@@ -7,5 +7,6 @@
 		"cargo": "cargo_gax",
 		"ferry": "ferry_fancy",
 		"emergency": "emergency_box"
-	}
+	},
+	"cryo_spawn": true
 }

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -396,6 +396,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"aiz" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "aiE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -834,6 +845,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"auN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "avc" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -1976,6 +1997,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"aXC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "aXP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -4703,12 +4730,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"ctp" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/emergency,
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/crew_quarters/cryopods)
 "ctx" = (
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -5042,12 +5063,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"czL" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/cryopods)
 "czT" = (
 /turf/closed/wall,
 /area/ai_monitored/security/armory)
@@ -9866,6 +9881,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"eKc" = (
+/obj/machinery/computer/cryopod{
+	dir = 8;
+	pixel_x = 26
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "eKg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -14919,13 +14944,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"hjq" = (
-/obj/machinery/computer/cryopod{
-	dir = 8;
-	pixel_x = 26
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/cryopods)
 "hjs" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -16512,6 +16530,12 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"hTx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "hTG" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -16764,17 +16788,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"ibv" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 1
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel,
-/area/crew_quarters/cryopods)
 "ibA" = (
 /obj/effect/decal/cleanable/xenoblood,
 /turf/open/floor/engine,
@@ -19618,24 +19631,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"jzP" = (
-/obj/effect/turf_decal/siding/thinplating/dark/corner{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/cryopods";
-	dir = 8;
-	name = "Cryogenic Crew Storage APC";
-	pixel_x = -25
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/cryopods)
 "jzY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
@@ -21398,6 +21393,25 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"kvA" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Cryogenics"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "kvW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -21565,6 +21579,13 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/medical/central)
+"kzh" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "kzS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -21659,6 +21680,18 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/hallway/primary/central)
+"kCg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "kCl" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -26667,6 +26700,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"nbF" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "nbL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -27373,21 +27418,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
-"ntu" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Cryogenics"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/cryopods)
 "ntC" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -27898,6 +27928,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"nEA" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/cryopods";
+	dir = 8;
+	name = "Cryogenic Crew Storage APC";
+	pixel_x = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "nEQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -33376,6 +33427,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"qtO" = (
+/obj/machinery/cryopod{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "qub" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -34363,6 +34421,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"qXH" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/emergency,
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "qXK" = (
 /obj/effect/landmark/stationroom/maint/threexfive,
 /turf/template_noop,
@@ -37017,14 +37084,6 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"skT" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -28
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/crew_quarters/cryopods)
 "skY" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -37091,12 +37150,6 @@
 /obj/effect/turf_decal/trimline/secred/warning/lower/corner,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"sng" = (
-/obj/machinery/cryopod{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/cryopods)
 "snj" = (
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/disposal/bin,
@@ -37797,6 +37850,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"sDZ" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "sEp" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/camera{
@@ -42881,12 +42943,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"vfX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/cryopods)
 "vgs" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 6
@@ -91729,11 +91785,11 @@ atx
 oaC
 nDd
 feh
-jzP
-czL
-czL
-czL
-skT
+nEA
+sDZ
+sDZ
+sDZ
+aiz
 eLr
 eLr
 vRP
@@ -91991,7 +92047,7 @@ hJl
 hJl
 xUY
 hJl
-sng
+qtO
 hHC
 aCD
 tkl
@@ -92248,7 +92304,7 @@ gQo
 lzs
 nDE
 hJl
-sng
+qtO
 hHC
 vRP
 tkl
@@ -92505,7 +92561,7 @@ nDE
 wMH
 aCP
 hJl
-sng
+qtO
 hHC
 aCD
 tkl
@@ -92757,11 +92813,11 @@ kqi
 sod
 nDd
 xmg
-ibv
-hjq
-vfX
-hJl
-ctp
+nbF
+eKc
+auN
+aXC
+qXH
 eLr
 eLr
 vRP
@@ -93016,7 +93072,7 @@ fXQ
 fXQ
 fXQ
 fXQ
-ntu
+kvA
 nDd
 eLr
 eLr
@@ -93272,9 +93328,9 @@ tSW
 tSW
 vRP
 sqz
-xBd
-tfe
-vaq
+kzh
+kCg
+hTx
 sqz
 vRP
 vRP

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -8456,15 +8456,6 @@
 "efI" = (
 /turf/closed/wall,
 /area/crew_quarters/toilet)
-"efO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "efX" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -13546,6 +13537,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
+"guf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "gug" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -32271,6 +32271,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"pRM" = (
+/turf/closed/wall/r_wall,
+/area/crew_quarters/cryopods)
 "pSg" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -91560,14 +91563,14 @@ uxf
 gIq
 nXc
 neX
-fXQ
-fXQ
-fXQ
+pRM
+pRM
+pRM
 hHC
 hHC
 hHC
-fXQ
-fXQ
+pRM
+pRM
 vRP
 vRP
 tkl
@@ -91824,8 +91827,8 @@ czL
 czL
 czL
 skT
-fXQ
-fXQ
+pRM
+pRM
 vRP
 tkl
 ubS
@@ -92852,8 +92855,8 @@ hjq
 vfX
 hJl
 ctp
-fXQ
-fXQ
+pRM
+pRM
 vRP
 tkl
 aCD
@@ -93108,8 +93111,8 @@ fXQ
 fXQ
 ntu
 nDd
-fXQ
-fXQ
+pRM
+pRM
 vRP
 vRP
 tkl
@@ -93358,8 +93361,8 @@ pKx
 lwC
 rWP
 nBO
-lMA
-lMA
+tSW
+tSW
 vRP
 sqz
 xBd
@@ -93615,7 +93618,7 @@ pKx
 cVQ
 hjp
 ryX
-lMA
+tSW
 aCD
 aCD
 sqz
@@ -93872,8 +93875,8 @@ faQ
 wtt
 lVK
 gsE
-lMA
-lMA
+tSW
+tSW
 sqz
 sqz
 eGD
@@ -94133,7 +94136,7 @@ xpQ
 mmo
 xpQ
 xpQ
-efO
+guf
 tfe
 unc
 xpQ

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -1120,6 +1120,12 @@
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"aCP" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "aCU" = (
 /obj/structure/chair{
 	dir = 4
@@ -4696,6 +4702,12 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"ctp" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/emergency,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "ctx" = (
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -5029,6 +5041,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"czL" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "czT" = (
 /turf/closed/wall,
 /area/ai_monitored/security/armory)
@@ -6392,15 +6410,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/fore)
-"deA" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "deH" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
@@ -6769,6 +6778,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"dkM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/entry)
 "dkN" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -8440,6 +8456,15 @@
 "efI" = (
 /turf/closed/wall,
 /area/crew_quarters/toilet)
+"efO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "efX" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -8573,6 +8598,13 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"ejV" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "ejY" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible,
 /turf/open/floor/plasteel,
@@ -9442,21 +9474,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"eBm" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "eBt" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -9704,6 +9721,13 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/heads/captain)
+"eGD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "eHi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -10661,6 +10685,19 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"feh" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 4
+	},
+/obj/structure/closet/emcloset,
+/obj/machinery/atmospherics/components/unary/tank/air{
+	piping_layer = 2
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "few" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -11076,6 +11113,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"foH" = (
+/obj/effect/turf_decal/siding/thinplating/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "foW" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -13038,11 +13083,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"giq" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "giB" = (
 /obj/machinery/power/smes,
 /obj/structure/cable{
@@ -14015,18 +14055,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"gIn" = (
-/obj/docking_port/stationary{
-	dir = 2;
-	dwidth = 3;
-	height = 15;
-	id = "arrivals_stationary";
-	name = "arrivals";
-	roundstart_template = /datum/map_template/shuttle/arrival/gax;
-	width = 7
-	},
-/turf/open/space/basic,
-/area/space)
 "gIp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -14107,6 +14135,21 @@
 "gJV" = (
 /turf/closed/wall/r_wall,
 /area/security/processing)
+"gJW" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "gKH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -14293,6 +14336,13 @@
 /obj/item/storage/toolbox/emergency,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"gQo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "gRH" = (
 /obj/machinery/light{
 	dir = 4
@@ -14904,6 +14954,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"hjq" = (
+/obj/machinery/computer/cryopod{
+	dir = 8;
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "hjs" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -16053,6 +16110,10 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"hHC" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/crew_quarters/cryopods)
 "hHG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -16108,6 +16169,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"hJl" = (
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "hJp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/firedoor/border_only,
@@ -16269,21 +16333,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
-"hOw" = (
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "hOz" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 4
@@ -16743,6 +16792,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"ibv" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "ibA" = (
 /obj/effect/decal/cleanable/xenoblood,
 /turf/open/floor/engine,
@@ -17698,6 +17758,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ixL" = (
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/cryopods)
 "iyb" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -18713,19 +18776,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"jam" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/advanced_airlock_controller{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "jaK" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
@@ -19596,6 +19646,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"jzP" = (
+/obj/effect/turf_decal/siding/thinplating/dark/corner{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/cryopods";
+	dir = 8;
+	name = "Cryogenic Crew Storage APC";
+	pixel_x = -25
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "jzY" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
@@ -23590,6 +23658,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"lzs" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "lzE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -26797,6 +26872,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
+"nfE" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "nfG" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/white/filled/line/lower{
@@ -27347,6 +27437,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
+"ntu" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Cryogenics"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "ntC" = (
 /obj/machinery/door/airlock/external{
 	name = "External Access";
@@ -27796,6 +27901,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
+"nDd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/crew_quarters/cryopods)
 "nDx" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -27811,6 +27920,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"nDE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "nDJ" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/engineering)
@@ -28829,18 +28944,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/main)
-"oha" = (
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Port Docking Bay 1"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "ohg" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -29551,19 +29654,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"oAE" = (
-/obj/item/beacon,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "oAK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -30263,6 +30353,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"oXk" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Cryogenics"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/cryopods)
 "oXp" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/effect/turf_decal/stripes/corner{
@@ -33668,18 +33772,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"qEh" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/advanced_airlock_controller{
-	pixel_y = 24
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "qEC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -34945,6 +35037,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"rlo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/cryopods)
 "rlY" = (
 /obj/machinery/portable_atmospherics/pump,
 /obj/effect/turf_decal/bot,
@@ -36047,11 +36146,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"rKC" = (
-/obj/structure/sign/warning/vacuum/external,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "rKM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -37011,6 +37105,14 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"skT" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -28
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "skY" = (
 /obj/structure/table,
 /obj/machinery/light,
@@ -37077,6 +37179,12 @@
 /obj/effect/turf_decal/trimline/secred/warning/lower/corner,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"sng" = (
+/obj/machinery/cryopod{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "snj" = (
 /obj/effect/turf_decal/stripes/box,
 /obj/machinery/disposal/bin,
@@ -38940,6 +39048,12 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"tfe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "tfA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -39762,15 +39876,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"tDj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "tDw" = (
 /obj/structure/sign/departments/minsky/medical/virology/virology2{
 	pixel_y = 32
@@ -41709,6 +41814,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"uEx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "uEI" = (
 /obj/machinery/shower{
 	pixel_y = 20
@@ -42863,6 +42975,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"vfX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "vgs" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 6
@@ -46153,6 +46271,12 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/aft)
+"wMH" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "wMY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -47240,21 +47364,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"xme" = (
-/obj/effect/turf_decal/stripes/corner{
+"xmg" = (
+/obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+/obj/structure/closet/firecloset/full,
+/obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/area/crew_quarters/cryopods)
 "xmi" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
@@ -47596,6 +47715,22 @@
 /obj/machinery/photocopier,
 /turf/open/floor/wood,
 /area/lawoffice)
+"xww" = (
+/obj/item/beacon,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xwU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -47818,6 +47953,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
+"xBd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/chair,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "xBC" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 6
@@ -48684,6 +48826,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"xUY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/cryopods)
 "xVi" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -89626,9 +89774,9 @@ vIw
 vIw
 vIw
 uzX
-vRP
-vRP
-vRP
+tkl
+tkl
+tkl
 tkl
 tkl
 tkl
@@ -89884,8 +90032,8 @@ vIw
 vIw
 uzX
 tkl
-tkl
-tkl
+aCD
+aCD
 ubS
 ubS
 ubS
@@ -90141,8 +90289,8 @@ uli
 vIw
 uzX
 tkl
-aCD
-aCD
+vRP
+vRP
 vRP
 aCD
 vRP
@@ -90398,9 +90546,9 @@ uzX
 uzX
 uzX
 tkl
-vRP
 aCD
-vRP
+aCD
+aCD
 aCD
 vRP
 vRP
@@ -90653,11 +90801,11 @@ xTV
 xTV
 xTV
 xTV
-xTV
-xTV
-uqY
-uqY
-xNw
+iwu
+tkl
+vRP
+aCD
+vRP
 ubS
 tTD
 tTD
@@ -90900,21 +91048,21 @@ aCD
 vRP
 vRP
 vRP
-tkl
+aCD
+vRP
+aCD
 vRP
 vRP
+aCD
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-tkl
-vRP
-ubS
+aCD
+aCD
 pCt
+ubS
+aCD
+ubS
+ubS
 aCD
 vRP
 vRP
@@ -91155,23 +91303,23 @@ tSW
 tSW
 tSW
 tSW
-lMA
-tkl
-tkl
-tkl
-tkl
-tkl
-tkl
-tkl
-tkl
-tkl
-tkl
-tkl
-tkl
-tkl
+tSW
+vRP
+aCD
+vRP
+aCD
+vRP
+vRP
+aCD
+vRP
+vRP
 tkl
 ubS
 jta
+vRP
+vRP
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -91412,25 +91560,25 @@ uxf
 gIq
 nXc
 neX
-lMA
-aCD
+fXQ
+fXQ
+fXQ
+hHC
+hHC
+hHC
+fXQ
+fXQ
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-aCD
-aCD
-aCD
 tkl
 aCD
-aCD
-aCD
-aCD
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -91669,23 +91817,23 @@ kbG
 vvd
 atx
 oaC
-sqz
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+nDd
+feh
+jzP
+czL
+czL
+czL
+skT
+fXQ
+fXQ
 vRP
 tkl
 ubS
-aCD
+vRP
+vRP
+vRP
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -91926,22 +92074,22 @@ nPi
 vvd
 atx
 pnP
-sqz
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+nDd
+ixL
+nfE
+hJl
+hJl
+xUY
+hJl
+sng
+hHC
+aCD
 tkl
 aCD
+vRP
+vRP
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -92180,25 +92328,25 @@ wcy
 lzE
 jWH
 lzE
-oAE
-atx
-pnP
-sqz
-gIn
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+xww
+foH
+dkM
+oXk
+rlo
+gJW
+gQo
+lzs
+nDE
+hJl
+sng
+hHC
 vRP
 tkl
 ubS
+vRP
+vRP
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -92440,22 +92588,22 @@ vvd
 rRY
 atx
 pnP
-sqz
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+nDd
+ixL
+ejV
+nDE
+wMH
+aCP
+hJl
+sng
+hHC
+aCD
 tkl
 aCD
+vRP
+vRP
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -92697,22 +92845,22 @@ oRf
 eXj
 kqi
 sod
-sqz
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+nDd
+xmg
+ibv
+hjq
+vfX
+hJl
+ctp
+fXQ
+fXQ
 vRP
 tkl
 aCD
+vRP
+vRP
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -92954,22 +93102,22 @@ smm
 rRY
 atx
 xHB
-lMA
-aCD
+fXQ
+fXQ
+fXQ
+fXQ
+ntu
+nDd
+fXQ
+fXQ
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-aCD
-aCD
-aCD
 tkl
 ubS
+vRP
+vRP
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -93212,21 +93360,21 @@ rWP
 nBO
 lMA
 lMA
-tkl
-tkl
-tkl
+vRP
 sqz
-oha
+xBd
+tfe
+vaq
 sqz
-oha
-sqz
-tkl
-tkl
-tkl
-tkl
-tkl
+vRP
+vRP
+vRP
 tkl
 ubS
+vRP
+vRP
+vRP
+vRP
 vRP
 vRP
 vRP
@@ -93470,16 +93618,16 @@ ryX
 lMA
 aCD
 aCD
-vRP
-aCD
 sqz
-jam
-tSW
-qEh
+xBd
+tfe
+vaq
 sqz
 aCD
 aCD
 aCD
+tkl
+tkl
 tkl
 tkl
 tkl
@@ -93728,12 +93876,12 @@ lMA
 lMA
 sqz
 sqz
+eGD
+tfe
+vaq
 sqz
 sqz
-hOw
-rKC
-hOw
-rrx
+sqz
 lMA
 lMA
 aCD
@@ -93985,11 +94133,11 @@ xpQ
 mmo
 xpQ
 xpQ
-tDj
+efO
+tfe
+unc
 xpQ
-eBm
 xpQ
-xme
 ktG
 eLA
 lMA
@@ -94243,10 +94391,10 @@ blt
 aAR
 aAR
 ofj
+uEx
 aAR
-deA
 aAR
-giq
+blt
 nOX
 wUk
 vha

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -804,13 +804,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"atJ" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/cryopods)
 "atQ" = (
 /obj/effect/turf_decal/trimline/white/filled/corner/lower{
 	dir = 1
@@ -2823,6 +2816,14 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"bvc" = (
+/obj/structure/rack,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "bvi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9932,6 +9933,9 @@
 /obj/item/storage/pencil_holder/crew,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"eLr" = (
+/turf/closed/wall/r_wall,
+/area/crew_quarters/cryopods)
 "eLA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -10757,6 +10761,10 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/port/aft)
+"fgy" = (
+/obj/item/stock_parts/micro_laser,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "fgB" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
@@ -10996,18 +11004,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"fme" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "fmk" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -12555,18 +12551,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"fWw" = (
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/cryopods";
-	dir = 8;
-	name = "Cryogenic Crew Storage APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/cryopods)
 "fWC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -13334,16 +13318,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"gql" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "gqK" = (
 /obj/structure/displaycase/labcage,
 /obj/structure/cable{
@@ -13537,15 +13511,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
-"guf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "gug" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -15474,6 +15439,13 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"hth" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "htr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
@@ -21808,17 +21780,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"kGF" = (
-/obj/machinery/computer/cryopod{
-	pixel_y = 26
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/carpet,
-/area/crew_quarters/cryopods)
 "kGI" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -25940,24 +25901,6 @@
 /obj/machinery/vending/boozeomat,
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"mDz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "mFc" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Tech Storage";
@@ -27073,6 +27016,11 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"nkl" = (
+/obj/effect/spawner/lootdrop/maintenance/four,
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "nky" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -27090,18 +27038,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ai_monitored/storage/eva)
-"nkM" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "nkP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -27504,6 +27440,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"nuD" = (
+/obj/item/circuitboard/machine/experimentor,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "nuI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/power/apc{
@@ -28534,13 +28474,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"nTF" = (
-/obj/structure/rack,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "nTH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28800,27 +28733,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"obf" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Cryogenics"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/cryopods)
 "obz" = (
 /obj/machinery/light{
 	dir = 1
@@ -29387,6 +29299,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
+"otf" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/corner/lower,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "otk" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -29801,17 +29729,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"oFK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/cryopods)
 "oGc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -32271,9 +32188,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"pRM" = (
-/turf/closed/wall/r_wall,
-/area/crew_quarters/cryopods)
 "pSg" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -32538,6 +32452,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"pXl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "pXn" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -33003,12 +32923,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"qhp" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/cryopods)
 "qhL" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -33780,6 +33694,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"qFp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "qFF" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/structure/sign/warning/pods{
@@ -34107,6 +34027,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/stairs/goon/stairs_middle,
 /area/hydroponics/garden)
+"qQe" = (
+/obj/structure/girder,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "qQC" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=CHW";
@@ -35581,18 +35509,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/aft)
-"rxz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/cryopods)
 "rxG" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -35733,13 +35649,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"rAS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/cryopods)
 "rBc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -39664,6 +39573,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"txz" = (
+/obj/item/stock_parts/manipulator,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "tyq" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -39912,10 +39825,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"tEs" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/crew_quarters/cryopods)
 "tEt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -40006,6 +39915,10 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"tHq" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "tHs" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/department/eva";
@@ -41689,6 +41602,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"uCH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "uCM" = (
 /obj/machinery/door/airlock/research{
 	name = "Genetics Research Access";
@@ -42212,25 +42134,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/theatre)
-"uNq" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/corner/lower,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "uNv" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
@@ -44863,6 +44766,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"wck" = (
+/obj/item/stock_parts/scanning_module,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "wcp" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -46432,6 +46339,10 @@
 /obj/effect/spawner/lootdrop/techstorage/security,
 /turf/open/floor/plasteel/white,
 /area/storage/tech)
+"wQm" = (
+/obj/structure/frame/machine,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "wQn" = (
 /obj/structure/disposalpipe/segment,
 /turf/template_noop,
@@ -48601,10 +48512,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
-"xPX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/carpet,
-/area/crew_quarters/cryopods)
 "xQb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -79219,7 +79126,7 @@ fbN
 geS
 xNy
 kgb
-nTF
+bvc
 mQK
 mpT
 abO
@@ -79735,13 +79642,13 @@ trH
 wTB
 wTB
 wTB
-fXQ
-fXQ
-fXQ
-fXQ
-fXQ
-fXQ
-fXQ
+xNs
+tHq
+txz
+nJe
+xNs
+xNs
+xNs
 hBZ
 nJe
 xNs
@@ -79992,13 +79899,13 @@ fCm
 wTB
 bJd
 eRu
-fXQ
-atJ
-fWw
-qhp
-qhp
-qhp
-fXQ
+xNs
+wck
+lId
+nuD
+fgy
+nkl
+xNs
 hBZ
 xNs
 xNs
@@ -80249,13 +80156,13 @@ wTB
 wTB
 jPa
 oyD
-fXQ
-kGF
-rAS
-rxz
-xPX
-oFK
-fXQ
+xNs
+wQm
+nYY
+txz
+nJe
+fgy
+qQe
 hBZ
 bnZ
 vNF
@@ -80506,13 +80413,13 @@ vrF
 wTB
 oci
 opt
-fXQ
-fXQ
-tEs
-obf
-tEs
-fXQ
-fXQ
+xNs
+xNs
+xNs
+xNs
+xNs
+xNs
+xNs
 hBZ
 vIr
 hWB
@@ -80766,7 +80673,7 @@ wTB
 wTB
 xGG
 vcc
-mDz
+lqe
 lqe
 xeO
 wTB
@@ -81023,7 +80930,7 @@ lqe
 xxy
 rXO
 hHK
-gql
+qFp
 kqt
 eFs
 wTB
@@ -81280,7 +81187,7 @@ kqt
 eDB
 kqt
 dtJ
-fme
+pXl
 vNq
 cKZ
 wTB
@@ -81537,8 +81444,8 @@ mVE
 eNT
 xIE
 yiu
-nkM
-uNq
+hth
+otf
 wqv
 wTB
 hBZ
@@ -91563,14 +91470,14 @@ uxf
 gIq
 nXc
 neX
-pRM
-pRM
-pRM
+eLr
+eLr
+eLr
 hHC
 hHC
 hHC
-pRM
-pRM
+eLr
+eLr
 vRP
 vRP
 tkl
@@ -91827,8 +91734,8 @@ czL
 czL
 czL
 skT
-pRM
-pRM
+eLr
+eLr
 vRP
 tkl
 ubS
@@ -92855,8 +92762,8 @@ hjq
 vfX
 hJl
 ctp
-pRM
-pRM
+eLr
+eLr
 vRP
 tkl
 aCD
@@ -93111,8 +93018,8 @@ fXQ
 fXQ
 ntu
 nDd
-pRM
-pRM
+eLr
+eLr
 vRP
 vRP
 tkl
@@ -94136,7 +94043,7 @@ xpQ
 mmo
 xpQ
 xpQ
-guf
+uCH
 tfe
 unc
 xpQ

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -893,38 +893,66 @@ SUBSYSTEM_DEF(job)
 		return
 
 	//bad mojo
-	var/area/shuttle/arrival/A = GLOB.areas_by_type[/area/shuttle/arrival]
-	if(A)
-		//first check if we can find a chair
-		var/obj/structure/chair/C = locate() in A
-		if(C)
-			C.JoinPlayerHere(M, buckle)
-			return
-
-		//last hurrah
-		var/list/avail = list()
-		for(var/turf/T in A)
-			if(!T.is_blocked_turf(TRUE))
-				avail += T
-		if(avail.len)
-			destination = pick(avail)
+	if(SSmapping.config.cryo_spawn)
+		var/area/shuttle/arrival/A = GLOB.areas_by_type[/area/crew_quarters/cryopods]
+		if(A)
+			var/list/pods = list()
+			var/list/unoccupied_pods = list()
+			for(var/obj/machinery/cryopod/pod in A)
+				pods |= pod
+				if(!pod.occupant)
+					unoccupied_pods |= pod
+			if(length(unoccupied_pods)) //if we have any unoccupied ones
+				destination = pick(unoccupied_pods)
+			else if(length(pods))
+				destination = pick(pods) //if they're all full somehow??
+			else //no pods at all
+				var/list/available = list()
+				for(var/turf/T in A)
+					if(!T.is_blocked_turf(TRUE))
+						available += T
+				if(length(available))
+					destination = pick(available)
+		if(destination)
 			destination.JoinPlayerHere(M, FALSE)
-			return
+		else
+			var/msg = "Unable to send mob [M] to late join (CRYOPODS)!"
+			message_admins(msg)
+			CRASH(msg)
 
-	//pick an open spot on arrivals and dump em
-	var/list/arrivals_turfs = shuffle(get_area_turfs(/area/shuttle/arrival))
-	if(arrivals_turfs.len)
-		for(var/turf/T in arrivals_turfs)
-			if(!T.is_blocked_turf(TRUE))
-				T.JoinPlayerHere(M, FALSE)
-				return
-		//last chance, pick ANY spot on arrivals and dump em
-		destination = arrivals_turfs[1]
-		destination.JoinPlayerHere(M, FALSE)
 	else
-		var/msg = "Unable to send mob [M] to late join!"
-		message_admins(msg)
-		CRASH(msg)
+		var/area/shuttle/arrival/A = GLOB.areas_by_type[/area/shuttle/arrival]
+		if(A)
+			//first check if we can find a chair
+			var/obj/structure/chair/C = locate() in A
+			if(C)
+				C.JoinPlayerHere(M, buckle)
+				return
+
+			//last hurrah
+			var/list/avail = list()
+			for(var/turf/T in A)
+				if(!T.is_blocked_turf(TRUE))
+					avail += T
+			if(avail.len)
+				destination = pick(avail)
+				destination.JoinPlayerHere(M, FALSE)
+				return
+
+		//pick an open spot on arrivals and dump em
+		var/list/arrivals_turfs = shuffle(get_area_turfs(/area/shuttle/arrival))
+		if(arrivals_turfs.len)
+			for(var/turf/T in arrivals_turfs)
+				if(!T.is_blocked_turf(TRUE))
+					T.JoinPlayerHere(M, FALSE)
+					return
+			//last chance, pick ANY spot on arrivals and dump em
+			destination = arrivals_turfs[1]
+			destination.JoinPlayerHere(M, FALSE)
+		else
+			var/msg = "Unable to send mob [M] to late join!"
+			message_admins(msg)
+			CRASH(msg)
 
 ///Lands specified mob at a random spot in the hallways
 /datum/controller/subsystem/job/proc/DropLandAtRandomHallwayPoint(mob/living/living_mob)

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -24,6 +24,7 @@
 	var/space_empty_levels = 1
 
 	var/minetype = "lavaland"
+	var/cryo_spawn = FALSE
 
 	var/allow_custom_shuttles = TRUE
 	var/shuttles = list(
@@ -134,6 +135,9 @@
 
 	if ("minetype" in json)
 		minetype = json["minetype"]
+
+	if("cryo_spawn" in json)
+		cryo_spawn = json["cryo_spawn"]
 
 	allow_custom_shuttles = json["allow_custom_shuttles"] != FALSE
 

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -442,3 +442,18 @@ GLOBAL_VAR_INIT(cryopods_enabled, FALSE)
 /obj/machinery/cryopod/proc/apply_effects_to_mob(mob/living/carbon/sleepyhead)
 	sleepyhead.SetSleeping(50)
 	to_chat(sleepyhead, span_boldnotice("You begin to wake from cryosleep..."))
+	sleepyhead.set_nutrition(200)
+	sleepyhead.SetSleeping(60) //if you read this comment and feel like shitting together something to adjust IPC charge on wakeup, be my guest.
+	//but it can be worse.
+	if(prob(90))
+		sleepyhead.adjust_drowsiness(rand(3 SECONDS, 10 SECONDS))
+	if(prob(75))
+		sleepyhead.blur_eyes(rand(3, 6))
+	//so much worse
+	if(prob(66))
+		sleepyhead.adjust_disgust(rand(25,35))
+	if(prob(33))
+		sleepyhead.adjust_disgust(rand(20,30))
+	if(prob(16))
+		sleepyhead.adjust_disgust(rand(10, 17))
+	to_chat(sleepyhead, "<span class='userdanger'>The symptoms of cryosleep set in as you awaken...")

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -432,3 +432,13 @@ GLOBAL_VAR_INIT(cryopods_enabled, FALSE)
 	log_admin(span_notice("[key_name(target)] entered a stasis pod."))
 	message_admins("[key_name_admin(target)] entered a stasis pod. (<A HREF='?_src_=holder;[HrefToken()];adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 	add_fingerprint(target)
+
+/obj/machinery/cryopod/JoinPlayerHere(mob/M, buckle)
+	. = ..()
+	open_machine()
+	if(iscarbon(M))
+		apply_effects_to_mob(M)
+
+/obj/machinery/cryopod/proc/apply_effects_to_mob(mob/living/carbon/sleepyhead)
+	sleepyhead.SetSleeping(50)
+	to_chat(sleepyhead, span_boldnotice("You begin to wake from cryosleep..."))

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -440,7 +440,6 @@ GLOBAL_VAR_INIT(cryopods_enabled, FALSE)
 		apply_effects_to_mob(M)
 
 /obj/machinery/cryopod/proc/apply_effects_to_mob(mob/living/carbon/sleepyhead)
-	sleepyhead.SetSleeping(50)
 	to_chat(sleepyhead, span_boldnotice("You begin to wake from cryosleep..."))
 	sleepyhead.set_nutrition(200)
 	sleepyhead.SetSleeping(60) //if you read this comment and feel like shitting together something to adjust IPC charge on wakeup, be my guest.


### PR DESCRIPTION
# Document the changes in your pull request

Steals partially from https://github.com/shiptest-ss13/Shiptest/pull/2056

Replaces Gax Arrivals with cryogenics
![image](https://github.com/yogstation13/Yogstation/assets/5091394/66806468-17a4-4868-b52d-cb011c80fbb9)
Messing with it holds the same rules as messing with arrivals in general. Has it's own air supply so it cant be plasmaflooded.
When you spawn you have a chance for some harmless but flavorful negative effects. Shiptest had a chance to damage you but I don't like that. Works even without power, works without the cryo pods not there (magic).

Also adds an "Experimentor room" in maint which gives you the stuff to build one yourself :^)

![image](https://github.com/yogstation13/Yogstation/assets/5091394/790c2204-fed5-46f2-a73a-ccc2dd867c8e)


# Why is this good for the game?
NVS Gax is a ship. You have a little ship move people to big ship???? Emergency shuttle makes sense because it is actually evacuating people.

# Testing

https://github.com/yogstation13/Yogstation/assets/5091394/255215af-cb47-4d67-ba12-f3bbd1938b48



# Wiki Documentation
No more arrivals shuttle for gax, Cryo is moved.
<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
mapping: Removes arrival shuttle from NVS Gax, people spawn in cryo now
/:cl:
