### PR TITLE
Redmoogle cant spell remotely AND forgets to qdel on deconstruction

### DIFF
--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -167,6 +167,7 @@
 				W.play_tool_sound(src)
 				to_chat(user, span_notice("You remove the frame."))
 				new /obj/item/wallframe/light_switch(loc)
+				qdel(src)
 				return
 		if(LIGHT_WIRE)
 			if(W.tool_behaviour == TOOL_WIRECUTTER && wires.is_cut(WIRE_POWER))

--- a/code/game/objects/items/remote_light_switch.dm
+++ b/code/game/objects/items/remote_light_switch.dm
@@ -1,6 +1,6 @@
 /obj/item/rls
 	name = "Rapid Light Switch (RLS)"
-	desc = "A device used to remotley switch lighting."
+	desc = "A device used to remotely switch lighting."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "multitool_red"
 	item_state = "multitool"


### PR DESCRIPTION
# Changelog

:cl:  
bugfix: Light switches are no longer a free source of frames
spellcheck: Fixed RLS description
/:cl:
