### PR TITLE
Nerfs Changeling Ability "Adrenaline Sacs"

### DIFF
--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -1,10 +1,10 @@
 /datum/action/changeling/adrenaline
 	name = "Adrenaline Sacs"
-	desc = "We evolve additional sacs of adrenaline throughout our body. Costs 50 chemicals."
+	desc = "We evolve additional sacs of adrenaline throughout our body. Costs 30 chemicals."
 	helptext = "Removes all stuns instantly. Can be used while unconscious. Continued use poisons the body." //yogs - changed text to suit the below change
 	button_icon_state = "adrenaline"
-	chemical_cost = 50
-	dna_cost = 2
+	chemical_cost = 30
+	dna_cost = 1
 	req_human = 1
 	req_stat = UNCONSCIOUS
 	conflicts = list(/datum/action/changeling/strained_muscles)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1346,7 +1346,7 @@
 
 /datum/reagent/medicine/changelinghaste/on_mob_metabolize(mob/living/L)
 	..()
-	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=0.9, blacklisted_movetypes=(FLYING|FLOATING))
+	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=-0.9, blacklisted_movetypes=(FLYING|FLOATING))
 
 /datum/reagent/medicine/changelinghaste/on_mob_end_metabolize(mob/living/L)
 	L.remove_movespeed_modifier(type)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1324,16 +1324,17 @@
 	name = "Changeling Adrenaline"
 	description = "Reduces the duration of unconsciousness, knockdown and stuns. Restores stamina, but deals toxin damage when overdosed."
 	color = "#C8A5DC"
-	overdose_threshold = 30
+	overdose_threshold = 15
 
 /datum/reagent/medicine/changelingadrenaline/on_mob_life(mob/living/carbon/M as mob)
-	M.AdjustAllImmobility(-20, FALSE)
-	M.adjustStaminaLoss(-15, 0)
+	M.AdjustAllImmobility(-10, FALSE)
+	M.adjustStaminaLoss(-10, 0)
+	M.adjustToxLoss(2,0)
 	..()
 	return TRUE
 
 /datum/reagent/medicine/changelingadrenaline/overdose_process(mob/living/M as mob)
-	M.adjustToxLoss(1, 0)
+	M.adjustToxLoss(5, 0)
 	..()
 	return TRUE
 
@@ -1345,7 +1346,7 @@
 
 /datum/reagent/medicine/changelinghaste/on_mob_metabolize(mob/living/L)
 	..()
-	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=-2, blacklisted_movetypes=(FLYING|FLOATING))
+	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=0.9, blacklisted_movetypes=(FLYING|FLOATING))
 
 /datum/reagent/medicine/changelinghaste/on_mob_end_metabolize(mob/living/L)
 	L.remove_movespeed_modifier(type)


### PR DESCRIPTION
# Document the changes in your pull request

Adjusts the OD threshold for "changelingadrenaline" to be 15 from 30
Adds low levels of toxin damage to "changelingadrenaline"'s base use
Reduces the effectiveness of it's stun removal by half
Increases the OD effect for spamming the ability
Reduces the multiplicative slowdown from -2 (methspeed and stun immunity, very fair) to 0.9

Adjusts the chemical cost of using the ability from 50 -> 30
Adjusts the DNA cost from 2 -> 1

# Why is this good for the game?

No longer a super free "get out of jail-free-card" this ability will require SOME thought on the player's behalf of when to use it, pretty much like with every other changeling ability minus the stings.

# Testing

Just numbers changes, tested but will show videos of before + after if requested.


# Wiki Documentation

Adjust chemical cost from 50 -> 30
Adjust DNA cost from 2 -> 1


# Changelog

:cl:  

tweak: adjusts changeling adrenaline sacs

/:cl:
