### PR TITLE
Mechs now double as oversized weed-whackers

### DIFF
--- a/code/game/mecha/equipment/weapons/melee_weapons.dm
+++ b/code/game/mecha/equipment/weapons/melee_weapons.dm
@@ -199,7 +199,7 @@
 
 			if((isstructure(A) || ismachinery(A) || istype(A, /obj/mecha)) && can_stab_at(chassis, A))	//if it's a big thing we hit anyways. Structures ALWAYS are hit, machines and mechs can be protected
 				var/obj/O = A
-				if(!O.density)	//Make sure it's not an open door or something
+				if(!O.density && !istype(O, /obj/structure/spacevine))	//Make sure it's not an open door or something
 					continue
 				var/object_damage = max(chassis.force + weapon_damage, minimum_damage) * structure_damage_mult * (istype(A, /obj/mecha) ? mech_damage_multiplier : 1)	//Half damage on mechs
 				O.take_damage(object_damage, dam_type, "melee", 0)


### PR DESCRIPTION
They don't normally have density so they weren't actually hit by the cleave attack, even though logically they would be. Now they get hit hooray!

# Why is this good for the game?
Adds another counter to mass space vines when scythes aren't enough.

# Testing
Before:
![image](https://github.com/yogstation13/Yogstation/assets/43766432/e5ee9c5c-f63b-4075-a721-fe940980379c)

After:
![image](https://github.com/yogstation13/Yogstation/assets/43766432/acdc595a-bb98-47b3-b3d3-85e3216c65bc)




# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: Mech melee weapons now also hit vines properly when using cleave attacks

/:cl:
