### PR TITLE
No more lowpop spacevines that kill everyone pls

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/spacevine
 	weight = 15
 	max_occurrences = 3
-	min_players = 10
+	min_players = 30
 
 /datum/round_event/spacevine
 	fakeable = FALSE


### PR DESCRIPTION
30 pop is good enough for now probably. Also I hate flowering vines.

# Testing

Number change


# Wiki Documentation

Min pop of 30

# Changelog

:cl:  

tweak: Min pop for space vines increased to 30

/:cl:
