### PR TITLE
FIx preset programs arent installed in pda/phone

### DIFF
--- a/code/modules/modular_computers/computers/item/pda/pda_presets.dm
+++ b/code/modules/modular_computers/computers/item/pda/pda_presets.dm
@@ -7,6 +7,9 @@
 								/obj/item/computer_hardware/printer/mini
 								)
 
+	starting_files = list(	new /datum/computer_file/program/budgetorders,
+							new /datum/computer_file/program/bounty_board)
+
 // This is literally the worst possible cheap tablet
 /obj/item/modular_computer/tablet/pda/preset/basic
 	desc = "A standard issue PDA often given to station personnel."

--- a/code/modules/modular_computers/computers/item/phone/phone_presets.dm
+++ b/code/modules/modular_computers/computers/item/phone/phone_presets.dm
@@ -13,14 +13,14 @@
 
 // Alternative version, an average one, for higher ranked positions mostly
 /obj/item/modular_computer/tablet/phone/preset/advanced
-	starting_components = list( /obj/item/computer_hardware/processor_unit/small,
+	starting_components = list(	/obj/item/computer_hardware/processor_unit/small,
 								/obj/item/stock_parts/cell/computer,
 								/obj/item/computer_hardware/hard_drive/small/pda,
 								/obj/item/computer_hardware/network_card,
 								/obj/item/computer_hardware/card_slot)
 
 /obj/item/modular_computer/tablet/phone/preset/cargo
-	starting_components = list( /obj/item/computer_hardware/processor_unit/small,
+	starting_components = list(	/obj/item/computer_hardware/processor_unit/small,
 								/obj/item/stock_parts/cell/computer,
 								/obj/item/computer_hardware/hard_drive/small/pda,
 								/obj/item/computer_hardware/network_card,
@@ -28,7 +28,7 @@
 								/obj/item/computer_hardware/printer/mini)
 
 /obj/item/modular_computer/tablet/phone/preset/advanced/atmos
-	starting_components = list( /obj/item/computer_hardware/processor_unit/small,
+	starting_components = list(	/obj/item/computer_hardware/processor_unit/small,
 								/obj/item/stock_parts/cell/computer,
 								/obj/item/computer_hardware/hard_drive/small/pda,
 								/obj/item/computer_hardware/network_card,
@@ -36,7 +36,7 @@
 								/obj/item/computer_hardware/sensorpackage)
 
 /obj/item/modular_computer/tablet/phone/preset/advanced/command
-	starting_components = list( /obj/item/computer_hardware/processor_unit/small,
+	starting_components = list(	/obj/item/computer_hardware/processor_unit/small,
 								/obj/item/stock_parts/cell/computer,
 								/obj/item/computer_hardware/hard_drive/small/pda,
 								/obj/item/computer_hardware/network_card,
@@ -71,7 +71,7 @@
 	finish_color = "red"
 
 /obj/item/modular_computer/tablet/phone/preset/advanced/command/ce
-	starting_components = list( /obj/item/computer_hardware/processor_unit/small,
+	starting_components = list(	/obj/item/computer_hardware/processor_unit/small,
 								/obj/item/stock_parts/cell/computer,
 								/obj/item/computer_hardware/hard_drive/small/pda,
 								/obj/item/computer_hardware/network_card,

--- a/code/modules/modular_computers/computers/item/phone/phone_presets.dm
+++ b/code/modules/modular_computers/computers/item/phone/phone_presets.dm
@@ -1,4 +1,8 @@
 // This is literally the worst possible cheap phone
+/obj/item/modular_computer/tablet/phone/preset
+	starting_files = list(	new /datum/computer_file/program/budgetorders,
+							new /datum/computer_file/program/bounty_board)
+
 /obj/item/modular_computer/tablet/phone/preset/cheap
 	desc = "A low-end tablet often seen among low ranked station personnel."
 	starting_components = list( /obj/item/computer_hardware/processor_unit/small,
@@ -32,8 +36,6 @@
 								/obj/item/computer_hardware/sensorpackage)
 
 /obj/item/modular_computer/tablet/phone/preset/advanced/command
-	starting_files = list(	new /datum/computer_file/program/budgetorders,
-							new /datum/computer_file/program/card_mod)
 	starting_components = list( /obj/item/computer_hardware/processor_unit/small,
 								/obj/item/stock_parts/cell/computer,
 								/obj/item/computer_hardware/hard_drive/small/pda,
@@ -41,6 +43,12 @@
 								/obj/item/computer_hardware/card_slot,
 								/obj/item/computer_hardware/card_slot/secondary,
 								/obj/item/computer_hardware/printer/mini)
+
+/obj/item/modular_computer/tablet/phone/preset/advanced/command/Initialize(mapload)
+	starting_files |= list(
+		new /datum/computer_file/program/card_mod
+	)	
+	. = ..()
 
 /obj/item/modular_computer/tablet/phone/preset/advanced/command/cap
 	finish_color = "yellow"
@@ -51,10 +59,13 @@
 	RegisterSignal(src, COMSIG_TABLET_CHECK_DETONATE, PROC_REF(pda_no_detonate))
 
 /obj/item/modular_computer/tablet/phone/preset/advanced/command/hop
-	starting_files = list(	new /datum/computer_file/program/budgetorders,
-							new /datum/computer_file/program/card_mod,
-							new /datum/computer_file/program/cargobounty)
 	finish_color = "brown"
+
+/obj/item/modular_computer/tablet/phone/preset/advanced/command/hop/Initialize(mapload)
+	starting_files |= list(
+		new /datum/computer_file/program/cargobounty
+	)	
+	. = ..()
 
 /obj/item/modular_computer/tablet/phone/preset/advanced/command/hos
 	finish_color = "red"
@@ -67,24 +78,26 @@
 								/obj/item/computer_hardware/card_slot,
 								/obj/item/computer_hardware/card_slot/secondary,
 								/obj/item/computer_hardware/sensorpackage)
+	finish_color = "orange"
 
-	starting_files = list(	new /datum/computer_file/program/budgetorders,
-							new /datum/computer_file/program/card_mod,
-							new /datum/computer_file/program/alarm_monitor,
+/obj/item/modular_computer/tablet/phone/preset/advanced/command/ce/Initialize(mapload)
+	starting_files |= list(	new /datum/computer_file/program/alarm_monitor,
 							new /datum/computer_file/program/supermatter_monitor,
 							new /datum/computer_file/program/nuclear_monitor,
 							new /datum/computer_file/program/energy_harvester_control)
-	finish_color = "orange"
+	. = ..()
 
 /obj/item/modular_computer/tablet/phone/preset/advanced/command/rd
-	starting_files = list(	new /datum/computer_file/program/budgetorders,
-							new /datum/computer_file/program/card_mod,
-							new /datum/computer_file/program/robocontrol)
 	finish_color = "purple"
 	pen_type = /obj/item/pen/fountain
 
+/obj/item/modular_computer/tablet/phone/preset/advanced/command/rd/Initialize(mapload)
+	starting_files |= list(	new /datum/computer_file/program/robocontrol)
+	. = ..()
+
 /obj/item/modular_computer/tablet/phone/preset/advanced/command/cmo
-	starting_files = list(	new /datum/computer_file/program/budgetorders,
-							new /datum/computer_file/program/card_mod,
-							new /datum/computer_file/program/crew_monitor)
 	finish_color = "white"
+
+/obj/item/modular_computer/tablet/phone/preset/advanced/command/cmo/Initialize(mapload)
+	starting_files |= list(	new /datum/computer_file/program/crew_monitor)
+	. = ..()

--- a/code/modules/modular_computers/hardware/hard_drive.dm
+++ b/code/modules/modular_computers/hardware/hard_drive.dm
@@ -221,8 +221,6 @@
 	..()
 	store_file(new/datum/computer_file/program/themeify(src))
 	store_file(new/datum/computer_file/program/pdamessager(src))
-	store_file(new/datum/computer_file/program/budgetorders(src))
-	store_file(new/datum/computer_file/program/bounty_board(src))
 
 /// For tablets given to nuke ops
 /obj/item/computer_hardware/hard_drive/small/nukeops


### PR DESCRIPTION

# Document the changes in your pull request
FIx preset programs arent installed in pda/phone


# Testing
works
![image](https://github.com/yogstation13/Yogstation/assets/89688125/5a60d1be-5c54-4e53-a27a-44229441bbc1)



# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

bugfix: FIx preset programs arent installed in pda/phone
/:cl:
