### PR TITLE
Modifies alien embryo to care about the host

### DIFF
--- a/code/game/objects/structures/beds_chairs/alien_nest.dm
+++ b/code/game/objects/structures/beds_chairs/alien_nest.dm
@@ -34,7 +34,7 @@
 					span_warning("[M.name] struggles to break free from the gelatinous resin!"),\
 					span_notice("You struggle to break free from the gelatinous resin... (Stay still for two minutes.)"),\
 					span_italics("You hear squelching..."))
-				if(!do_after(M, 2 MINUTES, src))
+				if(!do_after(M, 15 SECONDS, src))
 					if(M && M.buckled)
 						to_chat(M, span_warning("You fail to unbuckle yourself!"))
 					return
@@ -65,6 +65,8 @@
 			"[user.name] secretes a thick vile goo, securing [M.name] into [src]!",\
 			span_danger("[user.name] drenches you in a foul-smelling resin, trapping you in [src]!"),\
 			span_italics("You hear squelching..."))
+		var/obj/item/restraints/handcuffs/xeno/cuffs = new(M)
+		cuffs.apply_cuffs(M, user)
 
 /obj/structure/bed/nest/post_buckle_mob(mob/living/M)
 	M.pixel_y = 0
@@ -90,3 +92,9 @@
 		return attack_hand(user)
 	else
 		return ..()
+
+/obj/item/restraints/handcuffs/xeno
+	icon = 'icons/obj/mining.dmi'
+	icon_state = "sinewcuff"
+	item_flags = DROPDEL
+	color = COLOR_MAGENTA

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -109,7 +109,7 @@ Des: Gives the client of the alien an image on each infected mob.
 			if(HAS_TRAIT(L, TRAIT_XENO_HOST))
 				var/obj/item/organ/body_egg/alien_embryo/A = L.getorgan(/obj/item/organ/body_egg/alien_embryo)
 				if(A)
-					var/I = image('icons/mob/alien.dmi', loc = L, icon_state = "infected[A.stage]")
+					var/I = image('icons/mob/alien.dmi', loc = L, icon_state = "infected[A.current_stage]")
 					client.images += I
 	return
 

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -6,8 +6,8 @@
 	icon_state = "larva0_dead"
 	/// How long it has been growing, increases by 2 every 2 seconds based on the state of the host
 	var/growth_progress = 0
-	/// At what point can it burst (should be roughly 4 minutes)
-	var/burst_threshold = 240
+	/// At what point can it burst
+	var/burst_threshold = 270
 	/// what "stage" we are at (used for image handling)
 	var/current_stage = 0
 	/// Are we in the process of bursting out of the poor sucker who's the xeno mom?
@@ -32,7 +32,8 @@
 	return S
 
 /obj/item/organ/body_egg/alien_embryo/on_life()
-	growth_progress ++ //doesn't progress if the host is dead
+	if(owner.buckling && istype(owner.buckling, /obj/structure/bed/nest))
+		growth_progress += 2 //doesn't get the extra progress if the host is either dead or not buckled to an alien bed
 	switch(current_stage)
 		if(3, 4)
 			if(prob(2))

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -4,20 +4,22 @@
 	name = "alien embryo"
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "larva0_dead"
-	///What stage of growth the embryo is at. Developed embryos give the host symptoms suggesting that an embryo is inside them.
-	var/stage = 0
-	/// Are we bursting out of the poor sucker who's the xeno mom?
+	/// How long it has been growing, increases by 2 every 2 seconds based on the state of the host
+	var/growth_progress = 0
+	/// At what point can it burst (should be roughly 4 minutes)
+	var/burst_threshold = 240
+	/// what "stage" we are at (used for image handling)
+	var/current_stage = 0
+	/// Are we in the process of bursting out of the poor sucker who's the xeno mom?
 	var/bursting = FALSE
-	/// How long does it take to advance one stage? Growth time * 5 = how long till we make a Larva!
-	var/growth_time = 60 SECONDS
 
 /obj/item/organ/body_egg/alien_embryo/Initialize(mapload)
 	. = ..()
-	advance_embryo_stage()
+	RefreshInfectionImage()
 
 /obj/item/organ/body_egg/alien_embryo/on_find(mob/living/finder)
 	..()
-	if(stage < 5)
+	if(current_stage < 5)
 		to_chat(finder, span_notice("It's small and weak, barely the size of a foetus."))
 	else
 		to_chat(finder, "It's grown quite large, and writhes slightly as you look at it.")
@@ -30,7 +32,8 @@
 	return S
 
 /obj/item/organ/body_egg/alien_embryo/on_life()
-	switch(stage)
+	growth_progress ++ //doesn't progress if the host is dead
+	switch(current_stage)
 		if(3, 4)
 			if(prob(2))
 				owner.emote("sneeze")
@@ -57,17 +60,15 @@
 			to_chat(owner, span_danger("You feel something tearing its way out of your stomach..."))
 			owner.adjustToxLoss(10)
 
-/// Controls Xenomorph Embryo growth. If embryo is fully grown (or overgrown), stop the proc. If not, increase the stage by one and if it's not fully grown (stage 6), add a timer to do this proc again after however long the growth time variable is.
-/obj/item/organ/body_egg/alien_embryo/proc/advance_embryo_stage()
-	if(stage >= 6)
-		return
-	if(++stage < 6)
-		INVOKE_ASYNC(src, PROC_REF(RefreshInfectionImage))
-		addtimer(CALLBACK(src, PROC_REF(advance_embryo_stage)), growth_time)
-
-
 /obj/item/organ/body_egg/alien_embryo/egg_process()
-	if(stage == 6 && prob(50))
+	growth_progress ++ //continues to progress even if the host is dead
+
+	var/stage = clamp(round((growth_progress / burst_threshold) * 6), 0, 5)
+	if(stage != current_stage) //if we've gone through a progress threshold, update the icon
+		current_stage = stage
+		RefreshInfectionImage()
+
+	if(growth_progress >= burst_threshold && prob(50))
 		for(var/datum/surgery/S in owner.surgeries)
 			if(S.location == BODY_ZONE_CHEST && istype(S.get_surgery_step(), /datum/surgery_step/manipulate_organs))
 				AttemptGrow(0)
@@ -88,8 +89,10 @@
 
 	if(!candidates.len || !owner)
 		bursting = FALSE
-		stage = 5	// If no ghosts sign up for the Larva, let's regress our growth by one minute, we will try again!
-		addtimer(CALLBACK(src, PROC_REF(advance_embryo_stage)), growth_time)
+		// If no ghosts sign up for the Larva, let's regress our growth by twenty percent, we will try again!
+		growth_progress = max(growth_progress - (burst_threshold*0.2), 0)
+		current_stage = clamp(round((growth_progress / burst_threshold) * 6), 0, 5)
+		RefreshInfectionImage()
 		return
 
 	var/mob/dead/observer/ghost = pick(candidates)
@@ -135,7 +138,7 @@ Des: Adds the infection image to all aliens for this embryo
 /obj/item/organ/body_egg/alien_embryo/AddInfectionImages()
 	for(var/mob/living/carbon/alien/alien in GLOB.player_list)
 		if(alien.client)
-			var/I = image('icons/mob/alien.dmi', loc = owner, icon_state = "infected[stage]")
+			var/I = image('icons/mob/alien.dmi', loc = owner, icon_state = "infected[current_stage]")
 			alien.client.images += I
 
 /*----------------------------------------

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -4,7 +4,7 @@
 	name = "alien embryo"
 	icon = 'icons/mob/alien.dmi'
 	icon_state = "larva0_dead"
-	/// How long it has been growing, increases by 2 every 2 seconds based on the state of the host
+	/// How long it has been growing, increases by up to 3 every 2 seconds based on the state of the host
 	var/growth_progress = 0
 	/// At what point can it burst
 	var/burst_threshold = 270


### PR DESCRIPTION
Now it cares about life ticks

# Why is this good for the game?
Gives xenos a reason to keep bodies alive without forcing them to
stopping life ticks will greatly slow down progress, giving medical a bit of extra time if it's cutting it close
If xenos space maints to make it significantly easier to defend, they'll hatch slower, if they don't, they'll hatch faster

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/4f01e3dc-d9d1-4107-a49b-dbc82ad0da97)

:cl:  
tweak: xeno embryos now burst significantly faster if the host is alive and buckled to a xeno bed
tweak: xeno embryos now burst significantly slower if the host is dead or not buckled to a xeno bed
tweak: xeno beds now handcuff the person buckled to it
tweak: xeno beds are significantly faster to unbuckle from (if not handcuffed)
/:cl:
