### PR TITLE
Imperial jumpsuits can no longer be adjusted because there isn't a sprite for it

### DIFF
--- a/code/modules/clothing/outfits/imperial.dm
+++ b/code/modules/clothing/outfits/imperial.dm
@@ -18,6 +18,7 @@
 	desc = "A set of khaki fatigues. Standard issue for Imperial Guardsmen"
 	icon_state = "guard_uniform"
 	item_state = "guard_uniform"
+	can_adjust = 0
 
 /obj/item/clothing/shoes/combat/imperial
 	name = "flak boots"


### PR DESCRIPTION
Should hopefully fix the jumpsuit sprite not appearing properly probably. Otherwise there's a deeper problem with jumpsuit style togging (or manatee broke something with his warhammer pr which wouldn't be the first time)

# Changelog


:cl:  

bugfix: Imperial jumpsuits don't have alt styles, stop trying to break the dress code soldier!

/:cl:
