### PR TITLE
Flying fang fixes and leap nerf

### DIFF
--- a/code/datums/martial/flying_fang.dm
+++ b/code/datums/martial/flying_fang.dm
@@ -240,20 +240,17 @@
 					blocked = TRUE
 			L.visible_message("<span class ='danger'>[A] pounces on [L]!</span>", "<span class ='userdanger'>[A] pounces on you!</span>")
 
-			//Knockdown regardless of blocking, immobilize reduced significantly on block
+			//Knockdown regardless of blocking,
 			L.Knockdown(10 SECONDS)
-			L.Immobilize(1 SECONDS)	
 
-			//Blocking knocks the lizard down too and immobilizes longer
+			//Blocking knocks the lizard down too
 			if(blocked)
 				A.SetKnockdown(10 SECONDS)
-				A.Immobilize(2 SECONDS)
 			
-			//Otherwise the not-blocker gets stunned and the lizard is okay but stops for a moment
+			//Otherwise the not-blocker gets stunned and the lizard is okayt
 			else
 				L.Paralyze(6 SECONDS)
 				A.SetKnockdown(0)
-				A.Immobilize(1 SECONDS)
 
 			if(linked_leap && !blocked)
 				COOLDOWN_RESET(src, next_leap) // landing the leap resets the cooldown
@@ -261,7 +258,6 @@
 			step_towards(src,L)
 		else if(hit_atom.density && !hit_atom.CanPass(A))
 			A.visible_message("<span class ='danger'>[A] smashes into [hit_atom]!</span>", "<span class ='danger'>You smash into [hit_atom]!</span>")
-			A.Immobilize(1.5 SECONDS)
 			A.Knockdown(6 SECONDS)
 			playsound(A, 'sound/weapons/punch2.ogg', 50, 1) // ow oof ouch my head
 		if(leaping)

--- a/code/datums/martial/flying_fang.dm
+++ b/code/datums/martial/flying_fang.dm
@@ -215,7 +215,7 @@
 	linked_martial.leaping = TRUE
 	COOLDOWN_START(linked_martial, next_leap, 5 SECONDS)
 	if(A.buckled)
-		buckled.unbuckle_mob(A, force = TRUE)
+		A.buckled.unbuckle_mob(A, force = TRUE)
 	A.Knockdown(5 SECONDS)
 	A.Immobilize(3 SECONDS, TRUE, TRUE) //prevents you from breaking out of your pounce
 	A.throw_at(target, get_dist(A,target)+1, 1, A, FALSE, TRUE, callback = CALLBACK(src, PROC_REF(leap_end), A))

--- a/code/datums/martial/flying_fang.dm
+++ b/code/datums/martial/flying_fang.dm
@@ -247,7 +247,7 @@
 			if(blocked)
 				A.SetKnockdown(10 SECONDS)
 			
-			//Otherwise the not-blocker gets stunned and the lizard is okayt
+			//Otherwise the not-blocker gets stunned and the lizard is okay
 			else
 				L.Paralyze(6 SECONDS)
 				A.SetKnockdown(0)

--- a/code/datums/martial/flying_fang.dm
+++ b/code/datums/martial/flying_fang.dm
@@ -135,7 +135,7 @@
 	D.blur_eyes(4)
 	if(!istype(D.head, /obj/item/clothing/head/helmet))
 		D.dna.species.aiminginaccuracy += 25
-		addtimer(CALLBACK(src, PROC_REF(remove_bonk), D), 10 SECONDS, 0)
+		addtimer(CALLBACK(src, PROC_REF(remove_bonk), D), 10 SECONDS)
 	D.visible_message(span_danger("[A] headbutts [D]!"), \
 					  span_userdanger("[A] headbutts you!"))
 	log_combat(A, D, "headbutted (Flying Fang)")
@@ -214,7 +214,8 @@
 		return
 	linked_martial.leaping = TRUE
 	COOLDOWN_START(linked_martial, next_leap, 5 SECONDS)
-	unbuckle_mob(A)
+	if(A.buckled)
+		buckled.unbuckle_mob(A, force = TRUE)
 	A.Knockdown(5 SECONDS)
 	A.Immobilize(3 SECONDS, TRUE, TRUE) //prevents you from breaking out of your pounce
 	A.throw_at(target, get_dist(A,target)+1, 1, A, FALSE, TRUE, callback = CALLBACK(src, PROC_REF(leap_end), A))

--- a/code/datums/martial/flying_fang.dm
+++ b/code/datums/martial/flying_fang.dm
@@ -240,19 +240,20 @@
 					blocked = TRUE
 			L.visible_message("<span class ='danger'>[A] pounces on [L]!</span>", "<span class ='userdanger'>[A] pounces on you!</span>")
 
-			//Knockdown regardless of blocking, immobilize reduced significantly on block, lizard gets immobilized momentarily
+			//Knockdown regardless of blocking, immobilize reduced significantly on block
 			L.Knockdown(10 SECONDS)
 			L.Immobilize(1 SECONDS)	
-			A.Immobilize(blocked ? 2 SECONDS : 1 SECONDS)
 
-			//Blocking knocks the lizard down too
+			//Blocking knocks the lizard down too and immobilizes longer
 			if(blocked)
 				A.SetKnockdown(10 SECONDS)
+				A.Immobilize(2 SECONDS)
 			
-			//Otherwise the not-blocker gets stunned and the lizard is okay
+			//Otherwise the not-blocker gets stunned and the lizard is okay but stops for a moment
 			else
 				L.Paralyze(6 SECONDS)
 				A.SetKnockdown(0)
+				A.Immobilize(1 SECONDS)
 
 			if(linked_leap && !blocked)
 				COOLDOWN_RESET(src, next_leap) // landing the leap resets the cooldown

--- a/code/datums/martial/flying_fang.dm
+++ b/code/datums/martial/flying_fang.dm
@@ -240,7 +240,7 @@
 
 			//Knockdown regardless of blocking, immobilize reduced significantly on block, lizard gets immobilized momentarily
 			L.Knockdown(10 SECONDS)
-			L.Immobilize(blocked ? 1 SECONDS : 6 SECONDS)	
+			L.Immobilize(1 SECONDS)	
 			A.Immobilize(blocked ? 2 SECONDS : 1 SECONDS)
 
 			//Blocking knocks the lizard down too

--- a/code/datums/martial/flying_fang.dm
+++ b/code/datums/martial/flying_fang.dm
@@ -117,6 +117,8 @@
 
 //headbutt, deals moderate brute and stamina damage with an eye blur, causes poor aim for a few seconds to the target if they have no helmet on
 /datum/martial_art/flyingfang/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	if(!(A.mobility_flags & MOBILITY_STAND))	//No fancy tail slaps whe you're prone
+		return harm_act(A, D)
 	add_to_streak("D",D)
 	if(!can_use(A))
 		return

--- a/code/datums/martial/flying_fang.dm
+++ b/code/datums/martial/flying_fang.dm
@@ -214,6 +214,7 @@
 		return
 	linked_martial.leaping = TRUE
 	COOLDOWN_START(linked_martial, next_leap, 5 SECONDS)
+	unbuckle_mob(A)
 	A.Knockdown(5 SECONDS)
 	A.Immobilize(3 SECONDS, TRUE, TRUE) //prevents you from breaking out of your pounce
 	A.throw_at(target, get_dist(A,target)+1, 1, A, FALSE, TRUE, callback = CALLBACK(src, PROC_REF(leap_end), A))

--- a/code/datums/martial/flying_fang.dm
+++ b/code/datums/martial/flying_fang.dm
@@ -135,7 +135,7 @@
 	D.blur_eyes(4)
 	if(!istype(D.head, /obj/item/clothing/head/helmet))
 		D.dna.species.aiminginaccuracy += 25
-		addtimer(CALLBACK(src, PROC_REF(remove_bonk), D), 10 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
+		addtimer(CALLBACK(src, PROC_REF(remove_bonk), D), 10 SECONDS, 0)
 	D.visible_message(span_danger("[A] headbutts [D]!"), \
 					  span_userdanger("[A] headbutts you!"))
 	log_combat(A, D, "headbutted (Flying Fang)")
@@ -234,14 +234,24 @@
 			var/blocked = FALSE
 			if(ishuman(hit_atom))
 				var/mob/living/carbon/human/H = hit_atom
-				if(H.check_shields(src, 0, "[A]", attack_type = LEAP_ATTACK))
+				if(H.check_shields(H, 0, "[A]", attack_type = LEAP_ATTACK))
 					blocked = TRUE
 			L.visible_message("<span class ='danger'>[A] pounces on [L]!</span>", "<span class ='userdanger'>[A] pounces on you!</span>")
-			L.Paralyze(blocked ? 6 SECONDS : 0)
+
+			//Knockdown regardless of blocking, immobilize reduced significantly on block, lizard gets immobilized momentarily
 			L.Knockdown(10 SECONDS)
-			L.Immobilize(6 SECONDS)
-			A.SetKnockdown(0)
-			A.SetImmobilized(10 SECONDS) //due to our stun resistance this is actually about 6.6 seconds
+			L.Immobilize(blocked ? 1 SECONDS : 6 SECONDS)	
+			A.Immobilize(blocked ? 2 SECONDS : 1 SECONDS)
+
+			//Blocking knocks the lizard down too
+			if(blocked)
+				A.SetKnockdown(10 SECONDS)
+			
+			//Otherwise the not-blocker gets stunned and the lizard is okay
+			else
+				L.Paralyze(6 SECONDS)
+				A.SetKnockdown(0)
+
 			if(linked_leap && !blocked)
 				COOLDOWN_RESET(src, next_leap) // landing the leap resets the cooldown
 			sleep(0.2 SECONDS)//Runtime prevention (infinite bump() calls on hulks)


### PR DESCRIPTION
The leap now goes as follows:
1: On hitting the target, the target is knocked down for 10 seconds
2: If the lizard projectile is blocked, the lizard is knocked down for 10 seconds.
3: If they are not blocked, the target is stunned for 6 seconds

Immobilizes for the leap were removed because they didn't apply to the lizard anyways and not blocking the leap stuns so that's also irrelevant.

The headbutt no longer infinitely stacks and you cant abuse air shoes because leaping unbuckles you now hahaha no more cheese.

Disarm chain defaults to harm intent when prone so you don't immediately get tail slapped to death even if you DO block the leap.


# Why is this good for the game?
Blocking a lizard with a shield now actually punishes them. It won't stop you from being knocked down but you will still be able to act and they won't be able to use their bite combo

# Testing
thumbs up emoji

# Wiki Documentation

Blocking the lizard projectile actually helps.

# Changelog

:cl:  
bugfix: Flying fang inaccuracy debuff now actually goes away fully instead of stacking infinitely 
bugfix: Leaping with air shoes makes you fall over
tweak: Blocking the flying fang leap helps significantly but won't totally save you 
tweak: Disarm chain defaults to basic harm intent attacks when prone
/:cl:
