### PR TITLE
Holopad Bug Fix - I do NOT like to move it move it.

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -192,6 +192,10 @@ obj/machinery/holopad/secure/Initialize(mapload)
 		return
 
 	if(default_unfasten_wrench(user, P))
+		if(replay_mode)
+			replay_stop()
+		if(record_mode)
+			record_stop()
 		return
 
 	if(default_deconstruction_crowbar(P))


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Bugfix to make holopads stop recording when they are wrenched.
No more having a hologram in the middle of nowhere. Leave the pad where it is.

Fixes: #21359

# Testing
<!-- Describe what testing you did with this PR. Try to be thorough, especially if this is a larger project. -->
😸 

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: Holopads stop recording/playback when wrenched
/:cl:
