### PR TITLE
Raw croissants need raw pastry bases

### DIFF
--- a/code/game/objects/items/granters/crafting/desserts.dm
+++ b/code/game/objects/items/granters/crafting/desserts.dm
@@ -12,7 +12,7 @@
 	remarks = list(
 		"So that is how icing is made!",
 		"Placing fruit on top? How simple...",
-		"Huh layering cake seems harder then this...",
+		"Huh, layering cake seems harder than this...",
 		"This book smells like candy.",
 		"A clown must have made this page, or they forgot to spell check it before printing...",
 		"Wait, a way to cook slime to be safe?",

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
@@ -484,7 +484,7 @@ datum/crafting_recipe/food/donut/meat
 /datum/crafting_recipe/food/raw_croissant
 	name = "Raw Croissant"
 	reqs = list(
-		/obj/item/reagent_containers/food/snacks/pastrybase = 1,
+		/obj/item/reagent_containers/food/snacks/rawpastrybase = 1,
 		/datum/reagent/consumable/sugar = 1,
 		/obj/item/reagent_containers/food/snacks/butterslice = 2
 	)


### PR DESCRIPTION
makes raw croissants need raw pastry bases instead of baked ones, and fixes a spelling error.

# Why is this good for the game?
raw pastry base should make raw croissant, instead of baking it and then having to bake it again. makes sense to me

# Testing
doesnt need it

:cl:  ktlwjec
tweak: Croissants need raw pastry bases to craft, instead of cooked ones.
/:cl:
