### PR TITLE
Removes "yellow jacket matriarch" from the spawnable gold xenobio slime list

### DIFF
--- a/yogstation/code/modules/jungleland/jungle_alpha_mobs.dm
+++ b/yogstation/code/modules/jungleland/jungle_alpha_mobs.dm
@@ -352,7 +352,6 @@
 	attacktext = "stings"
 	attack_sound = 'sound/voice/moth/scream_moth.ogg'
 	deathmessage = "rolls over, falling to the ground."
-	gold_core_spawnable = NO_SPAWN
 	butcher_results = list(/obj/item/stinger = 1, /obj/item/stack/sheet/animalhide/weaver_chitin = 4, /obj/item/stack/sheet/sinew = 2, /obj/item/gem/topaz = 2)
 	loot = list()
 	crusher_loot = /obj/item/crusher_trophy/jungleland/wasp_head

--- a/yogstation/code/modules/jungleland/jungle_alpha_mobs.dm
+++ b/yogstation/code/modules/jungleland/jungle_alpha_mobs.dm
@@ -352,7 +352,7 @@
 	attacktext = "stings"
 	attack_sound = 'sound/voice/moth/scream_moth.ogg'
 	deathmessage = "rolls over, falling to the ground."
-	gold_core_spawnable = HOSTILE_SPAWN
+	gold_core_spawnable = NO_SPAWN
 	butcher_results = list(/obj/item/stinger = 1, /obj/item/stack/sheet/animalhide/weaver_chitin = 4, /obj/item/stack/sheet/sinew = 2, /obj/item/gem/topaz = 2)
 	loot = list()
 	crusher_loot = /obj/item/crusher_trophy/jungleland/wasp_head


### PR DESCRIPTION
# Document the changes in your pull request

Removes the possibility to get them from gold slimes

# Why is this good for the game?

This mob, when killed, drops a necropolis chest, and totally cool people who dont exploit the game (xenobiologists) probably don't need the ability to get all the mining loot as well.

# Testing

yeah

# Changelog

:cl:  

rscdel: Removed Yellow Jacket Matriarchs from the gold slime pool

/:cl:
