### PR TITLE
Reworks confusion to be less confusing

### DIFF
--- a/code/datums/status_effects/debuffs/confusion.dm
+++ b/code/datums/status_effects/debuffs/confusion.dm
@@ -33,3 +33,4 @@
 		source = get_step(owner, new_dir)
 		direction = new_dir
 
+#undef CONFUSION_STRONG_THRESHOLD

--- a/code/datums/status_effects/debuffs/confusion.dm
+++ b/code/datums/status_effects/debuffs/confusion.dm
@@ -1,3 +1,5 @@
+/// If remaining duration is longer than this, allows for stronger confusion movement
+#define CONFUSION_STRONG_THRESHOLD 10 SECONDS
 /// A status effect used for adding confusion to a mob.
 /datum/status_effect/confusion
 	id = "confusion"
@@ -19,10 +21,13 @@
 /datum/status_effect/confusion/proc/on_move(datum/source, direction)
 	SIGNAL_HANDLER
 
+	var/time_left = duration - world.time
 	var/new_dir
 
 	if(prob(50))
 		new_dir = angle2dir(dir2angle(direction) + pick(45, -45))
+	else if(time_left > CONFUSION_STRONG_THRESHOLD && prob(50))
+		new_dir = angle2dir(dir2angle(direction) + pick(90, -90))
 
 	if(!isnull(new_dir))
 		source = get_step(owner, new_dir)

--- a/code/datums/status_effects/debuffs/confusion.dm
+++ b/code/datums/status_effects/debuffs/confusion.dm
@@ -21,7 +21,7 @@
 
 	var/new_dir
 
-	if(prob(25))
+	if(prob(50))
 		new_dir = angle2dir(dir2angle(direction) + pick(45, -45))
 
 	if(!isnull(new_dir))

--- a/code/datums/status_effects/debuffs/confusion.dm
+++ b/code/datums/status_effects/debuffs/confusion.dm
@@ -1,10 +1,3 @@
-/// The threshold in which all of our movements are fully randomized, in seconds.
-#define CONFUSION_FULL_THRESHOLD 40
-/// A multiplier applied on how much time is left (in seconds) that determines the chance of moving sideways randomly
-#define CONFUSION_SIDEWAYS_MOVE_PROB_PER_SECOND 1.5
-/// A multiplier applied on how much time is left (in seconds) that determines the chance of moving diagonally randomly
-#define CONFUSION_DIAGONAL_MOVE_PROB_PER_SECOND 3
-
 /// A status effect used for adding confusion to a mob.
 /datum/status_effect/confusion
 	id = "confusion"
@@ -26,23 +19,12 @@
 /datum/status_effect/confusion/proc/on_move(datum/source, direction)
 	SIGNAL_HANDLER
 
-	// How much time is left in the duration, in seconds.
-	var/time_left = (duration - world.time) / 10
 	var/new_dir
 
-	if(time_left > CONFUSION_FULL_THRESHOLD)
-		new_dir = pick(GLOB.alldirs)
-
-	else if(prob(time_left * CONFUSION_SIDEWAYS_MOVE_PROB_PER_SECOND))
-		new_dir = angle2dir(dir2angle(direction) + pick(90, -90))
-
-	else if(prob(time_left * CONFUSION_DIAGONAL_MOVE_PROB_PER_SECOND))
+	if(prob(25))
 		new_dir = angle2dir(dir2angle(direction) + pick(45, -45))
 
 	if(!isnull(new_dir))
 		source = get_step(owner, new_dir)
 		direction = new_dir
 
-#undef CONFUSION_FULL_THRESHOLD
-#undef CONFUSION_SIDEWAYS_MOVE_PROB_PER_SECOND
-#undef CONFUSION_DIAGONAL_MOVE_PROB_PER_SECOND

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -140,6 +140,7 @@
 	else
 		move_delay = world.time
 
+	//this is in two areas, i have no clue why, all i know is that i hate it and don't have the time to fix it
 	if(L.has_status_effect(/datum/status_effect/confusion))
 		var/newdir = 0
 		if(prob(50))

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -142,12 +142,10 @@
 
 	if(L.has_status_effect(/datum/status_effect/confusion))
 		var/newdir = 0
-		if(L.get_timed_status_effect_duration(/datum/status_effect/confusion) > 40)
-			newdir = pick(GLOB.alldirs)
-		else if(prob(L.get_timed_status_effect_duration(/datum/status_effect/confusion) * 1.5))
-			newdir = angle2dir(dir2angle(direct) + pick(90, -90))
-		else if(prob(L.get_timed_status_effect_duration(/datum/status_effect/confusion) * 3))
+		if(prob(50))
 			newdir = angle2dir(dir2angle(direct) + pick(45, -45))
+		else if(prob(50) && L.get_timed_status_effect_duration(/datum/status_effect/confusion) > 10 SECONDS)
+			newdir = angle2dir(dir2angle(direct) + pick(90, -90))
 		if(newdir)
 			direct = newdir
 			n = get_step(L, direct)


### PR DESCRIPTION
Changes confusion to no longer scale up to completely randomized movement
Now it has a 50% chance on movement to make you walk +- 45 degrees of where you intended to
and a 25% chance on movement to make you walk +- 90 degrees if the remaining duration is above 10 seconds

# Why is this good for the game?
Confusion is too unreliable to be used in balance, it goes from minor movement fuckery to effective stun with the difference of a second or so

# Testing
Gotta

:cl:  
tweak: Confusion modified to not scale up to completely randomized movement
/:cl:
