### PR TITLE
AI Connection Ports correctly work for Newly Created Cyborgs

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -316,7 +316,7 @@
 			if(!lawsync)
 				O.lawupdate = 0
 				if(!M.laws.modified)
-					// Give the non-modified laws you can see on the MMI.
+					// Give the non-modified laws which is visible on the MMI.
 					O.laws = M.laws
 					M.laws.associate(O)
 				else if(!M.override_cyborg_laws) // MMI's laws were changed. Do not want to upload them if we say so.

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -320,6 +320,7 @@
 					O.laws = M.laws
 					M.laws.associate(O)
 				else if(!M.override_cyborg_laws) // MMI's laws were changed. Do not want to upload them if we say so.
+					// Give random default lawset.
 					O.make_laws()
 					// Obvious warning that their modified laws didn't get passed on.
 					to_chat(user, span_warning("Any laws uploaded to this MMI have not been transferred!"))

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -315,9 +315,14 @@
 					O.set_connected_ai(forced_ai)
 			if(!lawsync)
 				O.lawupdate = 0
-				if(M.laws.modified && !M.override_cyborg_laws) // Obvious warning that their modified laws didn't get passed on since the MMI doesn't allow it.
+				if(!M.laws.modified)
+					// Give the non-modified laws you can see on the MMI.
+					O.laws = M.laws
+					M.laws.associate(O)
+				else if(!M.override_cyborg_laws) // MMI's laws were changed. Do not want to upload them if we say so.
 					O.make_laws()
-					to_chat(user,span_warning("Any laws uploaded to this MMI have not been transferred!"))
+					// Obvious warning that their modified laws didn't get passed on.
+					to_chat(user, span_warning("Any laws uploaded to this MMI have not been transferred!"))
 
 			SSticker.mode.remove_antag_for_borging(BM.mind)
 			if(!istype(M.laws, /datum/ai_laws/ratvar))


### PR DESCRIPTION
# Document the changes in your pull request
Newly created cyborgs that are specifically set to be not linked to an AI no longer start out with said AI's laws. Instead, they get the MMI's laws (if it is unmodified) or a random default lawset (if it was modified).

# Testing
Create prebuilt cyborg suit/shell, set AI Connection Port to Closed, put MMI with default laws in, created Cyborg with MMI's default laws (and not the AI's laws).

# Changelog
:cl:  
bugfix: Newly created cyborgs with an closed AI Connection Port do not inherit an AI's laws (if any) before getting desynced.
/:cl:
