### PR TITLE
Shooting a Cyborg Snack Dispenser in zero gravity properly pushes you in the opposite direction

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -484,6 +484,7 @@
 			icecream.add_ice_cream("vanilla")
 			icecream.desc = "Eat the ice cream."
 		user.visible_message(span_notice("[src] launches a [snack.name] at [target]!"))
+		user.newtonian_move(get_dir(target, user)) // For no gravity.
 	else if(user.Adjacent(target) && is_allowed(target, user))
 		COOLDOWN_START(src, last_snack_disp, cooldown)
 		snack = new selected_snack(get_turf(target))


### PR DESCRIPTION
# Document the changes in your pull request
Shooting a cyborg snack dispenser while in a zero gravity environment correctly starts moving you in the opposite direction that you shot it.

# Testing
Shoot while floating in space. Moved in opposite direction. Works.

# Changelog
:cl:  
bugfix: Shooting a cyborg snack dispenser while in a zero gravity environment correctly starts moving you in the opposite direction that you shot it.
/:cl:
