### PR TITLE
Nerfs Changeling Ability "Resonant Shriek"

### DIFF
--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -1,10 +1,10 @@
 /datum/action/changeling/adrenaline
 	name = "Adrenaline Sacs"
-	desc = "We evolve additional sacs of adrenaline throughout our body. Costs 40 chemicals."
+	desc = "We evolve additional sacs of adrenaline throughout our body. Costs 50 chemicals."
 	helptext = "Removes all stuns instantly. Can be used while unconscious. Continued use poisons the body." //yogs - changed text to suit the below change
 	button_icon_state = "adrenaline"
-	chemical_cost = 30
-	dna_cost = 1
+	chemical_cost = 50
+	dna_cost = 2
 	req_human = 1
 	req_stat = UNCONSCIOUS
 	conflicts = list(/datum/action/changeling/strained_muscles)

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -1,10 +1,10 @@
 /datum/action/changeling/adrenaline
 	name = "Adrenaline Sacs"
-	desc = "We evolve additional sacs of adrenaline throughout our body. Costs 50 chemicals."
+	desc = "We evolve additional sacs of adrenaline throughout our body. Costs 40 chemicals."
 	helptext = "Removes all stuns instantly. Can be used while unconscious. Continued use poisons the body." //yogs - changed text to suit the below change
 	button_icon_state = "adrenaline"
-	chemical_cost = 50
-	dna_cost = 2
+	chemical_cost = 30
+	dna_cost = 1
 	req_human = 1
 	req_stat = UNCONSCIOUS
 	conflicts = list(/datum/action/changeling/strained_muscles)

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -23,7 +23,7 @@
 			var/mob/living/carbon/C = M
 			if(!C.mind || !C.mind.has_antag_datum(/datum/antagonist/changeling))
 				C.adjustEarDamage(0, 30)
-				C.adjust_confusion(5 SECONDS)
+				C.adjust_confusion(10 SECONDS)
 				C.adjust_jitter(10 SECONDS)
 			else
 				SEND_SOUND(C, sound('sound/effects/screech.ogg'))

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -1,6 +1,6 @@
 /datum/action/changeling/resonant_shriek
 	name = "Resonant Shriek"
-	desc = "Our lungs and vocal cords shift, allowing us to briefly emit a noise that deafens and confuses the weak-minded. Costs 60 chemicals."
+	desc = "Our lungs and vocal cords shift, allowing us to briefly emit a noise that deafens and confuses the weak-minded. Costs 45 chemicals."
 	helptext = "Emits a high-frequency sound that confuses and deafens humans, blows out nearby lights and overloads cyborg sensors."
 	button_icon_state = "resonant_shriek"
 	chemical_cost = 45

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -3,8 +3,8 @@
 	desc = "Our lungs and vocal cords shift, allowing us to briefly emit a noise that deafens and confuses the weak-minded. Costs 60 chemicals."
 	helptext = "Emits a high-frequency sound that confuses and deafens humans, blows out nearby lights and overloads cyborg sensors."
 	button_icon_state = "resonant_shriek"
-	chemical_cost = 60
-	dna_cost = 1
+	chemical_cost = 45
+	dna_cost = 2
 	req_human = 1
 	xenoling_available = FALSE
 
@@ -23,8 +23,8 @@
 			var/mob/living/carbon/C = M
 			if(!C.mind || !C.mind.has_antag_datum(/datum/antagonist/changeling))
 				C.adjustEarDamage(0, 30)
-				C.adjust_confusion(25 SECONDS)
-				C.adjust_jitter(50 SECONDS)
+				C.adjust_confusion(5 SECONDS)
+				C.adjust_jitter(10 SECONDS)
 			else
 				SEND_SOUND(C, sound('sound/effects/screech.ogg'))
 


### PR DESCRIPTION
# Document the changes in your pull request

Reduces chem cost from 60 -> 45
Increases DNA cost from 1 -> 2
Reduces the confusion from 25 seconds -> 10 seconds
Reduces the jitter from 50 seconds (what the fuck) -> 10 seconds

# Why is this good for the game?

This ability is too good at AOE crowd control, needs to be brought down to the same baselevel as the rest of the changeling's kit

# Testing

Numbers changes, will provide before/after vids if required

# Wiki Documentation

Adjust cost from 60 -> 45 & DNA cost from 1 -> 2

# Changelog


:cl:  

tweak: adjusts changeling's Resonant Shriek ability

/:cl:
