### PR TITLE
fixes some issues with mime fingerguns

### DIFF
--- a/code/modules/spells/spell_types/pointed/finger_guns.dm
+++ b/code/modules/spells/spell_types/pointed/finger_guns.dm
@@ -5,7 +5,7 @@
 	background_icon_state = "bg_mime"
 	overlay_icon_state = "bg_mime_border"
 	button_icon = 'icons/mob/actions/actions_mime.dmi'
-	button_icon_state = "finger_guns0"
+	button_icon_state = "finger_guns"
 	check_flags = AB_CHECK_CONSCIOUS|AB_CHECK_HANDS_BLOCKED|AB_CHECK_INCAPACITATED
 	panel = "Mime"
 	sound = null
@@ -47,4 +47,4 @@
 
 /datum/action/cooldown/spell/pointed/projectile/finger_guns/before_cast(atom/cast_on)
 	. = ..()
-	invocation = span_notice("<b>[cast_on]</b> fires [cast_on.p_their()] finger gun!")
+	invocation = span_notice("<b>[owner]</b> fires [owner.p_their()] finger gun at [cast_on]!")


### PR DESCRIPTION
makes the icon work:
![image](https://github.com/yogstation13/Yogstation/assets/122807629/3645f973-b52a-4fcc-b64e-ffbf8efd97a0)

and makes the text properly show who fired it and what it was aimed at. currently it says the target shot it (funny)


# Why is this good for the game?
makes it clearer what happened in chat, and stops mimes seeing ERROR icon instead of mime gun

# Testing
tested, works

# Spriting
no new sprites

:cl:  ktlwjec
bugfix: Mime finger guns properly show what was shot at, and by who.
imageadd: Mime finger gun button has a working icon.
/:cl: