### PR TITLE
Fixes a typo in the spelling of salicylic acid

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -228,7 +228,7 @@
 		return
 	var/static/items_inside = list(
 		/obj/item/reagent_containers/pill/patch/styptic = 2,
-		/obj/item/reagent_containers/pill/salicyclic = 2,
+		/obj/item/reagent_containers/pill/salicylic = 2,
 		/obj/item/reagent_containers/medspray/styptic = 1,
 		/obj/item/stack/medical/gauze = 2,
 		/obj/item/healthanalyzer = 1)

--- a/code/modules/antagonists/horror/horror_abilities_and_upgrades.dm
+++ b/code/modules/antagonists/horror/horror_abilities_and_upgrades.dm
@@ -437,7 +437,7 @@
 /datum/horror_upgrade/upgraded_chems
 	name = "Advanced reagent synthesis"
 	id = "upgraded_chems"
-	desc = "Lets you synthetize adrenaline, salicylic acid, oxandrolone, pentetic acid and rezadone into your host."
+	desc = "Lets you synthesize adrenaline, salicylic acid, oxandrolone, pentetic acid and rezadone into your host."
 	soul_price = 2
 
 /datum/horror_upgrade/upgraded_chems/apply_effects()

--- a/code/modules/antagonists/horror/horror_abilities_and_upgrades.dm
+++ b/code/modules/antagonists/horror/horror_abilities_and_upgrades.dm
@@ -437,7 +437,7 @@
 /datum/horror_upgrade/upgraded_chems
 	name = "Advanced reagent synthesis"
 	id = "upgraded_chems"
-	desc = "Lets you synthetize adrenaline, salicyclic acid, oxandrolone, pentetic acid and rezadone into your host."
+	desc = "Lets you synthetize adrenaline, salicylic acid, oxandrolone, pentetic acid and rezadone into your host."
 	soul_price = 2
 
 /datum/horror_upgrade/upgraded_chems/apply_effects()

--- a/code/modules/antagonists/horror/horror_chemicals.dm
+++ b/code/modules/antagonists/horror/horror_chemicals.dm
@@ -85,7 +85,7 @@
 	chem_desc = "Reduces massive amounts of radiation and toxin damage while purging other chemicals from the body."
 
 /datum/horror_chem/sal_acid
-	chemname = "salicyclic acid"
+	chemname = "salicylic acid"
 	R = /datum/reagent/medicine/sal_acid
 	chem_desc = "Stimulates the healing of severe bruises. Rapidly heals severe bruising and slowly heals minor ones."
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -556,7 +556,7 @@
 	. = 1
 
 /datum/reagent/medicine/sal_acid
-	name = "Salicyclic Acid"
+	name = "Salicylic Acid"
 	description = "Stimulates the healing of severe bruises. Extremely rapidly heals severe bruising and slowly heals minor ones. Overdose will worsen existing bruising."
 	reagent_state = LIQUID
 	color = "#D2D2D2"

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -100,7 +100,7 @@
 	required_reagents = list(/datum/reagent/fuel = 1, /datum/reagent/chlorine = 1, /datum/reagent/ammonia = 1, /datum/reagent/toxin/formaldehyde = 1, /datum/reagent/sodium = 1, /datum/reagent/toxin/cyanide = 1)
 
 /datum/chemical_reaction/sal_acid
-	name = "Salicyclic Acid"
+	name = "Salicylic Acid"
 	id = /datum/reagent/medicine/sal_acid
 	results = list(/datum/reagent/medicine/sal_acid = 5)
 	required_reagents = list(/datum/reagent/sodium = 1, /datum/reagent/phenol = 1, /datum/reagent/carbon = 1, /datum/reagent/oxygen = 1, /datum/reagent/toxin/acid = 1)

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -556,7 +556,7 @@
 	custom_premium_price = 30
 
 /obj/item/reagent_containers/glass/bottle/vial/sal_acid
-	name = "vial (Salicyclic Acid)"
+	name = "vial (Salicylic Acid)"
 	icon_state = "viallarge_white"
 	list_reagents = list(/datum/reagent/medicine/sal_acid = 15)
 	custom_premium_price = 50

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -166,7 +166,7 @@
 /obj/item/reagent_containers/pill/mutadone/five
 	list_reagents = list(/datum/reagent/medicine/mutadone = 5)
 
-/obj/item/reagent_containers/pill/salicyclic
+/obj/item/reagent_containers/pill/salicylic
 	name = "salicylic acid pill"
 	desc = "Used to stimulate bruise healing."
 	icon_state = "pill9"


### PR DESCRIPTION
# Document the changes in your pull request
This corrects all mentions of "salicyclic acid" to "salicylic acid" (just removes a single C)

# Why is this good for the game?
Grammar good

# Testing
It compiles, shouldn't need more than that

# Wiki Documentation
I'll correct every mention of this on the wiki too yeah

# Changelog
:cl: 
spellcheck: Salicylic acid is now spelled correctly
/:cl:
