### PR TITLE
Removes bonus demolition damage from the laser scalpel

### DIFF
--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -400,7 +400,6 @@
 	light_range = 1
 	light_color = LIGHT_COLOR_GREEN
 	light_power = 0.2	//Barely glows on low power
-	demolition_mod = 1.5 // lasers are good at cutting metal
 	sharpness = SHARP_EDGED
 
 


### PR DESCRIPTION
# Document the changes in your pull request

--- Removes the 1.5x demolition damage buff on the laser scalpel

-- WHY?

As stated above. It doesn't make any sense, the reasons why are listed in this PR: https://github.com/yogstation13/Yogstation/pull/18451

It's bizarre that after this PR was merged, another PR comes out immediately after and buffs laser scalpel's combat utility because "laser good at metal". Laser SCALPELS aren't designed to cut METAL, they are precision surgical tools to cut flesh and occasionally bone. 

There's a big difference between a surgical tool in a operating theatre being used by a surgeon to seperate flesh and some rando using it to, just SMACK a sheet of metal. If it's bad against human tissue when employed in a violent manner it's going to be bad against metal too. Because there's no time in combat to direct the laser at the metal, and it really is just -smacking- it'd stand to reason that the laser scalpel, having no metal edge to dint the metal, might actually be *worse* at damaging sturdy metal - because there's no immediate impact. It's a relatively weak laser that doesn't have any business being used as a weapon grazing across a thick(er) layer of steel. It literally doesn't have the time to cut the steel before the attack is over. 

# Why is this good for the game?
There's no reason a surgical implement that's designed to be especially effective in a medical context should also magically be extremely good at stopping military bots, mechs or trying to smash through barricades. That's what toolboxes and ion guns are for. As MajManatee said, it's an incredibly tiny laser beam - it'd probably do less damage to tissue (in an attack), it just doesn't have the oomph to do anything to armor, it's too tiny and you're not applying it correctly.

# Testing
<!-- Deleted line -->


# Wiki Documentation

<!-- Laser scalpel demolition damage goes from 1.5x to the original number (0.5x)? -->

# Changelog

:cl:  
tweak: Laser scalpels don't have their demolition damage modifier anymore.
/:cl:
