### PR TITLE
[IceMeta] Inn vendor fixes

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_inn.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_inn.dmm
@@ -274,7 +274,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/vending/hydroseeds,
+/obj/machinery/vending/hydroseeds{
+	onstation = 0
+	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered/inn)
 "jY" = (
@@ -894,7 +896,9 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/ruin/powered/inn)
 "My" = (
-/obj/machinery/vending/boozeomat,
+/obj/machinery/vending/boozeomat{
+	onstation = 0
+	},
 /turf/open/floor/wood,
 /area/ruin/powered/inn)
 "Na" = (
@@ -1049,7 +1053,9 @@
 /obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
-/obj/machinery/vending/hydronutrients,
+/obj/machinery/vending/hydronutrients{
+	onstation = 0
+	},
 /turf/open/floor/plasteel/white,
 /area/ruin/powered/inn)
 "Wx" = (

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_inn.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_inn.dmm
@@ -242,7 +242,9 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/ruin/powered/inn)
 "iG" = (
-/obj/machinery/vending/dinnerware,
+/obj/machinery/vending/dinnerware{
+	onstation = 0
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/ruin/powered/inn)
 "iH" = (


### PR DESCRIPTION
# Document the changes in your pull request

Sets the vendors for the kitchen/bar to onstation = 0 so the innkeeper can actually use stuff from it.

# Testing

Yes

# Changelog

:cl:  
bugfix: The innkeeper can now get stuff from their booze-o-matic and kitchen vending machines.
/:cl:
