### PR TITLE
[IceMeta] Fixes and reenables Icemoon Walkers

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_walkervillage.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_walkervillage.dmm
@@ -16,6 +16,9 @@
 	},
 /turf/open/floor/wood,
 /area/ruin/powered/walker_village)
+"br" = (
+/turf/closed/mineral/random/snow,
+/area/ruin/powered/walker_village)
 "bw" = (
 /obj/structure/railing,
 /turf/closed/wall/mineral/wood,
@@ -32,18 +35,6 @@
 /obj/structure/flora/rock/icy,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"en" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/head/helmet/skull,
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/ruin/powered/walker_village)
-"fl" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/ruin/powered/walker_village)
 "fC" = (
 /obj/effect/mob_spawn/human/corpse/damaged,
 /turf/open/floor/wood,
@@ -52,11 +43,6 @@
 /obj/structure/flora/stump,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/underground/explored)
-"fQ" = (
-/turf/open/floor/plasteel/stairs/goon/wood_stairs_wide2{
-	dir = 1
-	},
-/area/ruin/powered/walker_village)
 "fV" = (
 /obj/structure/fence/door{
 	dir = 4
@@ -73,28 +59,9 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/ruin/powered/walker_village)
-"hl" = (
-/obj/effect/decal/cleanable/blood/gibs,
-/turf/open/floor/wood,
-/area/ruin/powered/walker_village)
 "hy" = (
 /obj/item/pickaxe/bonepickaxe,
 /turf/open/floor/plating/asteroid/snow/icemoon,
-/area/ruin/powered/walker_village)
-"iD" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/ruin/powered/walker_village)
-"iL" = (
-/turf/closed/mineral/snowmountain/cavern/icemoon,
-/area/ruin/powered/walker_village)
-"iP" = (
-/obj/effect/decal/cleanable/blood/gibs,
-/obj/item/fireaxe/boneaxe,
-/obj/structure/table/wood,
-/turf/open/floor/wood,
 /area/ruin/powered/walker_village)
 "iX" = (
 /obj/structure/flora/tree/pine,
@@ -105,22 +72,25 @@
 /obj/structure/barricade/wooden/crude/snow,
 /turf/open/floor/plating,
 /area/ruin/powered/walker_village)
-"kt" = (
-/turf/closed/mineral/random/snow,
-/area/icemoon/underground/explored)
+"jF" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/stone,
+/area/ruin/powered/walker_village)
 "lB" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/bamboo,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/ruin/powered/walker_village)
-"lN" = (
-/obj/item/organ/liver,
-/turf/open/floor/wood,
-/area/ruin/powered/walker_village)
 "lP" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/reagent_containers/glass/bucket/wooden,
 /turf/open/floor/plating/asteroid/snow/icemoon,
+/area/ruin/powered/walker_village)
+"mt" = (
+/obj/item/organ/liver,
+/turf/open/floor/stone,
 /area/ruin/powered/walker_village)
 "mw" = (
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -147,6 +117,13 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/ruin/powered/walker_village)
+"nJ" = (
+/obj/effect/decal/cleanable/blood/gibs/up,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/stone,
+/area/ruin/powered/walker_village)
 "on" = (
 /turf/open/floor/wood,
 /area/ruin/powered/walker_village)
@@ -154,13 +131,6 @@
 /obj/machinery/hydroponics/soil,
 /obj/item/seeds/cotton,
 /turf/open/floor/plating/asteroid/snow/icemoon,
-/area/ruin/powered/walker_village)
-"oV" = (
-/obj/effect/decal/cleanable/blood/gibs/up,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood,
 /area/ruin/powered/walker_village)
 "pe" = (
 /obj/machinery/hydroponics/soil,
@@ -171,6 +141,9 @@
 /obj/machinery/hydroponics/soil,
 /obj/item/storage/bag/plants/portaseeder,
 /turf/open/floor/plating/asteroid/snow/icemoon,
+/area/ruin/powered/walker_village)
+"pu" = (
+/turf/open/floor/stone,
 /area/ruin/powered/walker_village)
 "pJ" = (
 /obj/structure/bonfire/dense,
@@ -216,10 +189,18 @@
 "sO" = (
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/underground/explored)
-"ux" = (
-/turf/open/floor/plasteel/stairs/goon/wood_stairs_wide{
+"tf" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/stone,
+/area/ruin/powered/walker_village)
+"ui" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
 	dir = 1
 	},
+/turf/open/floor/stone,
 /area/ruin/powered/walker_village)
 "uC" = (
 /obj/structure/table/wood,
@@ -233,6 +214,12 @@
 	pixel_y = 3
 	},
 /turf/open/floor/wood,
+/area/ruin/powered/walker_village)
+"uL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/head/helmet/skull,
+/obj/structure/table/wood,
+/turf/open/floor/stone,
 /area/ruin/powered/walker_village)
 "uO" = (
 /obj/structure/flora/tree/pine,
@@ -304,8 +291,22 @@
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/ruin/powered/walker_village)
+"Ep" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/turf/open/floor/stone,
+/area/ruin/powered/walker_village)
+"Fs" = (
+/obj/effect/decal/cleanable/blood/gibs,
+/obj/item/fireaxe/boneaxe,
+/obj/structure/table/wood,
+/turf/open/floor/stone,
+/area/ruin/powered/walker_village)
 "Gs" = (
 /obj/item/organ/lungs,
+/turf/open/floor/carpet/purple,
+/area/ruin/powered/walker_village)
+"Ii" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/purple,
 /area/ruin/powered/walker_village)
 "Ke" = (
@@ -317,6 +318,10 @@
 "Kh" = (
 /obj/effect/mob_spawn/human/icemoon_walker/chieftain,
 /turf/open/floor/plating/asteroid/snow/icemoon,
+/area/ruin/powered/walker_village)
+"Kz" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/stone,
 /area/ruin/powered/walker_village)
 "Mi" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -346,12 +351,9 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/ruin/powered/walker_village)
-"OV" = (
+"OK" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/wood,
+/turf/open/floor/stone,
 /area/ruin/powered/walker_village)
 "Pz" = (
 /obj/effect/mob_spawn/human/icemoon_walker,
@@ -359,15 +361,6 @@
 /area/ruin/powered/walker_village)
 "Qe" = (
 /obj/structure/mineral_door/wood,
-/turf/open/floor/wood,
-/area/ruin/powered/walker_village)
-"Qh" = (
-/turf/open/floor/plasteel/stairs/goon/wood_stairs_middle{
-	dir = 1
-	},
-/area/ruin/powered/walker_village)
-"QI" = (
-/obj/effect/decal/cleanable/blood,
 /turf/open/floor/wood,
 /area/ruin/powered/walker_village)
 "QT" = (
@@ -415,19 +408,6 @@
 /area/icemoon/underground/explored)
 
 (1,1,1) = {"
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
 mw
 mw
 mw
@@ -441,16 +421,29 @@ mw
 mw
 mw
 mw
-kt
-kt
-kt
-kt
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
 "}
 (2,1,1) = {"
-kt
-kt
-kt
-kt
+mw
+mw
+mw
+mw
 mw
 mw
 mw
@@ -475,12 +468,12 @@ mw
 mw
 mw
 mw
-kt
-kt
+mw
+mw
 "}
 (3,1,1) = {"
-kt
-kt
+mw
+mw
 mw
 mw
 mw
@@ -507,11 +500,11 @@ mw
 mw
 mw
 mw
-kt
-kt
+mw
+mw
 "}
 (4,1,1) = {"
-kt
+mw
 mw
 mw
 mw
@@ -539,11 +532,10 @@ mw
 mw
 uO
 mw
-kt
-kt
+mw
+mw
 "}
 (5,1,1) = {"
-kt
 mw
 mw
 mw
@@ -551,11 +543,12 @@ mw
 mw
 mw
 mw
-iL
+mw
 zN
-iL
-iL
-iL
+zN
+zN
+zN
+zN
 qB
 sO
 sO
@@ -572,79 +565,79 @@ mw
 mw
 mw
 mw
-kt
+mw
 "}
 (6,1,1) = {"
-kt
+mw
 mw
 mw
 mw
 mw
 mw
 zN
-iL
-iL
-iL
-iL
-iL
-iL
-iL
+zN
+zN
+br
+br
+br
+zN
+zN
 XD
 sO
 RX
 sO
 zN
 zN
-iL
-iL
-iL
+br
+br
+br
 mw
 mw
 mw
 mw
 mw
 mw
-kt
+mw
 "}
 (7,1,1) = {"
-kt
+mw
 mw
 mw
 mw
 mw
 zN
 zN
-iL
-iL
+br
+br
 Pz
 rp
 rp
-iL
-iL
-iL
-sO
-sO
-iL
-iL
+br
 zN
-iL
-iL
-iL
-iL
-iL
+zN
+sO
+sO
+zN
+zN
+zN
+zN
+zN
+zN
+br
+br
 fI
 mw
 dr
 mw
-kt
+mw
 "}
 (8,1,1) = {"
-kt
 mw
 mw
 mw
-iL
-iL
+mw
+br
+zN
 zN
 rp
 Ek
@@ -652,31 +645,31 @@ Kh
 UI
 Pz
 Ek
-iL
-iL
+br
+zN
 Bi
 Bi
-iL
-iL
+zN
+br
 Ta
 Ou
 rp
-iL
-iL
-iL
-iL
+zN
+zN
+zN
+zN
 mw
 mw
 mw
-kt
+mw
 "}
 (9,1,1) = {"
-kt
-kt
 mw
 mw
-iL
-iL
+mw
+mw
+br
+zN
 rp
 rp
 Ek
@@ -695,20 +688,20 @@ rp
 rp
 rp
 rp
-iL
-iL
+br
+zN
 mw
 mw
 mw
 mw
 "}
 (10,1,1) = {"
-kt
-kt
 mw
 mw
-iL
-iL
+mw
+mw
+br
+zN
 rp
 rp
 XB
@@ -727,20 +720,20 @@ Bj
 Bj
 Bj
 Bj
-iL
-iL
+br
+zN
 mw
 mw
 mw
 mw
 "}
 (11,1,1) = {"
-kt
-kt
+mw
+mw
 mw
 fI
-iL
-iL
+br
+zN
 hy
 rp
 rp
@@ -759,7 +752,7 @@ fC
 Wi
 on
 Bj
-iL
+br
 zN
 mw
 mw
@@ -767,12 +760,12 @@ mw
 dW
 "}
 (12,1,1) = {"
-kt
-kt
 mw
 mw
-iL
-iL
+mw
+mw
+br
+zN
 rp
 Bj
 Bj
@@ -791,7 +784,7 @@ on
 Of
 qN
 Bj
-iL
+br
 zN
 mw
 mw
@@ -799,21 +792,21 @@ mw
 mw
 "}
 (13,1,1) = {"
-kt
 mw
 mw
 mw
-iL
-iL
+mw
+br
+zN
 rp
 UQ
-iD
-on
-on
-iP
+tf
+pu
+pu
+Fs
 Bj
-fl
-Of
+jF
+OK
 Bj
 rp
 UI
@@ -823,29 +816,29 @@ aA
 Of
 xI
 Bj
-iL
-iL
+br
+zN
 mw
 mw
 mw
 mw
 "}
 (14,1,1) = {"
-kt
+mw
 wo
 mw
 pV
-iL
-iL
+br
+zN
 rp
 bw
 pK
 pK
 Gs
-QI
-ux
-Of
-Of
+Kz
+OK
+OK
+OK
 Bj
 Ke
 UI
@@ -855,29 +848,29 @@ Bj
 Bj
 Bj
 Bj
-iL
-iL
+br
+zN
 mw
 Mi
 mw
 mw
 "}
 (15,1,1) = {"
-kt
 mw
 mw
 mw
-iL
-iL
+mw
+br
+zN
 rp
 bw
 AC
 pK
-pK
-on
-Qh
-hl
-on
+Ii
+OK
+pu
+Ep
+pu
 Qe
 UI
 UI
@@ -887,8 +880,8 @@ rp
 rp
 rp
 rp
-iL
-iL
+br
+zN
 mw
 mw
 mw
@@ -899,17 +892,17 @@ mw
 mw
 mw
 mw
-iL
-iL
+br
+zN
 rp
 bw
 pK
 pK
 Ai
-lN
-fQ
-QI
-on
+mt
+pu
+Kz
+pu
 Bj
 Ke
 UI
@@ -931,17 +924,17 @@ mw
 mw
 mw
 mw
-iL
-iL
+br
+zN
 qW
 WJ
-oV
-on
-on
-en
+nJ
+pu
+pu
+uL
 Bj
-OV
-on
+ui
+pu
 Bj
 rp
 UI
@@ -951,8 +944,8 @@ Qe
 Bj
 Bj
 rp
-iL
-iL
+zN
+br
 mw
 mw
 mw
@@ -983,8 +976,8 @@ on
 AZ
 Bj
 rp
-iL
-iL
+zN
+br
 mw
 mw
 Mi
@@ -996,7 +989,7 @@ mw
 uO
 mw
 zN
-iL
+br
 rp
 iX
 rp
@@ -1015,8 +1008,8 @@ on
 xJ
 Bj
 rp
-iL
-iL
+zN
+br
 mw
 mw
 mw
@@ -1028,7 +1021,7 @@ mw
 mw
 mw
 zN
-iL
+br
 rp
 rp
 rp
@@ -1047,8 +1040,8 @@ Of
 gf
 Bj
 rp
-iL
-iL
+zN
+br
 mw
 mw
 mw
@@ -1060,7 +1053,7 @@ dr
 mw
 mw
 zN
-iL
+br
 rp
 rp
 ph
@@ -1079,20 +1072,20 @@ Of
 Of
 Bj
 rp
-iL
-iL
+zN
+br
 mw
 mw
 mw
-kt
+mw
 "}
 (22,1,1) = {"
 mw
 mw
 mw
 mw
-iL
-iL
+zN
+zN
 rp
 rp
 pe
@@ -1111,21 +1104,21 @@ Bj
 Bj
 Bj
 rp
-iL
-iL
+zN
+br
 mw
 mw
 mw
-kt
+mw
 "}
 (23,1,1) = {"
 mw
 mw
 mw
 mw
-iL
-iL
-iL
+br
+zN
+br
 mW
 lB
 UI
@@ -1142,13 +1135,13 @@ rp
 rp
 rp
 rp
-iL
-iL
-iL
+zN
+zN
+br
 mw
 mw
 dr
-kt
+mw
 "}
 (24,1,1) = {"
 mw
@@ -1156,9 +1149,9 @@ Mi
 mw
 mw
 fI
-iL
-iL
-iL
+zN
+zN
+br
 oI
 UI
 vf
@@ -1172,15 +1165,15 @@ rp
 rp
 hy
 rp
-iL
-iL
-iL
-iL
-iL
+br
+zN
+zN
+br
+br
 mw
 mw
 mw
-kt
+mw
 "}
 (25,1,1) = {"
 mw
@@ -1188,31 +1181,31 @@ mw
 mw
 mw
 mw
-iL
-iL
-iL
-iL
-iL
-iL
-iL
-iL
-iL
-iL
-iL
-iL
-iL
+br
 zN
-iL
-iL
-iL
-iL
-iL
-iL
+zN
+zN
+zN
+br
+br
+br
+br
+br
+br
+br
+br
+zN
+zN
+zN
+zN
+zN
+br
+br
 mw
 mw
 mw
 mw
-kt
+mw
 "}
 (26,1,1) = {"
 mw
@@ -1221,22 +1214,22 @@ mw
 mw
 mw
 mw
-iL
-iL
-iL
-iL
-iL
-iL
-iL
-iL
-iL
-iL
-iL
+br
+br
+br
 zN
 zN
-iL
-iL
-iL
+zN
+zN
+zN
+zN
+zN
+zN
+zN
+zN
+br
+br
+br
 mw
 mw
 mw
@@ -1244,7 +1237,7 @@ pV
 mw
 mw
 mw
-kt
+mw
 "}
 (27,1,1) = {"
 mw
@@ -1275,8 +1268,8 @@ mw
 mw
 mw
 mw
-kt
-kt
+mw
+mw
 "}
 (28,1,1) = {"
 mw
@@ -1307,12 +1300,12 @@ mw
 mw
 mw
 mw
-kt
-kt
+mw
+mw
 "}
 (29,1,1) = {"
-kt
-kt
+mw
+mw
 dW
 mw
 mw
@@ -1321,13 +1314,13 @@ mw
 mw
 mw
 wo
-kt
-kt
-kt
-kt
-kt
-kt
-kt
+mw
+mw
+mw
+mw
+mw
+mw
+mw
 mw
 mw
 mw
@@ -1339,28 +1332,10 @@ mw
 mw
 mw
 mw
-kt
-kt
+mw
+mw
 "}
 (30,1,1) = {"
-kt
-kt
-kt
-kt
-kt
-mw
-mw
-mw
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
 mw
 mw
 mw
@@ -1371,6 +1346,24 @@ mw
 mw
 mw
 mw
-kt
-kt
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
+mw
 "}

--- a/config/iceruinblacklist.txt
+++ b/config/iceruinblacklist.txt
@@ -11,7 +11,7 @@
 #_maps/RandomRuins/IceRuins/icemoon_surface_asteroid.dmm
 #_maps/RandomRuins/IceRuins/icemoon_surface_hotsprings.dmm
 #_maps/RandomRuins/IceRuins/icemoon_surface_hermit.dmm
-_maps/RandomRuins/IceRuins/icemoon_surface_walkervillage.dmm
+#_maps/RandomRuins/IceRuins/icemoon_surface_walkervillage.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_puzzle.dmm
 _maps/RandomRuins/IceRuins/icemoon_underground_abandoned_village.dmm
 #_maps/RandomRuins/IceRuins/icemoon_underground_mining_site.dmm


### PR DESCRIPTION
# Document the changes in your pull request

fixes the map of and reenables icemoon walkers in config, they were disabled in #21065 due to being moved to the surface as a bug was causing them to not spawn underground.

# Changelog

:cl:  cark
mapping: Reenables Icemoon Walkers
/:cl:
