### PR TITLE
Mindmachine UI correctly updates when person is ejected while UI is still visible

### DIFF
--- a/code/game/machinery/mindmachine.dm
+++ b/code/game/machinery/mindmachine.dm
@@ -316,6 +316,10 @@
 				if(DEAD)
 					.["firstStat"] = "Dead"
 			.["firstMindType"] = firstLiving.key ? "Sentient" : "Non-Sentient"
+		else
+			.["firstName"] = null
+			.["firstStat"] = null
+			.["firstMindType"] = null
 	else // If you don't null it and keep the ui open, then above data doesn't change until you reopen.
 		.["firstOpen"] = null
 		.["firstLocked"] = null
@@ -338,6 +342,10 @@
 				if(DEAD)
 					.["secondStat"] = "Dead"
 			.["secondMindType"] = secondLiving.key ? "Sentient" : "Non-Sentient"
+		else
+			.["secondName"] = null
+			.["secondStat"] = null
+			.["secondMindType"] = null
 	else
 		.["secondOpen"] = null
 		.["secondLocked"] = null


### PR DESCRIPTION
# Document the changes in your pull request
The information about both occupants in the Mindmachine Hub's UI is correctly updated to "None" when the occupant(s) leaves its pod(s).

# Testing
Put Moja in. Take Moja out. UI updates correctly.

# Changelog
:cl:  
bugfix: Mindmachine Hub's UI correctly updates information about it's occupants to "None" when they exit it's pods.
/:cl:
