### PR TITLE
Makes the reactor and supermatter crystal less unstable

### DIFF
--- a/code/controllers/subsystem/air_machinery.dm
+++ b/code/controllers/subsystem/air_machinery.dm
@@ -3,7 +3,7 @@ SUBSYSTEM_DEF(air_machinery)
 	name = "Atmospherics Machinery"
 	init_order = INIT_ORDER_AIR_MACHINERY
 	priority = FIRE_PRIORITY_AIR
-	wait = 1 SECONDS
+	wait = 0.5 SECONDS
 	flags = SS_BACKGROUND
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 	loading_points = 4.2 SECONDS // Yogs -- loading times


### PR DESCRIPTION
Atmos and atmos machinery being separated into different subsystems with different wait times wasn't a very good idea.

:cl:  
bugfix: supermatter crystal and nuclear reactor are less unstable
/:cl:
