### PR TITLE
[""""BUGFIX"""] Makes it so you cannot have infinite money selling syrup from cargo after ordering it. 

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2056,7 +2056,7 @@
 /datum/supply_pack/service/syrup
 	name = "Coffee Syrups Box"
 	desc = "A packaged box of various syrups, perfect for making your delicious coffee even more diabetic."
-	cost = 200
+	cost = 1400
 	contains = list(
 		/obj/item/reagent_containers/food/drinks/bottle/syrup_bottle/caramel,
 		/obj/item/reagent_containers/food/drinks/bottle/syrup_bottle/liqueur,


### PR DESCRIPTION
# Document the changes in your pull request

Adjusts the price of the syrup crate from 200 to 1400, because we can't have nice things. Ever.

Closes https://github.com/yogstation13/Yogstation/issues/21178

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

bugfix: removes infinite money in the form of syrup

/:cl:
