### PR TITLE
Remove's Borgs from BR

### DIFF
--- a/yogstation/code/game/gamemodes/battle_royale/loot.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/loot.dm
@@ -296,9 +296,6 @@ GLOBAL_LIST_INIT(battleroyale_utility, list(//bombs, explosives, anything that's
 		/obj/item/nullrod/unrestricted = -2,
 		/obj/effect/spawner/lootdrop/ammobox = -2,
 
-		/obj/item/antag_spawner/nuke_ops/borg_tele/medical = -3,
-		/obj/item/antag_spawner/nuke_ops/borg_tele/assault = -3,
-		/obj/item/antag_spawner/nuke_ops/borg_tele/saboteur = -3,
 		/obj/item/storage/box/syndie_kit/augmentation = -3,
 		/obj/item/storage/backpack/duffelbag/syndie/c4 = -3, //C4 Is kind of useless when you have AA
 		/obj/item/battleroyale/itemspawner/construct = -3,


### PR DESCRIPTION


# Document the changes in your pull request

Removes Borgs from BR

# Why is this good for the game?
No reason for these to be in the BR loot pool. They either functionally do not help the player that spawns them or will kill the player that spawned them in. Not very fun to be punished for playing the game, so they're getting removed. Rejoice.
# Changelog
:cl:  
rscdel: Syndie Borgs Spawners removed from BR loot pool.
 
/:cl:
