### PR TITLE
Mechs no longer deflect ion bolts

### DIFF
--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -112,7 +112,7 @@
 		occupant.bullet_act(Proj) //If the sides are open, the occupant can be hit
 		return BULLET_ACT_HIT
 	if(istype(Proj, /obj/projectile/ion))
-		return BULLET_ACT_HIT
+		return ..()
 	var/booster_deflection_modifier = 1
 	var/booster_damage_modifier = 1
 	var/attack_dir = get_dir(src, Proj)

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -111,6 +111,8 @@
 	if ((!enclosed || istype(Proj, /obj/projectile/bullet/shotgun/slug/uranium))&& occupant && !silicon_pilot && !Proj.force_hit && (Proj.def_zone == BODY_ZONE_HEAD || Proj.def_zone == BODY_ZONE_CHEST)) //allows bullets to hit the pilot of open-canopy mechs
 		occupant.bullet_act(Proj) //If the sides are open, the occupant can be hit
 		return BULLET_ACT_HIT
+	if(istype(Proj, /obj/projectile/ion))
+		return BULLET_ACT_HIT
 	var/booster_deflection_modifier = 1
 	var/booster_damage_modifier = 1
 	var/attack_dir = get_dir(src, Proj)


### PR DESCRIPTION
Here's your ion buff/mech nerf. Go ham.

# Why is this good for the game?
Ions are now CONSISTENTLY effective vs mechs rather than just more effective.

# Testing
I probably should but this is simple literally 2 lines of easy code

# Changelog


:cl:  

tweak: Mechs don't deflect ion bolts any more

/:cl:
