### PR TITLE
Yet another update to new bar... Paystand edition

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -61367,6 +61367,10 @@
 	name = "privacy shutter"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "barcounter";
+	name = "bar shutters"
+	},
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
 "tvb" = (
@@ -70112,10 +70116,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"wFS" = (
-/obj/effect/spawner/xmastree,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "wGq" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/camera{
@@ -73517,6 +73517,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
+"xYx" = (
+/obj/effect/spawner/xmastree,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "xYD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
@@ -111133,7 +111137,7 @@ mpT
 mpT
 mpT
 jYy
-wFS
+xYx
 mlf
 aPl
 qiP

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -29632,7 +29632,7 @@
 /obj/machinery/door/airlock/maintenance{
 	name = "Bar Maintenance";
 	req_access_txt = "0";
-	req_one_access_txt = "12,25"
+	req_one_access_txt = "12;25"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -1047,13 +1047,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"agW" = (
-/obj/effect/turf_decal/ramp_middle,
-/obj/structure/chair/americandiner{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "agX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -5822,8 +5815,11 @@
 /turf/open/floor/engine/cult,
 /area/library)
 "aPl" = (
-/obj/effect/turf_decal/ramp_middle,
 /obj/structure/table/wood/fancy,
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "aPm" = (
@@ -14810,9 +14806,8 @@
 /area/crew_quarters/theatre)
 "cyr" = (
 /obj/structure/railing,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
+/obj/structure/table/wood/fancy,
+/obj/effect/spawner/lootdrop/donkpockets,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "cyK" = (
@@ -16447,12 +16442,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
-"cYD" = (
-/obj/structure/table,
-/obj/item/book/manual/chef_recipes,
-/obj/item/stack/packageWrap,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "cZd" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -17215,10 +17204,13 @@
 /turf/open/floor/stone,
 /area/crew_quarters/heads/captain)
 "dnS" = (
-/obj/effect/turf_decal/ramp_middle,
 /obj/structure/chair/americandiner{
 	dir = 4
 	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "dof" = (
@@ -19175,19 +19167,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"ead" = (
-/obj/effect/turf_decal/siding/wood/thin{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "eaw" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = 32
@@ -21426,8 +21405,8 @@
 	id = "barcounter";
 	name = "bar shutters"
 	},
-/obj/machinery/coffeemaker,
 /obj/item/reagent_containers/food/drinks/bottle/coffeepot,
+/obj/machinery/coffeemaker/impressa,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "eOj" = (
@@ -22074,6 +22053,9 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "barcounter";
 	name = "bar shutters"
+	},
+/obj/item/reagent_containers/glass/rag{
+	pixel_y = 5
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -23616,7 +23598,18 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "fBR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/paystand/register{
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -26197,6 +26190,9 @@
 /obj/item/reagent_containers/food/condiment/peppermill{
 	pixel_x = -5;
 	pixel_y = 10
+	},
+/obj/item/reagent_containers/food/condiment/enzyme{
+	layer = 5
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -34783,11 +34779,7 @@
 /obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/light{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -39280,9 +39272,12 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "lna" = (
-/obj/effect/turf_decal/ramp_middle,
 /obj/item/kirbyplants/random,
 /obj/machinery/light/floor,
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle,
 /obj/effect/turf_decal/ramp_middle{
 	dir = 8
 	},
@@ -41733,6 +41728,7 @@
 /area/quartermaster/storage)
 "mlf" = (
 /obj/structure/railing,
+/obj/structure/table/wood/fancy,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "mlj" = (
@@ -45767,15 +45763,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "nGU" = (
-/obj/machinery/button/door{
-	id = "kitchen";
-	name = "Kitchen Shutters Control";
-	pixel_x = -27;
-	pixel_y = 34;
-	req_access_txt = "28"
+/obj/structure/railing,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
+/obj/structure/table/wood/fancy,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "nHm" = (
 /obj/structure/closet/wardrobe/pjs,
 /turf/open/floor/plasteel,
@@ -46067,6 +46061,9 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "barcounter";
 	name = "bar shutters"
+	},
+/obj/machinery/paystand/register{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -48948,11 +48945,14 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "oSG" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/bar,
-/turf/closed/wall,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "oSN" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -49854,6 +49854,10 @@
 	pixel_x = -1;
 	pixel_y = -35
 	},
+/obj/structure/table,
+/obj/item/book/manual/chef_recipes,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "pkD" = (
@@ -57709,12 +57713,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"saC" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/closed/wall,
-/area/crew_quarters/bar)
 "saG" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -58600,7 +58598,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "sth" = (
-/obj/effect/turf_decal/ramp_middle,
 /obj/structure/table/wood/fancy,
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_x = -2;
@@ -58610,6 +58607,10 @@
 	pixel_x = 5;
 	pixel_y = -2
 	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "sti" = (
@@ -60256,14 +60257,14 @@
 /area/hallway/primary/central)
 "sYA" = (
 /obj/machinery/light{
-	dir = 8
+	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 3
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "sYJ" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
@@ -70113,9 +70114,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "wFS" = (
-/obj/effect/turf_decal/siding/wood/thin{
-	dir = 8
-	},
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
@@ -71339,9 +71337,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "xgE" = (
-/obj/effect/turf_decal/ramp_middle,
 /obj/item/kirbyplants/random,
 /obj/machinery/light/floor,
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle,
 /obj/effect/turf_decal/ramp_middle{
 	dir = 4
 	},
@@ -73518,12 +73519,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
 "xYx" = (
-/obj/effect/turf_decal/ramp_corner{
-	dir = 8
-	},
 /obj/structure/chair/americandiner{
 	dir = 8
 	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "xYD" = (
@@ -109345,7 +109347,7 @@ oXZ
 aFd
 aFd
 gWx
-agW
+xYx
 kao
 cZd
 xSX
@@ -110103,7 +110105,7 @@ mkr
 aql
 fUp
 cAH
-oSG
+aql
 esY
 aql
 tBu
@@ -110360,7 +110362,7 @@ ggj
 aql
 aql
 ayz
-saC
+aql
 iVb
 aql
 kLq
@@ -111137,10 +111139,10 @@ ckQ
 jCi
 mpT
 mpT
-wFS
-wFS
 mpT
-ead
+mpT
+mpT
+mpT
 jYy
 drL
 cyr
@@ -111390,17 +111392,17 @@ aAh
 aAh
 aAh
 hLj
-fgc
-fgc
-sYS
-uBF
-lOY
-lOY
-clS
-fgc
-hCu
-mtr
-fgc
+aql
+oSG
+drL
+wFS
+wFS
+wFS
+drL
+sYA
+drL
+drL
+nGU
 xYx
 qiP
 aCr
@@ -111648,15 +111650,15 @@ bPA
 aAh
 cZh
 fgc
-fJj
-nGU
-fKR
-fKR
-fKR
+fgc
+sYS
+uBF
+lOY
+clS
 fBR
-sYA
-fKR
-cYD
+fgc
+hCu
+mtr
 fgc
 iSq
 nCt
@@ -113455,7 +113457,7 @@ fgc
 pLO
 bba
 fKR
-fKR
+fJj
 jMv
 sKP
 hRx

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -1047,6 +1047,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"agW" = (
+/obj/structure/chair/americandiner{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wideplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "agX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -14806,8 +14816,9 @@
 /area/crew_quarters/theatre)
 "cyr" = (
 /obj/structure/railing,
-/obj/structure/table/wood/fancy,
-/obj/effect/spawner/lootdrop/donkpockets,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "cyK" = (
@@ -19167,6 +19178,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
+"ead" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "eaw" = (
 /obj/machinery/newscaster/security_unit{
 	pixel_y = 32
@@ -22212,10 +22233,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "fdB" = (
-/obj/effect/turf_decal/siding/wood/corner/thin{
-	dir = 1
-	},
-/obj/effect/spawner/xmastree,
+/obj/structure/chair/stool,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "fdO" = (
@@ -41728,7 +41746,6 @@
 /area/quartermaster/storage)
 "mlf" = (
 /obj/structure/railing,
-/obj/structure/table/wood/fancy,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "mlj" = (
@@ -45762,14 +45779,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"nGU" = (
-/obj/structure/railing,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/structure/table/wood/fancy,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "nHm" = (
 /obj/structure/closet/wardrobe/pjs,
 /turf/open/floor/plasteel,
@@ -48944,16 +48953,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"oSG" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "oSN" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
@@ -57713,6 +57712,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"saC" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "saG" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -60255,16 +60264,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"sYA" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "sYJ" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
@@ -70114,7 +70113,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "wFS" = (
-/obj/structure/chair/stool,
+/obj/effect/spawner/xmastree,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "wGq" = (
@@ -73518,16 +73517,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft_starboard)
-"xYx" = (
-/obj/structure/chair/americandiner{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wideplating{
-	dir = 1
-	},
-/obj/effect/turf_decal/ramp_middle,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "xYD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
@@ -109347,7 +109336,7 @@ oXZ
 aFd
 aFd
 gWx
-xYx
+agW
 kao
 cZd
 xSX
@@ -110887,7 +110876,7 @@ jhx
 jhx
 ocO
 djq
-fdB
+jYy
 mlf
 dnS
 joU
@@ -111144,8 +111133,8 @@ mpT
 mpT
 mpT
 jYy
-drL
-cyr
+wFS
+mlf
 aPl
 qiP
 aCr
@@ -111393,17 +111382,17 @@ aAh
 aAh
 hLj
 aql
-oSG
+saC
 drL
-wFS
-wFS
-wFS
+fdB
+fdB
+fdB
 drL
-sYA
+ead
 drL
 drL
-nGU
-xYx
+cyr
+agW
 qiP
 aCr
 inS


### PR DESCRIPTION
# Document the changes in your pull request
Updates the new bar, gives both barkeep and chefs a paystand, decreases the wideness of the kitchen and adds wideplating to add 3d depth to the heightened section because it looks stupid without it. Also changes coffee machine to be the one cowbot actually wanted.

![image](https://github.com/yogstation13/Yogstation/assets/42524344/0b5a9757-d06f-46e8-bd7e-ba86f0c6f31a)

# Why is this good for the game?
Better visually. Barkeep can now charge for drinks easier. Barkeep has a little more room too work with on construction projects and the like.

# Testing
None.

# Changelog
:cl:  
mapping: Added paystand to bar and kitchen, decreased wideness of kitchen, made the raised section look logical.
/:cl:
