### PR TITLE
More turtlenecks!!

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -850,6 +850,8 @@
 	new /obj/item/clothing/suit/toggle/labcoat/cmo(src)
 	new /obj/item/clothing/under/rank/chief_medical_officer(src)
 	new /obj/item/clothing/under/rank/chief_medical_officer/skirt(src)
+	new /obj/item/clothing/under/rank/chief_medical_officer/turtleneck(src)
+	new /obj/item/clothing/under/rank/chief_medical_officer/skirt/turtleneck(src)
 	new /obj/item/clothing/shoes/sneakers/brown(src)
 	new /obj/item/clothing/shoes/xeno_wraps/command(src)
 	new /obj/item/clothing/head/beret/cmo(src)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -713,6 +713,8 @@
 /obj/item/storage/backpack/duffelbag/clothing/hop/PopulateContents()
 	new /obj/item/clothing/under/rank/head_of_personnel(src)
 	new /obj/item/clothing/under/rank/head_of_personnel/skirt(src)
+	new /obj/item/clothing/under/rank/head_of_personnel/turtleneck(src)
+	new /obj/item/clothing/under/rank/head_of_personnel/skirt/turtleneck(src)
 	new /obj/item/clothing/head/hopcap(src)
 	new /obj/item/clothing/head/beret/hop(src)
 	new /obj/item/clothing/shoes/sneakers/brown(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -8,6 +8,8 @@
 	new /obj/item/storage/lockbox/medal/cargo(src)
 	new /obj/item/clothing/under/rank/cargo(src)
 	new /obj/item/clothing/under/rank/cargo/skirt(src)
+	new /obj/item/clothing/under/rank/cargo/turtleneck(src)
+	new /obj/item/clothing/under/rank/cargo/skirt/turtleneck(src)
 	new /obj/item/clothing/shoes/sneakers/brown(src)
 	new /obj/item/radio/headset/headset_cargo(src)
 	new /obj/item/clothing/suit/fire/firefighter(src)

--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -53,6 +53,12 @@
 	item_state = "lb_suit"
 	mutantrace_variation = MUTANTRACE_VARIATION
 
+/obj/item/clothing/under/rank/cargo/turtleneck
+	name = "quartermaster's turtleneck jumpsuit"
+	desc = "It's a fashionable turtleneck worn by the quartermaster. It's specially designed to prevent back injuries caused by pushing paper."
+	icon_state = "turtleneck_qm"
+	item_state = "lb_suit"
+
 /obj/item/clothing/under/rank/cargo/skirt
 	name = "quartermaster's jumpskirt"
 	desc = "It's a jumpskirt worn by the quartermaster. It's specially designed to prevent back injuries caused by pushing paper."
@@ -64,6 +70,12 @@
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = NO_MUTANTRACE_VARIATION
 
+/obj/item/clothing/under/rank/cargo/skirt/turtleneck
+	name = "quartermaster's skirtleneck"
+	desc = "It's a stylish skirtleneck worn by the quartermaster. It's specially designed to prevent back injuries caused by pushing paper."
+	icon_state = "skirtleneckQM"
+	item_state = "lb_suit"
+
 /obj/item/clothing/under/rank/cargotech
 	name = "cargo technician's jumpsuit"
 	desc = "Shooooorts! They're comfy and easy to wear!"
@@ -73,6 +85,12 @@
 	mutantrace_variation = MUTANTRACE_VARIATION
 	alt_covers_chest = TRUE
 	mutantrace_variation = MUTANTRACE_VARIATION
+
+/obj/item/clothing/under/rank/cargotech/turtleneck
+	name = "cargo technician's turtleneck jumpsuit"
+	desc = "Perfect for pushing crates and looking good while doing it! Shorts not included."
+	icon_state = "turtleneck_cargo"
+	item_state = "lb_suit"
 
 /obj/item/clothing/under/rank/cargotech/skirt
 	name = "cargo technician's jumpskirt"
@@ -84,6 +102,12 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = NO_MUTANTRACE_VARIATION
+
+/obj/item/clothing/under/rank/cargotech/skirt/turtleneck
+	name = "cargo technician's skirtleneck"
+	desc = "Skiiiiirtlenecks! Even comfier and easier to wear!"
+	icon_state = "skirtleneck"
+	item_state = "lb_suit"
 
 /obj/item/clothing/under/rank/chaplain
 	desc = "It's a black jumpsuit, often worn by religious folk."

--- a/code/modules/clothing/under/jobs/civilian.dm
+++ b/code/modules/clothing/under/jobs/civilian.dm
@@ -210,14 +210,21 @@
 	AddComponent(/datum/component/squeak, list('sound/items/bikehorn.ogg'=1), 50)
 
 /obj/item/clothing/under/rank/head_of_personnel
-	desc = "It's a jumpsuit worn by someone who works in the position of \"Head of Personnel\"."
 	name = "head of personnel's jumpsuit"
+	desc = "It's a jumpsuit worn by someone who works in the position of \"Head of Personnel\"."
 	icon_state = "hop"
 	item_state = "b_suit"
 	can_adjust = FALSE
 	sensor_mode = SENSOR_COORDS
 	random_sensor = FALSE
 	mutantrace_variation = MUTANTRACE_VARIATION
+
+/obj/item/clothing/under/rank/head_of_personnel/turtleneck
+	name = "head of personnel's turtleneck jumpsuit"
+	desc = "It's a comfy turtleneck jumpsuit worn by someone who works in the position of \"Head of Personnel\"."
+	icon_state = "hopturtle"
+	item_state = "b_suit"
+	can_adjust = TRUE
 
 /obj/item/clothing/under/rank/head_of_personnel/skirt
 	name = "head of personnel's jumpskirt"
@@ -229,6 +236,13 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = NO_MUTANTRACE_VARIATION
+
+/obj/item/clothing/under/rank/head_of_personnel/skirt/turtleneck
+	name = "head of personnel's skirtleneck"
+	desc = "It's a fashionable skirtleneck worn by someone who works in the position of \"Head of Personnel\"."
+	icon_state = "hopturtle_skirt"
+	item_state = "b_suit"
+	can_adjust = TRUE
 
 /obj/item/clothing/under/rank/hydroponics
 	desc = "It's a jumpsuit designed to protect against minor plant-related hazards."

--- a/code/modules/clothing/under/jobs/medsci.dm
+++ b/code/modules/clothing/under/jobs/medsci.dm
@@ -118,7 +118,7 @@
 /obj/item/clothing/under/rank/chief_medical_officer/turtleneck
 	desc = "It's a jumpsuit worn by those with the experience, and the style, to be \"Chief Medical Officer\". It provides minor biological protection."
 	name = "chief medical officer's turtleneck jumpsuit"
-	icon_state = "turtle"
+	icon_state = "cmoturtle"
 	item_state = "w_suit"
 
 /obj/item/clothing/under/rank/chief_medical_officer/skirt

--- a/code/modules/clothing/under/jobs/medsci.dm
+++ b/code/modules/clothing/under/jobs/medsci.dm
@@ -115,6 +115,12 @@
 	random_sensor = FALSE
 	mutantrace_variation = MUTANTRACE_VARIATION
 
+/obj/item/clothing/under/rank/chief_medical_officer/turtleneck
+	desc = "It's a jumpsuit worn by those with the experience, and the style, to be \"Chief Medical Officer\". It provides minor biological protection."
+	name = "chief medical officer's turtleneck jumpsuit"
+	icon_state = "turtle"
+	item_state = "w_suit"
+
 /obj/item/clothing/under/rank/chief_medical_officer/skirt
 	name = "chief medical officer's jumpskirt"
 	desc = "It's a jumpskirt worn by those with the experience to be \"Chief Medical Officer\". It provides minor biological protection."
@@ -125,6 +131,12 @@
 	can_adjust = FALSE
 	fitted = FEMALE_UNIFORM_TOP
 	mutantrace_variation = NO_MUTANTRACE_VARIATION
+
+/obj/item/clothing/under/rank/chief_medical_officer/skirt/turtleneck
+	name = "chief medical officer's skirtleneck"
+	desc = "It's a jumpskirt worn by those with the experience, and the style, to be \"Chief Medical Officer\". It provides minor biological protection."
+	icon_state = "cmoturtle_skirt"
+	item_state = "w_suit"
 
 /obj/item/clothing/under/rank/geneticist
 	desc = "It's made of a special fiber that gives special protection against biohazards. It has a genetics rank stripe on it."

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -174,6 +174,8 @@
 	products = list(/obj/item/clothing/suit/hooded/wintercoat/cargo = 3,
 					/obj/item/clothing/under/rank/cargotech = 3,
 					/obj/item/clothing/under/rank/cargotech/skirt = 3,
+					/obj/item/clothing/under/rank/cargotech/turtleneck = 3,
+					/obj/item/clothing/under/rank/cargotech/skirt/turtleneck = 3,					
 					/obj/item/clothing/shoes/sneakers/black = 3,
 					/obj/item/clothing/shoes/xeno_wraps/cargo = 3,
 					/obj/item/clothing/gloves/fingerless = 3,


### PR DESCRIPTION
Adds turtlenecks and skirtlenecks for cargo (QM and cargo tech):

![image](https://github.com/yogstation13/Yogstation/assets/43766432/d17b848d-1dd4-42f1-bb4e-5f598b7eea70)

And for CMO:

![image](https://github.com/yogstation13/Yogstation/assets/43766432/2ef5852d-dff2-4529-aadc-5ecf692dfa2b)

Very fabulous. These sprites were as of yet unused because I forgot to add them.

Edit: and also hop versions

:cl: Mqiib, @Ebin-Halcyon 

imageadd: Added new turtlenecks for cargo, CMO, and HoP!

/:cl: