### PR TITLE
Bear Traps Can Now Be Anchored

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -283,12 +283,13 @@
 	if(ishuman(user) && !user.stat && !user.restrained())
 		armed = !armed
 		update_appearance(UPDATE_ICON)
-		to_chat(user, span_notice("[src] is now [armed ? "armed" : "disarmed"]"))
+		to_chat(user, span_notice("[src] is now [armed ? "armed" : "disarmed"]."))
 
 /obj/item/restraints/legcuffs/beartrap/wrench_act(mob/living/user, obj/item/wrench/W)
 	if(armed && !anchored)
 		if(do_after(user, 1 SECONDS, src)) // Take the time to wrench it this trap to be more effective.
 			anchored = TRUE
+			playsound(src, 'sound/items/deconstruct.ogg', 50, 1)
 		return
 	..()
 

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -285,8 +285,23 @@
 		update_appearance(UPDATE_ICON)
 		to_chat(user, span_notice("[src] is now [armed ? "armed" : "disarmed"]"))
 
+/obj/item/restraints/legcuffs/beartrap/wrench_act(mob/living/user, obj/item/wrench/W)
+	if(armed && !anchored)
+		if(do_after(user, 1 SECONDS, src)) // Take the time to wrench it this trap to be more effective.
+			anchored = TRUE
+		return
+	..()
+
+/obj/item/restraints/legcuffs/beartrap/attack_hand(mob/user)
+	. = ..()
+	if(.)
+		return
+	if(armed && anchored && do_after(user, 1 SECONDS, src)) // And take the time to disarm this anchored trap.
+		close_trap()
+
 /obj/item/restraints/legcuffs/beartrap/proc/close_trap()
 	armed = FALSE
+	anchored = FALSE
 	update_appearance(UPDATE_ICON)
 	playsound(src, 'sound/effects/snap.ogg', 50, TRUE)
 


### PR DESCRIPTION
# Document the changes in your pull request
You can wrench down a bear trap to anchor to the floor after a second delay. Equally, you can stick your hand in to disarm it after a second delay. Disarming it does not hurt you.

Grammar for bear trap (dis-)arming.

# Why is this good for the game?
Rewards planning ahead of the time by making it slightly more troublesome to deal with it instead of just picking up the armed bear trap and walking past.

# Testing
Can wrench to anchor. Can stick my hand in to disarm.
![trap](https://github.com/yogstation13/Yogstation/assets/30399783/22782bd8-0ba8-40e9-8bdd-9a70e11e6d54)

# Wiki Documentation
Tips for Traitoring in Janitor's page. Mention that beartraps can be wrenched down.

# Changelog

:cl:  
rscadd: You can now use a wrench to anchor armed beartraps after a second delay. It can be disarmed with an empty hand with a second delay.
spellcheck: Message for arming and disarming beartraps properly ends with a period.
/:cl:
