### PR TITLE
Nerfs Adrenaline Sac & Resonant Shriek (real)

### DIFF
--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -1,6 +1,6 @@
 /datum/action/changeling/adrenaline
 	name = "Adrenaline Sacs"
-	desc = "We evolve additional sacs of adrenaline throughout our body. Costs 50 chemicals."
+	desc = "We evolve additional sacs of adrenaline throughout our body. Costs 75 chemicals."
 	helptext = "Removes all stuns instantly. Can be used while unconscious. Continued use poisons the body." //yogs - changed text to suit the below change
 	button_icon_state = "adrenaline"
 	chemical_cost = 75

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -3,8 +3,8 @@
 	desc = "We evolve additional sacs of adrenaline throughout our body. Costs 50 chemicals."
 	helptext = "Removes all stuns instantly. Can be used while unconscious. Continued use poisons the body." //yogs - changed text to suit the below change
 	button_icon_state = "adrenaline"
-	chemical_cost = 50
-	dna_cost = 2
+	chemical_cost = 75
+	dna_cost = 3
 	req_human = 1
 	req_stat = UNCONSCIOUS
 	conflicts = list(/datum/action/changeling/strained_muscles)

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -1,6 +1,6 @@
 /datum/action/changeling/resonant_shriek
 	name = "Resonant Shriek"
-	desc = "Our lungs and vocal cords shift, allowing us to briefly emit a noise that deafens and confuses the weak-minded. Costs 60 chemicals."
+	desc = "Our lungs and vocal cords shift, allowing us to briefly emit a noise that deafens and confuses the weak-minded. Costs 75 chemicals."
 	helptext = "Emits a high-frequency sound that confuses and deafens humans, blows out nearby lights and overloads cyborg sensors."
 	button_icon_state = "resonant_shriek"
 	chemical_cost = 75

--- a/code/modules/antagonists/changeling/powers/shriek.dm
+++ b/code/modules/antagonists/changeling/powers/shriek.dm
@@ -3,7 +3,7 @@
 	desc = "Our lungs and vocal cords shift, allowing us to briefly emit a noise that deafens and confuses the weak-minded. Costs 60 chemicals."
 	helptext = "Emits a high-frequency sound that confuses and deafens humans, blows out nearby lights and overloads cyborg sensors."
 	button_icon_state = "resonant_shriek"
-	chemical_cost = 60
+	chemical_cost = 75
 	dna_cost = 1
 	req_human = 1
 	xenoling_available = FALSE
@@ -23,8 +23,8 @@
 			var/mob/living/carbon/C = M
 			if(!C.mind || !C.mind.has_antag_datum(/datum/antagonist/changeling))
 				C.adjustEarDamage(0, 30)
-				C.adjust_confusion(25 SECONDS)
-				C.adjust_jitter(50 SECONDS)
+				C.adjust_confusion(10 SECONDS)
+				C.adjust_jitter(10 SECONDS)
 			else
 				SEND_SOUND(C, sound('sound/effects/screech.ogg'))
 


### PR DESCRIPTION
# Document the changes in your pull request

Adjusts the costs of both abilities to 75 chemicals,
Adjusts the DNA cost of Adrenal sacs to 3 DNA points.
Reduces the effects of the confusion & jitter for resonant shriek to 10 seconds each

# Why is this good for the game?

These abilities are really strong, and should be more costly to use.

# Testing

numbers changes lois


# Wiki Documentation

Change the costs on the wiki

# Changelog

:cl:  

tweak: Tweaks changeling abilities

/:cl:
