### PR TITLE
Airalarm draught mode now set scrubber range from normal to expanded

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -583,7 +583,7 @@
 			for(var/device_id in A.air_scrub_names)
 				send_signal(device_id, list(
 					"power" = 1,
-					"widenet" = 0,
+					"widenet" = 1,
 					"scrubbing" = 0
 				), signal_source)
 			for(var/device_id in A.air_vent_names)


### PR DESCRIPTION

# Document the changes in your pull request
Airalarm draught mode now set scrubber range from normal to expanded

# Why is this good for the game?
make it faster replacing gas

# Testing
![crate](https://github.com/yogstation13/Yogstation/assets/89688125/0a151424-37ff-4aa3-8116-b8c6c7673a65)





# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: Airalarm draught mode now set scrubber range from normal to expanded
/:cl:
