### PR TITLE
Anti megafauna ert

### DIFF
--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -59,11 +59,12 @@
 	polldesc = "an elite Nanotrasen Strike Team"
 
 /datum/ert/mining
+	leader_role = /datum/antagonist/ert/mining
 	roles = list(/datum/antagonist/ert/mining)
 	rename_team = "Megafauna Kill Team"
-	code = "Grey"
+	code = "Rock and STONE"
 	mission = "Eliminate hostile fauna while minimizing casualties."
-	polldesc = "an elite Nanotrasen Strike Team"
+	polldesc = "A merry band of Megafauna-hunting dwarves"
 
 /datum/ert/official
 	code = "Green"

--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -14,7 +14,7 @@
 	var/dusting = FALSE
 
 	// this can be safely set as default because it doesnt do anything unless specifically making uplinked ERT
-	var/obj/item/uplinktype = /obj/item/ntuplink/official 
+	var/obj/item/uplinktype = /obj/item/ntuplink/official
 
 /datum/ert/New()
 	if (!polldesc)
@@ -42,7 +42,7 @@
 	polldesc = "the Peacekeeping Force"
 	teamsize = 5 // redundant but keeping this here for clarity
 	leader_role = /datum/antagonist/ert/occupying/commander
-	roles = list(/datum/antagonist/ert/occupying,/datum/antagonist/ert/occupying/heavy,/datum/antagonist/ert/occupying,/datum/antagonist/ert/occupying) 
+	roles = list(/datum/antagonist/ert/occupying,/datum/antagonist/ert/occupying/heavy,/datum/antagonist/ert/occupying,/datum/antagonist/ert/occupying)
 
 /datum/ert/red
 	leader_role = /datum/antagonist/ert/commander/red
@@ -56,6 +56,13 @@
 	openmech = TRUE
 	code = "Delta"
 	mission = "Leave no witnesses."
+	polldesc = "an elite Nanotrasen Strike Team"
+
+/datum/ert/mining
+	roles = list(/datum/antagonist/ert/mining)
+	rename_team = "Megafauna Kill Team"
+	code = "Grey"
+	mission = "Eliminate hostile fauna while minimizing casualties."
 	polldesc = "an elite Nanotrasen Strike Team"
 
 /datum/ert/official

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -78,7 +78,7 @@
 /datum/antagonist/ert/deathsquad/New()
 	. = ..()
 	name_source = GLOB.commando_names
-	
+
 /datum/antagonist/ert/clown/New()
 	. = ..()
 	name_source = GLOB.clown_names
@@ -137,6 +137,10 @@
 	name = "Deathsquad Trooper"
 	outfit = /datum/outfit/death_commando
 	role = "Trooper"
+
+/datum/antagonist/ert/mining
+	name = "Dwarven Miner"
+	outfit = /datum/outfit/dorf_miner
 
 /datum/antagonist/ert/medic/inquisitor
 	outfit = /datum/outfit/ert/medic/inquisitor
@@ -207,7 +211,7 @@
 	name = "Occupying Riot Officer"
 	outfit = /datum/outfit/occupying/heavy
 	role = "Riot Officer"
-	
+
 /datum/antagonist/ert/occupying/commander
 	name = "Occupying Commander"
 	outfit = /datum/outfit/occupying/commander
@@ -222,7 +226,7 @@
 	name = "HONK Squad Trooper"
 	outfit = /datum/outfit/centcom_clown/honk_squad
 	role = "HONKER"
-	
+
 /datum/antagonist/ert/imperial
 	name = "Imperial Guardsman"
 	outfit = /datum/outfit/imperial

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -140,7 +140,7 @@
 
 /datum/antagonist/ert/mining
 	name = "Dwarven Miner"
-	outfit = /datum/outfit/dorf_miner
+	outfit = /datum/outfit/ert/mining
 
 /datum/antagonist/ert/medic/inquisitor
 	outfit = /datum/outfit/ert/medic/inquisitor

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -68,21 +68,34 @@
 	id = /obj/item/card/id/ert
 	suit = /obj/item/clothing/suit/space/hardsuit/ert/paranormal/beserker
 	suit_store = /obj/item/tank/internals/oxygen/tactical
+	r_hand = /obj/item/kinetic_crusher/mega
 	glasses = /obj/item/clothing/glasses/hud/health/meson
 	gloves = /obj/item/clothing/gloves/gauntlets
 	back = /obj/item/storage/backpack/explorer
 	belt = /obj/item/storage/belt/mining
 	mask = /obj/item/clothing/mask/gas/explorer
 	shoes = /obj/item/clothing/shoes/bhop
+	uniform = /obj/item/clothing/under/rank/miner/lavaland
 	backpack_contents = list(
 		/obj/item/storage/box/survival_mining=1,
-		/obj/item/crusher_trophy/demon_claws=1
-		/obj/item/crusher_trophy/watcher_wing=1
-		/obj/item/reagent_containers/autoinjector/medipen/survival=3
-		/obj/item/kinetic_javelin=1
+		/obj/item/crusher_trophy/demon_claws=1,
+		/obj/item/crusher_trophy/watcher_wing=1,
+		/obj/item/reagent_containers/autoinjector/medipen/survival=3,
+		/obj/item/kinetic_javelin=1,
+		/obj/item/dnainjector/dwarf=1,
 		/obj/item/kinetic_javelin_core/green=1
 		)
 	l_pocket = /obj/item/reagent_containers/glass/beaker/bluespace/dorf
+
+/datum/outfit/ert/mining/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	..()
+
+	if(visualsOnly)
+		return
+
+	var/obj/item/radio/R = H.ears
+	R.keyslot = new /obj/item/encryptionkey/heads/cmo
+	R.recalculateChannels()
 
 /datum/outfit/ert/commander/alert
 	name = "ERT Commander - High Alert"

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -62,6 +62,28 @@
 	R.keyslot = new /obj/item/encryptionkey/heads/captain
 	R.recalculateChannels()
 
+/datum/outfit/ert/mining
+	name = "A Dwarven Miner"
+
+	id = /obj/item/card/id/ert
+	suit = /obj/item/clothing/suit/space/hardsuit/ert/paranormal/beserker
+	suit_store = /obj/item/tank/internals/oxygen/tactical
+	glasses = /obj/item/clothing/glasses/hud/health/meson
+	gloves = /obj/item/clothing/gloves/gauntlets
+	back = /obj/item/storage/backpack/explorer
+	belt = /obj/item/storage/belt/mining
+	mask = /obj/item/clothing/mask/gas/explorer
+	shoes = /obj/item/clothing/shoes/bhop
+	backpack_contents = list(
+		/obj/item/storage/box/survival_mining=1,
+		/obj/item/crusher_trophy/demon_claws=1
+		/obj/item/crusher_trophy/watcher_wing=1
+		/obj/item/reagent_containers/autoinjector/medipen/survival=3
+		/obj/item/kinetic_javelin=1
+		/obj/item/kinetic_javelin_core/green=1
+		)
+	l_pocket = /obj/item/reagent_containers/glass/beaker/bluespace/dorf
+
 /datum/outfit/ert/commander/alert
 	name = "ERT Commander - High Alert"
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -209,6 +209,10 @@
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,300)
 
+/obj/item/reagent_containers/glass/beaker/bluespace/dorf
+	name = "A perfectly normal bottle of beer"
+	list_reagents = list(/datum/reagent/consumable/ethanol/manly_dorf = 300)
+
 /obj/item/reagent_containers/glass/beaker/cryoxadone
 	list_reagents = list(/datum/reagent/medicine/cryoxadone = 30)
 


### PR DESCRIPTION
This PR adds an additional ERT for admin spawn, equipped with OP mining kit for killing megafauna that have breached onto the station. (And a single reagent container filled with Manly Dorf.)

It has been tested on a local server.

# Why is this good for the game?
None of the other ERT's are equipped for dealing with megafauna, except for perhaps deathsquad. They are simply balanced differently. Hisakaki requested it.

# Testing
Booted local server, spawned an ERT.

# Wiki Documentation
Nil(probably)

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: Adds Miner ERT
/:cl:
