### PR TITLE
Adds in the contributing guidelines that all PRs that can be tested must be tested

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -131,6 +131,8 @@ There is no strict process when it comes to merging pull requests. Pull requests
 
 * While we have no issue helping contributors (and especially new contributors) bring reasonably sized contributions up to standards via the pull request review process, larger contributions are expected to pass a higher bar of completeness and code quality *before* you open a pull request. Maintainers may close such pull requests that are deemed to be substantially flawed. You should take some time to discuss with maintainers or other contributors on how to improve the changes.
 
+* Any PR submitted after February 13th, 2024 must be accompanied by giving visual evidence of testing if the changes in the PR have any visual indication of changes. Omitting or filling out the testing part of the template with "I tested it" does not show these changes. Maintainers may hold your PR until testing is provided at the discretion of the Head Developers.
+
 ## Porting features/sprites/sounds/tools from other codebases
 
 If you are porting features/tools from other codebases, you must give them credit where it's due. Typically, crediting them in your pull request and the changelog is the recommended way of doing it. Take note of what license they use though, porting stuff from AGPLv3 and GPLv3 codebases are allowed.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -131,7 +131,7 @@ There is no strict process when it comes to merging pull requests. Pull requests
 
 * While we have no issue helping contributors (and especially new contributors) bring reasonably sized contributions up to standards via the pull request review process, larger contributions are expected to pass a higher bar of completeness and code quality *before* you open a pull request. Maintainers may close such pull requests that are deemed to be substantially flawed. You should take some time to discuss with maintainers or other contributors on how to improve the changes.
 
-* Any PR submitted after February 13th, 2024 must be accompanied by giving visual evidence of testing if the changes in the PR have any visual indication of changes. Omitting or filling out the testing part of the template with "I tested it" does not show these changes. Maintainers may hold your PR until testing is provided at the discretion of the Head Developers.
+* Any PR submitted after February 13th, 2024 must be accompanied by giving visual evidence (images, gifs, videos) of testing if the changes in the PR have any visual indication of changes. Omitting or filling out the testing part of the template with "I tested it" does not show these changes. Maintainers may hold your PR until testing is provided at the discretion of the Head Developers.
 
 ## Porting features/sprites/sounds/tools from other codebases
 


### PR DESCRIPTION
# Document the changes in your pull request

Adds `Any PR submitted after February 13th, 2024 must be accompanied by giving visual evidence (images, gifs, videos) of testing if the changes in the PR have any visual indication of changes. Omitting or filling out the testing part of the template with "I tested it" does not show these changes. Maintainers may hold your PR until testing is provided at the discretion of the Head Developers.`

# Why is this good for the game?
More checks for the maintainers to give accurate reviews. It's ultimately up to you to test it correctly. 

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/5091394/fd6d8a06-5d50-4b9e-9c29-b5882f5b757c)