### PR TITLE
Revert "Removes the donk-soft vendor from roundstart asteroid"

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -4737,6 +4737,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
+"aQd" = (
+/obj/machinery/vending/donksofttoyvendor,
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "aQh" = (
 /turf/closed/wall,
 /area/science/explab)
@@ -93534,7 +93538,7 @@ wsD
 qTR
 new
 uVl
-aeM
+aQd
 sfH
 jdd
 aXp
@@ -93791,7 +93795,7 @@ eXm
 aAw
 mSV
 uVl
-aii
+aeM
 lEF
 wNI
 aXp


### PR DESCRIPTION
Reverts yogstation13/Yogstation#21325

A better title would be "Re-adds fun"
why doesn't this auto-populate with the template?

Removed because "Admin issue" which is dumb.  you don't have to remove the enjoyment for everyone just because some people abuse stuff.