### PR TITLE
Removing/Extracting IPC's Positron Brain Properly Moves Mind To Brain

### DIFF
--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -106,9 +106,9 @@
 			brainmob.stored_dna = new /datum/dna/stored(brainmob)
 		C.dna.copy_dna(brainmob.stored_dna)
 		if(HAS_TRAIT(L, TRAIT_BADDNA))
-			brainmob.status_traits[TRAIT_BADDNA] = L.status_traits[TRAIT_BADDNA]
+			LAZYSET(brainmob.status_traits, TRAIT_BADDNA, L.status_traits[TRAIT_BADDNA])
 		if(HAS_TRAIT(L, TRAIT_NOCLONE)) // YOU CAN'T ESCAPE
-			brainmob.status_traits[TRAIT_NOCLONE] = L.status_traits[TRAIT_NOCLONE]
+			LAZYSET(brainmob.status_traits, TRAIT_NOCLONE, L.status_traits[TRAIT_NOCLONE])
 		var/obj/item/organ/zombie_infection/ZI = L.getorganslot(ORGAN_SLOT_ZOMBIE)
 		if(ZI)
 			brainmob.set_species(ZI.old_species)	//For if the brain is cloned


### PR DESCRIPTION
# Document the changes in your pull request
Fixes runtime involving setting no clone status trait which caused minds not to be transferred when brain was removed.
Closes #21026
Closes #20628
Closes #20416
Closes #20336

# Testing
Mind is moved to brain when IPC brain is removed. Gibbing IPC causes mind to move to IPC brain. No runtime.

# Changelog
:cl:  
bugfix: Removing/extracting IPC's positron brain properly moves their mind.
/:cl:
