### PR TITLE
Makes the beam rifle's code less bad

### DIFF
--- a/code/__DEFINES/projectiles.dm
+++ b/code/__DEFINES/projectiles.dm
@@ -1,0 +1,10 @@
+///Not actually hitscan but close as we get without actual hitscan.
+#define MOVES_HITSCAN -1
+///How many pixels to move the muzzle flash up so your character doesn't look like they're shitting out lasers.
+#define MUZZLE_EFFECT_PIXEL_INCREMENT 17	
+///Will always ricochet off of coins.
+#define ALWAYS_RICOSHOT 2
+
+// Penetration flags
+#define PENETRATE_OBJECTS (1<<0)
+#define PENETRATE_MOBS (1<<1)

--- a/code/datums/martial/ultra_violence.dm
+++ b/code/datums/martial/ultra_violence.dm
@@ -168,7 +168,8 @@
 	wound_falloff_tile = -2.5
 	ricochets_max = 1 // so you can't use it in a small room to obliterate everyone inside
 	ricochet_chance = INFINITY // ALWAYS ricochet
-	penetrating = TRUE
+	penetrations = INFINITY
+	can_ricoshot = ALWAYS_RICOSHOT // +RICOSHOT
 
 /obj/projectile/bullet/ipcmartial/on_hit(atom/target, blocked)
 	. = ..()
@@ -196,7 +197,7 @@
 /obj/projectile/bullet/ipcmartial/on_ricochet(atom/A)
 	damage += 10 // more damage if you ricochet it, good luck hitting it consistently though
 	speed *= 0.5 // faster so it can hit more reliably
-	penetrating = FALSE
+	penetrations = 0
 	return ..()
 
 /obj/projectile/bullet/ipcmartial/check_ricochet()

--- a/code/game/objects/items/flamethrower.dm
+++ b/code/game/objects/items/flamethrower.dm
@@ -360,4 +360,4 @@
 	damage = 0
 	sharpness = SHARP_NONE
 	range = 6
-	penetration_type = 2
+	penetration_flags = PENETRATE_OBJECTS | PENETRATE_MOBS

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -72,6 +72,7 @@
 	P.ignore_source_check = TRUE
 	P.range = P.decayedRange
 	P.decayedRange = max(P.decayedRange--, 0)
+	P.store_hitscan_collision(P.trajectory.copy_to())
 	return BULLET_ACT_FORCE_PIERCE
 
 /obj/structure/reflector/attackby(obj/item/W, mob/user, params)

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -72,7 +72,8 @@
 	P.ignore_source_check = TRUE
 	P.range = P.decayedRange
 	P.decayedRange = max(P.decayedRange--, 0)
-	P.store_hitscan_collision(P.trajectory.copy_to())
+	if(P.hitscan)
+		P.store_hitscan_collision(P.trajectory.copy_to())
 	return BULLET_ACT_FORCE_PIERCE
 
 /obj/structure/reflector/attackby(obj/item/W, mob/user, params)

--- a/code/modules/antagonists/eldritch_cult/eldritch_gun.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_gun.dm
@@ -134,8 +134,8 @@
 	// If fired without aiming or at someone too close, it will do much less
 	damage = 30
 	stamina = 30
-	penetration_type = 2
-	penetrating = TRUE
+	penetration_flags = PENETRATE_OBJECTS | PENETRATE_MOBS
+	penetrations = INFINITY
 
 // Extra ammunition can be made with a heretic ritual.
 /obj/item/ammo_box/strilka310/lionhunter

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -415,7 +415,6 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	var/value = 1
 	var/coinflip
 	var/coin_stack_icon_state = "coin_stack"
-	var/list/allowed_ricochet_types = list(/obj/projectile/bullet/c38, /obj/projectile/bullet/a357, /obj/projectile/bullet/ipcmartial)
 
 /obj/item/coin/get_item_credit_value()
 	return value
@@ -624,10 +623,10 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	transform = initial(transform)
 
 /obj/item/coin/bullet_act(obj/projectile/P)
-	if(P.armor_flag != LASER && P.armor_flag != ENERGY && !is_type_in_list(P, allowed_ricochet_types)) //only energy projectiles get deflected (also revolvers because damn thats cool)
+	if(P.armor_flag != LASER && P.armor_flag != ENERGY && !P.can_ricoshot) //only energy projectiles get deflected (also revolvers because damn thats cool)
 		return ..()
 
-	if(cooldown >= world.time || istype(P, /obj/projectile/bullet/ipcmartial))//we ricochet the projectile
+	if(cooldown >= world.time || P.can_ricoshot == ALWAYS_RICOSHOT)//we ricochet the projectile
 		var/list/targets = list()
 		for(var/mob/living/T in viewers(5, src))
 			if(istype(T) && T != P.firer && T.stat != DEAD) //don't fire at someone if they're dead or if we already hit them
@@ -635,6 +634,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 		P.damage *= 1.5
 		P.speed *= 0.5
 		P.ricochets++
+		P.store_hitscan_collision(P.trajectory.copy_to()) // ULTRA-RICOSHOT
 		P.on_ricochet(src)
 		P.impacted = list(src)
 		P.pixel_x = pixel_x

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -634,7 +634,8 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 		P.damage *= 1.5
 		P.speed *= 0.5
 		P.ricochets++
-		P.store_hitscan_collision(P.trajectory.copy_to()) // ULTRA-RICOSHOT
+		if(P.hitscan)
+			P.store_hitscan_collision(P.trajectory.copy_to()) // ULTRA-RICOSHOT
 		P.on_ricochet(src)
 		P.impacted = list(src)
 		P.pixel_x = pixel_x

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -86,6 +86,8 @@
 			if(check_reflect(def_zone)) // Checks if you've passed a reflection% check
 				visible_message(span_danger("The [P.name] gets reflected by [src]!"), \
 								span_userdanger("The [P.name] gets reflected by [src]!"))
+				if(P.hitscan) // hitscan check
+					P.store_hitscan_collision(P.trajectory.copy_to())
 				// Find a turf near or on the original location to bounce to
 				if(!isturf(loc)) //Open canopy mech (ripley) check. if we're inside something and still got hit
 					P.force_hit = TRUE //The thing we're in passed the bullet to us. Pass it back, and tell it to take the damage.

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -78,6 +78,8 @@
 						return BULLET_ACT_BLOCK
 					else
 						P.firer = src
+						if(P.hitscan)
+							P.store_hitscan_collision(P.trajectory.copy_to())
 						P.setAngle(rand(0, 360))//SHING
 						return BULLET_ACT_FORCE_PIERCE
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -79,7 +79,7 @@
 			apply_damage(P.damage, P.damage_type, def_zone, armor, wound_bonus = P.wound_bonus, bare_wound_bonus = P.bare_wound_bonus, sharpness = P.sharpness, attack_direction = attack_direction)
 		if(P.dismemberment)
 			check_projectile_dismemberment(P, def_zone)
-	if(P.penetrating && (P.penetration_type == 0 || P.penetration_type == 2) && P.penetrations > 0)
+	if((P.penetration_flags & PENETRATE_MOBS) && P.penetrations > 0)
 		P.penetrations -= 1
 		return P.on_hit(src, armor) && BULLET_ACT_FORCE_PIERCE
 	return P.on_hit(src, armor)? BULLET_ACT_HIT : BULLET_ACT_BLOCK

--- a/code/modules/projectiles/attachments/laser_sight.dm
+++ b/code/modules/projectiles/attachments/laser_sight.dm
@@ -68,7 +68,7 @@
 		return
 	aiming_lastangle = lastangle
 	var/obj/projectile/beam/beam_rifle/hitscan/aiming_beam/P = new
-	P.gun = attached_gun
+	P.fired_from = attached_gun
 	P.color = laser_color
 	var/turf/curloc = get_turf(src)
 	

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -26,7 +26,7 @@
 	modifystate = FALSE
 	weapon_weight = WEAPON_HEAVY
 	w_class = WEIGHT_CLASS_BULKY
-	ammo_type = list(/obj/item/ammo_casing/energy/beam_rifle/hitscan)
+	ammo_type = list(/obj/item/ammo_casing/energy/beam_rifle/hitscan/piercing, /obj/item/ammo_casing/energy/beam_rifle/hitscan/impact)
 	actions_types = list(/datum/action/item_action/zoom_lock_action)
 	cell_type = /obj/item/stock_parts/cell/beam_rifle
 	canMouseDown = TRUE
@@ -44,20 +44,6 @@
 	var/aiming_lastangle = 0
 	var/mob/current_user = null
 
-	var/structure_piercing = 2				//Amount * 2. For some reason structures aren't respecting this unless you have it doubled. Probably with the objects in question's Bump() code instead of this but I'll deal with this later.
-	var/structure_bleed_coeff = 0.7
-	var/wall_pierce_amount = 0
-	var/wall_devastate = 0
-	var/aoe_structure_range = 1
-	var/aoe_structure_damage = 50
-	var/aoe_fire_range = 2
-	var/aoe_fire_chance = 40
-	var/aoe_mob_range = 1
-	var/aoe_mob_damage = 30
-	var/impact_structure_damage = 60
-	var/projectile_damage = 30
-	var/projectile_stun = 0
-	var/projectile_setting_pierce = TRUE
 	var/delay = 25
 	var/lastfire = 0
 
@@ -156,9 +142,8 @@
 	else
 		. += drained_overlay
 
-/obj/item/gun/energy/beam_rifle/attack_self(mob/user)
-	projectile_setting_pierce = !projectile_setting_pierce
-	to_chat(user, span_boldnotice("You set \the [src] to [projectile_setting_pierce? "pierce":"impact"] mode."))
+/obj/item/gun/energy/beam_rifle/select_fire(mob/living/user)
+	. = ..()
 	aiming_beam()
 
 /obj/item/gun/energy/beam_rifle/proc/update_slowdown()
@@ -179,13 +164,6 @@
 	listeningTo = null
 	return ..()
 
-/obj/item/gun/energy/beam_rifle/emp_act(severity)
-	. = ..()
-	if(. & EMP_PROTECT_SELF)
-		return
-	chambered = null
-	recharge_newshot()
-
 /obj/item/gun/energy/beam_rifle/proc/aiming_beam(force_update = FALSE)
 	var/diff = abs(aiming_lastangle - lastangle)
 	check_user()
@@ -193,10 +171,7 @@
 		return
 	aiming_lastangle = lastangle
 	var/obj/projectile/beam/beam_rifle/hitscan/aiming_beam/P = new
-	P.gun = src
-	P.wall_pierce_amount = wall_pierce_amount
-	P.structure_pierce_amount = structure_piercing
-	P.do_pierce = projectile_setting_pierce
+	P.fired_from = src
 	if(aiming_time)
 		var/percent = ((100/aiming_time)*aiming_time_left)
 		P.color = rgb(255 * percent,255 * ((100 - percent) / 100),0)
@@ -299,7 +274,6 @@
 		return
 	process_aim()
 	if(aiming_time_left <= aiming_time_fire_threshold && check_user())
-		sync_ammo()
 		var/atom/target = M.client.mouse_object_ref?.resolve()
 		if(target)
 			afterattack(target, M, FALSE, M.client.mouseParams, passthrough = TRUE)
@@ -323,73 +297,15 @@
 	. = ..()
 	stop_aiming()
 
-/obj/item/gun/energy/beam_rifle/proc/sync_ammo()
-	for(var/obj/item/ammo_casing/energy/beam_rifle/AC in contents)
-		AC.sync_stats()
-
 /obj/item/gun/energy/beam_rifle/proc/delay_penalty(amount)
 	aiming_time_left = clamp(aiming_time_left + amount, 0, aiming_time)
 
 /obj/item/ammo_casing/energy/beam_rifle
 	name = "particle acceleration lens"
 	desc = "Don't look into barrel!"
-	var/wall_pierce_amount = 0
-	var/wall_devastate = 0
-	var/aoe_structure_range = 1
-	var/aoe_structure_damage = 30
-	var/aoe_fire_range = 2
-	var/aoe_fire_chance = 66
-	var/aoe_mob_range = 1
-	var/aoe_mob_damage = 20
-	var/impact_structure_damage = 50
-	var/projectile_damage = 40
-	var/projectile_stun = 0
-	var/structure_piercing = 2
-	var/structure_bleed_coeff = 0.7
-	var/do_pierce = TRUE
-	var/obj/item/gun/energy/beam_rifle/host
-
-/obj/item/ammo_casing/energy/beam_rifle/proc/sync_stats()
-	var/obj/item/gun/energy/beam_rifle/BR = loc
-	if(!istype(BR))
-		stack_trace("Beam rifle syncing error")
-	host = BR
-	do_pierce = BR.projectile_setting_pierce
-	wall_pierce_amount = BR.wall_pierce_amount
-	wall_devastate = BR.wall_devastate
-	aoe_structure_range = BR.aoe_structure_range
-	aoe_structure_damage = BR.aoe_structure_damage
-	aoe_fire_range = BR.aoe_fire_range
-	aoe_fire_chance = BR.aoe_fire_chance
-	aoe_mob_range = BR.aoe_mob_range
-	aoe_mob_damage = BR.aoe_mob_damage
-	impact_structure_damage = BR.impact_structure_damage
-	projectile_damage = BR.projectile_damage
-	projectile_stun = BR.projectile_stun
-	delay = BR.delay
-	structure_piercing = BR.structure_piercing
-	structure_bleed_coeff = BR.structure_bleed_coeff
-
-/obj/item/ammo_casing/energy/beam_rifle/ready_proj(atom/target, mob/living/user, quiet, zone_override = "")
-	. = ..()
-	var/obj/projectile/beam/beam_rifle/hitscan/HS_BB = BB
-	if(!istype(HS_BB))
-		return
-	HS_BB.impact_direct_damage = projectile_damage
-	HS_BB.stun = projectile_stun
-	HS_BB.impact_structure_damage = impact_structure_damage
-	HS_BB.aoe_mob_damage = aoe_mob_damage
-	HS_BB.aoe_mob_range = clamp(aoe_mob_range, 0, 15)				//Badmin safety lock
-	HS_BB.aoe_fire_chance = aoe_fire_chance
-	HS_BB.aoe_fire_range = aoe_fire_range
-	HS_BB.aoe_structure_damage = aoe_structure_damage
-	HS_BB.aoe_structure_range = clamp(aoe_structure_range, 0, 15)	//Badmin safety lock
-	HS_BB.wall_devastate = wall_devastate
-	HS_BB.wall_pierce_amount = wall_pierce_amount
-	HS_BB.structure_pierce_amount = structure_piercing
-	HS_BB.structure_bleed_coeff = structure_bleed_coeff
-	HS_BB.do_pierce = do_pierce
-	HS_BB.gun = host
+	select_name = "beam"
+	e_cost = 10000
+	fire_sound = 'sound/weapons/beam_sniper.ogg'
 
 /obj/item/ammo_casing/energy/beam_rifle/throw_proj(atom/target, turf/targloc, mob/living/user, params, spread)
 	var/turf/curloc = get_turf(user)
@@ -412,125 +328,30 @@
 
 /obj/item/ammo_casing/energy/beam_rifle/hitscan
 	projectile_type = /obj/projectile/beam/beam_rifle/hitscan
-	select_name = "beam"
-	e_cost = 10000
-	fire_sound = 'sound/weapons/beam_sniper.ogg'
+
+/obj/item/ammo_casing/energy/beam_rifle/hitscan/impact
+	projectile_type = /obj/projectile/beam/beam_rifle/hitscan/impact
+	select_name = "impact"
+
+/obj/item/ammo_casing/energy/beam_rifle/hitscan/piercing
+	projectile_type = /obj/projectile/beam/beam_rifle/hitscan/piercing
+	select_name = "pierce"
 
 /obj/projectile/beam/beam_rifle
 	name = "particle beam"
 	icon = null
 	hitsound = 'sound/effects/explosion3.ogg'
-	damage = 0				//Handled manually.
+	damage = 0
 	damage_type = BURN
 	armor_flag = ENERGY
 	range = 150
 	jitter = 10
 	demolition_mod = 4
-	var/obj/item/gun/gun
-	var/structure_pierce_amount = 0				//All set to 0 so the gun can manually set them during firing.
-	var/structure_bleed_coeff = 0
-	var/structure_pierce = 0
-	var/do_pierce = TRUE
-	var/wall_pierce_amount = 0
-	var/wall_pierce = 0
-	var/wall_devastate = 0
-	var/aoe_structure_range = 0
-	var/aoe_structure_damage = 0
-	var/aoe_fire_range = 0
+	can_ricoshot = ALWAYS_RICOSHOT
+	var/aoe_range = 0
 	var/aoe_fire_chance = 0
-	var/aoe_mob_range = 0
-	var/aoe_mob_damage = 0
-	var/impact_structure_damage = 0
-	var/impact_direct_damage = 0
-	var/turf/cached
-	var/list/pierced = list()
-
-/obj/projectile/beam/beam_rifle/proc/AOE(turf/epicenter)
-	set waitfor = FALSE
-	if(!epicenter)
-		return
-	new /obj/effect/temp_visual/explosion/fast(epicenter)
-	for(var/mob/living/L in range(aoe_mob_range, epicenter))		//handle aoe mob damage
-		L.adjustFireLoss(aoe_mob_damage)
-		to_chat(L, span_userdanger("\The [src] sears you!"))
-	for(var/turf/T in range(aoe_fire_range, epicenter))		//handle aoe fire
-		if(prob(aoe_fire_chance))
-			new /obj/effect/hotspot(T)
-	for(var/obj/O in range(aoe_structure_range, epicenter))
-		if(!isitem(O))
-			if(O.level == 1)	//Please don't break underfloor items!
-				continue
-			O.take_damage(aoe_structure_damage * get_damage_coeff(O), BURN, LASER, FALSE)
-
-/obj/projectile/beam/beam_rifle/proc/check_pierce(atom/target)
-	if(!do_pierce)
-		return FALSE
-	if(pierced[target])		//we already pierced them go away
-		return TRUE
-	if(isclosedturf(target))
-		if(wall_pierce++ < wall_pierce_amount)
-			if(prob(wall_devastate))
-				if(iswallturf(target))
-					var/turf/closed/wall/W = target
-					W.dismantle_wall(TRUE, TRUE)
-				else
-					SSexplosions.medturf += target
-			return TRUE
-	if(ismovable(target))
-		var/atom/movable/AM = target
-		if(AM.density && !AM.CanPass(src, get_turf(target)) && !ismob(AM))
-			if(structure_pierce < structure_pierce_amount)
-				if(isobj(AM))
-					var/obj/O = AM
-					O.take_damage((impact_structure_damage + aoe_structure_damage) * structure_bleed_coeff * get_damage_coeff(AM), BURN, ENERGY, FALSE)
-				pierced[AM] = TRUE
-				structure_pierce++
-				return TRUE
-	return FALSE
-
-/obj/projectile/beam/beam_rifle/proc/get_damage_coeff(atom/target)
-	if(istype(target, /obj/machinery/door))
-		return 0.4
-	if(istype(target, /obj/structure/window))
-		return 0.5
-	return 1
-
-/obj/projectile/beam/beam_rifle/proc/handle_impact(atom/target)
-	if(isobj(target))
-		var/obj/O = target
-		O.take_damage(impact_structure_damage * get_damage_coeff(target), BURN, LASER, FALSE)
-	if(isliving(target))
-		var/mob/living/L = target
-		L.adjustFireLoss(impact_direct_damage)
-		L.emote("scream")
-
-/obj/projectile/beam/beam_rifle/proc/handle_hit(atom/target)
-	set waitfor = FALSE
-	if(!cached && !QDELETED(target))
-		cached = get_turf(target)
-	if(nodamage)
-		return FALSE
-	playsound(cached, 'sound/effects/explosion3.ogg', 100, 1)
-	AOE(cached)
-	if(!QDELETED(target))
-		handle_impact(target)
-
-/obj/projectile/beam/beam_rifle/Bump(atom/target)
-	if(check_pierce(target))
-		impacted += target
-		trajectory_ignore_forcemove = TRUE
-		forceMove(target.loc)
-		trajectory_ignore_forcemove = FALSE
-		return FALSE
-	if(!QDELETED(target))
-		cached = get_turf(target)
-	return ..()
-
-/obj/projectile/beam/beam_rifle/on_hit(atom/target, blocked = FALSE)
-	if(!QDELETED(target))
-		cached = get_turf(target)
-	handle_hit(target)
-	return ..()
+	var/tracer_fire_chance = 0
+	var/fire_color = "green"
 
 /obj/projectile/beam/beam_rifle/hitscan
 	icon_state = ""
@@ -538,17 +359,67 @@
 	tracer_type = /obj/effect/projectile/tracer/tracer/beam_rifle
 	var/constant_tracer = FALSE
 
+/obj/projectile/beam/beam_rifle/hitscan/piercing
+	damage = 60 // same as the impact version, but applied all at once
+	aoe_range = 0 // no AOE, has piercing instead
+	penetrations = 2
+	tracer_fire_chance = 50
+	penetration_flags = PENETRATE_OBJECTS | PENETRATE_MOBS
+
+/obj/projectile/beam/beam_rifle/hitscan/impact
+	damage = 30 // total of 60 on direct hit
+	aoe_range = 2
+	aoe_fire_chance = 50
+	tracer_fire_chance = 20
+
+/obj/projectile/beam/beam_rifle/Move(atom/newloc, dir)
+	. = ..()
+	if(prob(tracer_fire_chance))
+		var/turf/new_turf = newloc
+		new_turf.IgniteTurf(rand(16, 22), fire_color) // FIRE IN THE HOLE!!!!
+
+/obj/projectile/beam/beam_rifle/proc/do_area_damage(turf/epicenter)
+	set waitfor = FALSE
+	if(!epicenter)
+		return
+	new /obj/effect/temp_visual/explosion/fast(epicenter)
+	for(var/turf/T in spiral_range_turfs(aoe_range, epicenter))
+		var/modified_damage = damage / max(get_dist(epicenter, T), 1) // damage decreases with range
+		if(prob(aoe_fire_chance))
+			T.IgniteTurf(rand(16, 22), fire_color)
+		for(var/mob/living/L in T) //handle aoe mob damage
+			L.apply_damage(modified_damage, BURN, null, L.getarmor(null, BOMB))
+			to_chat(L, span_userdanger("\The [src] sears you!"))
+		for(var/obj/O in T)
+			if(!isitem(O))
+				if(O.level == 1) //Please don't break underfloor items!
+					continue
+				O.take_damage(modified_damage, BURN, BOMB, FALSE)
+
+/obj/projectile/beam/beam_rifle/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	var/turf/target_turf = (isclosedturf(target) && penetrations <= 0) ? get_turf(src) : get_turf(target)
+	playsound(target_turf, 'sound/effects/explosion3.ogg', 100, 1)
+	if(isclosedturf(target)) // if hitting a wall
+		SSexplosions.lowturf += target
+	target_turf.IgniteTurf(rand(16, 22), fire_color)
+	if(aoe_range)
+		do_area_damage(target_turf)
+
 /obj/projectile/beam/beam_rifle/hitscan/generate_hitscan_tracers(cleanup = TRUE, duration = 5, impacting = TRUE, highlander)
 	set waitfor = FALSE
 	if(isnull(highlander))
 		highlander = constant_tracer
-	if(highlander && istype(gun))
+
+	if(highlander && istype(fired_from, /obj/item/gun))
+		var/obj/item/gun/gun = fired_from
 		QDEL_LIST(gun.current_tracers)
 		for(var/datum/point/p in beam_segments)
 			gun.current_tracers += generate_tracer_between_points(p, beam_segments[p], tracer_type, color, 0, hitscan_light_range, hitscan_light_color_override, hitscan_light_intensity)
 	else
 		for(var/datum/point/p in beam_segments)
 			generate_tracer_between_points(p, beam_segments[p], tracer_type, color, duration, hitscan_light_range, hitscan_light_color_override, hitscan_light_intensity)
+
 	if(cleanup)
 		QDEL_LIST(beam_segments)
 		beam_segments = null
@@ -561,6 +432,7 @@
 	hitsound_wall = null
 	nodamage = TRUE
 	damage = 0
+	aoe_range = 0
 	constant_tracer = TRUE
 	hitscan_light_range = 0
 	hitscan_light_intensity = 0

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -1,7 +1,4 @@
 
-#define MOVES_HITSCAN -1		//Not actually hitscan but close as we get without actual hitscan.
-#define MUZZLE_EFFECT_PIXEL_INCREMENT 17	//How many pixels to move the muzzle flash up so your character doesn't look like they're shitting out lasers.
-
 /obj/projectile
 	name = "projectile"
 	icon = 'icons/obj/projectiles.dmi'
@@ -49,10 +46,12 @@
 	var/ricochet_chance = 30
 	var/force_hit = FALSE //If the object being hit can pass ths damage on to something else, it should not do it for this bullet.
 
-	//Atom penetration, set to mobs by default
-	var/penetrating = FALSE
-	var/penetrations = INFINITY
-	var/penetration_type = 0 //Set to 1 if you only want to have it penetrate objects. Set to 2 if you want it to penetrate objects and mobs.
+	///Whether this projectile can ricochet off of coins
+	var/can_ricoshot = FALSE
+	///How many things can this penetrate?
+	var/penetrations = 0
+	///Flags used to specify what this projectile can penetrate. Default is mobs only.
+	var/penetration_flags = PENETRATE_MOBS
 
 	//Hitscan
 	var/hitscan = FALSE		//Whether this is hitscan. If it is, speed is basically ignored.
@@ -209,7 +208,7 @@
 
 		W.add_dent(WALL_DENT_SHOT, hitx, hity)
 
-		if(penetrating && (penetration_type == 1 || penetration_type == 2) && penetrations > 0)
+		if((penetration_flags & PENETRATE_OBJECTS) && penetrations > 0)
 			penetrations -= 1
 			return BULLET_ACT_FORCE_PIERCE
 
@@ -219,7 +218,7 @@
 		if(impact_effect_type && !hitscan)
 			new impact_effect_type(target_loca, hitx, hity)
 
-		if(penetrating && (penetration_type == 1 || penetration_type == 2) && penetrations > 0)
+		if((penetration_flags & PENETRATE_OBJECTS) && penetrations > 0)
 			penetrations -= 1
 			return BULLET_ACT_FORCE_PIERCE
 

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -22,6 +22,7 @@
 	wound_bonus = -30
 	wound_falloff_tile = -2.5
 	bare_wound_bonus = 15
+	can_ricoshot = TRUE
 
 /obj/projectile/bullet/c38/rubber
 	name = ".38 rubber bullet"
@@ -86,6 +87,7 @@
 	armour_penetration = 15
 	wound_bonus = -45
 	wound_falloff_tile = -2.5
+	can_ricoshot = TRUE
 
 /obj/projectile/bullet/pellet/a357_ironfeather
 	name = ".357 Ironfeather pellet"
@@ -119,8 +121,7 @@
 	name = ".357 Heartpiercer bullet"
 	damage = 35
 	armour_penetration = 45
-	penetrating = TRUE //Goes through a single mob before ending on the next target
-	penetrations = 1
+	penetrations = 1 //Goes through a single mob before ending on the next target
 
 /obj/projectile/bullet/a357/wallstake
 	name = ".357 Wallstake bullet"

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -34,7 +34,7 @@
 	name = ".308 penetrator bullet"
 	damage = 35
 	armour_penetration = 35
-	penetrating = TRUE
+	penetrations = INFINITY
 
 // 7.62 (Nagant Rifle + K-41s DMR)
 
@@ -61,9 +61,8 @@
 	name = "7.62mm anti-material bullet"
 	damage = 52
 	armour_penetration = 40
-	penetrating = TRUE //Passes through two objects, stops on a mob or on a third object
-	penetrations = 2
-	penetration_type = 1
+	penetrations = 2 //Passes through two objects, stops on a mob or on a third object
+	penetration_flags = PENETRATE_OBJECTS
 	demolition_mod = 1.5 // anti-armor
 
 /obj/projectile/bullet/a762/vulcan

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -76,7 +76,7 @@
 	armour_penetration = 60 // he he funny round go through armor
 	wound_bonus = -40
 	demolition_mod = 3 // very good at smashing through stuff
-	penetrating = TRUE //Goes through an infinite number of mobs
+	penetrations = INFINITY //Goes through an infinite number of mobs
 
 /obj/projectile/bullet/shotgun/slug/Range()
 	..()

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -26,8 +26,8 @@
 	name = ".50 penetrator bullet"
 	icon_state = "gauss"
 	damage = 60
-	penetrating = TRUE //Passes through everything and anything until it reaches the end of its range
-	penetration_type = 2
+	penetrations = INFINITY //Passes through everything and anything until it reaches the end of its range
+	penetration_flags = PENETRATE_OBJECTS | PENETRATE_MOBS
 	dismemberment = 0 //It goes through you cleanly.
 	paralyze = 0
 

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -105,6 +105,7 @@
 #include "code\__DEFINES\preferences.dm"
 #include "code\__DEFINES\procpath.dm"
 #include "code\__DEFINES\profile.dm"
+#include "code\__DEFINES\projectiles.dm"
 #include "code\__DEFINES\qdel.dm"
 #include "code\__DEFINES\radiation.dm"
 #include "code\__DEFINES\radio.dm"


### PR DESCRIPTION
# Document the changes in your pull request

Updates the beam rifle's code to be much simpler and easier to read, makes them actually work in turrets and emitters, and fixes hitscan projectiles not rendering properly when reflected.

Also makes the beam rifle's projectile reflect off of coins more easily because that's cool as hell.

# Why is this good for the game?
Makes an old and rarely used weapon less weird and buggy.

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/93578146/53b72876-907c-4d20-a006-792d71a8889d)

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: beam rifles now create turf fires instead of hotspots
tweak: beam rifle projectiles can always reflect off of coins
bugfix: fixed hitscan projectiles not rendering properly when reflected
bugfix: fixed beam rifle projectiles not doing damage when fired from turrets or emitters
/:cl:
