### PR TITLE
Adjusts the costs of several changeling abilities

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -227,13 +227,13 @@
 
 /datum/action/changeling/weapon/tentacle
 	name = "Tentacle"
-	desc = "We ready a tentacle to grab items or victims with. Costs 10 chemicals."
+	desc = "We ready a tentacle to grab items or victims with. Costs 5 chemicals."
 	helptext = "We can use it once to retrieve a distant item. If used on living creatures, the effect depends on the intent: \
 	Help will simply drag them closer, Disarm will grab whatever they're holding instead of them, Grab will put the victim in our hold after catching it, \
 	and Harm will stab it if we're also holding a sharp weapon. Cannot be used while in lesser form."
 	button_icon_state = "tentacle"
-	chemical_cost = 10
-	dna_cost = 2
+	chemical_cost = 5
+	dna_cost = 1
 	req_human = 1
 	weapon_type = /obj/item/gun/magic/tentacle
 	weapon_name_simple = "tentacle"

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -41,7 +41,7 @@
 	name = "Dissonant Shriek"
 	desc = "We shift our vocal cords to release a high-frequency sound that overloads nearby electronics. Costs 40 chemicals."
 	button_icon_state = "dissonant_shriek"
-	chemical_cost = 40
+	chemical_cost = 30
 	dna_cost = 1
 	xenoling_available = FALSE
 

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -255,7 +255,7 @@
 
 /datum/action/changeling/sting/cryo
 	name = "Cryogenic Sting"
-	desc = "We silently sting our victim with a cocktail of chemicals that freezes them from the inside. Costs 30 chemicals."
+	desc = "We silently sting our victim with a cocktail of chemicals that freezes them from the inside. Costs 25 chemicals."
 	helptext = "Does not provide a warning to the victim, though they will likely realize they are suddenly freezing."
 	button_icon_state = "sting_cryo"
 	sting_icon = "sting_cryo"

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -136,7 +136,7 @@
 	helptext = "The victim will form an armblade much like a changeling would, except the armblade is less sharp and powerful."
 	button_icon_state = "sting_armblade"
 	sting_icon = "sting_armblade"
-	chemical_cost = 20
+	chemical_cost = 5
 	dna_cost = 1
 	xenoling_available = FALSE
 
@@ -223,11 +223,11 @@
 
 /datum/action/changeling/sting/blind
 	name = "Blind Sting"
-	desc = "We temporarily blind our victim. Costs 40 chemicals."
+	desc = "We temporarily blind our victim. Costs 20 chemicals."
 	helptext = "This sting completely blinds a target for a short time, and leaves them with blurred vision for a long time."
 	button_icon_state = "sting_blind"
 	sting_icon = "sting_blind"
-	chemical_cost = 40
+	chemical_cost = 20
 	dna_cost = 1
 
 /datum/action/changeling/sting/blind/sting_action(mob/user, mob/living/carbon/target)
@@ -240,11 +240,11 @@
 
 /datum/action/changeling/sting/LSD
 	name = "Hallucination Sting"
-	desc = "We cause mass terror to our victim. Costs 10 chemicals."
+	desc = "We cause mass terror to our victim. Costs 30 chemicals."
 	helptext = "We evolve the ability to sting a target with a powerful hallucinogenic chemical. The target does not notice they have been stung, and the effect occurs after 30 to 60 seconds."
 	button_icon_state = "sting_lsd"
 	sting_icon = "sting_lsd"
-	chemical_cost = 10
+	chemical_cost = 30
 	dna_cost = 1
 
 /datum/action/changeling/sting/LSD/sting_action(mob/user, mob/living/carbon/target)
@@ -259,7 +259,7 @@
 	helptext = "Does not provide a warning to the victim, though they will likely realize they are suddenly freezing."
 	button_icon_state = "sting_cryo"
 	sting_icon = "sting_cryo"
-	chemical_cost = 30
+	chemical_cost = 25
 	dna_cost = 2
 	xenoling_available = FALSE
 


### PR DESCRIPTION
# Document the changes in your pull request

Adjusts the chemical cost of Changeling Tentacle from 10 -> 5
Adjusts the DNA cost of Tentacle from 2 -> 1

Adjusts the chemical cost of Dissonant Shriek from 40 -> 30

Adjusts the chemical costof False Armblade Sting from 20 -> 5

Adjusts the chemical cost of Blind Sting from 40 -> 20

Adjusts the chemical cost of Hallucination Sting from 10 -> 30

Adjusts the chemical cost of Cryogenic Sting from 30 -> 25

# Why is this good for the game?

Makes some underused/purchased abilities a bit more favourable to get, while adjusting one in particular that should cost more

# Testing

Numbers changes.

# Wiki Documentation

adjust all the costs as listed above

# Changelog

:cl:  

tweak: adjusts the cost of several changeling abilities

/:cl:
