### PR TITLE
Physiology Siemens Coeff is now accounted for when getting shocked

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -502,6 +502,8 @@
 
 //Added a safety check in case you want to shock a human mob directly through electrocute_act.
 /mob/living/carbon/human/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, zone = BODY_ZONE_R_ARM, override = FALSE, tesla_shock = FALSE, illusion = FALSE, stun = TRUE, gib = FALSE)
+	if(!override && physiology)
+		siemens_coeff *= physiology.siemens_coeff
 	. = ..()
 	if(.)
 		electrocution_animation(40)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -502,7 +502,7 @@
 
 //Added a safety check in case you want to shock a human mob directly through electrocute_act.
 /mob/living/carbon/human/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, zone = BODY_ZONE_R_ARM, override = FALSE, tesla_shock = FALSE, illusion = FALSE, stun = TRUE, gib = FALSE)
-	if(!override && physiology)
+	if(!override)
 		siemens_coeff *= physiology.siemens_coeff
 	. = ..()
 	if(.)


### PR DESCRIPTION
# Document the changes in your pull request
When humans get electrocuted, their physiology's siemens coeff is now accounted for instead of completely forgotten/ignored.
Closes #21196

# Testing
VV physiology's siemens coeff to 0. Touched shocked grille. No shock.

# Changelog
:cl:  
bugfix: Nerve Grounding and other ways that change your physiology's siemens coeff properly protect you from getting electrocuted.
/:cl:
