### PR TITLE
Buffs and nerfs monk staff null rod slightly

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -359,6 +359,11 @@
 	menutab = MENU_WEAPON
 	additional_desc = "The weapon of choice for a devout monk. Block incoming blows while striking weak points until your opponent is too exhausted to continue."
 
+/obj/item/nullrod/bostaff/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	if(attack_type == PROJECTILE_ATTACK)
+		final_block_chance = 0 //Don't bring a stick to a gunfight
+	return ..()
+
 /obj/item/nullrod/tribal_knife
 	name = "arrhythmic knife"
 	desc = "They say fear is the true mind killer, but stabbing them in the head works too. Honour compels you to not sheathe it once drawn."

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -352,7 +352,7 @@
 	attack_verb = list("smashed", "slammed", "whacked", "thwacked")
 	w_class = WEIGHT_CLASS_BULKY
 	damtype = STAMINA
-	force = 15
+	force = 18
 	block_chance = 40
 	slot_flags = ITEM_SLOT_BACK
 	sharpness = SHARP_NONE


### PR DESCRIPTION
With the addition of the stamina regen rework, the monk staff's stamina damage has become SIGNIFICANTLY less effective if a fight lasts more than 10 seconds (which is likely given its low damage and complete lack of AP). Originally it was more or less just as effective because you didn't have that bit of stamina regen but now its really quite bad comparatively. This puts it back up to the same damage as other null rods to make it slightly less of a terrible option compared to the swords for combat.

Edit: It also now doesn't block bullets because the other null rods also didn't.

# Wiki Documentation

Monk staff null rod now does 18 damage (same as normal null rod) and can't block projectiles any more, just melee.

# Changelog



:cl:  

tweak: Chaplain monk staff null rod (stamina) damage increased (15 -> 18)
tweak: The above no longer can block projectiles

/:cl:
