### PR TITLE
Adds tesla generator crate

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1162,6 +1162,13 @@
 	contains = list(/obj/machinery/the_singularitygen)
 	crate_name = "singularity generator crate"
 
+/datum/supply_pack/engine/tesla_gen
+	name = "Energy Ball Generator Crate"
+	desc = "For invoking the swirling balls of electric doom. Particle Accelerator not included."
+	cost = 5000
+	contains = list(/obj/machinery/the_singularitygen/tesla)
+	crate_name = "energy ball generator crate"
+
 /datum/supply_pack/engine/solar
 	name = "Solar Panel Crate"
 	desc = "Go green with this DIY advanced solar array. Contains twenty one solar assemblies, a solar-control circuit board, and tracker. If you have any questions, please check out the enclosed instruction book."


### PR DESCRIPTION
# Document the changes in your pull request
This adds a crate containing a tesla generator to cargo for 5000cr. The price is based off the cost for a singulo generator crate, and since both engines are pretty similar, why not?

# Why is this good for the game?
People are able to order pretty much everything needed to build a new engine from cargo. Weirdly, the only engine that can't be replaced is the tesla. So it makes sense to me having this crate exist.

# Testing
Very small code change, but I'll test it in the morning just to make sure.

# Wiki Documentation
Should be documented here: https://wiki.yogstation.net/wiki/Supply_crates#Engine_Construction

# Changelog
:cl:  
rscadd: You can now order tesla generators from cargo, same price as the singulo generators
/:cl:
