### PR TITLE
Cautery cig lighting

### DIFF
--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -91,6 +91,9 @@
 	if(!attempt_initiate_surgery(src, M, user))
 		..()
 
+/obj/item/cautery/ignition_effect(atom/A, mob/living/user)
+	. = span_danger("[user] carefully lights their [A.name] with [src].")
+
 /obj/item/cautery/augment
 	name = "cautery"
 	desc = "A heated element that cauterizes wounds."

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -89,16 +89,10 @@
 
 /obj/item/cautery/attack(mob/living/M, mob/user)
 	if(!attempt_initiate_surgery(src, M, user))
-	var/obj/item/clothing/mask/cigarette/cig = help_light_cig(M)
-		if(cig && M == user)
-			if(cig.lit)
-				to_chat(user, span_notice("[cig] is already lit."))
-				return
-			else
-				cig.light(span_notice("[user] carefully lights their [cig] with [src]."))
-				playsound(src, 'sound/items/lighter/light.ogg', 50, 2)
-				return
 		..()
+
+/obj/item/cautery/ignition_effect(atom/A, mob/living/user)
+	. = span_danger("[user] carefully lights their [A.name] with [src].")
 
 /obj/item/cautery/augment
 	name = "cautery"

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -89,6 +89,14 @@
 
 /obj/item/cautery/attack(mob/living/M, mob/user)
 	if(!attempt_initiate_surgery(src, M, user))
+		if(cig && M == user)
+			if(cig.lit)
+				to_chat(user, span_notice("[cig] is already lit."))
+				return
+			else
+				cig.light(span_notice("[user] carefully lights their [cig] with [src]."))
+				playsound(src, 'sound/items/lighter/light.ogg', 50, 2)
+				return
 		..()
 
 /obj/item/cautery/augment

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -89,6 +89,7 @@
 
 /obj/item/cautery/attack(mob/living/M, mob/user)
 	if(!attempt_initiate_surgery(src, M, user))
+	var/obj/item/clothing/mask/cigarette/cig = help_light_cig(M)
 		if(cig && M == user)
 			if(cig.lit)
 				to_chat(user, span_notice("[cig] is already lit."))

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -91,9 +91,6 @@
 	if(!attempt_initiate_surgery(src, M, user))
 		..()
 
-/obj/item/cautery/ignition_effect(atom/A, mob/living/user)
-	. = span_danger("[user] carefully lights their [A.name] with [src].")
-
 /obj/item/cautery/augment
 	name = "cautery"
 	desc = "A heated element that cauterizes wounds."


### PR DESCRIPTION
Adds the necessary 2 lines of text in modules\surgery\tools.

Enables the lighting of cigarettes with a cautery. Something simple that seemed odd you were unable to do, given how cauteries work. Should have no particular effect on balance ect.

Tested on local server with multiple cautery and cig types, did not seem to interfere with surgery or attacking.



# Wiki Documentation

Nil

# Changelog

:cl:  
tweak: Adds an ignition_effect to the cautery.
/:cl:
