### PR TITLE
Add pluoxium + antinoblium gas recipe to HFR

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_fuel_datums.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_fuel_datums.dm
@@ -125,6 +125,20 @@ GLOBAL_LIST_INIT(hfr_fuels_list, hfr_fuels_create_list())
 	secondary_products = list(GAS_ANTINOB, GAS_HEALIUM, GAS_PLUONIUM, GAS_ZAUKER, GAS_NITRIUM, GAS_MIASMA)
 	meltdown_flags = HYPERTORUS_FLAG_DEVASTATING_EXPLOSION | HYPERTORUS_FLAG_RADIATION_PULSE | HYPERTORUS_FLAG_EMP | HYPERTORUS_FLAG_BIG_SPREAD
 
+/datum/hfr_fuel/pluox_antinob_fuel
+	id = "pluox_antinob_fuel"
+	name = "Pluoxium + Antinoblium fuel"
+	negative_temperature_multiplier = 0.1
+	positive_temperature_multiplier = 2.7
+	energy_concentration_multiplier = 1.5
+	fuel_consumption_multiplier = 0.05
+	gas_production_multiplier = 2
+	temperature_change_multiplier = 0.97
+	requirements = list(GAS_PLUOXIUM, GAS_ANTINOB)
+	primary_products = list(GAS_HYPERNOB, GAS_MIASMA)
+	secondary_products = list(GAS_HALON, GAS_HEXANE, GAS_BZ, GAS_NITRIUM, GAS_HEALIUM, GAS_ZAUKER)
+	meltdown_flags = HYPERTORUS_FLAG_DEVASTATING_EXPLOSION | HYPERTORUS_FLAG_RADIATION_PULSE | HYPERTORUS_FLAG_EMP | HYPERTORUS_FLAG_MASSIVE_SPREAD
+
 /datum/hfr_fuel/hypernob_antinob_fuel
 	id = "hypernob_antinob_fuel"
 	name = "Hypernoblium + Antinoblium fuel"
@@ -137,18 +151,4 @@ GLOBAL_LIST_INIT(hfr_fuels_list, hfr_fuels_create_list())
 	requirements = list(GAS_HYPERNOB, GAS_ANTINOB)
 	primary_products = list(GAS_ZAUKER, GAS_MIASMA)
 	secondary_products = list(GAS_O2, GAS_NITRIUM, GAS_BZ, GAS_PLUONIUM, GAS_HEXANE, GAS_HEALIUM)
-	meltdown_flags = HYPERTORUS_FLAG_DEVASTATING_EXPLOSION | HYPERTORUS_FLAG_RADIATION_PULSE | HYPERTORUS_FLAG_EMP | HYPERTORUS_FLAG_MASSIVE_SPREAD | HYPERTORUS_FLAG_CRITICAL_MELTDOWN
-
-/datum/hfr_fuel/pluox_antinob_fuel
-	id = "pluox_antinob_fuel"
-	name = "Pluoxium + Antinoblium fuel"
-	negative_temperature_multiplier = 1.5
-	positive_temperature_multiplier = 1.5
-	energy_concentration_multiplier = 10
-	fuel_consumption_multiplier = 0.5
-	gas_production_multiplier = 1.5
-	temperature_change_multiplier = 0.6
-	requirements = list(GAS_PLUOXIUM, GAS_ANTINOB)
-	primary_products = list(GAS_FREON, GAS_BZ)
-	secondary_products = list(GAS_HALON, GAS_HEXANE, GAS_MIASMA, GAS_NITRIUM, GAS_HEALIUM, GAS_ZAUKER)
 	meltdown_flags = HYPERTORUS_FLAG_DEVASTATING_EXPLOSION | HYPERTORUS_FLAG_RADIATION_PULSE | HYPERTORUS_FLAG_EMP | HYPERTORUS_FLAG_MASSIVE_SPREAD | HYPERTORUS_FLAG_CRITICAL_MELTDOWN

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_fuel_datums.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_fuel_datums.dm
@@ -149,6 +149,6 @@ GLOBAL_LIST_INIT(hfr_fuels_list, hfr_fuels_create_list())
 	gas_production_multiplier = 3
 	temperature_change_multiplier = 0.6
 	requirements = list(GAS_PLUOXIUM, GAS_ANTINOB)
-	primary_products = list(GAS_FREON, GAS_HYPERNOB)
+	primary_products = list(GAS_FREON, GAS_BZ)
 	secondary_products = list(GAS_HALON, GAS_HEXANE, GAS_MIASMA, GAS_NITRIUM, GAS_HEALIUM, GAS_ZAUKER)
 	meltdown_flags = HYPERTORUS_FLAG_DEVASTATING_EXPLOSION | HYPERTORUS_FLAG_RADIATION_PULSE | HYPERTORUS_FLAG_EMP | HYPERTORUS_FLAG_MASSIVE_SPREAD | HYPERTORUS_FLAG_CRITICAL_MELTDOWN

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_fuel_datums.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_fuel_datums.dm
@@ -145,8 +145,8 @@ GLOBAL_LIST_INIT(hfr_fuels_list, hfr_fuels_create_list())
 	negative_temperature_multiplier = 1.5
 	positive_temperature_multiplier = 1.5
 	energy_concentration_multiplier = 10
-	fuel_consumption_multiplier = 0.01
-	gas_production_multiplier = 3
+	fuel_consumption_multiplier = 0.5
+	gas_production_multiplier = 1.5
 	temperature_change_multiplier = 0.6
 	requirements = list(GAS_PLUOXIUM, GAS_ANTINOB)
 	primary_products = list(GAS_FREON, GAS_BZ)

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_fuel_datums.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_fuel_datums.dm
@@ -138,3 +138,17 @@ GLOBAL_LIST_INIT(hfr_fuels_list, hfr_fuels_create_list())
 	primary_products = list(GAS_ZAUKER, GAS_MIASMA)
 	secondary_products = list(GAS_O2, GAS_NITRIUM, GAS_BZ, GAS_PLUONIUM, GAS_HEXANE, GAS_HEALIUM)
 	meltdown_flags = HYPERTORUS_FLAG_DEVASTATING_EXPLOSION | HYPERTORUS_FLAG_RADIATION_PULSE | HYPERTORUS_FLAG_EMP | HYPERTORUS_FLAG_MASSIVE_SPREAD | HYPERTORUS_FLAG_CRITICAL_MELTDOWN
+
+/datum/hfr_fuel/pluox_antinob_fuel
+	id = "pluox_antinob_fuel"
+	name = "Pluoxium + Antinoblium fuel"
+	negative_temperature_multiplier = 1.5
+	positive_temperature_multiplier = 1.5
+	energy_concentration_multiplier = 10
+	fuel_consumption_multiplier = 0.01
+	gas_production_multiplier = 3
+	temperature_change_multiplier = 0.6
+	requirements = list(GAS_PLUOXIUM, GAS_ANTINOB)
+	primary_products = list(GAS_FREON, GAS_HYPERNOB)
+	secondary_products = list(GAS_HALON, GAS_HEXANE, GAS_MIASMA, GAS_NITRIUM, GAS_HEALIUM, GAS_ZAUKER)
+	meltdown_flags = HYPERTORUS_FLAG_DEVASTATING_EXPLOSION | HYPERTORUS_FLAG_RADIATION_PULSE | HYPERTORUS_FLAG_EMP | HYPERTORUS_FLAG_MASSIVE_SPREAD | HYPERTORUS_FLAG_CRITICAL_MELTDOWN

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -303,7 +303,7 @@
 				heat_output *= 1.025
 				var/remove_amount = round(min(moderator_internal.get_moles(GAS_PLUONIUM), scaled_production * 1.35), 0.01)
 				moderator_internal.adjust_moles(GAS_PLUONIUM, -remove_amount)
-				delta_mod_list[GAS_PLUONIUM] += remove_amount
+				delta_mod_list[GAS_PLUONIUM] -= remove_amount
 
 		if(3, 4)
 			if(moderator_list[GAS_PLASMA] > 10)


### PR DESCRIPTION
# Document the changes in your pull request
<details><summary>   

### Pluoxium + Antinoblium gas recipe stat: 

</summary>

* Fusion Byproducts: Freon + Miasma
* Fusion Secondary Products: T1-Halon, T2-Hexane, T3-BZ, T4-Nitrium, T5-Healium, T6-Zauker

- other stats

	negative_temperature_multiplier = 0.1
	positive_temperature_multiplier = 2.7
	energy_concentration_multiplier = 1.5
	fuel_consumption_multiplier = 0.05
	gas_production_multiplier = 2
	temperature_change_multiplier = 0.97

Same explosive stats as the HN-AN recipe just without the critical meltdown

</details>

# Why is this good for the game?
more recipe diversity, look more colorful on the recipe list

# Testing
The recipe worked


# Wiki Documentation
New HFR recipe i guess look in document of change for more info

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

rscadd: Add pluoxium + antinoblium gas recipe to HFR
bugfix: fix tier 2 moderator pluonium production output on tgui
/:cl:
