### PR TITLE
Adds more ghetto options to mechanical surgery

### DIFF
--- a/code/modules/surgery/mechanic_steps.dm
+++ b/code/modules/surgery/mechanic_steps.dm
@@ -106,7 +106,7 @@
 	name = "unwrench bolts"
 	implements = list(
 		TOOL_WRENCH = 100,
-		TOOL_CROWBAR = 80,//this sounds like a REALLY bad idea
+		TOOL_CROWBAR = 100,//this sounds like a REALLY bad idea
 		TOOL_RETRACTOR = 20)
 	time = 2.4 SECONDS
 	bloody_chance = FALSE
@@ -142,7 +142,7 @@
 	name = "wrench bolts"
 	implements = list(
 		TOOL_WRENCH = 100,
-		TOOL_WELDER = 80, //also a terrible idea
+		TOOL_WELDER = 100, //also a terrible idea
 		TOOL_RETRACTOR = 20)
 	time = 2.4 SECONDS
 	bloody_chance = FALSE

--- a/code/modules/surgery/mechanic_steps.dm
+++ b/code/modules/surgery/mechanic_steps.dm
@@ -57,7 +57,11 @@
 	name = "prepare electronics"
 	implements = list(
 		TOOL_MULTITOOL = 100,
-		TOOL_HEMOSTAT = 10) // try to reboot internal controllers via short circuit with some conductor
+		/obj/item/melee/touch_attack/shock = 90,
+		/obj/item/gun/energy = 90,
+		/obj/item/melee/baton = 90, // try to reboot internal controllers via short circuit with some conductor
+		/obj/item/shockpaddles = 90,
+		TOOL_HEMOSTAT = 20) //"safe" option, but super tedious
 	time = 2.4 SECONDS
 	bloody_chance = FALSE
 	preop_sound = 'sound/items/tape_flip.ogg'
@@ -69,21 +73,64 @@
 			"[user] begins to prepare electronics in [target]'s [parse_zone(target_zone)].",
 			"[user] begins to prepare electronics in [target]'s [parse_zone(target_zone)].")
 
+/datum/surgery_step/prepare_electronics/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if(!(tool.tool_behaviour == TOOL_MULTITOOL || tool.tool_behaviour == TOOL_HEMOSTAT))
+		target.electrocute_act(10, tool, stun = FALSE)//reduced damage if successful
+	return ..()
+
+/datum/surgery_step/prepare_electronics/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if(!(tool.tool_behaviour == TOOL_MULTITOOL || tool.tool_behaviour == TOOL_HEMOSTAT))
+		target.electrocute_act(20, tool, stun = FALSE)//reduced damage if successful
+	return ..()
+
+/datum/surgery_step/prepare_electronics/play_success_sound(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if(!success_sound)
+		return
+	var/sound_file_use
+	if(islist(success_sound ))	
+		for(var/typepath in success_sound )//iterate and assign subtype to a list, works best if list is arranged from subtype first and parent last
+			if(istype(tool, typepath))
+				sound_file_use = success_sound [typepath]	
+				break	
+	else
+		sound_file_use = success_sound
+	if(!sound_file_use)
+		return
+	if(tool.tool_behaviour == TOOL_MULTITOOL || tool.tool_behaviour == TOOL_HEMOSTAT)
+		playsound(get_turf(target), sound_file_use, 30, TRUE, falloff_exponent = 2)
+	else
+		playsound(get_turf(target), 'sound/machines/defib_zap.ogg', 30, TRUE, falloff_exponent = 2)
+
 //unwrench
 /datum/surgery_step/mechanic_unwrench
 	name = "unwrench bolts"
 	implements = list(
 		TOOL_WRENCH = 100,
-		TOOL_RETRACTOR = 10)
+		TOOL_CROWBAR = 80,//this sounds like a REALLY bad idea
+		TOOL_RETRACTOR = 20)
 	time = 2.4 SECONDS
 	bloody_chance = FALSE
 	preop_sound = 'sound/items/ratchet.ogg'
 
 /datum/surgery_step/mechanic_unwrench/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	display_results(user, target, span_notice("You begin to unwrench some bolts in [target]'s [parse_zone(target_zone)]..."),
-			"[user] begins to unwrench some bolts in [target]'s [parse_zone(target_zone)].",
-			"[user] begins to unwrench some bolts in [target]'s [parse_zone(target_zone)].")
+	if(item.tool_behaviour == TOOL_CROWBAR)
+		display_results(user, target, span_notice("You begin reefing on the bolts in [target]'s [parse_zone(target_zone)]..."),
+				"[user] begins reefing on some bolts in [target]'s [parse_zone(target_zone)].",
+				"[user] begins reefing on some bolts in [target]'s [parse_zone(target_zone)].")
+	else
+		display_results(user, target, span_notice("You begin to unwrench some bolts in [target]'s [parse_zone(target_zone)]..."),
+				"[user] begins to unwrench some bolts in [target]'s [parse_zone(target_zone)].",
+				"[user] begins to unwrench some bolts in [target]'s [parse_zone(target_zone)].")
 
+/datum/surgery_step/mechanic_unwrench/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if(item.tool_behaviour == TOOL_CROWBAR)
+		target.apply_damage(10, BRUTE, target_zone)//reduced damage if successful
+	return ..()
+
+/datum/surgery_step/mechanic_unwrench/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if(item.tool_behaviour == TOOL_CROWBAR)
+		target.apply_damage(20, BRUTE, target_zone)
+	return ..()
 
 /datum/surgery_step/mechanic_unwrench/tool_check(mob/user, obj/item/tool)
 	if(tool.usesound)
@@ -95,16 +142,31 @@
 	name = "wrench bolts"
 	implements = list(
 		TOOL_WRENCH = 100,
-		TOOL_RETRACTOR = 10)
+		TOOL_WELDER = 80, //also a terrible idea
+		TOOL_RETRACTOR = 20)
 	time = 2.4 SECONDS
 	bloody_chance = FALSE
 	preop_sound = 'sound/items/ratchet.ogg'
 
 /datum/surgery_step/mechanic_wrench/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	display_results(user, target, span_notice("You begin to wrench some bolts in [target]'s [parse_zone(target_zone)]..."),
-			"[user] begins to wrench some bolts in [target]'s [parse_zone(target_zone)].",
-			"[user] begins to wrench some bolts in [target]'s [parse_zone(target_zone)].")
+	if(item.tool_behaviour == TOOL_WELDER)
+		display_results(user, target, span_notice("You begin to weld some bolts in [target]'s [parse_zone(target_zone)]..."),
+				"[user] begins to weld some bolts in [target]'s [parse_zone(target_zone)].",
+				"[user] begins to weld some bolts in [target]'s [parse_zone(target_zone)].")
+	else
+		display_results(user, target, span_notice("You begin to wrench some bolts in [target]'s [parse_zone(target_zone)]..."),
+				"[user] begins to wrench some bolts in [target]'s [parse_zone(target_zone)].",
+				"[user] begins to wrench some bolts in [target]'s [parse_zone(target_zone)].")
 
+/datum/surgery_step/mechanic_wrench/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if(item.tool_behaviour == TOOL_WELDER)
+		target.apply_damage(10, BURN, target_zone)//reduced damage if successful
+	return ..()
+
+/datum/surgery_step/mechanic_wrench/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if(item.tool_behaviour == TOOL_WELDER)
+		target.apply_damage(20, BURN, target_zone)
+	return ..()
 
 /datum/surgery_step/mechanic_wrench/tool_check(mob/user, obj/item/tool)
 	if(tool.usesound)

--- a/code/modules/surgery/mechanic_steps.dm
+++ b/code/modules/surgery/mechanic_steps.dm
@@ -113,7 +113,7 @@
 	preop_sound = 'sound/items/ratchet.ogg'
 
 /datum/surgery_step/mechanic_unwrench/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	if(item.tool_behaviour == TOOL_CROWBAR)
+	if(tool.tool_behaviour == TOOL_CROWBAR)
 		display_results(user, target, span_notice("You begin reefing on the bolts in [target]'s [parse_zone(target_zone)]..."),
 				"[user] begins reefing on some bolts in [target]'s [parse_zone(target_zone)].",
 				"[user] begins reefing on some bolts in [target]'s [parse_zone(target_zone)].")
@@ -123,12 +123,12 @@
 				"[user] begins to unwrench some bolts in [target]'s [parse_zone(target_zone)].")
 
 /datum/surgery_step/mechanic_unwrench/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	if(item.tool_behaviour == TOOL_CROWBAR)
+	if(tool.tool_behaviour == TOOL_CROWBAR)
 		target.apply_damage(10, BRUTE, target_zone)//reduced damage if successful
 	return ..()
 
 /datum/surgery_step/mechanic_unwrench/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	if(item.tool_behaviour == TOOL_CROWBAR)
+	if(tool.tool_behaviour == TOOL_CROWBAR)
 		target.apply_damage(20, BRUTE, target_zone)
 	return ..()
 
@@ -149,7 +149,7 @@
 	preop_sound = 'sound/items/ratchet.ogg'
 
 /datum/surgery_step/mechanic_wrench/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	if(item.tool_behaviour == TOOL_WELDER)
+	if(tool.tool_behaviour == TOOL_WELDER)
 		display_results(user, target, span_notice("You begin to weld some bolts in [target]'s [parse_zone(target_zone)]..."),
 				"[user] begins to weld some bolts in [target]'s [parse_zone(target_zone)].",
 				"[user] begins to weld some bolts in [target]'s [parse_zone(target_zone)].")
@@ -159,12 +159,12 @@
 				"[user] begins to wrench some bolts in [target]'s [parse_zone(target_zone)].")
 
 /datum/surgery_step/mechanic_wrench/success(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	if(item.tool_behaviour == TOOL_WELDER)
+	if(tool.tool_behaviour == TOOL_WELDER)
 		target.apply_damage(10, BURN, target_zone)//reduced damage if successful
 	return ..()
 
 /datum/surgery_step/mechanic_wrench/failure(mob/user, mob/living/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	if(item.tool_behaviour == TOOL_WELDER)
+	if(tool.tool_behaviour == TOOL_WELDER)
 		target.apply_damage(20, BURN, target_zone)
 	return ..()
 


### PR DESCRIPTION
multitool step also gets
shock touch 90%
energy gun 90%
stun baton 90%
shockpaddles 90%
but it will shock the target, doing more damage on failure
(lower chance than the others because multitools aren't quite as common as the other tools)

unwrench step gets crowbar 100%
but it will do brute damage to the target, doing more damage on failure

wrench step gets welder 100%
but it will do burn damage to the target, doing more damage on failure

also increases the success chance of regular medical tools to 20 from 10 because at 10 they're painful to try and use, despite the comparable safety

screw shell step is untouched because it already has great ghetto options

# Why is this good for the game?
more stuff i guess?

# Testing


:cl:  
rscadd: Adds more tool options for ghetto mechanical surgery
tweak: existing ghetto mechanical surgery options are slightly better
/:cl:
