### PR TITLE
fixes mime's mail cheesewheel being invisible

### DIFF
--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -27,13 +27,13 @@
 
 	mail_goodies = list(
 		/obj/item/reagent_containers/food/snacks/baguette = 15,
-		/obj/item/reagent_containers/food/snacks/store/cheesewheel = 10,
+		/obj/item/reagent_containers/food/snacks/store/cheesewheel/brie = 10,
 		/obj/item/reagent_containers/food/drinks/bottle/bottleofnothing = 10,
 		/obj/item/book/mimery = 1,
 	)
 
 	minimal_lightup_areas = list(/area/crew_quarters/theatre)
-	
+
 	smells_like = "complete nothingness"
 
 /datum/job/mime/after_spawn(mob/living/carbon/human/H, mob/M)
@@ -103,7 +103,7 @@
 
 		if("Invisible Box")
 			picked_spell_type = /datum/action/cooldown/spell/conjure_item/invisible_box
-		
+
 		if("Invisible Touch")
 			picked_spell_type = /datum/action/cooldown/spell/touch/invisible_touch
 


### PR DESCRIPTION
I asked our cheese expert (tessa) which cheese is the most French and they said brie. So instead of an invisible cheesewheel, mimes now get a brie cheesewheel in the mail.

# Why is this good for the game?
so they can eat their cheese instead of getting PRANK cheese

# Testing
doesnt need it

:cl:  ktlwjec
bugfix: Mime's mail cheesewheel is now visible.
/:cl: