### PR TITLE
Rune Scimitar Now Works As Intended

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -611,13 +611,13 @@ GLOBAL_LIST_EMPTY(aide_list)
 		var/mob/living/L = target
 		if(ismegafauna(L) || istype(L, /mob/living/simple_animal/hostile/asteroid)) //no loot allowed from the little skulls
 			if(!istype(L, /mob/living/simple_animal/hostile/asteroid/hivelordbrood))
-				RegisterSignal(target,COMSIG_GLOB_MOB_DEATH, PROC_REF(roll_loot), TRUE)
+				RegisterSignal(target, COMSIG_LIVING_DEATH, PROC_REF(roll_loot), TRUE)
 			//after quite a bit of grinding, you'll be doing a total of 120 damage to fauna per hit. A lot, but i feel like the grind justifies the payoff. also this doesn't effect crew. so. go nuts.
 			L.apply_damage(mobs_grinded*5,BRUTE)
 
 ///This proc handles rolling the loot on the loot table and "drops" the loot where the hostile fauna died
 /obj/item/rune_scimmy/proc/roll_loot(mob/living/target)
-	UnregisterSignal(target, COMSIG_GLOB_MOB_DEATH)
+	UnregisterSignal(target, COMSIG_LIVING_DEATH)
 	if(mobs_grinded<max_grind)
 		mobs_grinded++
 	var/spot = get_turf(target)


### PR DESCRIPTION
# Document the changes in your pull request
Rune scimitar works as intended; you can now properly grind and obtain loot.
Closes #19685

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/30399783/729f3eae-e13d-45de-a56e-a6d754a8feb9)

# Changelog
:cl:  
bugfix: Rune scimitar works as intended; you can now properly grind and obtain loot.
/:cl:
