### PR TITLE
Buckling to operating tables no longer requires cuffs

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -528,7 +528,6 @@
 	buildstack = /obj/item/stack/sheet/mineral/silver
 	smooth = SMOOTH_FALSE
 	can_buckle = TRUE
-	buckle_requires_restraints = TRUE
 
 /obj/structure/table/optable/Initialize(mapload)
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request
Allows buckling mobs to operating tables without them being cuffed.

# Why is this good for the game?
<!-- Describe why you think this change is good for the game. This section is not required for bugfixes. -->
For the sake of QoL, it's nice to not have to deal with whoever you're doing surgery on standing up in the middle of surgery and having to ask them to lie down again.

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/93578146/284b00e4-69a9-4093-aa7f-39a83f8e7042)

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: buckling to operating tables no longer requires cuffs
/:cl:
