### PR TITLE
Makes hardly wounded trait actually work

### DIFF
--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -430,6 +430,9 @@
   */
 /obj/item/bodypart/proc/check_wounding(woundtype, damage, wound_bonus, bare_wound_bonus, attack_direction)
 	// note that these are fed into an exponent, so these are magnified
+	if(HAS_TRAIT(owner, TRAIT_HARDLY_WOUNDED))
+		damage *= 0.33
+
 	if(HAS_TRAIT(owner, TRAIT_EASILY_WOUNDED))
 		damage *= 1.5
 	else


### PR DESCRIPTION
It was created as a trait define, given to people via various means, but never actually checked when it came to wounding

:cl:  
bugfix: TRAIT_HARDLY_WOUNDED now actually does what it says
/:cl:
