### PR TITLE
AI ambience now follows the AI Eye rather than the ai core. No more space jam. Please. End the space jam. Im sick of heaing space jam. Please. Please no more space jam. Please.

### DIFF
--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -30,8 +30,9 @@ SUBSYSTEM_DEF(ambience)
 	var/area/current_area = get_area(current_mob)
 
 	if(isAI(current_mob))
-		var/mob/living/silicon/ai/aicurrent_mob = current_mob
-		current_area = get_area(aicurrent_mob.eyeobj)
+		var/mob/living/silicon/ai/ai_current_mob = current_mob
+		if(ai_current_mob.eyeobj)
+			current_area = get_area(ai_current_mob.eyeobj)
 
 	if(!current_area) //Something's gone horribly wrong
 		stack_trace("[key_name(to_process)] has somehow ended up in nullspace. WTF did you do -xoxo ambience subsystem")

--- a/code/controllers/subsystem/ambience.dm
+++ b/code/controllers/subsystem/ambience.dm
@@ -28,6 +28,11 @@ SUBSYSTEM_DEF(ambience)
 /datum/controller/subsystem/ambience/proc/process_ambience_client(client/to_process)
 	var/mob/current_mob = to_process.mob
 	var/area/current_area = get_area(current_mob)
+
+	if(isAI(current_mob))
+		var/mob/living/silicon/ai/aicurrent_mob = current_mob
+		current_area = get_area(aicurrent_mob.eyeobj)
+
 	if(!current_area) //Something's gone horribly wrong
 		stack_trace("[key_name(to_process)] has somehow ended up in nullspace. WTF did you do -xoxo ambience subsystem")
 		ambience_listening_clients -= to_process


### PR DESCRIPTION
# Document the changes in your pull request
As title, ambience and buzz will refer to the ai eye rather than the ai core.

# Why is this good for the game?
I DO NOT WANT TO LISTEN TO SPACE JAM OVER AND OVER I DO NOT WANT TO LISTEN TO SPACE JAM OVER AND OVER I DO NOT WANT TO LISTEN TO SPACE JAM OVER AND OVER I DO NOT WANT TO LISTEN TO SPACE JAM OVER AND OVER I DO NOT WANT TO LISTEN TO SPACE JAM OVER AND OVER I DO NOT WANT TO LISTEN TO SPACE JAM OVER AND OVER I DO NOT WANT TO LISTEN TO SPACE JAM OVER AND OVER I DO NOT WANT TO LISTEN TO SPACE JAM OVER AND OVER I DO NOT WANT TO LISTEN TO SPACE JAM OVER AND OVER I DO NOT WANT TO LISTEN TO SPACE JAM OVER AND OVER I DO NOT WANT TO LISTEN TO SPACE JAM OVER AND OVER I DO NOT WANT TO LISTEN TO SPACE JAM OVER AND OVER I DO NOT WANT TO LISTEN TO SPACE JAM OVER AND OVER 

# Changelog
:cl:  
tweak: Ambience follows ai eye rather than its core.
/:cl:
