### PR TITLE
seafood ingredients box

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1033,7 +1033,7 @@
 #undef HEART
 #undef SMILEY
 
-/obj/item/storage/box/ingredients //This box is for the randomely chosen version the chef spawns with, it shouldn't actually exist.
+/obj/item/storage/box/ingredients //This box is for the randomly chosen version the chef spawns with, it shouldn't actually exist.
 	name = "ingredients box"
 	illustration = "fruit"
 	var/theme_name
@@ -1173,6 +1173,18 @@
 		new /obj/item/reagent_containers/food/snacks/grown/soybeans(src)
 		new /obj/item/reagent_containers/food/snacks/grown/cabbage(src)
 	new /obj/item/reagent_containers/food/snacks/grown/chili(src)
+
+/obj/item/storage/box/ingredients/seafood
+	theme_name = "seafood"
+
+/obj/item/storage/box/ingredients/seafood/PopulateContents()
+	new /obj/item/reagent_containers/food/snacks/grown/citrus/lemon(src)
+	for(var/i in 1 to 6)
+		var/randomFood = pick(/obj/item/reagent_containers/food/snacks/carpmeat,
+							  /obj/item/reagent_containers/food/snacks/dolphinmeat,
+							  /obj/item/reagent_containers/food/snacks/fish/tuna,
+							  /obj/item/reagent_containers/food/snacks/fish/shrimp)
+		new randomFood(src)
 
 /obj/item/storage/box/cheese
 	name = "box of advanced cheese bacteria"


### PR DESCRIPTION
adds a seafood ingredients box for cooks. 1 lemon, then randomly 6 of (carp meat, dolphin meat, tuna, shrimp). lemon is for shrimp cocktail, i wanted it for tuna pizza too but apparently it only juices 4 units and im very angery about that

# Why is this good for the game?
more variety good, it gets boring getting the same boxes

# Testing
tested it works yes

:cl:  ktlwjec
rscadd: Seafood ingredients box for cooks.
/:cl: