### PR TITLE
Removes the two engines from the PA template, adds a singularity engine generator to secure storage

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/engine_singulo_tesla.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/engine_singulo_tesla.dmm
@@ -957,10 +957,6 @@
 /obj/item/wrench,
 /turf/open/space/basic,
 /area/engine/engineering)
-"Rn" = (
-/obj/machinery/the_singularitygen,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "Rw" = (
 /obj/machinery/power/rad_collector,
 /obj/structure/cable/orange{
@@ -1036,10 +1032,6 @@
 "WN" = (
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall/r_wall,
-/area/engine/engineering)
-"XG" = (
-/obj/machinery/the_singularitygen/tesla,
-/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "Zr" = (
 /obj/structure/cable/yellow{
@@ -1513,7 +1505,7 @@ gm
 gm
 gm
 yi
-XG
+yi
 yi
 kU
 kU
@@ -1569,7 +1561,7 @@ sd
 kU
 kU
 yi
-Rn
+yi
 yi
 gm
 gm

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -71787,6 +71787,10 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"xqi" = (
+/obj/machinery/the_singularitygen,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "xqr" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/stripes/corner,
@@ -100874,7 +100878,7 @@ bCq
 uzc
 ccw
 ppM
-wil
+xqi
 bQa
 cmD
 cmD


### PR DESCRIPTION
# Document the changes in your pull request

This PR will remove the tesla generator and singularity generate from the PA engine template in engineering, and add a singularity generator to the secure storage where the tesla one already is.

# Why is this good for the game?

New engineers wont fuck the station as easy

# Testing

yes



# Wiki Documentation

no

# Changelog


:cl:  

mapping: Adjusts the singulo/tesla engine template

/:cl:
