### PR TITLE
Gives Mr Freeze syndikit a frost oil chem sprayer

### DIFF
--- a/code/datums/components/wet_floor.dm
+++ b/code/datums/components/wet_floor.dm
@@ -83,7 +83,7 @@
 			lube_flags = SLIDE | GALOSHES_DONT_HELP
 		if(TURF_WET_ICE)
 			intensity = 120
-			lube_flags = SLIDE | GALOSHES_DONT_HELP
+			lube_flags = SLIDE_ICE | GALOSHES_DONT_HELP
 		if(TURF_WET_PERMAFROST)
 			intensity = 120
 			lube_flags = SLIDE_ICE | GALOSHES_DONT_HELP

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -225,7 +225,7 @@
 			new /obj/item/reagent_containers/glass/bottle/beesease(src) // 10 tc?
 			new /obj/item/gun/magic/staff/spellblade/beesword(src) //priceless
 
-		if("mr_freeze") // ~17 tc
+		if("mr_freeze") // ~25 tc
 			new /obj/item/clothing/glasses/cold(src) // 0 tc
 			new /obj/item/clothing/gloves/color/black(src) // 0 tc
 			new /obj/item/clothing/mask/chameleon/syndicate(src) // 0 tc on its own
@@ -237,8 +237,9 @@
 			new /obj/item/grenade/gluon(src) //
 			new /obj/item/dnainjector/geladikinesis(src) // 0 tc
 			new /obj/item/dnainjector/cryokinesis(src) // 1 or 2 tc, kind of useful
-			new /obj/item/gun/energy/temperature/security(src) // the crutch of this kit, alongside esword, ~4 tc
+			new /obj/item/gun/energy/temperature/security(src) // ~4 tc
 			new /obj/item/melee/transforming/energy/sword/saber/blue(src) //see see it fits the theme bc its blue and ice is blue, 8 tc
+			new /obj/item/reagent_containers/spray/chemsprayer/freeze(src) // filled with frost oil and you can refill it with whatever, ~8 tc
 
 		if("neo")
 			new /obj/item/clothing/glasses/sunglasses(src)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -328,6 +328,8 @@
 /obj/item/reagent_containers/spray/chemsprayer/bioterror
 	list_reagents = list(/datum/reagent/toxin/sodium_thiopental = 100, /datum/reagent/toxin/coniine = 100, /datum/reagent/toxin/venom = 100, /datum/reagent/consumable/condensedcapsaicin = 100, /datum/reagent/toxin/initropidril = 100, /datum/reagent/toxin/polonium = 100)
 
+/obj/item/reagent_containers/spray/chemsprayer/freeze
+	list_reagents = list(/datum/reagent/consumable/frostoil = 600)
 
 /obj/item/reagent_containers/spray/chemsprayer/janitor
 	name = "janitor chem sprayer"


### PR DESCRIPTION
# Document the changes in your pull request

Adds a variant of the chem sprayer loaded with frost oil instead of poison.
Puts it in the Mr Freeze syndikit.
Changes the flag for the ice created by frost oil to match the type created by gluon grenades, so you don't slip on it while wearing winter boots or whatever else gives NOSLIP_ICE.

# Why is this good for the game?

Mr Freeze kit is garbage and the only kit worth less than 20 TC. It needs to be improved or removed. Adding the chem sprayer gives it a neat item that is otherwise inaccessible to traitors, helps with the theme by adding more ice, and gives much-needed combat and defensive utility.

In terms of balance: this is basically a slip gun, as another option to complement your esword. You get 20 shots on "spray" and the ice thaws right away, unless you've already fired a few shots to make the air colder. If you want to lock down an area you've already got the gluon grenades which make tiles icy for a whopping 6 minutes. You can refill the sprayer with poison or whatever, but despite normally being a nukie weapon the reagent transfer to people isn't any better than a regular spray bottle.

# Wiki Documentation

add chem sprayer to list of items in the mr freeze kit

# Changelog

:cl:  
rscadd: Added a frost oil chem sprayer to the mr freeze syndikit
/:cl:
