### PR TITLE
Fixes Paladin laws and removes traitor AIs ability to change their own laws.

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -589,6 +589,7 @@
 	inherent = list("Never willingly commit an evil act.",
 					"Respect legitimate authority.",
 					"Act with honour.",
+					"Help those in need.",
 					"Punish those who harm or threaten innocents.")
 
 /datum/ai_laws/paladin5

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -318,7 +318,7 @@
 				owner.show_laws()
 			if(usr != owner)
 				to_chat(usr, span_notice("Laws displayed."))
-		// Antag && Admin actions:
+		//Admin actions:
 		if("edit_law")
 			var/index = text2num(params["index"])
 			var/type = params["type"]
@@ -383,7 +383,7 @@
 		if("delete_law")
 			var/index = text2num(params["index"])
 			var/type = params["type"]
-			if(owner == usr && !is_special_character(owner) && !is_admin(usr))
+			if(owner == usr && !is_admin(usr))
 				message_admins("Warning: Non-antag silicon and non-admin[usr] attempted to delete one of their laws!")
 				return
 			if(ispAI(owner))
@@ -433,7 +433,7 @@
 						connected_cyborg.law_change_counter++
 		if("add_law")
 			var/type = params["type"]
-			if(owner == usr && !is_special_character(owner) && !is_admin(usr))
+			if(owner == usr && !is_admin(usr))
 				message_admins("Warning: Non-antag silicon and non-admin [usr] attempted to give themselves a law!")
 				return
 			if(ispAI(owner))
@@ -497,7 +497,7 @@
 			if(isnum(new_position) && (!..()))
 				supplied_law_position = clamp(new_position, MIN_SUPPLIED_LAW_NUMBER, MAX_SUPPLIED_LAW_NUMBER)
 		if("transfer_laws")
-			if(owner == usr && !is_special_character(owner) && !is_admin(usr))
+			if(owner == usr && !is_admin(usr))
 				message_admins("Warning: Non-antag silicon and non-admin [usr] attempted to transfer themselves a lawset!")
 				return
 			if(ispAI(owner))
@@ -531,12 +531,7 @@
 		data["syndiemmi"] = FALSE
 	data["pai"] = ispAI(owner) // pAIs are much different from AIs and Cyborgs. They are heavily restricted.
 	
-	// These two usually gives the power to add/delete/edit the laws. Some exceptions apply (like being a pAI)!
-	data["antag"] = FALSE // While this seems like it should use `is_special_character()`, it only considers AIs to be an antag if it has a special role AND a zeroth law. Given that admins can remove the antag's zeroth law, this is not ideal.
-	if(isAI(owner))
-		var/mob/living/silicon/ai/AI_owner = owner
-		if(AI_owner.laws && AI_owner.mind && AI_owner.mind.special_role)
-			data["antag"] = TRUE
+	// This usually gives the power to add/delete/edit the laws. Some exceptions apply (like being a pAI)!
 	data["admin"] = is_admin(user)
 
 	handle_laws(data, owner.laws)

--- a/tgui/packages/tgui/interfaces/LawManager.tsx
+++ b/tgui/packages/tgui/interfaces/LawManager.tsx
@@ -62,16 +62,13 @@ type LawAddData = {
 
 export const LawManager = (props, context) => {
   const { act, data } = useBackend<LawManagerData>(context);
-  const { cyborg, ai, pai, connected, lawsync, syndiemmi, antag, admin, view } = data;
+  const { cyborg, ai, pai, connected, lawsync, syndiemmi, admin, view } = data;
 
   return (
     <Window height="600" width="800" title="Law Manager">
       <Window.Content scrollable>
         {!!admin && (
           <NoticeBox>You are viewing this from an admin prespective.</NoticeBox>
-        ) }
-        {!!(admin && ai && antag) && (
-          <NoticeBox>This AI is currently an antagonist.</NoticeBox>
         ) }
         {!!(admin && cyborg && syndiemmi) && (
           <NoticeBox>This Cyborg is using a syndicate MMI.</NoticeBox>
@@ -88,16 +85,13 @@ export const LawManager = (props, context) => {
         {!!(admin && pai) && (
           <NoticeBox>This pAI has less editing features due to their nature of being a pAI.</NoticeBox>
         ) }
-        {!!(!admin && ai && antag) && (
-          <NoticeBox>You have the ability to edit a majority of your laws as a malfunctioning AI.</NoticeBox>
-        ) }
         <Box>
           <Button
             content="Law Management"
             selected={view === 0}
             onClick={() => act('set_view', { set_view: 0 })}
           />
-          {!!(antag || admin) && !pai && (
+          {!!(admin) && !pai && (
             <Button
               content="Lawsets"
               selected={view === 1}
@@ -114,12 +108,12 @@ export const LawManager = (props, context) => {
 
 const LawManagementView = (props, context) => {
   const { data } = useBackend<LawManagementData>(context);
-  const { pai, antag, admin } = data;
+  const { pai, admin } = data;
   return (
     <Fragment>
       <LawSection />
       <LawStatementSection />
-      {!!((antag || admin) && !pai) && (
+      {!!(admin && !pai) && (
         <LawAddSection />
       )}
     </Fragment>


### PR DESCRIPTION
# Document the changes in your pull request

https://github.com/yogstation13/Yogstation/pull/21294 removes part of paladin lawset, this fixes it.
Also removes the ability for traitor AIs to change their laws.

# Why is this good for the game?
- Adds own law that says "Plasmaflood and kill everyone"

# Testing

Gone as AI:
![image](https://github.com/yogstation13/Yogstation/assets/5091394/1b3fc38a-e7d5-4121-bf0a-f1185d4f83d8)

Paladin Fixed:
![image](https://github.com/yogstation13/Yogstation/assets/5091394/e0bd61ca-574a-4a66-a5c3-c36814dfaf79)


# Changelog

:cl:  
rscdel: Traitor AIs can no longer edit their laws.
bugfix: Paladin now has the correct laws again.
/:cl:
