### PR TITLE
Drink Mood event tweaks (Mood change + Timeout increase) & Allies cocktail mood is less cringe text

### DIFF
--- a/code/datums/mood_events/drink_events.dm
+++ b/code/datums/mood_events/drink_events.dm
@@ -4,22 +4,22 @@
 
 /datum/mood_event/quality_nice
 	description = "<span class='nicegreen'>That drink wasn't bad at all.</span>\n"
-	mood_change = 10
+	mood_change = 5
 	timeout = 5 MINUTES
 
 /datum/mood_event/quality_good
 	description = "<span class='nicegreen'>That drink was pretty good.</span>\n"
-	mood_change = 20
+	mood_change = 10
 	timeout = 5 MINUTES
 
 /datum/mood_event/quality_verygood
 	description = "<span class='nicegreen'>That drink was great!</span>\n"
-	mood_change = 30
+	mood_change = 15
 	timeout = 5 MINUTES
 
 /datum/mood_event/quality_fantastic
 	description = "<span class='nicegreen'>That drink was amazing!</span>\n"
-	mood_change = 40
+	mood_change = 20
 	timeout = 10 MINUTES
 
 /datum/mood_event/amazingtaste

--- a/code/datums/mood_events/drink_events.dm
+++ b/code/datums/mood_events/drink_events.dm
@@ -4,23 +4,23 @@
 
 /datum/mood_event/quality_nice
 	description = "<span class='nicegreen'>That drink wasn't bad at all.</span>\n"
-	mood_change = 1
-	timeout = 2 MINUTES
+	mood_change = 10
+	timeout = 5 MINUTES
 
 /datum/mood_event/quality_good
 	description = "<span class='nicegreen'>That drink was pretty good.</span>\n"
-	mood_change = 2
-	timeout = 2 MINUTES
+	mood_change = 20
+	timeout = 5 MINUTES
 
 /datum/mood_event/quality_verygood
 	description = "<span class='nicegreen'>That drink was great!</span>\n"
-	mood_change = 3
-	timeout = 2 MINUTES
+	mood_change = 30
+	timeout = 5 MINUTES
 
 /datum/mood_event/quality_fantastic
 	description = "<span class='nicegreen'>That drink was amazing!</span>\n"
-	mood_change = 4
-	timeout = 2 MINUTES
+	mood_change = 40
+	timeout = 10 MINUTES
 
 /datum/mood_event/amazingtaste
 	description = "<span class='nicegreen'>Amazing taste!</span>\n"

--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -1,5 +1,5 @@
 /datum/mood_event/ally_power
-	description= "<span class='nicegreen'>There are Allies everywhere.</span>\n"
+	description= "<span class='nicegreen'>You feel at ease, from being surrounded by your friends.</span>\n"
 	mood_change = 1
 	timeout = 2 MINUTES
 


### PR DESCRIPTION
# Document the changes in your pull request

With mood now being enabled, I thought I would tweak the timeout numbers and up the mood change cause drinking is mediocre whilst eating gives you insane stacks. It is as following:

Stats for drinks:
Nice quality: Mood increased to 5, Timeout is now 5m
Good quality: Mood increased to 10, Timeout is now 5m
Very good quality: Mood increased to 15, Timeout is now 5m
Fantastic quality: Mood increased to 20, Timeout is now 10m

I also rewrote the line for Allies cocktail mood trigger which is now "You feel at ease, from being surrounded by your friends" cause the previous I wrote actually makes me look inept.


# Why is this good for the game?
Makes drinking actually last long like most other things and gives people a reason to drink more. As well as the type of drink gives a bigger impact of mood change than the small number it previously did. With fantastic drinks obviously being the best which there are only a handful around.

# Testing

Who cares about mood?

# Changelog

:cl:  

tweak: Nice, Good, Very good and Fantastic quality drinks have their mood changes increased, and their timeouts increased
tweak: Allies cocktail mood flavour text is less cringe

/:cl:
