### PR TITLE
Mood Newlines & Smoker Space Cigarette Bugfix

### DIFF
--- a/code/datums/mood_events/drug_events.dm
+++ b/code/datums/mood_events/drug_events.dm
@@ -27,19 +27,19 @@
 	mood_change = -2
 
 /datum/mood_event/withdrawal_light/add_effects(drug_name)
-	description = "<span class='warning'>I could use some [drug_name]</span>\n"
+	description = "<span class='warning'>I could use some [drug_name].</span>\n"
 
 /datum/mood_event/withdrawal_medium
 	mood_change = -5
 
 /datum/mood_event/withdrawal_medium/add_effects(drug_name)
-	description = "<span class='warning'>I really need [drug_name]</span>\n"
+	description = "<span class='warning'>I really need [drug_name].</span>\n"
 
 /datum/mood_event/withdrawal_severe
 	mood_change = -8
 
 /datum/mood_event/withdrawal_severe/add_effects(drug_name)
-	description = "<span class='boldwarning'>Oh god I need some [drug_name]</span>\n"
+	description = "<span class='boldwarning'>Oh god I need some [drug_name]!</span>\n"
 
 /datum/mood_event/withdrawal_critical
 	mood_change = -10

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -87,7 +87,7 @@
 	hidden = TRUE
 
 /datum/mood_event/badass_antag
-	description = "I'm a fucking badass and everyone around me knows it. Just look at them; they're all fucking shaking at the mere thought of me around."
+	description = span_nicegreen("I'm a fucking badass and everyone around me knows it. Just look at them; they're all fucking shaking at the mere thought of me around.\n")
 	mood_change = 15
 	hidden = TRUE
 	special_screen_obj = "badass_sun"
@@ -143,7 +143,7 @@
 	timeout = 3 MINUTES
 
 /datum/mood_event/religiously_comforted
-	description = span_nicegreen("You are comforted by the presence of a holy person.")
+	description = span_nicegreen("You are comforted by the presence of a holy person.\n")
 	mood_change = 3
 	timeout = 5 MINUTES
 
@@ -189,22 +189,22 @@
 	timeout = 4 MINUTES
 
 /datum/mood_event/confident_mane
-	description = "I'm feeling confident with a head full of hair."
+	description = span_nicegreen("I'm feeling confident with a head full of hair.\n")
 	mood_change = 2
 
 /datum/mood_event/pet_borg
-	description = span_nicegreen("I just love my robotic friends!")
+	description = span_nicegreen("I just love my robotic friends!\n")
 	mood_change = 3
 	timeout = 5 MINUTES
 	required_job = list("Research Director", "Scientist", "Roboticist", "Geneticist") // Only for science and science-adjacent jobs.
 
 /datum/mood_event/nice_tool
-	description = span_nicegreen("I recently used a nice tool.")
+	description = span_nicegreen("I recently used a nice tool.\n")
 	mood_change = 2
 	timeout = 2 MINUTES
 
 /datum/mood_event/adrenaline
-	description = span_nicegreen("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA!")
+	description = span_nicegreen("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA!\n")
 	mood_change = 10
 
 /datum/mood_event/area

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -193,7 +193,7 @@
 
 /obj/item/storage/fancy/cigarettes/PopulateContents()
 	for(var/i in 1 to 6)
-		new /obj/item/clothing/mask/cigarette(src)
+		new /obj/item/clothing/mask/space_cigarette(src)
 
 /obj/item/storage/fancy/cigarettes/examine(mob/user)
 	. = ..()

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -193,7 +193,7 @@
 
 /obj/item/storage/fancy/cigarettes/PopulateContents()
 	for(var/i in 1 to 6)
-		new /obj/item/clothing/mask/space_cigarette(src)
+		new /obj/item/clothing/mask/cigarette/space_cigarette(src)
 
 /obj/item/storage/fancy/cigarettes/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request
Fixes issue for some moods descriptions not getting a new line.
Closes #21138

Fixes issue where space cigarettes don't spawn their spawn type which causes Smokers to not recognize it as their favorite brand.
Closes #20994

Adds punctuation for various mood withdrawals and properly colors some uncolored descriptions.

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/30399783/3c9d7481-0f0c-45d6-80fd-9a1035a46aed)

Having a space cigarette while it is the favorite brand gives no mood debuff.

# Changelog
:cl:  
bugfix: Various mood descriptions now properly start on a new line.
bugfix: Space cigarettes now properly spawn with their branded cigarette rather than the base cigarette.
spellcheck: Ending punctuation for a few mood descriptions.
/:cl:
