### PR TITLE
Decoy Brains In MMIs Can Be Properly Removed & Adjacent Bugfixes

### DIFF
--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -129,15 +129,14 @@
 
 /obj/item/mmi/attack_self(mob/user)
 	if(brain)
-		user.visible_message(span_notice("[user] begins to remove the brain from [src]"), span_danger("You begin to pry the brain out of [src], ripping out the wires and probes"))
-		to_chat(brainmob, span_userdanger("You feel your mind failing as you are slowly ripped from the [src]"))
+		user.visible_message(span_notice("[user] begins to remove the brain from [src]."), span_danger("You begin to pry the brain out of [src], ripping out the wires and probes."))
+		to_chat(brainmob, span_userdanger("You feel your mind failing as you are slowly ripped from the [src]."))
 		if(do_after(user, remove_time, src))
-			if(!brainmob) return
-			to_chat(brainmob, span_userdanger("Due to the traumatic danger of your removal, all memories of the events leading to your brain being removed are lost[rebooting ? ", along with all memories of the events leading to your death as a cyborg" : ""]"))
+			to_chat(brainmob, span_userdanger("Due to the traumatic danger of your removal, all memories of the events leading to your brain being removed are lost[rebooting ? ", along with all memories of the events leading to your death as a cyborg." : ""]."))
 			eject_brain(user)
 			update_appearance(UPDATE_ICON)
 			name = initial(name)
-			user.visible_message(span_notice("[user] rips the brain out of [src]"), span_danger("You successfully remove the brain from the [src][rebooting ? ", interrupting the reboot process" : ""]"))
+			user.visible_message(span_notice("[user] rips the brain out of [src]."), span_danger("You successfully remove the brain from the [src][rebooting ? ", interrupting the reboot process." : ""]."))
 			if(rebooting)
 				rebooting = FALSE
 				deltimer(reboot_timer)
@@ -148,28 +147,30 @@
 	to_chat(user, span_notice("You toggle [src]'s radio system [radio.on==1 ? "on" : "off"]."))
 
 /obj/item/mmi/proc/eject_brain(mob/user)
-	brainmob.container = null //Reset brainmob mmi var.
-	brainmob.forceMove(brain) //Throw mob into brain.
-	brainmob.set_stat(DEAD)
-	brainmob.emp_damage = 0
+	if(brainmob)
+		brainmob.container = null //Reset brainmob mmi var.
+		brainmob.forceMove(brain) //Throw mob into brain.
+		brainmob.set_stat(DEAD)
+		brainmob.emp_damage = 0
 
-	if(syndicate_mmi)
-		// Remove the mindslaving that came with this.
-		if(brainmob.mind && brainmob.mind.has_antag_datum(/datum/antagonist/mindslave))
-			brainmob.mind.remove_antag_datum(/datum/antagonist/mindslave)
+		if(syndicate_mmi)
+			// Remove the mindslaving that came with this.
+			if(brainmob.mind && brainmob.mind.has_antag_datum(/datum/antagonist/mindslave))
+				brainmob.mind.remove_antag_datum(/datum/antagonist/mindslave)
 
-	brainmob.reset_perspective() //so the brainmob follows the brain organ instead of the mmi. And to update our vision
-	brainmob.remove_from_alive_mob_list() //Get outta here
-	brainmob.add_to_dead_mob_list()
-	brain.brainmob = brainmob //Set the brain to use the brainmob
-	brainmob = null //Set mmi brainmob var to null
+		brainmob.reset_perspective() //so the brainmob follows the brain organ instead of the mmi. And to update our vision
+		brainmob.remove_from_alive_mob_list() //Get outta here
+		brainmob.add_to_dead_mob_list()
+		brain.brainmob = brainmob //Set the brain to use the brainmob
+		brainmob = null //Set mmi brainmob var to null
+
 	brain.setOrganDamage(brain.maxHealth) // Kill the brain, requiring mannitol
-	if(user)
-		user.put_in_hands(brain) //puts brain in the user's hand or otherwise drops it on the user's turf
+	// Put brain in the user's hand if they're nearby. Otherwise, drop it on the MMI's turf.
+	if(Adjacent(user))
+		user.put_in_hands(brain)
 	else
 		brain.forceMove(get_turf(src))
 	brain = null //No more brain in here
-
 
 /obj/item/mmi/proc/transfer_identity(mob/living/L) //Same deal as the regular brain proc. Used for human-->robot people.
 	if(!brainmob)

--- a/code/modules/paperwork/paperplane.dm
+++ b/code/modules/paperwork/paperplane.dm
@@ -134,5 +134,6 @@
 	if(origami_action?.active)
 		plane_type = /obj/item/paperplane/syndicate
 
-	I = new plane_type(user, src)
-	user.put_in_hands(I)
+	I = new plane_type(loc, src)
+	if(I.Adjacent(user))
+		user.put_in_hands(I)


### PR DESCRIPTION
# Document the changes in your pull request
Taking out a brain checked for brainmob and prevents removal if there is no brainmob, but decoy brains often do not have a brainmob. Brain now can be removed without brainmob.

Ripping out a brain from a MMI no longer teleports the removed brain into your hand if you're not adjacent. Same goes for folding paper.

Ending punctuation for ripping out brain from MMI.

# Testing
Yes. Adjacent checks works. Vampire/changeling brains can be put into MMIs and removed properly. Punctuation works.

# Changelog
:cl:  
bugfix: Trying to remove decoy brains from MMIs properly works.
bugfix: Removing MMI brains from range no longer teleport it into your hands if you're far away (e.g. through walls/windows with TK). Same for folding paper.
spellcheck: Ending punctuation for ripping out brain from MMI.
/:cl: