### PR TITLE
Cryo pod joining actually puts you inside the pod

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -8,6 +8,8 @@
 GLOBAL_LIST_EMPTY(cryopods)
 GLOBAL_LIST_EMPTY(cryopod_computers)
 
+#define JOIN_SLEEP_DURATION 6 SECONDS
+
 //Main cryopod console.
 
 /obj/machinery/computer/cryopod
@@ -435,8 +437,6 @@ GLOBAL_VAR_INIT(cryopods_enabled, FALSE)
 	log_admin(span_notice("[key_name(target)] entered a stasis pod."))
 	message_admins("[key_name_admin(target)] entered a stasis pod. (<A HREF='?_src_=holder;[HrefToken()];adminplayerobservecoodjump=1;X=[x];Y=[y];Z=[z]'>JMP</a>)")
 	add_fingerprint(target)
-
-#define JOIN_SLEEP_DURATION 6 SECONDS
 
 /obj/machinery/cryopod/JoinPlayerHere(mob/M, buckle)
 	. = ..()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -442,8 +442,8 @@ GLOBAL_VAR_INIT(cryopods_enabled, FALSE)
 	. = ..()
 	close_machine(M, TRUE) // put the mob inside instead of on the turf
 	playsound(src, join_sound, 30)
-	if(iscarbon(user))
-		apply_effects_to_mob(user)
+	if(iscarbon(M))
+		apply_effects_to_mob(M)
 	addtimer(CALLBACK(src, PROC_REF(open_machine)), JOIN_SLEEP_DURATION)
 
 /obj/machinery/cryopod/proc/apply_effects_to_mob(mob/living/carbon/sleepyhead)


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Joining on a map where you start in a cryo pod will now actually put you inside the pod and then open it after you wake up, instead of immediately dumping you on the ground while still asleep.

# Why is this good for the game?
Looks a lot less weird this way.

# Testing

https://github.com/yogstation13/Yogstation/assets/93578146/8a1f56b4-c367-4efa-9a83-ff2d87f0e42d

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: cryo pod joining puts you inside the pod instead of on the ground
/:cl:
