### PR TITLE
Mediborg Gripper can hold more things

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -932,9 +932,15 @@
 	name = "medical gripper"
 	desc = "A simple grasping tool for interacting with various medical related items."
 	can_hold = list(
-		/obj/item/reagent_containers/glass/bottle, // Bottles & Vials
+		/obj/item/reagent_containers/medspray, // Without this, just syringe the content out and put it into a beaker to get around it.
+		/obj/item/reagent_containers/blood, // To insert blood bags into IV drips.
+		/obj/item/reagent_containers/food/snacks/lollipop, // Given that they have a snack dispenser, might as well.
+		// All chemistry specific concerns:
+		/obj/item/reagent_containers/glass/bottle,
 		/obj/item/reagent_containers/glass/beaker,
-		/obj/item/reagent_containers/blood // Blood Bags.
+		/obj/item/reagent_containers/pill,
+		/obj/item/reagent_containers/gummy,
+		/obj/item/storage/bag/chemistry // QOL for moving a billion pills into the chemfridge.
 	)
   
 /obj/item/borg/gripper/service

--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -938,7 +938,7 @@
 		// All chemistry specific concerns:
 		/obj/item/reagent_containers/glass/bottle,
 		/obj/item/reagent_containers/glass/beaker,
-		/obj/item/reagent_containers/pill,
+		/obj/item/reagent_containers/pill, // Includes patches... because they're are pills too?
 		/obj/item/reagent_containers/gummy,
 		/obj/item/storage/bag/chemistry // QOL for moving a billion pills into the chemfridge.
 	)


### PR DESCRIPTION
# Document the changes in your pull request
Allows mediborg's gripper to grab medsprays, gummies, pills, patches, chemistry bags, and lollipops.

# Why is this good for the game?
It is terribly annoying when you make a few 10u pills as a medical cyborg and realize "wow, I literally can't pick these up at all and I have to live with the fact that there is a bunch of pills ontop of the ChemMaster forever now." So, now they can pick them up and move somewhere more convenient aka the chemfridge. As for medsprays, it is just a simpler way of using them instead of having to syringing out the contents and putting it into a beaker, aka QOL.

# Testing
I can pick up every type I mentioned. Works.

# Changelog
:cl:  
tweak: Medical gripper can now hold medsprays, lollipops, pills, patches, gummies, and chemistry bags.
/:cl:
