### PR TITLE
Printed IPCs no longer have human names

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1182,9 +1182,9 @@
 /mob/living/carbon/human/species
 	var/race = null
 
-/mob/living/carbon/human/species/Initialize(mapload)
-	. = ..()
-	set_species(race)
+/mob/living/carbon/human/species/create_dna()
+	dna = new /datum/dna(src)
+	dna.species = new race()
 
 /mob/living/carbon/human/species/abductor
 	race = /datum/species/abductor


### PR DESCRIPTION
What the title says. Also happens to fix the issue where admin-spawned nonhuman species have human names as well.

![image](https://github.com/yogstation13/Yogstation/assets/93578146/04233aec-3afd-4829-b664-662f650bc267)

:cl:  
bugfix: fixed printed IPCs having human names instead of IPC names
/:cl:
