### PR TITLE
Small condiment number tweak (making the packets full because NT got sued) + Condiment typo

### DIFF
--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -392,25 +392,25 @@
 /obj/item/reagent_containers/food/condiment/pack/astrotame
 	name = "astrotame pack"
 	originalname = "astrotame"
-	list_reagents = list(/datum/reagent/consumable/astrotame = 5)
+	list_reagents = list(/datum/reagent/consumable/astrotame = 10)
 
 /obj/item/reagent_containers/food/condiment/pack/bbqsauce
 	name = "bbq sauce pack"
 	originalname = "bbq sauce"
-	list_reagents = list(/datum/reagent/consumable/bbqsauce = 5)
+	list_reagents = list(/datum/reagent/consumable/bbqsauce = 10)
 
 /obj/item/reagent_containers/food/condiment/pack/sugar
 	name = "sugar pack"
 	originalname = "sugar"
-	list_reagents = list(/datum/reagent/consumable/sugar = 5)
+	list_reagents = list(/datum/reagent/consumable/sugar = 10)
 
 /obj/item/reagent_containers/food/condiment/pack/creamer
 	name = "creamer" /// dont laugh you child
 	originalname = "cream"
-	list_reagents = list(/datum/reagent/consumable/cream = 5)
+	list_reagents = list(/datum/reagent/consumable/cream = 10)
 
 /obj/item/reagent_containers/food/condiment/pack/chocolate
 	name = "creamer"
 	originalname = "cream"
-	list_reagents = list(/datum/reagent/consumable/chocolate = 5)
+	list_reagents = list(/datum/reagent/consumable/chocolate = 10)
 

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -410,7 +410,7 @@
 	list_reagents = list(/datum/reagent/consumable/cream = 10)
 
 /obj/item/reagent_containers/food/condiment/pack/chocolate
-	name = "creamer"
-	originalname = "cream"
+	name = "chocolate"
+	originalname = "chocolate"
 	list_reagents = list(/datum/reagent/consumable/chocolate = 10)
 


### PR DESCRIPTION
# Document the changes in your pull request

We live in the future where we should be "greener" why is some of the packets filled with 5u's but others with 10u's? Why not just fill them all to the max and stop making everyone litter plastic packets everywhere? 

Lore wise- Space Environmentalists have successfully sued NT (or did they???) for their lack of care on polluting and have been hit with a massive fine. NT have now cut down on their excessive plastic packaging......

Long story short: I got no idea why some condiments have the max volume in them and others have half which makes using the coffeepot an actual prison sentence because I have to combine two packets to make one fucking coffee and when I eject the packets from the machine they come out in 5u's which makes more clutter.

All I've done is put all the condiment packets that are at 5u's to their max volume with is 10u which will sort it out.

Just noticed as well, apparently chocolate packets are also creamer. Genius

# Why is this good for the game?

Means people can actually use the coffeepot without making a mountain of non-biodegradable plastic

# Testing

Numbers change = no testing

# Changelog

:cl: 

tweak: Astrotame, bbq, sugar, cream & chocolate are now 10u's instead of 5.
tweak: Chocolate packets are now correctly called chocolate packets instead of Creamer....

/:cl:
