### PR TITLE
Allows all colors to be used on non-canvases again

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -82,7 +82,7 @@
 	var/value = max(read) // Reads the V from HSV, essentially the brightness
 
 	if(value >= 64) // Min V is 64, 3 quarters to black from white
-		return
+		return color
 
 	if(value > 0) // Div by zero avoidance
 		var/difference = 64/value


### PR DESCRIPTION

Yeah so I forgot to make it actually return a color when it wasnt too dark oops

# Changelog

:cl:  

bugfix: Fixes spray cans/crayons not working

/:cl:
