### PR TITLE
[BUGFIX] Fixes Decals Not Showing Up Roundstart

### DIFF
--- a/code/game/objects/effects/decals/decal.dm
+++ b/code/game/objects/effects/decals/decal.dm
@@ -51,6 +51,7 @@
 	var/turf/T = loc
 	if(!istype(T)) //you know this will happen somehow
 		CRASH("Turf decal initialized in an object/nullspace")
+	T.AddComponent(/datum/component/decal, icon, icon_state, dir, FALSE, color, null, null, alpha)
 	T.AddElement(/datum/element/decal, icon, icon_state, dir, FALSE, color, null, null, alpha, FALSE)
 	if(detail_overlay)
 		T.AddElement(/datum/element/decal, icon, detail_overlay, dir, FALSE, detail_color, null, null, alpha, appearance_flags)


### PR DESCRIPTION
# Document the changes in your pull request

Makes it so decals now show up roundstart again


# Testing

![image](https://github.com/yogstation13/Yogstation/assets/75333826/182409c3-3c4c-4aae-a354-8fa7c921bafd)


# Changelog

:cl:  

bugfix: fixes decals

/:cl:
