### PR TITLE
Moonshine is too good for the eyes

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -751,6 +751,16 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "Moonshine"
 	glass_desc = "You've really hit rock bottom now... your liver packed its bags and left last night."
 
+/datum/reagent/consumable/ethanol/moonshine/on_mob_life(mob/living/carbon/M)
+if(!M.mind?.assigned_role == "Assistant")
+	ADD_TRAIT(M, TRAIT_BLIND, type)
+	return ..()
+
+/datum/reagent/consumable/ethanol/moonshine/on_mob_end_metabolize(mob/living/carbon/M)
+if(!M.mind?.assigned_role == "Assistant")
+	REMOVE_TRAIT(M, TRAIT_BLIND, type)
+	return ..()
+
 /datum/reagent/consumable/ethanol/b52
 	name = "B-52"
 	description = "Coffee, Irish Cream, and cognac. You will get bombed."

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -751,9 +751,12 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "Moonshine"
 	glass_desc = "You've really hit rock bottom now... your liver packed its bags and left last night."
 
-/datum/reagent/consumable/ethanol/moonshine/on_mob_life(mob/living/carbon/M)
-	if(ishuman(M) && !M.job == "Mime")
-		M.adjust_blurriness(30)
+/datum/reagent/consumable/ethanol/moonshine/on_mob_metabolize(mob/living/carbon/M)
+	M.adjust_blurriness(30)
+	return ..()
+
+/datum/reagent/consumable/ethanol/moonshine/on_mob_end_metabolize(mob/living/carbon/M)
+	M.adjust_blurriness(30)
 	return ..()
 
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -751,8 +751,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "Moonshine"
 	glass_desc = "You've really hit rock bottom now... your liver packed its bags and left last night."
 
-/datum/reagent/consumable/ethanol/moonshine/on_mob_metabolize(mob/living/carbon/M)
-	M.adjust_blurriness(50)
+/datum/reagent/consumable/ethanol/moonshine/on_mob_life(mob/living/carbon/M)
+	M.adjust_blurriness_up_to(2.4 SECONDS, 20 SECONDS)
 	return ..()
 
 /datum/reagent/consumable/ethanol/b52

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -751,9 +751,9 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "Moonshine"
 	glass_desc = "You've really hit rock bottom now... your liver packed its bags and left last night."
 
-/datum/reagent/consumable/ethanol/moonshine/on_mob_metabolize(mob/living/M)
-	if(!M.mind?.assigned_role == "Assistant")
-		M.adjust_blurriness(50)
+/datum/reagent/consumable/ethanol/moonshine/on_mob_life(mob/living/carbon/M)
+	if(ishuman(M) && !M.job == "Mime")
+		M.adjust_blurriness(30)
 	return ..()
 
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -752,7 +752,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "You've really hit rock bottom now... your liver packed its bags and left last night."
 
 /datum/reagent/consumable/ethanol/moonshine/on_mob_metabolize(mob/living/carbon/M)
-	M.adjust_blurriness(30)
+	M.adjust_blurriness(50)
 	return ..()
 
 /datum/reagent/consumable/ethanol/b52

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -752,7 +752,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "You've really hit rock bottom now... your liver packed its bags and left last night."
 
 /datum/reagent/consumable/ethanol/moonshine/on_mob_life(mob/living/carbon/M)
-	M.adjust_blurriness(0.5)
+	M.adjust_blurriness(2)
 	return ..()
 
 /datum/reagent/consumable/ethanol/b52

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -752,7 +752,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "You've really hit rock bottom now... your liver packed its bags and left last night."
 
 /datum/reagent/consumable/ethanol/moonshine/on_mob_life(mob/living/carbon/M)
-	M.adjust_blurriness(3)
+	M.adjust_blurriness(0.5)
 	return ..()
 
 /datum/reagent/consumable/ethanol/b52

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -759,7 +759,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/moonshine/on_mob_end_metabolize(mob/living/carbon/M)
 	if(!M.mind?.assigned_role == "Assistant")
 		REMOVE_TRAIT(M, TRAIT_BLIND, type)
-		return ..()
+		return ..() 
 
 /datum/reagent/consumable/ethanol/b52
 	name = "B-52"

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -751,9 +751,9 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_name = "Moonshine"
 	glass_desc = "You've really hit rock bottom now... your liver packed its bags and left last night."
 
-/datum/reagent/consumable/ethanol/moonshine/on_mob_life(mob/living/carbon/M)
+/datum/reagent/consumable/ethanol/moonshine/on_mob_metabolize(mob/living/M)
 	if(!M.mind?.assigned_role == "Assistant")
-		M.adjust_blurriness(10)
+		M.adjust_blurriness(30)
 	return ..()
 
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -753,13 +753,9 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/moonshine/on_mob_life(mob/living/carbon/M)
 	if(!M.mind?.assigned_role == "Assistant")
-		ADD_TRAIT(M, TRAIT_BLIND, type)
+		M.set_blur_eyes(2 SECONDS)
 		return ..()
 
-/datum/reagent/consumable/ethanol/moonshine/on_mob_end_metabolize(mob/living/carbon/M)
-	if(!M.mind?.assigned_role == "Assistant")
-		REMOVE_TRAIT(M, TRAIT_BLIND, type)
-		return ..() 
 
 /datum/reagent/consumable/ethanol/b52
 	name = "B-52"

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -753,7 +753,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/moonshine/on_mob_metabolize(mob/living/M)
 	if(!M.mind?.assigned_role == "Assistant")
-		M.adjust_blurriness(30)
+		M.adjust_blurriness(50)
 	return ..()
 
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -753,7 +753,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/moonshine/on_mob_life(mob/living/carbon/M)
 	M.adjust_blurriness(30)
-		return ..()
+	return ..()
 
 
 /datum/reagent/consumable/ethanol/b52

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -756,7 +756,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	return ..()
 
 /datum/reagent/consumable/ethanol/moonshine/on_mob_end_metabolize(mob/living/carbon/M)
-	M.adjust_blurriness(30)
+	M.remove_blurriness
 	return ..()
 
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -752,7 +752,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "You've really hit rock bottom now... your liver packed its bags and left last night."
 
 /datum/reagent/consumable/ethanol/moonshine/on_mob_life(mob/living/carbon/M)
-	M.adjust_blurriness(2)
+	M.adjust_blurriness(1.5)
 	return ..()
 
 /datum/reagent/consumable/ethanol/b52

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -753,7 +753,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/moonshine/on_mob_life(mob/living/carbon/M)
 	if(!M.mind?.assigned_role == "Assistant")
-		M.set_blur_eyes(2 SECONDS)
+		M.setblur_eyes(2 SECONDS)
 		return ..()
 
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -752,7 +752,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "You've really hit rock bottom now... your liver packed its bags and left last night."
 
 /datum/reagent/consumable/ethanol/moonshine/on_mob_life(mob/living/carbon/M)
-	M.adjust_blurriness_up_to(2.4 SECONDS, 20 SECONDS)
+	M.adjust_blurriness(3)
 	return ..()
 
 /datum/reagent/consumable/ethanol/b52

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -752,7 +752,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "You've really hit rock bottom now... your liver packed its bags and left last night."
 
 /datum/reagent/consumable/ethanol/moonshine/on_mob_life(mob/living/carbon/M)
-	M.adjust_blurriness(30)
+	if(!M.mind?.assigned_role == "Assistant")
+		M.adjust_blurriness(10)
 	return ..()
 
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -752,14 +752,14 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "You've really hit rock bottom now... your liver packed its bags and left last night."
 
 /datum/reagent/consumable/ethanol/moonshine/on_mob_life(mob/living/carbon/M)
-if(!M.mind?.assigned_role == "Assistant")
-	ADD_TRAIT(M, TRAIT_BLIND, type)
-	return ..()
+	if(!M.mind?.assigned_role == "Assistant")
+		ADD_TRAIT(M, TRAIT_BLIND, type)
+		return ..()
 
 /datum/reagent/consumable/ethanol/moonshine/on_mob_end_metabolize(mob/living/carbon/M)
-if(!M.mind?.assigned_role == "Assistant")
-	REMOVE_TRAIT(M, TRAIT_BLIND, type)
-	return ..()
+	if(!M.mind?.assigned_role == "Assistant")
+		REMOVE_TRAIT(M, TRAIT_BLIND, type)
+		return ..()
 
 /datum/reagent/consumable/ethanol/b52
 	name = "B-52"

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -755,11 +755,6 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	M.adjust_blurriness(30)
 	return ..()
 
-/datum/reagent/consumable/ethanol/moonshine/on_mob_end_metabolize(mob/living/carbon/M)
-	M.adjust_blurriness(-30)
-	return ..()
-
-
 /datum/reagent/consumable/ethanol/b52
 	name = "B-52"
 	description = "Coffee, Irish Cream, and cognac. You will get bombed."

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -752,8 +752,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "You've really hit rock bottom now... your liver packed its bags and left last night."
 
 /datum/reagent/consumable/ethanol/moonshine/on_mob_life(mob/living/carbon/M)
-	if(!M.mind?.assigned_role == "Assistant")
-		M.setblur_eyes(2 SECONDS)
+	M.adjust_blurriness(30)
 		return ..()
 
 

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -756,7 +756,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	return ..()
 
 /datum/reagent/consumable/ethanol/moonshine/on_mob_end_metabolize(mob/living/carbon/M)
-	M.remove_blurriness
+	M.adjust_blurriness(-30)
 	return ..()
 
 


### PR DESCRIPTION
# Document the changes in your pull request

Moonshine does nothing to the eyes? What in tarnation is this? Amurica perfected cheap ethanol enthused alcohol and by my freedom to bare alcohol we will give it an effect.

Moonshine now makes you have blurry vision
[EDIT]
 I can't be bothered to tailor it so assistants don't get affected so I've scrapped it.
Blurry vision stacks at 1.5 per tick

# Why is this good for the game?

Gives some funny booze effects

# Testing

Yes, I tested a wide variety of different shit and values to make sure blurry isn't cbt if you drink a little.

# Wiki Documentation

Change the moonshine description to include anyone that drinks it will experience blurry vision.

# Changelog

:cl:  

rscadd: Moonshine now makes you gain blurry, long live blurry vision
/:cl:
