### PR TITLE
Deletes military synths

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1377,9 +1377,6 @@
 /mob/living/carbon/human/species/synth
 	race = /datum/species/synth
 
-/mob/living/carbon/human/species/synth/military
-	race = /datum/species/synth/military
-
 /mob/living/carbon/human/species/vampire
 	race = /datum/species/vampire
 

--- a/code/modules/mob/living/carbon/human/species_types/synths.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synths.dm
@@ -30,15 +30,6 @@
 	initial_inherent_traits = inherent_traits.Copy()
 	..()
 
-/datum/species/synth/military
-	name = "Military Synth"
-	id = "military_synth"
-	armor = 25
-	punchdamagelow = 10
-	punchdamagehigh = 19
-	punchstunthreshold = 14 //about 50% chance to stun
-	disguise_fail_health = 50
-
 /datum/species/synth/on_species_gain(mob/living/carbon/human/H, datum/species/old_species)
 	..()
 	assume_disguise(old_species, H)


### PR DESCRIPTION
# Why is this good for the game?
They're only used by xenobiologists to powergame

i also plan to roll regular synths into an IPC subtype eventually and make them thematic for the SELF movement

# Testing
gotta (probably don't need to)

:cl:  
rscdel: Removes military synths
/:cl:
