### PR TITLE
Ammo box description properly updates with how much bullets are left

### DIFF
--- a/code/modules/projectiles/boxes_magazines/_box_magazine.dm
+++ b/code/modules/projectiles/boxes_magazines/_box_magazine.dm
@@ -138,7 +138,7 @@
 		if(!silent)
 			to_chat(user, span_notice("You load [num_loaded] round\s into \the [src]!"))
 			playsound(src, 'sound/weapons/bulletinsert.ogg', 60, TRUE)
-		A.update_appearance(UPDATE_ICON)
+		A.update_appearance(UPDATE_ICON|UPDATE_DESC)
 		update_appearance(UPDATE_ICON|UPDATE_DESC)
 	return num_loaded
 


### PR DESCRIPTION
# Document the changes in your pull request
Using an ammo box (first) onto an another ammo box (second) now properly updates the description of the first ammo box.
Closes #20877
Closes #21180

# Testing
Used ammo box on pistol magazine. Descriptions updated.

# Changelog
:cl:  
bugfix: The description of ammo boxes now accurately show how much bullets are left when you use an ammo box on another ammo box.
/:cl:
