### PR TITLE
Increases the value of limb loss/skeletonization in brazil & should prevent people getting stuck

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -1,7 +1,7 @@
 #define PENANCE_LIFE "Lose your life (10 marbles)"
 #define PENANCE_SOUL "Lose your soul (14 marbles)"
-#define PENANCE_LIMB "Lose a limb (5 marbles)"
-#define PENANCE_SKELETON "Lose your flesh (1 marbles)"
+#define PENANCE_LIMB "Lose a limb (7 marbles)"
+#define PENANCE_SKELETON "Lose your flesh (3 marbles)"
 #define PENANCE_TRAUMA_ADV "Lose your mind (5 marbles)"
 #define PENANCE_TRAUMA_BASIC "Lose a smaller, but still important part of your mind (1 marbles)"
 #define TRAUMA_ADV_CAP 1
@@ -335,7 +335,7 @@
 	var/list/unspooked_limbs = list(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG)
 
 /atom/movable/screen/alert/status_effect/brazil_penance
-	name = "Otherworldly Tarrif"
+	name = "Otherworldly Tariff"
 	desc = "The things of this place want something from you. You won't be able to leave until enough has been taken."
 	icon_state = "shadow_mend"
 
@@ -378,8 +378,8 @@
 					var/obj/item/bodypart/BP
 					while(!BP)
 						if(!LAZYLEN(unspooked_limbs))
-							message_admins(span_notice("Someone managed to break brazil limb sacrificing stuff tell theos"))
-							break
+							message_admins(span_notice("Someone managed to break brazil limb sacrificing stuff"))
+							return
 						var/target_zone = pick_n_take(unspooked_limbs)
 						BP = C.get_bodypart(target_zone)
 					C.visible_message(span_warning("[owner]'s [BP] suddenly disintegrates!"), span_warning("In a flash, your [BP] is torn from your body and disintegrates!"))
@@ -388,8 +388,8 @@
 					var/obj/item/bodypart/BP
 					while(!BP || BP.species_id == "skeleton")
 						if(!LAZYLEN(unspooked_limbs))
-							message_admins(span_notice("Someone managed to break brazil limb sacrificing stuff tell theos"))
-							break
+							message_admins(span_notice("Someone managed to break brazil limb sacrificing stuff"))
+							return
 						var/target_zone = pick_n_take(unspooked_limbs)
 						BP = C.get_bodypart(target_zone)
 					var/obj/item/bodypart/replacement_part = new BP.type
@@ -472,7 +472,7 @@
 	icon_state = "shell_narsie_active"
 	pixel_x = -16
 	pixel_y = -17
-	penance_given = list(PENANCE_LIFE = 10, PENANCE_LIMB = 5)
+	penance_given = list(PENANCE_LIFE = 10, PENANCE_LIMB = 7)
 
 /obj/effect/penance_giver/mind
 	name = "Headache"
@@ -488,7 +488,7 @@
 	icon = 'icons/mob/evilpope.dmi' //fun fact the pope's mask is off center on his north sprite and now you have to see it too
 	icon_state = "EvilPope"
 	light_color = COLOR_SILVER
-	penance_given = list(PENANCE_SOUL = 14, PENANCE_SKELETON = 1)
+	penance_given = list(PENANCE_SOUL = 14, PENANCE_SKELETON = 3)
 
 #undef PENANCE_LIFE
 #undef PENANCE_SOUL

--- a/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_effects.dm
@@ -378,7 +378,7 @@
 					var/obj/item/bodypart/BP
 					while(!BP)
 						if(!LAZYLEN(unspooked_limbs))
-							message_admins(span_notice("Someone managed to break brazil limb sacrificing stuff"))
+							to_chat(C, span_warning("Something you did managed to break brazil limb sacrificing stuff, make a bug report!"))
 							return
 						var/target_zone = pick_n_take(unspooked_limbs)
 						BP = C.get_bodypart(target_zone)
@@ -388,7 +388,7 @@
 					var/obj/item/bodypart/BP
 					while(!BP || BP.species_id == "skeleton")
 						if(!LAZYLEN(unspooked_limbs))
-							message_admins(span_notice("Someone managed to break brazil limb sacrificing stuff"))
+							to_chat(C, span_warning("Something you did managed to break brazil limb sacrificing stuff, make a bug report!"))
 							return
 						var/target_zone = pick_n_take(unspooked_limbs)
 						BP = C.get_bodypart(target_zone)


### PR DESCRIPTION
# Document the changes in your pull request


Increases value of limb loss from 5 to 7 marbles, allowing 2 limbs to make up most of an escape
Increases value of limb skeletonization from 1 to 3 marbles since brain damage is already worth 1

Also switches the breaks in the limb modifying effects with returns, in the case someone does a silly they shouldn't end up trapped by a runtime.

# Why is this good for the game?
Increases the number of viable marble combinations that aren't dying

# Wiki Documentation

limb loss in brazil is now worth 7 marbles
limb skeletonization in brazil is now worth 3 marbles

# Changelog

:cl:  
tweak: limb loss in brazil is now worth 7 marbles
tweak: limb skeletonization in brazil is now worth 3 marbles
bugfix: If you somehow manage to run out of limbs while leaving brazil, you will be ejected
/:cl:
