### PR TITLE
Fixes a runtime with polysmorph tails

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -11,8 +11,11 @@
 
 	icon_state = ""		//Remove the inherent human icon that is visible on the map editor. We're rendering ourselves limb by limb, having it still be there results in a bug where the basic human icon appears below as south in all directions and generally looks nasty.
 
+	physiology = new() //create physiology early so organs and bodyparts can modify it
+
 	//initialize limbs first
 	create_bodyparts()
+
 
 	setup_human_dna()
 
@@ -26,7 +29,6 @@
 
 	//initialise organs
 	create_internal_organs() //most of it is done in set_species now, this is only for parent call
-	physiology = new()
 
 	. = ..()
 

--- a/code/modules/surgery/organs/tails.dm
+++ b/code/modules/surgery/organs/tails.dm
@@ -103,7 +103,8 @@
 			else
 				H.dna.species.mutant_bodyparts["tail_polysmorph"] = H.dna.features["tail_polysmorph"]
 		H.update_body()
-		H.physiology.crawl_speed += 0.5
+		if(H.physiology)
+			H.physiology.crawl_speed += 0.5
 
 /obj/item/organ/tail/polysmorph/Remove(mob/living/carbon/human/H,  special = 0)
 	..()
@@ -111,4 +112,5 @@
 		H.dna.species.mutant_bodyparts -= "tail_polysmorph"
 		tail_type = H.dna.features["tail_polysmorph"]
 		H.update_body()
-		H.physiology.crawl_speed -= 0.5
+		if(H.physiology)
+			H.physiology.crawl_speed -= 0.5

--- a/code/modules/surgery/organs/tails.dm
+++ b/code/modules/surgery/organs/tails.dm
@@ -103,8 +103,7 @@
 			else
 				H.dna.species.mutant_bodyparts["tail_polysmorph"] = H.dna.features["tail_polysmorph"]
 		H.update_body()
-		if(H.physiology)
-			H.physiology.crawl_speed += 0.5
+		H.physiology.crawl_speed += 0.5
 
 /obj/item/organ/tail/polysmorph/Remove(mob/living/carbon/human/H,  special = 0)
 	..()
@@ -112,5 +111,4 @@
 		H.dna.species.mutant_bodyparts -= "tail_polysmorph"
 		tail_type = H.dna.features["tail_polysmorph"]
 		H.update_body()
-		if(H.physiology)
-			H.physiology.crawl_speed -= 0.5
+		H.physiology.crawl_speed -= 0.5


### PR DESCRIPTION
The runtime is caused by adding an organ to a human body without physiology
The problem is that bodies initialize organs before initializing physiology
so anyone that spawns with an organ that modifies physiology will cause a runtime because physiology doesn't exist yet

:cl:  
bugfix: Fixes a bug with polysmorph tail crawlspeed
/:cl:
