### PR TITLE
Live xeno aliens on station level now generate research

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -147,3 +147,8 @@ Des: Removes all infected images from the alien.
 
 /mob/living/carbon/alien/can_hold_items()
 	return has_fine_manipulation
+
+/mob/living/carbon/alien/Life(seconds_per_tick, times_fired)
+	. = ..()
+	if(client)
+		linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, seconds_per_tick * 5) // 5/s, server passive is ~60/s

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -150,5 +150,5 @@ Des: Removes all infected images from the alien.
 
 /mob/living/carbon/alien/Life(seconds_per_tick, times_fired)
 	. = ..()
-	if(client)
+	if(is_station_level(z))
 		linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, seconds_per_tick * 5) // 5/s, server passive is ~60/s

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -25,6 +25,7 @@
 
 	var/static/regex/alien_name_regex = new("alien (larva|sentinel|drone|hunter|praetorian|queen)( \\(\\d+\\))?")
 	blood_volume = BLOOD_VOLUME_XENO //Yogs -- Makes monkeys/xenos have different amounts of blood from normal carbonbois
+	var/datum/techweb/linked_techweb
 
 /mob/living/carbon/alien/Initialize(mapload)
 	add_verb(src, /mob/living/proc/mob_sleep)
@@ -33,6 +34,9 @@
 	create_bodyparts() //initialize bodyparts
 
 	create_internal_organs()
+
+	if(!linked_techweb)
+		linked_techweb = SSresearch.science_tech
 
 	. = ..()
 

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -147,8 +147,3 @@ Des: Removes all infected images from the alien.
 
 /mob/living/carbon/alien/can_hold_items()
 	return has_fine_manipulation
-
-/mob/living/carbon/alien/Life(seconds_per_tick, times_fired)
-	. = ..()
-	if(is_station_level(z))
-		linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, seconds_per_tick * 5) // 5/s, server passive is ~60/s

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon/alien/Life(seconds_per_tick = SSMOBS_DT, times_fired)
 	findQueen()
-	if(is_station_level(z)) // 5/s, server passive is ~60/s
+	if(linked_techweb && is_station_level(z)) // 5/s, server passive is ~60/s
 		linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, seconds_per_tick * 5)
 	return..()
 

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -1,5 +1,7 @@
 /mob/living/carbon/alien/Life(seconds_per_tick = SSMOBS_DT, times_fired)
 	findQueen()
+	if(is_station_level(z)) // 5/s, server passive is ~60/s
+		linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, seconds_per_tick * 5)
 	return..()
 
 /mob/living/carbon/alien/check_breath(datum/gas_mixture/breath)


### PR DESCRIPTION
# Document the changes in your pull request
Every life tick, xenos add 5*seconds points to the generic techweb

# Why is this good for the game?
Incentive (besides grief) to have xenos in xenobiology containment

# Testing
![](https://i.imgur.com/C5yubJd.gif)

# Wiki Documentation
5 research per second per alien
Default passive research is ~60/s
Would need 12 aliens on station to double research rate

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Live xeno aliens on station level now passively generate research points
/:cl:
