### PR TITLE
Shapechange Actions Properly Transfer Over

### DIFF
--- a/code/datums/actions/action.dm
+++ b/code/datums/actions/action.dm
@@ -135,7 +135,8 @@
 
 	if(target == owner)
 		RegisterSignal(target, COMSIG_PARENT_QDELETING, PROC_REF(clear_ref))
-	owner = null
+	if(owner == remove_from)
+		owner = null
 
 /// Actually triggers the effects of the action.
 /// Called when the on-screen button is clicked, for example.


### PR DESCRIPTION
# Document the changes in your pull request
Actions that had a previous owner properly transfer over to the new owner; mainly fixes transferring over shapechange spells.
Closes #21135
Closes #21136

Removal of the action from the previous owner causes the new/current owner to be null. This fixes that.

# Testing
Wizard shapechange spell successfully transfers over. Xenobiology's burning black shapechange spell successfully transfers over. 

# Changelog
:cl:  
bugfix: Spells properly transfer over from one mob to another; e.g. wizard shapechange & xenobio burning black shapechange.
/:cl:
