### PR TITLE
Fixes powerless mechs being immune to EMPs

### DIFF
--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -181,7 +181,8 @@
 		return
 	if(get_charge())
 		use_power((cell.charge * severity / 15))
-		take_damage(4 * severity, BURN, ENERGY, 1)
+		
+	take_damage(4 * severity, BURN, ENERGY, 1)
 	log_message("EMP detected", LOG_MECHA, color="red")
 
 	if(istype(src, /obj/mecha/combat))


### PR DESCRIPTION
Now they still take damage regardless of cell power since they can move regardless of cell power.


# Why is this good for the game?

Ion spam actually kills mechs fr fr on god

# Testing

They both took damage!
![image](https://github.com/yogstation13/Yogstation/assets/43766432/92465a38-5aaa-49c0-9c6f-7d2dee4eb32b)



# Changelog


:cl:  

bugfix: Mechs without any power are no longer immune to EMPs

/:cl:
