### PR TITLE
Airalarm  tweaks

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -119,6 +119,7 @@
 		GAS_ZAUKER = new/datum/tlv/dangerous,	
 		GAS_HALON = new/datum/tlv/dangerous,
 		GAS_HEXANE = new/datum/tlv/dangerous,
+		GAS_ANTINOB = new/datum/tlv/dangerous,
 	)
 
 /obj/machinery/airalarm/server // No checks here.
@@ -144,6 +145,7 @@
 		GAS_PLUONIUM = new/datum/tlv/dangerous,
 		GAS_HALON = new/datum/tlv/dangerous,
 		GAS_HEXANE = new/datum/tlv/dangerous,
+		GAS_ANTINOB = new/datum/tlv/dangerous,
 	)
 
 /obj/machinery/airalarm/kitchen_cold_room // Kitchen cold rooms start off at -80°C or 193.15°K.
@@ -170,6 +172,7 @@
 		GAS_ZAUKER = new/datum/tlv/dangerous,
 		GAS_HALON = new/datum/tlv/dangerous,
 		GAS_HEXANE = new/datum/tlv/dangerous,
+		GAS_ANTINOB = new/datum/tlv/dangerous,
 	)
 
 /obj/machinery/airalarm/unlocked

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -557,6 +557,7 @@
 						GAS_PLASMA,
 						GAS_H2O,
 						GAS_HYPERNOB,
+						GAS_ANTINOB,
 						GAS_NITROUS,
 						GAS_NITRIUM,
 						GAS_TRITIUM,

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -321,10 +321,11 @@
 		if(!(gas_id in TLV)) // We're not interested in this gas, it seems.
 			continue
 		cur_tlv = TLV[gas_id]
+		var/moles = environment?.get_moles(gas_id)
+		var/portion = moles / total_moles
 		data["environment_data"] += list(list(
 								"name" = GLOB.gas_data.names[gas_id],
-								"value" = environment.get_moles(gas_id) / total_moles * 100,
-								"unit" = "%",
+								"value" = "[round(moles, 0.01)] moles / [round(100 * portion, 0.01)] % / [round(portion * pressure, 0.01)] kPa",
 								"danger_level" = cur_tlv.get_danger_level(environment.get_moles(gas_id) * partial_pressure)
 		))
 
@@ -590,7 +591,7 @@
 				send_signal(device_id, list(
 					"power" = 1,
 					"checks" = 1,
-					"set_external_pressure" = ONE_ATMOSPHERE*2
+					"set_external_pressure" = ONE_ATMOSPHERE
 				), signal_source)
 		if(AALARM_MODE_PANIC,
 			AALARM_MODE_REPLACEMENT)

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -321,11 +321,10 @@
 		if(!(gas_id in TLV)) // We're not interested in this gas, it seems.
 			continue
 		cur_tlv = TLV[gas_id]
-		var/moles = environment?.get_moles(gas_id)
-		var/portion = moles / total_moles
 		data["environment_data"] += list(list(
 								"name" = GLOB.gas_data.names[gas_id],
-								"value" = "[round(moles, 0.01)] moles / [round(100 * portion, 0.01)] % / [round(portion * pressure, 0.01)] kPa",
+								"value" = environment.get_moles(gas_id) / total_moles * 100,
+								"unit" = "%",
 								"danger_level" = cur_tlv.get_danger_level(environment.get_moles(gas_id) * partial_pressure)
 		))
 


### PR DESCRIPTION


# Document the changes in your pull request
Add Antinob to airalarm contaminated filter mode
Change draught vent pressure limit to 101kpa

# Why is this good for the game?
draught currently can make room overpressure

# Testing
works

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Add Antinob to airalarm contaminated filter mode
tweak: Change draught vent pressure limit to 101kpa
/:cl:
