### PR TITLE
Alcoholism wins again (Slurring nerf)

### DIFF
--- a/code/datums/status_effects/debuffs/drunk.dm
+++ b/code/datums/status_effects/debuffs/drunk.dm
@@ -145,7 +145,7 @@
 	owner.adjust_jitter(-6 SECONDS)
 
 	// If lightweight, over 11, we will constantly gain slurring up to 10 seconds of slurring.
-	if(HAS_TRAIT(drinker, TRAIT_LIGHT_DRINKER) & (drunk_value >= 11))
+	if(HAS_TRAIT(owner, TRAIT_LIGHT_DRINKER) & (drunk_value >= 11))
 		owner.adjust_slurring_up_to(2.4 SECONDS, 10 SECONDS)
 
 	// Over 41, we have a 30% chance to gain confusion, and we will always have 20 seconds of dizziness.
@@ -164,7 +164,7 @@
 			if(iscarbon(owner))
 				var/mob/living/carbon/carbon_owner = owner
 				carbon_owner.vomit() // Vomiting clears toxloss - consider this a blessing
-		if(!HAS_TRAIT(drinker, TRAIT_ALCOHOL_TOLERANCE))
+		if(!HAS_TRAIT(owner, TRAIT_ALCOHOL_TOLERANCE))
 			owner.adjust_slurring_up_to(2.4 SECONDS, 10 SECONDS)
 
 	// Over 71, we will constantly have blurry eyes
@@ -176,7 +176,7 @@
 		owner.adjustToxLoss(1)
 		if(owner.stat == CONSCIOUS && prob(5))
 			to_chat(owner, span_warning("Maybe you should lie down for a bit..."))
-		if(HAS_TRAIT(drinker, TRAIT_ALCOHOL_TOLERANCE))
+		if(HAS_TRAIT(owner, TRAIT_ALCOHOL_TOLERANCE))
 			owner.adjust_slurring_up_to(2.4 SECONDS, 10 SECONDS)
 
 	// Over 91, we gain even more toxloss, brain damage, and have a chance of dropping into a long sleep

--- a/code/datums/status_effects/debuffs/drunk.dm
+++ b/code/datums/status_effects/debuffs/drunk.dm
@@ -141,15 +141,11 @@
 		if(drunk_value > BALLMER_PEAK_WINDOWS_ME) // by this point you're into windows ME territory
 			owner.say(pick_list_replacements(VISTA_FILE, "ballmer_windows_me_msg"), forced = "ballmer")
 
-	// There's always a 30% chance to gain some drunken slurring
-	if(prob(30))
-		owner.adjust_slurring(4 SECONDS)
-
 	// And drunk people will always lose jitteriness
 	owner.adjust_jitter(-6 SECONDS)
 
-	// Over 11, we will constantly gain slurring up to 10 seconds of slurring.
-	if(drunk_value >= 11)
+	// If lightweight, over 11, we will constantly gain slurring up to 10 seconds of slurring.
+	if(HAS_TRAIT(drinker, TRAIT_LIGHT_DRINKER) & (drunk_value >= 11))
 		owner.adjust_slurring_up_to(2.4 SECONDS, 10 SECONDS)
 
 	// Over 41, we have a 30% chance to gain confusion, and we will always have 20 seconds of dizziness.
@@ -160,7 +156,7 @@
 		owner.set_dizzy_if_lower(20 SECONDS)
 		ADD_TRAIT(src, TRAIT_SURGERY_PREPARED, "drunk")
 
-	// Over 51, we have a 3% chance to gain a lot of confusion and vomit, and we will always have 50 seconds of dizziness
+	// Over 51, we have a 3% chance to gain a lot of confusion and vomit, and we will always have 50 seconds of dizziness and normal drinkers will start to slur
 	if(drunk_value >= 51)
 		owner.set_dizzy_if_lower(50 SECONDS)
 		if(prob(3))
@@ -168,16 +164,20 @@
 			if(iscarbon(owner))
 				var/mob/living/carbon/carbon_owner = owner
 				carbon_owner.vomit() // Vomiting clears toxloss - consider this a blessing
+		if(!HAS_TRAIT(drinker, TRAIT_ALCOHOL_TOLERANCE))
+			owner.adjust_slurring_up_to(2.4 SECONDS, 10 SECONDS)
 
 	// Over 71, we will constantly have blurry eyes
 	if(drunk_value >= 71)
 		owner.blur_eyes(drunk_value * 2 - 140)
 
-	// Over 81, we will gain constant toxloss
+	// Over 81, we will gain constant toxloss and experienced drunks will now begin to slur
 	if(drunk_value >= 81)
 		owner.adjustToxLoss(1)
 		if(owner.stat == CONSCIOUS && prob(5))
 			to_chat(owner, span_warning("Maybe you should lie down for a bit..."))
+		if(HAS_TRAIT(drinker, TRAIT_ALCOHOL_TOLERANCE))
+			owner.adjust_slurring_up_to(2.4 SECONDS, 10 SECONDS)
 
 	// Over 91, we gain even more toxloss, brain damage, and have a chance of dropping into a long sleep
 	if(drunk_value >= 91)

--- a/code/datums/status_effects/debuffs/drunk.dm
+++ b/code/datums/status_effects/debuffs/drunk.dm
@@ -144,7 +144,7 @@
 	// And drunk people will always lose jitteriness
 	owner.adjust_jitter(-6 SECONDS)
 
-	// If lightweight, over 11, we will constantly gain slurring up to 10 seconds of slurring.
+	// Over 11, Light drinkers will constantly gain slurring up to 10 seconds of slurring.
 	if(HAS_TRAIT(owner, TRAIT_LIGHT_DRINKER) & (drunk_value >= 11))
 		owner.adjust_slurring_up_to(2.4 SECONDS, 10 SECONDS)
 

--- a/code/datums/status_effects/debuffs/drunk.dm
+++ b/code/datums/status_effects/debuffs/drunk.dm
@@ -165,7 +165,7 @@
 				var/mob/living/carbon/carbon_owner = owner
 				carbon_owner.vomit() // Vomiting clears toxloss - consider this a blessing
 		if(!HAS_TRAIT(owner, TRAIT_ALCOHOL_TOLERANCE))
-			owner.adjust_slurring_up_to(2.4 SECONDS, 10 SECONDS)
+			owner.adjust_slurring_up_to(2.4 SECONDS, 7 SECONDS)
 
 	// Over 71, we will constantly have blurry eyes
 	if(drunk_value >= 71)
@@ -177,7 +177,7 @@
 		if(owner.stat == CONSCIOUS && prob(5))
 			to_chat(owner, span_warning("Maybe you should lie down for a bit..."))
 		if(HAS_TRAIT(owner, TRAIT_ALCOHOL_TOLERANCE))
-			owner.adjust_slurring_up_to(2.4 SECONDS, 10 SECONDS)
+			owner.adjust_slurring_up_to(2.4 SECONDS, 4 SECONDS)
 
 	// Over 91, we gain even more toxloss, brain damage, and have a chance of dropping into a long sleep
 	if(drunk_value >= 91)


### PR DESCRIPTION
# Document the changes in your pull request

Every non-american can understand that you don't slur on 2-3 beers. I don't know who made it that drinking anything with 11% boozepwr would make you slur but clearly they haven't drank. I've fiddled with the numbers to make it more realistic for lightweight drinkers, normal drinkers & alcoholics(drinkers with alcohol tolerance) for slurring.

Drunk value:
>11 - Light drinkers will slur for 10 seconds
>51- Normal drinkers will slur for 7 seconds
>81- Alcohol Tolerant drinkers will slur for 4 seconds

I also removed the constant chance for you to slur as it was pointless considering if you were over 11 in drunk value you were already constantly slurring. Which meant that you would slur on any drink which is fucking dumb.

[Edit}
After thinking over it, I've also reduced the slurring duration based on tiers as well since better drinkers will be able to pull themselves together.

# Why is this good for the game?
Because I am a Brit who was an alcoholic at 12 and I didn't slur nearly as much after having 1 drink like these weak-stomached spacemen. 

# Testing
I can't test because I dont know how to compile to 515 and its my day off

# Wiki Documentation

The drunk chart for alcohol drinks need to be edited to reflect the slur for each tier of drinker.

# Changelog

:cl:  

rscadd: Slurring now happens based on what kind of drinker you are (Light, normal or heavy drinker which are based on traits)
rscadd: Slurring duration changed based on drinker type
rscdel: The constant chance to randomly slur, we can drink now

/:cl:
