### PR TITLE
IPCs Now Properly Play Their Servostep/Special Walk Sound When They Move

### DIFF
--- a/code/datums/elements/footstep.dm
+++ b/code/datums/elements/footstep.dm
@@ -142,6 +142,9 @@
 	if(!prepared_steps)
 		return
 
+	if(source.dna.species.special_walk_sounds) // Plays in addition to shoe/barefoot sound.
+		playsound(source.loc, pick(source.dna.species.special_walk_sounds), 50, TRUE, falloff_distance = 1, vary = sound_vary)
+
 	//cache for sanic speed (lists are references anyways)
 	var/static/list/footstep_sounds = GLOB.footstep
 


### PR DESCRIPTION
# Document the changes in your pull request
IPCs now properly play their servostep/special walk sound when they move. Bug was caused by #20822.
Closes #20861

# Testing
The sounds happens when moving, yes.

# Changelog
:cl:  
bugfix: IPCs now play their special walk sound when they move as intended.
/:cl:
