### PR TITLE
REWORKS BOX LAWOFFICE 1.2

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -25152,7 +25152,6 @@
 	name = "Lawyer Shutters"
 	},
 /obj/structure/table/wood,
-/obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law{
 	pixel_x = 6;
 	pixel_y = 2

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -9721,11 +9721,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bwN" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 4
-	},
-/obj/structure/chair/office/dark{
-	dir = 8
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	layer = 3
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
@@ -15098,7 +15098,6 @@
 "cCl" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/computer/atmos_sim{
-	dir = 2;
 	mode = 1
 	},
 /turf/open/floor/plasteel,
@@ -17817,7 +17816,6 @@
 /area/hallway/primary/central)
 "dAx" = (
 /obj/structure/plasticflaps{
-	density = 0;
 	opacity = 1
 	},
 /obj/structure/cable{
@@ -19297,9 +19295,6 @@
 	dir = 8
 	},
 /obj/machinery/door/window/southleft{
-	base_state = "left";
-	dir = 2;
-	icon_state = "left";
 	name = "Kitchen Delivery";
 	req_access_txt = "28"
 	},
@@ -20142,9 +20137,7 @@
 "esY" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/southleft{
-	base_state = "left";
 	dir = 8;
-	icon_state = "left";
 	name = "Bar Delivery";
 	req_access_txt = "25"
 	},
@@ -22610,7 +22603,6 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "fjZ" = (
 /obj/structure/plasticflaps{
-	density = 0;
 	opacity = 1
 	},
 /obj/structure/cable{
@@ -22953,8 +22945,7 @@
 	dir = 4
 	},
 /obj/machinery/door/poddoor/preopen{
-	id = "cell6 blast";
-	name = "blast door"
+	id = "cell6 blast"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -22968,22 +22959,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
-"fpv" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/toy/figure/lawyer{
-	pixel_x = 7;
-	pixel_y = 5
-	},
-/obj/item/taperecorder{
-	pixel_x = -7;
-	pixel_y = 2
-	},
-/turf/open/floor/wood,
-/area/lawoffice)
 "fpR" = (
 /obj/machinery/computer/shuttle/labor,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -23391,12 +23366,8 @@
 	freq = 1400;
 	location = "Kitchen"
 	},
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
-/turf/open/floor/plasteel{
-	dir = 2
-	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "fwE" = (
 /obj/structure/flora/ausbushes/grassybush,
@@ -23715,6 +23686,18 @@
 	name = "Lawyer Shutters"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/item/toy/figure/lawyer{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/obj/item/flashlight/lamp/green{
+	pixel_x = 1
+	},
+/obj/item/taperecorder{
+	pixel_x = -7;
+	pixel_y = 2
+	},
+/obj/structure/table/wood,
 /turf/open/floor/plating,
 /area/lawoffice)
 "fCV" = (
@@ -24781,7 +24764,6 @@
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2;
-	sortType = 0;
 	sortTypes = list("13","28")
 	},
 /turf/open/floor/plasteel/white,
@@ -25165,10 +25147,23 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "gdE" = (
-/obj/structure/table/wood,
 /obj/machinery/door/poddoor/shutters{
 	id = "phoenixwright";
 	name = "Lawyer Shutters"
+	},
+/obj/structure/table/wood,
+/obj/structure/table/wood,
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = 6;
+	pixel_y = 2
+	},
+/obj/item/book/manual/wiki/security_space_law{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/obj/item/stamp/law{
+	pixel_x = -10;
+	pixel_y = -2
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
@@ -27031,7 +27026,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/effect/landmark/start/lawyer,
 /turf/open/floor/wood,
 /area/lawoffice)
 "gRR" = (
@@ -29292,9 +29286,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "hED" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/machinery/requests_console{
 	department = "Law office";
 	pixel_y = 32
@@ -29309,6 +29300,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/vending/wardrobe/law_wardrobe,
 /turf/open/floor/wood,
 /area/lawoffice)
 "hEG" = (
@@ -29608,8 +29603,7 @@
 	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 1;
-	sortType = 13;
-	sortTypes = list()
+	sortType = 13
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -29643,7 +29637,6 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Bar Maintenance";
-	req_access_txt = "0";
 	req_one_access_txt = "12;25"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -29828,7 +29821,14 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "hPG" = (
-/obj/machinery/vending/wardrobe/law_wardrobe,
+/obj/machinery/photocopier,
+/obj/machinery/button/door{
+	id = "lawyer_blast";
+	name = "Privacy Shutters";
+	req_access_txt = "38";
+	pixel_y = -20;
+	pixel_x = -9
+	},
 /turf/open/floor/wood,
 /area/lawoffice)
 "hPT" = (
@@ -30507,13 +30507,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "hZq" = (
-/obj/machinery/photocopier,
-/obj/machinery/button/door{
-	id = "lawyer_blast";
-	name = "Privacy Shutters";
-	pixel_x = -24;
-	req_access_txt = "38"
-	},
+/obj/structure/filingcabinet/chestdrawer/wheeled,
 /turf/open/floor/wood,
 /area/lawoffice)
 "hZw" = (
@@ -33162,9 +33156,7 @@
 	location = "Bar"
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel{
-	dir = 2
-	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "iVd" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -33732,8 +33724,7 @@
 	dir = 4
 	},
 /obj/machinery/door/poddoor/preopen{
-	id = "cell5 blast";
-	name = "blast door"
+	id = "cell5 blast"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -35304,24 +35295,19 @@
 	icon_state = "0-4"
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
 	pixel_y = -27
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
-	broadcasting = 0;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
 	pixel_y = 20
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
 	freerange = 1;
-	listening = 1;
 	name = "Common Channel";
 	pixel_y = -37
 	},
@@ -37151,13 +37137,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "kyP" = (
-/obj/machinery/button/door{
-	id = "phoenixwright";
-	name = "Lawyer Shutters";
-	pixel_x = -24;
-	pixel_y = 32;
-	req_access_txt = "38"
+/obj/structure/chair/comfy/brown{
+	dir = 4
 	},
+/obj/effect/landmark/start/lawyer,
 /turf/open/floor/wood,
 /area/lawoffice)
 "kyX" = (
@@ -39967,6 +39950,12 @@
 /area/security/main)
 "lBI" = (
 /obj/machinery/light,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/lawoffice)
 "lBO" = (
@@ -40466,7 +40455,6 @@
 /obj/machinery/camera{
 	c_tag = "Psychiatrist Office";
 	dir = 4;
-	network = list("ss13");
 	pixel_x = 1;
 	pixel_y = -4
 	},
@@ -42784,8 +42772,7 @@
 	dir = 8
 	},
 /obj/machinery/door/poddoor/preopen{
-	id = "cell4 blast";
-	name = "blast door"
+	id = "cell4 blast"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -45849,7 +45836,6 @@
 /obj/machinery/requests_console{
 	department = "AI";
 	departmentType = 5;
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/circuit/telecomms/server,
@@ -51714,18 +51700,17 @@
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
 "pRS" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
-	dir = 1
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching Prison Wing holding areas.";
+	name = "Prison Monitor";
+	network = list("prison");
+	pixel_y = -6
 	},
 /turf/closed/wall,
 /area/lawoffice)
 "pRU" = (
 /obj/machinery/camera{
-	c_tag = "Kitchen North";
-	dir = 2
+	c_tag = "Kitchen North"
 	},
 /obj/machinery/griddle,
 /turf/open/floor/plasteel/cafeteria,
@@ -51780,9 +51765,9 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "pTb" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/effect/landmark/start/lawyer,
+/obj/structure/chair/comfy/teal{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
@@ -55843,17 +55828,12 @@
 /area/quartermaster/storage)
 "rsk" = (
 /obj/structure/table/wood,
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = 2;
-	pixel_y = 5
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
 	},
-/obj/item/book/manual/wiki/security_space_law{
-	pixel_x = 6;
-	pixel_y = 2
-	},
-/obj/item/stamp/law{
-	pixel_x = -10;
-	pixel_y = -2
+/obj/item/storage/pencil_holder/crew{
+	pixel_x = 9
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
@@ -56887,8 +56867,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/poddoor/preopen{
-	id = "cell3 blast";
-	name = "blast door"
+	id = "cell3 blast"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -57001,6 +56980,12 @@
 "rNk" = (
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
@@ -60540,8 +60525,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/poddoor/preopen{
-	id = "cell2 blast";
-	name = "blast door"
+	id = "cell2 blast"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -60946,6 +60930,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/lawoffice)
 "tlg" = (
@@ -64212,17 +64197,14 @@
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "uAs" = (
-/obj/structure/table/wood,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching Prison Wing holding areas.";
+	name = "Prison Monitor";
+	network = list("prison");
+	pixel_y = 6;
+	dir = 1
 	},
-/obj/item/pen,
-/obj/item/pen{
-	pixel_x = 7;
-	pixel_y = 6
-	},
-/turf/open/floor/wood,
+/turf/closed/wall,
 /area/lawoffice)
 "uAL" = (
 /obj/structure/sign/departments/minsky/medical/medical1,
@@ -64665,8 +64647,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/door/poddoor/preopen{
-	id = "cell1 blast";
-	name = "blast door"
+	id = "cell1 blast"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -65906,9 +65887,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "vdb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
@@ -66478,7 +66456,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/landmark/start/lawyer,
 /turf/open/floor/wood,
 /area/lawoffice)
 "voe" = (
@@ -68306,9 +68283,9 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "vUu" = (
-/obj/structure/table/wood,
-/obj/item/folder/blue,
-/obj/item/pen,
+/obj/machinery/door/window{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/lawoffice)
 "vUB" = (
@@ -68699,6 +68676,9 @@
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/item/pen,
 /turf/open/floor/wood,
 /area/lawoffice)
 "waq" = (
@@ -70520,6 +70500,9 @@
 	dir = 1;
 	pixel_y = -26
 	},
+/obj/structure/table/wood,
+/obj/item/folder/blue,
+/obj/item/pen,
 /turf/open/floor/wood,
 /area/lawoffice)
 "wPh" = (
@@ -72774,6 +72757,10 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/wood,
 /area/lawoffice)
 "xHc" = (
@@ -73312,8 +73299,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "xSN" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
+/obj/machinery/button/door{
+	id = "phoenixwright";
+	name = "Lawyer Shutters";
+	req_access_txt = "38";
+	pixel_x = -23
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
@@ -100363,13 +100353,13 @@ dDy
 aiX
 fzs
 iNE
-aph
-apS
+pRS
+pTb
 xSN
 gdE
 xSN
 kyP
-aph
+uAs
 lVQ
 ayL
 bts
@@ -100622,9 +100612,9 @@ tsu
 kUv
 aph
 wap
-vUu
+apS
 fCI
-vUu
+apS
 wPg
 aph
 avt
@@ -100879,7 +100869,7 @@ dtW
 wnk
 aph
 rNk
-bwN
+vUu
 aph
 bwN
 lBI
@@ -101136,9 +101126,9 @@ gcP
 kUv
 aph
 xGW
-vjz
+apS
 hZq
-dma
+apS
 eqF
 aph
 avt
@@ -101906,12 +101896,12 @@ tsu
 aKE
 kUv
 aph
-pTb
-fpv
+vjz
+dma
 apS
-uAs
+apS
 rsk
-pRS
+aph
 hal
 ayL
 aug


### PR DESCRIPTION
# Document the changes in your pull request
(if this is broken im going to scream)
updates the layout of box law office once again
![image](https://github.com/yogstation13/Yogstation/assets/88801435/6e64d219-f1cb-4daa-bd52-c557cbdbb060)
adds holodeck and holopad to the law office (standard across other maps but not this)
moves a table under the shutters containing some of the stuff, adds a button to the otherside of shutters
adds a filing cabinet and pencil holder


# Why is this good for the game?
more so to keep consistency across law offices... also lawyers should have the ability to check if there are prisoners in perma, that way they don't have to be assistants with brig access.

# Changelog
:cl:  
rscadd; adds pencilholder, holopad, and Perma cams terminals.
mapping; updated layout to box lawoffice and rearrangements

/:cl:
