### PR TITLE
mammi and pea soup need bowls to craft

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_soup.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_soup.dm
@@ -251,6 +251,7 @@
 	name = "Pea soup"
 	reqs = list(
 		/datum/reagent/water = 10,
+		/obj/item/reagent_containers/glass/bowl = 1,
 		/obj/item/reagent_containers/food/snacks/grown/peas = 2,
 		/obj/item/reagent_containers/food/snacks/grown/parsnip = 1,
 		/obj/item/reagent_containers/food/snacks/grown/carrot = 1

--- a/code/modules/holiday/easter.dm
+++ b/code/modules/holiday/easter.dm
@@ -214,6 +214,7 @@
 /datum/crafting_recipe/food/mammi
 	name = "Mammi"
 	reqs = list(
+		/obj/item/reagent_containers/glass/bowl = 1,
 		/obj/item/reagent_containers/food/snacks/store/bread/plain = 1,
 		/obj/item/reagent_containers/food/snacks/chocolatebar = 1,
 		/datum/reagent/consumable/milk = 5


### PR DESCRIPTION
adds bowls to the crafting recipe of mammi and pea soup

# Why is this good for the game?
the bowls magically appear on the sprite when you craft them currently and leave behind bowls that were not there to begin with. makes them the same as other soups.

# Testing
yes

:cl:  ktlwjec
tweak: Mammi and Pea Soup need bowls to craft.
/:cl: