### PR TITLE
Removes the confusion stacking from shock touch

### DIFF
--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -32,7 +32,6 @@
 		if(carbon_victim.electrocute_act(15, caster, 1, zone=caster.zone_selected, stun = FALSE))//doesnt stun. never let this stun
 			carbon_victim.dropItemToGround(carbon_victim.get_active_held_item())
 			carbon_victim.dropItemToGround(carbon_victim.get_inactive_held_item())
-			carbon_victim.adjust_timed_status_effect(15 SECONDS, /datum/status_effect/confusion)
 			carbon_victim.visible_message(
 				span_danger("[caster] electrocutes [victim]!"),
 				span_userdanger("[caster] electrocutes you!"),


### PR DESCRIPTION
Because 15 seconds of **STACKING** confusion is kind of bullshit when it has a 10 second cooldown lol



# Why is this good for the game?

Shock touch can no longer be used to completely immobilize people after 2 uses



# Changelog

:cl:  

tweak: Removes the absurd stacking confusion of shock touch

/:cl:
