### PR TITLE
Airalarm can now turn on/off vent space detection

### DIFF
--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -346,6 +346,7 @@
 					"excheck"	= info["checks"]&1,
 					"incheck"	= info["checks"]&2,
 					"direction"	= info["direction"],
+					"space_detection" = info["space_detection"],
 					"external"	= info["external"],
 					"internal"	= info["internal"],
 					"extdefault"= (info["external"] == ONE_ATMOSPHERE),
@@ -418,7 +419,7 @@
 			if(usr.has_unlimited_silicon_privilege && !wires.is_cut(WIRE_IDSCAN))
 				locked = !locked
 				. = TRUE
-		if("power", "toggle_filter", "widenet", "scrubbing", "direction")
+		if("power", "toggle_filter", "widenet", "scrubbing", "direction", "space_detection")
 			send_signal(device_id, list("[action]" = params["val"]), usr)
 			. = TRUE
 		if("excheck")

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -111,7 +111,7 @@
 		icon_state = "vent_in"
 
 /obj/machinery/atmospherics/components/unary/vent_pump/process_atmos()
-	if(!is_operational() || !isopenturf(loc))
+	if(!is_operational() || (!isopenturf(loc) && space_detection))
 		last_moles_added = 0
 		return
 	if(space_shutoff_ticks > 0)
@@ -313,6 +313,18 @@
 		pipe_vision_img = image(src, loc, layer = ABOVE_HUD_LAYER, dir = dir)
 		pipe_vision_img.plane = ABOVE_HUD_PLANE
 		investigate_log("was [welded ? "welded shut" : "unwelded"] by [key_name(user)]", INVESTIGATE_ATMOS)
+		add_fingerprint(user)
+	return TRUE
+
+/obj/machinery/atmospherics/components/unary/vent_pump/multitool_act(mob/living/user, obj/item/I)
+	if(do_after(user, 5))
+		if(space_detection)
+			to_chat(user, span_notice("You disable space detection."))
+			space_detection = FALSE
+		else
+			to_chat(user, span_notice("You enable space detection."))
+			space_detection = TRUE
+		investigate_log("space detection [space_detection ? "enabled" : "disabled"] by [key_name(user)]", INVESTIGATE_ATMOS)
 		add_fingerprint(user)
 	return TRUE
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -203,6 +203,7 @@
 		"checks" = pressure_checks,
 		"internal" = internal_pressure_bound,
 		"external" = external_pressure_bound,
+		"space_detection" = space_detection,
 		"sigtype" = "status",
 		"has_aac" = aac != null
 	))
@@ -261,6 +262,12 @@
 
 	if("direction" in signal.data)
 		pump_direction = text2num(signal.data["direction"])
+
+	if("space_detection" in signal.data)
+		space_detection = !space_detection
+		space_shutoff_ticks = 0
+		if(!space_detection)
+			investigate_log(" space detection was disabled by [key_name(user)]", INVESTIGATE_ATMOS)
 
 	if("set_internal_pressure" in signal.data)
 		var/old_pressure = internal_pressure_bound

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -264,7 +264,7 @@
 		pump_direction = text2num(signal.data["direction"])
 
 	if("space_detection" in signal.data)
-		space_detection = !space_detection
+		space_detection = text2num(signal.data["space_detection"])
 		space_shutoff_ticks = 0
 		if(!space_detection)
 			investigate_log(" space detection was disabled by [key_name(signal_sender)]", INVESTIGATE_ATMOS)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -323,17 +323,6 @@
 		add_fingerprint(user)
 	return TRUE
 
-/obj/machinery/atmospherics/components/unary/vent_pump/multitool_act(mob/living/user, obj/item/I)
-	if(space_detection)
-		to_chat(user, span_notice("You disable space detection."))
-		space_detection = FALSE
-	else
-		to_chat(user, span_notice("You enable space detection."))
-		space_detection = TRUE
-	investigate_log("space detection [space_detection ? "enabled" : "disabled"] by [key_name(user)]", INVESTIGATE_ATMOS)
-	add_fingerprint(user)
-	return TRUE
-
 /obj/machinery/atmospherics/components/unary/vent_pump/can_unwrench(mob/user)
 	. = ..()
 	if(. && on && is_operational())

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -267,7 +267,7 @@
 		space_detection = !space_detection
 		space_shutoff_ticks = 0
 		if(!space_detection)
-			investigate_log(" space detection was disabled by [key_name(user)]", INVESTIGATE_ATMOS)
+			investigate_log(" space detection was disabled by [key_name(signal_sender)]", INVESTIGATE_ATMOS)
 
 	if("set_internal_pressure" in signal.data)
 		var/old_pressure = internal_pressure_bound

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -317,15 +317,14 @@
 	return TRUE
 
 /obj/machinery/atmospherics/components/unary/vent_pump/multitool_act(mob/living/user, obj/item/I)
-	if(do_after(user, 5))
-		if(space_detection)
-			to_chat(user, span_notice("You disable space detection."))
-			space_detection = FALSE
-		else
-			to_chat(user, span_notice("You enable space detection."))
-			space_detection = TRUE
-		investigate_log("space detection [space_detection ? "enabled" : "disabled"] by [key_name(user)]", INVESTIGATE_ATMOS)
-		add_fingerprint(user)
+	if(space_detection)
+		to_chat(user, span_notice("You disable space detection."))
+		space_detection = FALSE
+	else
+		to_chat(user, span_notice("You enable space detection."))
+		space_detection = TRUE
+	investigate_log("space detection [space_detection ? "enabled" : "disabled"] by [key_name(user)]", INVESTIGATE_ATMOS)
+	add_fingerprint(user)
 	return TRUE
 
 /obj/machinery/atmospherics/components/unary/vent_pump/can_unwrench(mob/user)

--- a/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/vent_pump.dm
@@ -200,10 +200,10 @@
 		"timestamp" = world.time,
 		"power" = on,
 		"direction" = pump_direction,
+		"space_detection" = space_detection,
 		"checks" = pressure_checks,
 		"internal" = internal_pressure_bound,
 		"external" = external_pressure_bound,
-		"space_detection" = space_detection,
 		"sigtype" = "status",
 		"has_aac" = aac != null
 	))

--- a/tgui/packages/tgui/interfaces/common/AtmosControls.js
+++ b/tgui/packages/tgui/interfaces/common/AtmosControls.js
@@ -15,6 +15,7 @@ export const Vent = (props, context) => {
     direction,
     external,
     internal,
+    space_detection,
     extdefault,
     intdefault,
   } = vent;
@@ -39,6 +40,16 @@ export const Vent = (props, context) => {
             content={direction ? 'Pressurizing' : 'Scrubbing'}
             color={!direction && 'danger'}
             onClick={() => act('direction', {
+              id_tag,
+              val: Number(!direction),
+            })} />
+        </LabeledList.Item>
+        <LabeledList.Item label="Space Detection">
+          <Button
+            icon="wind"
+            content={space_detection ? 'Enabled' : 'Disabled'}
+            color={!space_detection && 'danger'}
+            onClick={() => act('space_detection', {
               id_tag,
               val: Number(!direction),
             })} />

--- a/tgui/packages/tgui/interfaces/common/AtmosControls.js
+++ b/tgui/packages/tgui/interfaces/common/AtmosControls.js
@@ -13,9 +13,9 @@ export const Vent = (props, context) => {
     excheck,
     incheck,
     direction,
+    space_detection,
     external,
     internal,
-    space_detection,
     extdefault,
     intdefault,
   } = vent;
@@ -51,7 +51,7 @@ export const Vent = (props, context) => {
             color={!space_detection && 'danger'}
             onClick={() => act('space_detection', {
               id_tag,
-              val: Number(!direction),
+              val: Number(!space_detection),
             })} />
         </LabeledList.Item>
         <LabeledList.Item label="Pressure Regulator">


### PR DESCRIPTION
# Document the changes in your pull request
Airalarm can now turn on/off vent space detection

# Why is this good for the game?
Allow unary vent to pump gas into space, a good feature i guess. Probally help pump gas out faster into space

This one is faster than injector and be remotely controlled which makes it the best way to dump waste into space

# Testing
tested, was able to pump gas into space after multitooling the vent





# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: Airalarm can now turn on/off vent space detection
/:cl:
