### PR TITLE
Undoes Undocumented Preternis Limb Burn Damage Reduction

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -59,8 +59,8 @@
 	for (var/obj/item/bodypart/BP in C.bodyparts)
 		BP.render_like_organic = TRUE 	// Makes limbs render like organic limbs instead of augmented limbs, check bodyparts.dm
 		BP.emp_reduction = EMP_LIGHT
-		BP.burn_reduction = 0
-		BP.brute_reduction = 0
+		BP.burn_reduction = 1
+		BP.brute_reduction = 1
 		if(BP.body_zone == BODY_ZONE_CHEST)
 			continue
 		if(BP.body_zone == BODY_ZONE_HEAD)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -59,8 +59,8 @@
 	for (var/obj/item/bodypart/BP in C.bodyparts)
 		BP.render_like_organic = TRUE 	// Makes limbs render like organic limbs instead of augmented limbs, check bodyparts.dm
 		BP.emp_reduction = EMP_LIGHT
-		BP.burn_reduction = 2
-		BP.brute_reduction = 1
+		BP.burn_reduction = 0
+		BP.brute_reduction = 0
 		if(BP.body_zone == BODY_ZONE_CHEST)
 			continue
 		if(BP.body_zone == BODY_ZONE_HEAD)


### PR DESCRIPTION
# Document the changes in your pull request
#16822 has an undocumented change in which it increased the burn damage reduction for the limbs of preternis from 1 to 2. This PR undoes this.

# Testing
Does one more damage when getting hit by a welder than before, yep.

# Changelog
:cl:  
bugfix: Decreases the unintended burn damage reduction from 2 to 1 for preternis limbs.
/:cl:
