### PR TITLE
Tidies and Adjusts Cyborg Upgrade Tech Nodes

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -346,7 +346,7 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 500)
 
 /datum/techweb_node/cyborg_upgrades_engineering_adv
-	id = "cyborg_upgrades_engineering"
+	id = "cyborg_upgrades_engineering_adv"
 	display_name = "Cyborg Upgrades: Advanced Engineering"
 	description = "Advanced upgrades that can only be used on cyborgs with a engineering-related module."
 	prereq_ids = list("cyborg_upgrades_engineering", "practical_bluespace", "exp_tools")

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -335,20 +335,28 @@
 	description = "Upgrades that can be used on all cyborg module types that increases their general utility."
 	prereq_ids = list("engineering", "adv_robotics")
 	design_ids = list("borg_upgrade_thrusters", "borg_upgrade_language", "borg_upgrade_expand", "borg_upgrade_selfrepair")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1500)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 
 /datum/techweb_node/cyborg_upgrades_engineering
 	id = "cyborg_upgrades_engineering"
 	display_name = "Cyborg Upgrades: Engineering"
 	description = "Upgrades that can only be used on cyborgs with a engineering-related module."
-	prereq_ids = list("cyborg_upgrades_utility", "practical_bluespace", "exp_tools")
+	prereq_ids = list("cyborg_upgrades_utility")
+	design_ids = list("borg_upgrade_rped")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 500)
+
+/datum/techweb_node/cyborg_upgrades_engineering_adv
+	id = "cyborg_upgrades_engineering"
+	display_name = "Cyborg Upgrades: Advanced Engineering"
+	description = "Advanced upgrades that can only be used on cyborgs with a engineering-related module."
+	prereq_ids = list("cyborg_upgrades_engineering", "practical_bluespace", "exp_tools")
 	design_ids = list("borg_upgrade_engi_advancedtools", "borg_upgrade_holofan", "borg_upgrade_brped")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
-/datum/techweb_node/cyborg_upgrades_engineering_adv
-	id = "cyborg_upgrades_engineering_adv" // This is its own seperate node solely ONLY because it wasn't obvious on how to find this upgrade.
-	display_name = "Cyborg Upgrades: Advanced Engineering"
-	description = "Upgrades that can only be used on cyborgs with a engineering-related module."
+/datum/techweb_node/cyborg_upgrades_nvg
+	id = "cyborg_upgrades_nvg" // This is its own seperate node solely ONLY because it wasn't obvious on how to find this upgrade.
+	display_name = "Cyborg Upgrades: NVG"
+	description = "Upgrade that swaps a cyborg's mesons to nightvision mesons."
 	prereq_ids = list("cyborg_upgrades_engineering", "NVGtech")
 	design_ids = list("borg_upgrade_nv_mesons")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 500)
@@ -585,7 +593,7 @@
 	display_name = "Advanced Mining Technology"
 	description = "Efficiency Level 127"	//dumb mc references
 	prereq_ids = list("basic_mining", "adv_engi", "adv_power", "adv_plasma")
-	design_ids = list("drill_diamond", "jackhammer", "hypermod", "plasmacutter_adv","miningcharge")
+	design_ids = list("drill_diamond", "jackhammer", "hypermod", "plasmacutter_adv", "miningcharge")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /datum/techweb_node/magmite_mining

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -335,7 +335,7 @@
 	description = "Upgrades that can be used on all cyborg module types that increases their general utility."
 	prereq_ids = list("engineering", "adv_robotics")
 	design_ids = list("borg_upgrade_thrusters", "borg_upgrade_language", "borg_upgrade_expand", "borg_upgrade_selfrepair")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1500)
 
 /datum/techweb_node/cyborg_upgrades_engineering
 	id = "cyborg_upgrades_engineering"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -312,7 +312,6 @@
 	display_name = "Advanced Robotics Research"
 	description = "It can even do the dishes!"
 	prereq_ids = list("robotics")
-	design_ids = list("borg_upgrade_diamonddrill", "borg_upgrade_trashofholding", "borg_upgrade_advancedmop")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /datum/techweb_node/neural_programming
@@ -330,37 +329,61 @@
 	design_ids = list("mmi_posi")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
-/datum/techweb_node/cyborg_upg_util
-	id = "cyborg_upg_util"
+/datum/techweb_node/cyborg_upgrades_utility
+	id = "cyborg_upgrades_utility"
 	display_name = "Cyborg Upgrades: Utility"
-	description = "Utility upgrades for cyborgs."
-	prereq_ids = list("engineering")
-	design_ids = list("borg_upgrade_holding", "borg_upgrade_lavaproof", "borg_upgrade_thrusters", "borg_upgrade_selfrepair", "borg_upgrade_expand", "borg_upgrade_rped", "borg_upgrade_language", "borg_upgrade_broomer", "borg_upgrade_snacks", "borg_upgrade_gemsatchel", "borg_upgrade_condiment_synthesizer", "borg_upgrade_service_cookbook", "borg_upgrade_janitor_autocleaner")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
+	description = "Upgrades that can be used on all cyborg module types that increases their general utility."
+	prereq_ids = list("engineering", "adv_robotics")
+	design_ids = list("borg_upgrade_thrusters", "borg_upgrade_language", "borg_upgrade_expand", "borg_upgrade_selfrepair")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1500)
 
-/datum/techweb_node/adv_cyborg_upg_util
-	id = "adv_cyborg_upg_util"
-	display_name = "Cyborg Upgrades: Advanced Utility"
-	description = "Advanced utility upgrades for cyborgs."
-	prereq_ids = list("cyborg_upg_util", "practical_bluespace", "exp_tools") // Experimental tools covers tools & holofan. Bluespace covers BRPED.
+/datum/techweb_node/cyborg_upgrades_engineering
+	id = "cyborg_upgrades_engineering"
+	display_name = "Cyborg Upgrades: Engineering"
+	description = "Upgrades that can only be used on cyborgs with a engineering-related module."
+	prereq_ids = list("cyborg_upgrades_utility", "practical_bluespace", "exp_tools")
 	design_ids = list("borg_upgrade_engi_advancedtools", "borg_upgrade_holofan", "borg_upgrade_brped")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
-/datum/techweb_node/cyborg_upg_med
-	id = "cyborg_upg_med"
+/datum/techweb_node/cyborg_upgrades_engineering_adv
+	id = "cyborg_upgrades_engineering_adv" // This is its own seperate node solely ONLY because it wasn't obvious on how to find this upgrade.
+	display_name = "Cyborg Upgrades: Advanced Engineering"
+	description = "Upgrades that can only be used on cyborgs with a engineering-related module."
+	prereq_ids = list("cyborg_upgrades_engineering", "NVGtech")
+	design_ids = list("borg_upgrade_nv_mesons")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 500)
+
+/datum/techweb_node/cyborg_upgrades_medical
+	id = "cyborg_upgrades_medical"
 	display_name = "Cyborg Upgrades: Medical"
-	description = "Medical upgrades for cyborgs."
-	prereq_ids = list("adv_biotech")
-	design_ids = list("borg_upgrade_defibrillator", "borg_upgrade_piercinghypospray", "borg_upgrade_expandedsynthesiser", "borg_upgrade_medigripper")
+	description = "Upgrades that focus on cyborgs with a medical-related module."
+	prereq_ids = list("cyborg_upgrades_utility", "adv_biotech")
+	design_ids = list("borg_upgrade_defibrillator", "borg_upgrade_expandedsynthesiser", "borg_upgrade_medigripper")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 
-/datum/techweb_node/cyborg_upg_surgkit
-	id = "cyborg_upg_surgkit"
-	display_name = "Cyborg Upgrade: Medical Advanced Medical Tools"
-	description = "Advanced Surgical Kit and Advanced Health Scanner upgrade design for medical cyborgs."
-	prereq_ids = list("cyborg_upg_med", "exp_tools")
-	design_ids = list("borg_upgrade_surgerykit", "borg_upgrade_analyzer")
+/datum/techweb_node/cyborg_upgrades_medical_adv
+	id = "cyborg_upgrades_medical_adv"
+	display_name = "Cyborg Upgrades: Advanced Medical"
+	description = "Advanced upgrades that focus on cyborgs with a medical-related module."
+	prereq_ids = list("cyborg_upgrades_medical", "exp_tools")
+	design_ids = list("borg_upgrade_piercinghypospray", "borg_upgrade_surgerykit", "borg_upgrade_analyzer")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
+
+/datum/techweb_node/cyborg_upgrades_mining
+	id = "cyborg_upgrades_mining"
+	display_name = "Cyborg Upgrades: Mining"
+	description = "Upgrades that focus on cyborgs with a mining-related module."
+	prereq_ids = list("cyborg_upgrades_utility", "adv_mining")
+	design_ids = list("borg_upgrade_diamonddrill", "borg_upgrade_plasmacutter", "borg_upgrade_holding", "borg_upgrade_gemsatchel", "borg_upgrade_lavaproof")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 500)
+
+/datum/techweb_node/cyborg_upgrades_service
+	id = "cyborg_upgrades_service"
+	display_name = "Cyborg Upgrades: Service"
+	description = "Upgrades that focus on cyborgs with a service-related module." // Janitor & "Service/Bartender".
+	prereq_ids = list("cyborg_upgrades_utility", "janitor")
+	design_ids = list("borg_upgrade_trashofholding", "borg_upgrade_advancedmop", "borg_upgrade_broomer", "borg_upgrade_janitor_autocleaner", "borg_upgrade_condiment_synthesizer", "borg_upgrade_service_cookbook", "borg_upgrade_snacks")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 500) // Roleplay discount.
 
 /datum/techweb_node/ai
 	id = "ai"
@@ -463,7 +486,7 @@
 	display_name = "Night Vision Technology"
 	description = "Allows seeing in the dark without actual light!"
 	prereq_ids = list("integrated_HUDs", "adv_engi", "emp_adv")
-	design_ids = list("health_hud_night", "security_hud_night", "diagnostic_hud_night", "night_visision_goggles", "nvgmesons", "nightscigoggles", "borg_upgrade_nv_mesons")
+	design_ids = list("health_hud_night", "security_hud_night", "diagnostic_hud_night", "night_visision_goggles", "nvgmesons", "nightscigoggles")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 
 ////////////////////////Medical////////////////////////
@@ -562,7 +585,7 @@
 	display_name = "Advanced Mining Technology"
 	description = "Efficiency Level 127"	//dumb mc references
 	prereq_ids = list("basic_mining", "adv_engi", "adv_power", "adv_plasma")
-	design_ids = list("drill_diamond", "jackhammer", "hypermod", "plasmacutter_adv", "borg_upgrade_plasmacutter","miningcharge")
+	design_ids = list("drill_diamond", "jackhammer", "hypermod", "plasmacutter_adv","miningcharge")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /datum/techweb_node/magmite_mining

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -382,7 +382,7 @@
 	display_name = "Cyborg Upgrades: Mining"
 	description = "Upgrades that focus on cyborgs with a mining-related module."
 	prereq_ids = list("cyborg_upgrades_utility", "adv_mining")
-	design_ids = list("borg_upgrade_diamonddrill", "borg_upgrade_plasmacutter", "borg_upgrade_holding", "borg_upgrade_gemsatchel", "borg_upgrade_lavaproof")
+	design_ids = list("borg_upgrade_lavaproof", "borg_upgrade_diamonddrill", "borg_upgrade_plasmacutter", "borg_upgrade_holding", "borg_upgrade_gemsatchel")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 500)
 
 /datum/techweb_node/cyborg_upgrades_service

--- a/code/modules/research/techweb/layout.dm
+++ b/code/modules/research/techweb/layout.dm
@@ -163,6 +163,10 @@
 	ui_x = 32
 	ui_y = 160
 
+/datum/techweb_node/cyborg_upgrades_nvg
+	ui_x = 96
+	ui_y = 160
+
 /datum/techweb_node/cyborg_upgrades_medical
 	ui_x = -32
 	ui_y = 224

--- a/code/modules/research/techweb/layout.dm
+++ b/code/modules/research/techweb/layout.dm
@@ -151,13 +151,33 @@
 	ui_x = 32
 	ui_y = -320
 
-/datum/techweb_node/cyborg_upg_util
+/datum/techweb_node/cyborg_upgrades_utility
 	ui_x = -96
 	ui_y = 160
 
-/datum/techweb_node/adv_cyborg_upg_util
+/datum/techweb_node/cyborg_upgrades_engineering
 	ui_x = -32
 	ui_y = 160
+
+/datum/techweb_node/cyborg_upgrades_engineering_adv
+	ui_x = 32
+	ui_y = 160
+
+/datum/techweb_node/cyborg_upgrades_medical
+	ui_x = -32
+	ui_y = 224
+
+/datum/techweb_node/cyborg_upgrades_medical_adv
+	ui_x = 32
+	ui_y = 224
+
+/datum/techweb_node/cyborg_upgrades_mining
+	ui_x = -32
+	ui_y = 288
+
+/datum/techweb_node/cyborg_upgrades_service
+	ui_x = -32
+	ui_y = 352
 
 /datum/techweb_node/basic_mining
 	ui_x = 96
@@ -230,10 +250,6 @@
 /datum/techweb_node/xenoorgan_biotech
 	ui_x = 256
 	ui_y = -64
-
-/datum/techweb_node/cyborg_upg_med
-	ui_x = 352
-	ui_y = -160
 
 /datum/techweb_node/cyber_organs
 	ui_x = 352
@@ -458,10 +474,6 @@
 /datum/techweb_node/shuttle_route_upgrade_hyper
 	ui_x = -224
 	ui_y = -736
-
-/datum/techweb_node/cyborg_upg_surgkit
-	ui_x = 416
-	ui_y = -160
 
 /datum/techweb_node/cyber_organs_upgraded
 	ui_x = 416


### PR DESCRIPTION
# Document the changes in your pull request
In sum, moves cyborg upgrades in the techweb, changes some prices, moves some designs, adds new tech nodes, and finds out that apparently you could of printed a trash bag of holding upgrade without the tech node that prints the human version of it.

Advanced Robotics Research
- No longer gives any designs: Janiborg Advanced Mop, Janiborg Trashbag of Holding, Minerborg Diamond Drill

Night Vision Technology
- No longer gives cyborg's upgrade for NVG.

Advanced Mining Technology
- No longer gives cyborg's upgrade for advanced plasma cutter.

Cyborg Upgrades: Utility
- Requires Advanced Robotics Research now.
- No longer gives module-specific designs: Mining Upgrades (3), Engineering Upgrades (1), Service/Bartender Upgrades (2), Janitor Upgrades (3), and Snack Dispenser.
- Price cut in half from 2,000 -> 1,500.

Cyborg Upgrades: Engineering (New)
- Requires Cyborg Upgrades: Utility.
- Only gives one design: RPED
- Price is 500.

Cyborg Upgrades: Advanced Engineering (Renamed)
- Now also requires Cyborg Upgrades: Engineering along with what it had previously.
- Price cut in half from 5,000 -> 2,500.

Cyborg Upgrades: NVG (New)
- Now also requires Cyborg Upgrades: Engineering along with NVG.
- Price is 500.

Cyborg Upgrades: Medical
- Now also requires Cyborg Upgrades: Utility along with what it had previously (Advanced Biotech).
- Removed design: Piercing Hypospray

Cyborg Upgrades: Advanced Medical
- Added design: Piercing Hypospray

Cyborg Upgrades: Mining (New)
- Requires Cyborg Upgrades: Utility and Advanced Mining Technology.
- Gives all mining cyborg upgrades (5) that was previously in Adv. Mining Tech., Adv. Robotics Research, and Cyborg Upgrades: Utility.
- Price is 500.

Cyborg Upgrades: Service (New)
- Requires Cyborg Upgrades: Utility and Advanced Sanitation Technology.
- Gives all service upgrades (2), janitor upgrades (4), and snack dispenser.
- Price is 500.

# Why is this good for the game?
It was very annoying to find tech nodes that had cyborg upgrades in it. So, just moved them all to one neat spot for people that use Normal View to click on. Also was a long time coming because it was all disorganized and like why could janiborgs get trashbag of holding upgrades printed before human janitors get their equivalent? That was fixed here.

# Testing
Works.
![image](https://github.com/yogstation13/Yogstation/assets/30399783/e13325fc-2311-4c81-a208-f827dc81cb65)

# Wiki Documentation
Lots of things to change in https://wiki.yogstation.net/wiki/Tech_Webs#Robotics.

# Changelog
:cl:  
rscadd: Four tech node dedicated for cyborgs upgrades: Night Vision, Engineering, Mining, and Service. Each costing 500 points.
tweak: Various cyborg upgrades have been moved to more relevant/dedicated technodes.
tweak: Most tech nodes that involve cyborg upgrades now require the "Advanced Robotics" tech node or a node that already has it as a prerequisite.
tweak: Most tech nodes that involve cyborg upgrades have now a better description that explains the purpose of the node.
tweak: "Cyborg Upgrades: Advanced Utility" tech node has been renamed to "Cyborg Upgrades: Advanced Engineering".
tweak: "Cyborg Upgrades: Advanced Engineering" tech node cost reduced to 2,500 from 5,000.
tweak: "Cyborg Upgrades: Utility" tech node cost reduced to 1,500 from 2,000.
tweak: "Cyborg Upgrades: Engineering" and "Cyborg Upgrades: Mining" tech node's icon has been changed to better visualize the node.
bugfix: Janiborg's trashbag of holding upgrade is properly locked behind Advanced Sanitation Technology.
/:cl:
