### PR TITLE
Being on fire no longer causes a negative mood effect if you're immune to fire

### DIFF
--- a/code/datums/status_effects/debuffs/fire_stacks.dm
+++ b/code/datums/status_effects/debuffs/fire_stacks.dm
@@ -200,6 +200,7 @@
 	var/thermal_protection = victim.get_thermal_protection()
 
 	if(thermal_protection >= FIRE_IMMUNITY_MAX_TEMP_PROTECT && !no_protection)
+		SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, "on_fire")
 		return
 
 	if(thermal_protection >= FIRE_SUIT_MAX_TEMP_PROTECT && !no_protection)
@@ -207,7 +208,10 @@
 		return
 
 	victim.adjust_bodytemperature((BODYTEMP_HEATING_MAX + (stacks * 12)) * 0.5 * seconds_per_tick)
-	SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "on_fire", /datum/mood_event/on_fire)
+	if(!HAS_TRAIT(victim, TRAIT_RESISTHEAT))
+		SEND_SIGNAL(owner, COMSIG_ADD_MOOD_EVENT, "on_fire", /datum/mood_event/on_fire)
+	else
+		SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, "on_fire")
 
 /**
  * Handles mob ignition, should be the only way to set on_fire to TRUE

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -158,7 +158,7 @@
 	var/thermal_protection = 0 //Simple check to estimate how protected we are against multiple temperatures
 	if(wear_suit)
 		if(wear_suit.max_heat_protection_temperature >= FIRE_SUIT_MAX_TEMP_PROTECT)
-			thermal_protection += (wear_suit.max_heat_protection_temperature*0.7)
+			thermal_protection += (wear_suit.max_heat_protection_temperature*(1-THERMAL_PROTECTION_HEAD))
 	if(head)
 		if(head.max_heat_protection_temperature >= FIRE_HELM_MAX_TEMP_PROTECT)
 			thermal_protection += (head.max_heat_protection_temperature*THERMAL_PROTECTION_HEAD)


### PR DESCRIPTION
# Document the changes in your pull request

Being on fire no longer gives a negative moodlet for being on fire if you're immune to fire, and also fixed an issue with it not clearing itself when it should.

# Why is this good for the game?
This is already the case for suits that provide full fire protection, so I see this as just an oversight.

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/93578146/ff162c32-cb89-46db-8aa5-90234bf88900)
![image](https://github.com/yogstation13/Yogstation/assets/93578146/17703a9a-070e-499a-b540-69103730ecc2)

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: being on fire no longer gives a negative moodlet if you're immune to fire
/:cl:
