### PR TITLE
Cyborg engineering gripper can now hold server rack and cpu

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -925,7 +925,9 @@
 		/obj/item/stock_parts,
 		/obj/item/tank/internals,
 		/obj/item/conveyor_switch_construct,
-		/obj/item/stack/conveyor
+		/obj/item/stack/conveyor,
+		/obj/item/server_rack,
+		/obj/item/ai_cpu,
 	)
 
 /obj/item/borg/gripper/medical


### PR DESCRIPTION


# Document the changes in your pull request
Cyborg engineering gripper can now hold server rack and cpu



# Why is this good for the game?
Allows AI to assist netmin/RD/CE upgrading or self upgrade if none available 

# Testing
Tested, was able to hold them



# Wiki Documentation
Cyborg engineering gripper can now hold server rack and cpu

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: Cyborg engineering gripper can now hold server rack and cpu
/:cl:
