### PR TITLE
Sinful Demon jaunt abilities

### DIFF
--- a/code/modules/antagonists/demon/demons.dm
+++ b/code/modules/antagonists/demon/demons.dm
@@ -27,6 +27,8 @@
 		/datum/action/cooldown/spell/touch/mend,
 		/datum/action/cooldown/spell/touch/torment,
 		/datum/action/cooldown/spell/conjure/cursed_item,
+		/datum/action/cooldown/spell/jaunt/ethereal_jaunt/sin,
+		/datum/action/cooldown/spell/jaunt/ethereal_jaunt/sin/wrath,
 		))
 
 	var/static/list/sinfuldemon_traits = list(
@@ -127,6 +129,9 @@
 			var/datum/action/cooldown/spell/shapeshift/demon/gluttony/fat_demon = new(owner.current)
 			fat_demon.Grant(owner.current)
 
+			var/datum/action/cooldown/spell/jaunt/ethereal_jaunt/sin/jaunt = new(owner.current)
+			jaunt.Grant(owner.current)
+
 			ADD_TRAIT(owner.current, TRAIT_AGEUSIA, SINFULDEMON_TRAIT) // nothing disgusts you
 			ADD_TRAIT(owner.current, TRAIT_EAT_MORE, SINFULDEMON_TRAIT) // 3x hunger rate
 			ADD_TRAIT(owner.current, TRAIT_BOTTOMLESS_STOMACH, SINFULDEMON_TRAIT) // nutrition is capped for infinite eating
@@ -142,6 +147,9 @@
 			var/datum/action/cooldown/spell/conjure/cursed_item/immortal_temptation = new(owner.current)
 			immortal_temptation.Grant(owner.current)
 
+			var/datum/action/cooldown/spell/jaunt/ethereal_jaunt/sin/jaunt = new(owner.current)
+			jaunt.Grant(owner.current)
+
 		if(SIN_WRATH)
 			var/datum/action/cooldown/spell/shapeshift/demon/wrath/wrath_demon = new(owner.current)
 			wrath_demon.Grant(owner.current)
@@ -151,6 +159,9 @@
 
 			var/datum/action/cooldown/spell/touch/torment/pain_hand = new(owner.current)
 			pain_hand.Grant(owner.current)
+
+			var/datum/action/cooldown/spell/jaunt/ethereal_jaunt/sin/wrath/jaunt = new(owner.current)
+			jaunt.Grant(owner.current)
 
 		if(SIN_ENVY)
 			var/datum/action/cooldown/spell/shapeshift/demon/demon_form = new(owner.current)
@@ -162,6 +173,9 @@
 			var/datum/action/cooldown/spell/touch/torment/pain_hand = new(owner.current)
 			pain_hand.Grant(owner.current)
 
+			var/datum/action/cooldown/spell/jaunt/ethereal_jaunt/sin/jaunt = new(owner.current)
+			jaunt.Grant(owner.current)
+
 		if(SIN_PRIDE)
 			var/datum/action/cooldown/spell/shapeshift/demon/demon_form = new(owner.current)
 			demon_form.Grant(owner.current)
@@ -171,6 +185,9 @@
 
 			var/datum/action/cooldown/spell/touch/mend/heal_hand = new(owner.current)
 			heal_hand.Grant(owner.current)
+
+			var/datum/action/cooldown/spell/jaunt/ethereal_jaunt/sin/jaunt = new(owner.current)
+			jaunt.Grant(owner.current)
 
 	return ..()
 

--- a/code/modules/antagonists/demon/general_powers.dm
+++ b/code/modules/antagonists/demon/general_powers.dm
@@ -120,3 +120,18 @@
 	victim.emote("scream")
 	to_chat(victim, span_warning("You feel an explosion of pain erupt in your mind!"))
 	return TRUE
+
+/datum/action/cooldown/spell/jaunt/ethereal_jaunt/sin
+	name = "Demonic Jaunt"
+	desc = "Briefly turn to cinder and ash, allowing you to freely pass through objects."
+	background_icon_state = "bg_demon"
+	overlay_icon_state = "bg_demon_border"
+	sound = 'sound/magic/fireball.ogg'
+	spell_requirements = NONE
+
+	cooldown_time = 50 SECONDS
+
+	jaunt_duration = 3 SECONDS
+	jaunt_out_time = 0.5 SECONDS
+	jaunt_in_type = /obj/effect/temp_visual/dir_setting/ash_shift
+	jaunt_out_type = /obj/effect/temp_visual/dir_setting/ash_shift/out

--- a/code/modules/antagonists/demon/sins/wrath.dm
+++ b/code/modules/antagonists/demon/sins/wrath.dm
@@ -45,3 +45,12 @@
 
 #undef WRATHFUL_FIRE_AMOUNT
 
+/datum/action/cooldown/spell/jaunt/ethereal_jaunt/sin/wrath
+	name = "Greater Demonic Jaunt"
+	desc = "Briefly turn to cinder and ash, allowing you to freely pass through objects. Lasts slightly shorter than normal, but is more easily used."
+
+	cooldown_time = 25 SECONDS
+
+	jaunt_duration = 2 SECONDS
+	jaunt_out_time = 0 SECONDS
+


### PR DESCRIPTION

# Document the changes in your pull request
Adds a weak form of jaunt for sinful demons. Jaunts them for 3 seconds with a 50 second cooldown. Wrath instead jaunts for 2 seconds with a 25 second cooldown.

# Why is this good for the game?
Sinful demons are pretty weak and have no escape abilities while also being considered PTEs. A weak form of jaunt will make them not be annoying to deal with while also having some form of escape.

# Testing
<!-- Describe what testing you did with this PR. Try to be thorough, especially if this is a larger project. -->

Hosted a server to ensure the spells were given upon being assigned the antag, and that they worked as intended.

# Spriting
Icon is just the standard jaunt icon.

# Wiki Documentation
Adds a weak form of jaunt for sinful demons. Jaunts them for 3 seconds with a 50 second cooldown. Wrath instead jaunts for 2 seconds with a 25 second cooldown.

# Changelog

:cl:  
rscadd: Adds jaunt abilities for sinful demons.
/:cl:
