### PR TITLE
Silicon Fake Laws: Hugboxed

### DIFF
--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -280,6 +280,7 @@
 	if(.)
 		return
 
+	// They must be either the silicon owner OR admin.
 	if(owner != usr && !is_admin(usr))
 		message_admins("Warning: Non-silicon and non-admin [usr] attempted to open [owner]'s Law Manager!")
 		return
@@ -338,8 +339,8 @@
 		if("edit_law")
 			var/index = text2num(params["index"])
 			var/type = params["type"]
-			if(owner == usr && !is_special_character(owner) && !is_admin(usr))
-				message_admins("Warning: Non-antag silicon and non-admin [usr] attempted to edit one of their laws!")
+			if(!is_admin(usr))
+				message_admins("Warning: Non-admin [usr] attempted to edit one of their laws!")
 				return
 			if(type == "devil" && owner.laws.devil.len >= index)
 				if(!is_admin(usr))
@@ -399,8 +400,8 @@
 		if("delete_law")
 			var/index = text2num(params["index"])
 			var/type = params["type"]
-			if(owner == usr && !is_admin(usr))
-				message_admins("Warning: Non-antag silicon and non-admin[usr] attempted to delete one of their laws!")
+			if(!is_admin(usr))
+				message_admins("Warning: Non-admin [usr] attempted to delete one of their laws!")
 				return
 			if(ispAI(owner))
 				to_chat(usr, span_warning("You cannot delete a law from a pAI."))
@@ -449,8 +450,8 @@
 						connected_cyborg.law_change_counter++
 		if("add_law")
 			var/type = params["type"]
-			if(owner == usr && !is_admin(usr))
-				message_admins("Warning: Non-antag silicon and non-admin [usr] attempted to give themselves a law!")
+			if(!is_admin(usr))
+				message_admins("Warning: Non-admin [usr] attempted to give themselves a law!")
 				return
 			if(ispAI(owner))
 				to_chat(usr, span_warning("You cannot add laws to a pAI."))
@@ -487,8 +488,8 @@
 						connected_cyborg.lawsync()
 						connected_cyborg.law_change_counter++
 		if("transfer_laws")
-			if(owner == usr && !is_admin(usr))
-				message_admins("Warning: Non-antag silicon and non-admin [usr] attempted to transfer themselves a lawset!")
+			if(!is_admin(usr))
+				message_admins("Warning: Non-admin [usr] attempted to transfer themselves a lawset!")
 				return
 			if(ispAI(owner))
 				to_chat(usr, span_warning("You cannot transfer laws to a pAI."))
@@ -527,9 +528,6 @@
 		if("edit_law_fake")
 			var/index = text2num(params["index"])
 			var/type = params["type"]
-			if(owner != usr && !is_admin(usr))
-				message_admins("Warning: Non-owner silicon and non-admin [usr] attempted to edit one of their fake laws!")
-				return
 			if(type == "devil" && fake_laws.devil.len >= index)
 				var/new_law = sanitize(input(usr, "Enter new law. Leaving the field blank will cancel the edit.", "Edit Law", fake_laws.devil[index]))
 				if(new_law != "" && new_law != fake_laws.devil[index])
@@ -557,9 +555,6 @@
 		if("delete_law_fake")
 			var/index = text2num(params["index"])
 			var/type = params["type"]
-			if(owner != usr && !is_admin(usr))
-				message_admins("Warning: Non-owner silicon and non-admin [usr] attempted to delete one of their fake laws!")
-				return
 			if(ispAI(owner))
 				to_chat(usr, span_warning("You cannot delete a law from a pAI."))
 				return
@@ -577,9 +572,6 @@
 				fake_laws.remove_supplied_law(index)
 		if("add_law_fake")
 			var/type = params["type"]
-			if(owner != usr && !is_admin(usr))
-				message_admins("Warning: Non-owner silicon and non-admin [usr] attempted to give themselves a fake law!")
-				return
 			if(ispAI(owner))
 				to_chat(usr, span_warning("You cannot add laws to a pAI."))
 				return
@@ -594,9 +586,6 @@
 			if(type == "supplied" && length(supplied_law) > 0 && supplied_law_position >= MIN_SUPPLIED_LAW_NUMBER && supplied_law_position <= MAX_SUPPLIED_LAW_NUMBER)
 				fake_laws.add_supplied_law(supplied_law_position, supplied_law, FALSE)
 		if("transfer_laws_fake")
-			if(owner != usr && !is_admin(usr))
-				message_admins("Warning: Non-owner silicon and non-admin [usr] attempted to transfer themselves a fake lawset!")
-				return
 			if(ispAI(owner))
 				to_chat(usr, span_warning("You cannot transfer laws to a pAI."))
 				return
@@ -610,9 +599,6 @@
 					current_view = 0
 					break
 		if("reset_fake_view")
-			if(owner != usr && !is_admin(usr))
-				message_admins("Warning: Non-owner silicon and non-admin [usr] attempted to reset their fake laws!")
-				return
 			if(!owner.laws)
 				return
 			fake_laws.set_devil_laws(owner.laws.devil)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -192,7 +192,7 @@
 				say("[radiomod] 666. [stated_laws.devil[index]]")
 				sleep(1 SECONDS)
 	if(stated_laws.zeroth && (force || stated_laws.zerothstate))
-		say("[radiomod] 0. [laws.zeroth]")
+		say("[radiomod] 0. [stated_laws.zeroth]")
 		sleep(1 SECONDS)
 	for (var/index = 1, index <= stated_laws.hacked.len, index++)
 		var/law = stated_laws.hacked[index]

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -178,48 +178,44 @@
 		return TRUE
 	return FALSE
 
-/mob/living/silicon/proc/statelaws(force = 0)
+/mob/living/silicon/proc/statelaws(force = 0, datum/ai_laws/alternative_lawset)
 	laws_sanity_check()
 
 	//"radiomod" is inserted before a hardcoded message to change if and how it is handled by an internal radio.
 	say("[radiomod] Current Active Laws:")
 	sleep(1 SECONDS)
-
-	if(laws.devil && laws.devil.len)
-		for(var/index = 1, index <= laws.devil.len, index++)
+	
+	var/datum/ai_laws/stated_laws = isnull(alternative_lawset) ? laws : alternative_lawset
+	if(stated_laws.devil && stated_laws.devil.len)
+		for(var/index = 1, index <= stated_laws.devil.len, index++)
 			if(force || laws.devilstate[index])
-				say("[radiomod] 666. [laws.devil[index]]")
+				say("[radiomod] 666. [stated_laws.devil[index]]")
 				sleep(1 SECONDS)
-
-	if(laws.zeroth && (force || laws.zerothstate))
+	if(stated_laws.zeroth && (force || stated_laws.zerothstate))
 		say("[radiomod] 0. [laws.zeroth]")
 		sleep(1 SECONDS)
-
-	for (var/index = 1, index <= laws.hacked.len, index++)
-		var/law = laws.hacked[index]
+	for (var/index = 1, index <= stated_laws.hacked.len, index++)
+		var/law = stated_laws.hacked[index]
 		var/num = ionnum()
-		if(length(law) > 0 && (force || laws.hackedstate[index]) )
+		if(length(law) > 0 && (force || stated_laws.hackedstate[index]) )
 			say("[radiomod] [num]. [law]")
 			sleep(1 SECONDS)
-
-	for (var/index = 1, index <= laws.ion.len, index++)
-		var/law = laws.ion[index]
+	for (var/index = 1, index <= stated_laws.ion.len, index++)
+		var/law = stated_laws.ion[index]
 		var/num = ionnum()
-		if(length(law) > 0 && (force || laws.ionstate[index]) )
+		if(length(law) > 0 && (force || stated_laws.ionstate[index]) )
 			say("[radiomod] [num]. [law]")
 			sleep(1 SECONDS)
-
 	var/number = 1
-	for (var/index = 1, index <= laws.inherent.len, index++)
-		var/law = laws.inherent[index]
-		if(length(law) > 0 && (force || laws.inherentstate[index]) )
+	for (var/index = 1, index <= stated_laws.inherent.len, index++)
+		var/law = stated_laws.inherent[index]
+		if(length(law) > 0 && (force || stated_laws.inherentstate[index]) )
 			say("[radiomod] [number]. [law]")
 			number++
 			sleep(1 SECONDS)
-
-	for (var/index = 1, index <= laws.supplied.len, index++)
-		var/law = laws.supplied[index]
-		if(length(law) > 0 && (force || laws.suppliedstate[index]) )
+	for (var/index = 1, index <= stated_laws.supplied.len, index++)
+		var/law = stated_laws.supplied[index]
+		if(length(law) > 0 && (force || stated_laws.suppliedstate[index]) )
 			say("[radiomod] [number]. [law]")
 			number++
 			sleep(1 SECONDS)


### PR DESCRIPTION
# Document the changes in your pull request
Adds an separate section in Law Manager for the sole purpose of making and stating fake laws.
Solves the griefing potential that led to #21424.

Since this has no gameplay impact besides letting silicons have an easier time saying a bunch of words in chat, this has been granted to all silicons (except pAIs) instead of only antag AIs.

# Why is this good for the game?
Same reason as I've given in #21294 in which trying to fake your laws without resorting to copy pasting is not worth the effort. This make it convenient to do so. 

# Testing
Default view:
![image](https://github.com/yogstation13/Yogstation/assets/30399783/d2e74b68-659d-4d6b-8db9-dd917f2e6809)

Fake laws view:
![image](https://github.com/yogstation13/Yogstation/assets/30399783/7269665f-7fe5-4c60-8508-9553c0bb6afe)

Clicking state laws while in fake laws view:
![image](https://github.com/yogstation13/Yogstation/assets/30399783/59b5f750-7810-40ff-9732-abb851e23efa)

# Wiki Documentation
Add tip to any of the silicon's wikis saying that they can fake laws.

# Changelog
:cl:  
rscadd: Silicon Law Manager now has a separate section for making and stating fake laws. This has no impact on real laws.
rscadd: All silicons (except pAIs) can make and state fake laws.
/:cl:
