### PR TITLE
Removes the donk-soft vendor from roundstart asteroid

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -4737,10 +4737,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
-"aQd" = (
-/obj/machinery/vending/donksofttoyvendor,
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
 "aQh" = (
 /turf/closed/wall,
 /area/science/explab)
@@ -93538,7 +93534,7 @@ wsD
 qTR
 new
 uVl
-aQd
+aeM
 sfH
 jdd
 aXp
@@ -93795,7 +93791,7 @@ eXm
 aAw
 mSV
 uVl
-aeM
+aii
 lEF
 wNI
 aXp


### PR DESCRIPTION
# Document the changes in your pull request

Removes the roundstart vendor 

![image](https://github.com/yogstation13/Yogstation/assets/75333826/7862feb1-0241-4113-8152-4ef2d1683660)


# Why is this good for the game?

Leads to less problems for admins and players alike when riot darts get out of control.

# Changelog

:cl:  

rscdel: Removes the donksoft vendor from asteroid

/:cl:
