### PR TITLE
[Admin] Cryoing as a Valentine no longer tells you to ahelp

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -413,8 +413,11 @@ GLOBAL_VAR_INIT(cryopods_enabled, FALSE)
 			tgui_alert(target, "You're a Head of Staff![generic_plsnoleave_message]")
 			caught = TRUE
 		if(A)
-			tgui_alert(target, "You're a [A.name]![generic_plsnoleave_message]")
-			caught = TRUE
+			if(A.name == "valentine")
+				caught = TRUE
+			else
+				tgui_alert(target, "You're a [A.name]![generic_plsnoleave_message]")
+				caught = TRUE
 		if(caught)
 			target.client.cryo_warned = world.time
 			return

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -412,12 +412,9 @@ GLOBAL_VAR_INIT(cryopods_enabled, FALSE)
 		if(target.mind.assigned_role in GLOB.command_positions)
 			tgui_alert(target, "You're a Head of Staff![generic_plsnoleave_message]")
 			caught = TRUE
-		if(A)
-			if(A.name == "valentine")
-				caught = TRUE
-			else
-				tgui_alert(target, "You're a [A.name]![generic_plsnoleave_message]")
-				caught = TRUE
+		if(A && A.name != "valentine")
+			tgui_alert(target, "You're a [A.name]![generic_plsnoleave_message]")
+			caught = TRUE
 		if(caught)
 			target.client.cryo_warned = world.time
 			return


### PR DESCRIPTION
# Document the changes in your pull request

As the title states, you not longer get a warning message before cryoing if you are a Valentine.


# Why is this good for the game?

Valentine's aren't *real* antags. If they wanna go they should be able to go.

# Testing

I tested it, it works.

# Changelog

:cl:  
tweak: No longer told to ahelp when cryoing as a valentine
/:cl:
