### PR TITLE
Makes the chat message from losing obsession more visible

### DIFF
--- a/code/modules/antagonists/creep/creep.dm
+++ b/code/modules/antagonists/creep/creep.dm
@@ -66,6 +66,10 @@
 	to_chat(owner, span_boldannounce("This role does NOT enable you to otherwise surpass what's deemed creepy behavior per the rules."))//ironic if you know the history of the antag
 	owner.announce_objectives()
 
+/datum/antagonist/obsessed/farewell()
+	to_chat(owner, span_userdanger("The Voices fall silent, you are once again alone in your own mind."))
+	owner.announce_objectives()
+
 /datum/antagonist/obsessed/Destroy()
 	if(trauma)
 		qdel(trauma)


### PR DESCRIPTION
# Document the changes in your pull request

Makes the message you get when you lose obsession more visible, because it's way too small.

# Why is this good for the game?
Antagonists should know when they stop being an antagonist, or they'll keep doing antagonist things when they aren't one.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: made the chat message from losing obsession more visible
/:cl:
