### PR TITLE
You can now place items on the Altar of the Gods

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_meteorite.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_meteorite.dmm
@@ -671,7 +671,7 @@
 /area/lavaland/surface/outdoors)
 "mf" = (
 /obj/structure/stone_tile/surrounding,
-/obj/structure/altar_of_gods,
+/obj/structure/table/altar_of_gods,
 /obj/item/flashlight/lantern{
 	on = 1
 	},

--- a/_maps/RandomRuins/StationRuins/BoxStation/chapel1.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/chapel1.dmm
@@ -664,7 +664,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "Sa" = (
-/obj/structure/altar_of_gods,
+/obj/structure/table/altar_of_gods,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "Sf" = (

--- a/_maps/RandomRuins/StationRuins/BoxStation/chapel2.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/chapel2.dmm
@@ -787,7 +787,7 @@
 /area/chapel/office)
 "Nz" = (
 /obj/structure/railing,
-/obj/structure/altar_of_gods,
+/obj/structure/table/altar_of_gods,
 /turf/open/floor/carpet/red,
 /area/chapel/main)
 "NN" = (

--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -18123,7 +18123,7 @@
 /turf/open/floor/plating,
 /area/science/misc_lab)
 "eTa" = (
-/obj/structure/altar_of_gods,
+/obj/structure/table/altar_of_gods,
 /obj/item/storage/book/bible{
 	pixel_x = -2;
 	pixel_y = -2

--- a/_maps/map_files/DonutStation/DonutStation.dmm
+++ b/_maps/map_files/DonutStation/DonutStation.dmm
@@ -12415,7 +12415,7 @@
 /turf/open/space/basic,
 /area/space)
 "fgr" = (
-/obj/structure/altar_of_gods,
+/obj/structure/table/altar_of_gods,
 /turf/open/floor/plasteel/chapel{
 	dir = 8
 	},

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -44405,7 +44405,7 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "vPc" = (
-/obj/structure/altar_of_gods,
+/obj/structure/table/altar_of_gods,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/carpet/purple,

--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -42371,7 +42371,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/altar_of_gods,
+/obj/structure/table/altar_of_gods,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "moT" = (

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -907,7 +907,7 @@ GLOBAL_LIST_INIT(cheese_recipes, list (
 	merge_type = /obj/item/stack/sheet/ruinous_metal
 
 GLOBAL_LIST_INIT(ruinous_metal_recipes, list (
-	new/datum/stack_recipe("altar of the gods", /obj/structure/altar_of_gods, 6, one_per_turf = 1, on_floor = 1, time = 40), \
+	new/datum/stack_recipe("altar of the gods", /obj/structure/table/altar_of_gods, 6, one_per_turf = 1, on_floor = 1, time = 40), \
 	new/datum/stack_recipe("holy fountain", /obj/structure/holyfountain, 3, one_per_turf = 1, on_floor = 1, time = 40 )))
 
 /obj/item/stack/sheet/ruinous_metal/Initialize(mapload, new_amount, merge = TRUE)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -72,7 +72,8 @@
 
 /obj/structure/table/examine(mob/user)
 	. = ..()
-	. += deconstruction_hints(user)
+	if(!(flags_1 & NODECONSTRUCT_1))
+		. += deconstruction_hints(user)
 
 /obj/structure/table/proc/deconstruction_hints(mob/user)
 	return span_notice("The top is <b>screwed</b> on, but the main <b>bolts</b> are also visible.")

--- a/code/modules/religion/religion_structures.dm
+++ b/code/modules/religion/religion_structures.dm
@@ -1,4 +1,4 @@
-/obj/structure/altar_of_gods
+/obj/structure/table/altar_of_gods
 	name = "\improper Altar of the Gods"
 	desc = "An altar which allows the head of the church to choose a sect of religious teachings as well as provide sacrifices to earn favor."
 	icon = 'icons/obj/hand_of_god_structures.dmi'
@@ -8,17 +8,21 @@
 	layer = TABLE_LAYER
 	pass_flags = LETPASSTHROW
 	can_buckle = TRUE
+	smooth = SMOOTH_FALSE
+	canSmoothWith = null
+	flags_1 = NODECONSTRUCT_1 // no, don't
 	buckle_lying = 90 //we turn to you!
+	max_integrity = 300
+	integrity_failure = 0
 	///Avoids having to check global everytime by referencing it locally.
 	var/datum/religion_sect/sect_to_altar
 
-/obj/structure/altar_of_gods/Initialize(mapload)
+/obj/structure/table/altar_of_gods/Initialize(mapload)
 	. = ..()
 	reflect_sect_in_icons()
-	AddElement(/datum/element/climbable)
 	AddComponent(/datum/component/religious_tool, ALL, FALSE, CALLBACK(src, PROC_REF(reflect_sect_in_icons)))
 
-/obj/structure/altar_of_gods/attack_hand(mob/living/user)
+/obj/structure/table/altar_of_gods/attack_hand(mob/living/user)
 	if(!Adjacent(user) || !user.pulling)
 		return ..()
 	if(!isliving(user.pulling))
@@ -33,7 +37,12 @@
 	pushed_mob.forceMove(loc)
 	return ..()
 
-/obj/structure/altar_of_gods/proc/reflect_sect_in_icons()
+/obj/structure/table/altar_of_gods/attackby(obj/item/I, mob/user, params)
+	if(SEND_SIGNAL(src, COMSIG_PARENT_ATTACKBY, I, user, params) & COMPONENT_NO_AFTERATTACK)
+		return TRUE // this signal needs to be sent early so the bible can actually be used on it
+	return ..()
+
+/obj/structure/table/altar_of_gods/proc/reflect_sect_in_icons()
 	if(GLOB.religious_sect)
 		sect_to_altar = GLOB.religious_sect
 		if(sect_to_altar.altar_icon)

--- a/code/modules/religion/religion_structures.dm
+++ b/code/modules/religion/religion_structures.dm
@@ -14,6 +14,8 @@
 	buckle_lying = 90 //we turn to you!
 	max_integrity = 300
 	integrity_failure = 0
+	buildstackamount = 6
+	buildstack = /obj/item/stack/sheet/ruinous_metal
 	///Avoids having to check global everytime by referencing it locally.
 	var/datum/religion_sect/sect_to_altar
 

--- a/code/modules/religion/religion_structures.dm
+++ b/code/modules/religion/religion_structures.dm
@@ -22,21 +22,6 @@
 	reflect_sect_in_icons()
 	AddComponent(/datum/component/religious_tool, ALL, FALSE, CALLBACK(src, PROC_REF(reflect_sect_in_icons)))
 
-/obj/structure/table/altar_of_gods/attack_hand(mob/living/user)
-	if(!Adjacent(user) || !user.pulling)
-		return ..()
-	if(!isliving(user.pulling))
-		return ..()
-	var/mob/living/pushed_mob = user.pulling
-	if(pushed_mob.buckled)
-		to_chat(user, span_warning("[pushed_mob] is buckled to [pushed_mob.buckled]!"))
-		return ..()
-	to_chat(user, span_notice("You try to coax [pushed_mob] onto [src]..."))
-	if(!do_after(user, 5 SECONDS, pushed_mob))
-		return ..()
-	pushed_mob.forceMove(loc)
-	return ..()
-
 /obj/structure/table/altar_of_gods/attackby(obj/item/I, mob/user, params)
 	if(SEND_SIGNAL(src, COMSIG_PARENT_ATTACKBY, I, user, params) & COMPONENT_NO_AFTERATTACK)
 		return TRUE // this signal needs to be sent early so the bible can actually be used on it


### PR DESCRIPTION
# Document the changes in your pull request

The Altar of the Gods now works like an actual table, allowing you to place items directly on it instead of having to climb on it and then drop the items.

# Why is this good for the game?
Because having to climb on top of the altar to place items on it is silly.

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/93578146/e2cab2e7-63ee-4d58-9785-705c1ef918de)

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: you can now place items on the altar of the gods without having to climb on top of it
/:cl:
