### PR TITLE
Adjusts how morphine affects the body

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -46,7 +46,7 @@
 	///what chemical we're injecting with the "sedate" function
 	var/sedate_chem = /datum/reagent/medicine/morphine
 	///maximum allowed chemical volume
-	var/sedate_limit = 20
+	var/sedate_limit = 10
 	///what are we putting in the tgui
 	var/sedate_button_text = "Sedate"
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -755,7 +755,7 @@
 		if(12 to 24)
 			M.adjust_drugginess(1 SECONDS)
 		if(24 to INFINITY)
-			M.Stun(15, 0)
+			M.blur_eyes(15)
 			. = 1
 	if(M.stat > CONSCIOUS)
 		M.adjustBruteLoss(-1*REM)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -734,8 +734,8 @@
 	reagent_state = LIQUID
 	color = "#A9FBFB"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
-	overdose_threshold = 30
-	addiction_threshold = 25
+	overdose_threshold = 35
+	addiction_threshold = 15
 
 /datum/reagent/medicine/morphine/on_mob_metabolize(mob/living/L)
 	..()
@@ -751,11 +751,11 @@
 /datum/reagent/medicine/morphine/on_mob_life(mob/living/carbon/M)
 	switch(current_cycle)
 		if(11)
-			to_chat(M, span_warning("You start to feel tired...") )
+			to_chat(M, span_warning("You start to feel good, and very bad...") )
 		if(12 to 24)
-			M.adjust_drowsiness(1 SECONDS)
+			M.adjust_drugginess(1 SECONDS)
 		if(24 to INFINITY)
-			M.Sleeping(40, 0)
+			M.Stun(15, 0)
 			. = 1
 	if(M.stat > CONSCIOUS)
 		M.adjustBruteLoss(-1*REM)


### PR DESCRIPTION
# Document the changes in your pull request

This PR adjusts morphine from being a slightly annoying tool which is very easy to grief with due to it's rapid abundance, to something that may give people some form of counterplay. It will also adjust it's overdose and addiction threasholds

Adjusts OD threshold to 35u
Adjust Addiction OD to 15u

Removes the Sleep and Drowsiness from it, replacing it with drugginess & eye blur

Additionally adjusts sleeper maximum injection amount to 10u to avoid doctors or anyone with access to be able to addict you.

# Why is this good for the game?

I think it's good to shake things up, and morphine is a pretty common chemical that can probably do with a change.

# Testing

Ill show a test if required, otherwise it works.

# Wiki Documentation

Changes OD thresholds and descriptions

# Changelog

:cl:  

tweak: Changes how morphine affects the body 

/:cl:
