### PR TITLE
Reduces Shock Touch's confusion from 15 to 3 seconds

### DIFF
--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -32,7 +32,6 @@
 		if(carbon_victim.electrocute_act(15, caster, 1, zone=caster.zone_selected, stun = FALSE))//doesnt stun. never let this stun
 			carbon_victim.dropItemToGround(carbon_victim.get_active_held_item())
 			carbon_victim.dropItemToGround(carbon_victim.get_inactive_held_item())
-			carbon_victim.adjust_timed_status_effect(15 SECONDS, /datum/status_effect/confusion)
 			carbon_victim.visible_message(
 				span_danger("[caster] electrocutes [victim]!"),
 				span_userdanger("[caster] electrocutes you!"),

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -29,9 +29,14 @@
 /datum/action/cooldown/spell/touch/shock/cast_on_hand_hit(obj/item/melee/touch_attack/hand, atom/victim, mob/living/carbon/caster)
 	if(iscarbon(victim))
 		var/mob/living/carbon/carbon_victim = victim
-		if(carbon_victim.electrocute_act(15, caster, 1, zone=caster.zone_selected, stun = FALSE))//doesnt stun. never let this stun
+		var returned_damage = carbon_victim.electrocute_act(15, caster, 1, zone = caster.zone_selected, stun = FALSE) // Does not stun. Never let this stun.
+		if(returned_damage != FALSE && returned_damage > 0)
 			carbon_victim.dropItemToGround(carbon_victim.get_active_held_item())
 			carbon_victim.dropItemToGround(carbon_victim.get_inactive_held_item())
+			// Confusion is more or less expected to happen due to the rarity of electric armor and the ability to select zones.
+			// Expected defense items: hardsuit (all @ 100), insulated gloves (arms @ 100), any engineering shoes (legs @ 100), hardsuit (head @ 100), hazard vest / engineering coat (chest @ 20).
+			var/shock_multiplier = returned_damage / 15 // Accounts for armor, siemens_coeff, and future changes.
+			carbon_victim.adjust_timed_status_effect(max(3 SECONDS * shock_multiplier, 5), /datum/status_effect/confusion)
 			carbon_victim.visible_message(
 				span_danger("[caster] electrocutes [victim]!"),
 				span_userdanger("[caster] electrocutes you!"),


### PR DESCRIPTION
# Document the changes in your pull request
Shock touch (along with the ranged variant) now causes confusion down from 15 seconds to 3 seconds. Duration can be reduced or increased based on ELECTRIC armor of the selected zone and other factors that may protect you from getting shocked. 

Since non-hardsuit ELECTRIC armor is rare, aiming for chest is the only reliable method of shocking with this. A short list of armor to use:
- Hardhat (100% Head)
- Hazard Vest / Engineering Wintercoat (20% Chest)
- Galoshes / Combat Boots / Magboots / Any Engineering Shoes (100% Legs)
- Combat Gloves / Insulated Gloves (100% Arms)

# Why is this good for the game?
Shock touch is a genetics power/spell that that has four characteristics that make it a really good power: easy to spam (10 second cooldown), safe to use (can be upgraded to be used at range), forced disarm of the target, and the long lasting confusion (15 seconds which is longer than the cooldown). Given the buff to this spell from [#21002], it makes sense that this power gets toned down as the only counter to this is: wearing a hardsuit, insulated genetics power, or anything that gives full-body protection.

# Testing
Aiming for arms (100% protection from insulated gloves).
![0sec_confusion_gloves](https://github.com/yogstation13/Yogstation/assets/30399783/d6c85c91-72a1-42de-8d04-ceee810523cc)

Aiming for arms (0% protection from nothing).
![3sec_confusion](https://github.com/yogstation13/Yogstation/assets/30399783/e1397199-df3e-495e-8a7e-fc5f783bb3aa)

Aiming for chest (0% protection from nothing, despite wearing insulated gloves).
![3sec_confusion_pt2](https://github.com/yogstation13/Yogstation/assets/30399783/508adc33-14e7-4200-ad74-580638e479ce)

# Wiki Documentation
Shock touch's confusion is now 3 seconds. Can be reduced or increased up to 5 seconds.

# Changelog
:cl:  
tweak: The genetics power, Shock Touch, causes confusion down from 15 seconds to 3 seconds. Can be reduced/increased based on targeted electric armor.
/:cl:
