### PR TITLE
[GAX] Fixes some issues in disposals area

### DIFF
--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -6606,6 +6606,12 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 1;
+	icon_state = "right";
+	layer = 3
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "diG" = (
@@ -10568,9 +10574,6 @@
 	},
 /obj/machinery/light/small{
 	dir = 1
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -15231,12 +15234,6 @@
 "hoO" = (
 /obj/structure/window/reinforced{
 	dir = 4
-	},
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 1;
-	icon_state = "right";
-	layer = 3
 	},
 /obj/machinery/disposal/deliveryChute{
 	dir = 1


### PR DESCRIPTION
# Document the changes in your pull request

Removes Air Alarm in disposals room in maint.
Moves windoor in disposals room in maint to be less suicidal to open.

# Testing

Yes.

# Changelog

:cl:  
mapping: Removed disposals air alarm
mapping: Moved windoor in disposals
/:cl:
