### PR TITLE
Threshold description for symbiotic regeneration is now accurate

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -580,8 +580,8 @@
 
 	compatible_biotypes = ALL_BIOTYPES // bungus
 	threshold_descs = list(
-		"Stage speed 9" = "Shorter delay until healing starts.",
-		"Resistance 9" = "Increased rate of healing.",
+		"Stealth 5" = "Shorter delay until healing starts.",
+		"Resistance 10" = "Increased rate of healing.",
 	)
 
 /datum/symptom/heal/symbiotic/Start(datum/disease/advance/A)


### PR DESCRIPTION
# Document the changes in your pull request
Threshold description for symbiotic regeneration is now accurate aka not lying.

# Testing
It appears, yes.

# Wiki Documentation
Change the thresholds for it.

# Changelog
:cl:
spellcheck: The threshold description for symbiotic regeneration is now accurate.
/:cl:
