### PR TITLE
Fixes Lasombra clan favorite vassal & eye examine

### DIFF
--- a/code/modules/antagonists/bloodsuckers/clans/clan_lasombra.dm
+++ b/code/modules/antagonists/bloodsuckers/clans/clan_lasombra.dm
@@ -36,6 +36,7 @@
 	if(ishuman(bloodsuckerdatum.owner.current))
 		var/mob/living/carbon/human/human_user = bloodsuckerdatum.owner.current
 		human_user.eye_color = BLOODCULT_EYE
+		human_user.update_body()
 		human_user.updateappearance()
 	ADD_TRAIT(bloodsuckerdatum.owner.current, CULT_EYES, BLOODSUCKER_TRAIT)
 	bloodsuckerdatum.owner.current.faction |= "bloodhungry"
@@ -51,12 +52,17 @@
 	bloodsuckerdatum.owner.teach_crafting_recipe(/datum/crafting_recipe/restingplace)
 
 /datum/bloodsucker_clan/lasombra/on_favorite_vassal(datum/antagonist/bloodsucker/source, datum/antagonist/vassal/vassaldatum)
+	vassaldatum.BuyPower(new /datum/action/cooldown/spell/pointed/lesser_glare)
+	vassaldatum.BuyPower(new /datum/action/cooldown/spell/jaunt/shadow_walk)
 	if(ishuman(vassaldatum.owner.current))
 		var/mob/living/carbon/human/vassal = vassaldatum.owner.current
-		vassal.see_in_dark = 8
 		vassal.eye_color = BLOODCULT_EYE
-		vassal.updateappearance()
-	var/list/powers = list(/datum/action/cooldown/spell/pointed/lesser_glare, /datum/action/cooldown/spell/jaunt/shadow_walk)
-	for(var/datum/action/cooldown/spell/power in powers)
-		power = new(vassaldatum.owner.current)
-		power.Grant(vassaldatum.owner.current)
+		vassal.dna.update_ui_block(DNA_EYE_COLOR_BLOCK)
+		ADD_TRAIT(vassal, CULT_EYES, BLOODSUCKER_TRAIT)	
+		var/obj/item/organ/eyes/current_eyes = vassal.getorganslot(ORGAN_SLOT_EYES)
+		if(current_eyes)
+			current_eyes.see_in_dark = 8
+			current_eyes.lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE	
+		vassal.update_body()
+		vassal.update_sight()
+		vassal.update_appearance()


### PR DESCRIPTION
# Document the changes in your pull request

Lasombra's favorite vassal was broken and got absolutely nothing compared to regular vassals except the mindshield immunity. Now it properly receives its spells and night vision. Additionally, both the bloodsucker and favorite vassal will show the intended examine text for having glowing red eyes.

# Testing
Tested on a private server, everything works, except the character sprite doesn't actually have red eyes. I don't know why. Checking the character variable for eye color shows that they're supposed to be red. Using magic mirror to change eye color didn't do anything either, even as a non-bloodsucker. It's either a separate bug or something wrong with my own game. Should be fine probably.

# Changelog

:cl:  
bugfix: fixed lasombra vassals and eye examine
/:cl:
