### PR TITLE
Adjusts some population requirements for certain antags

### DIFF
--- a/code/game/gamemodes/brother/traitor_bro.dm
+++ b/code/game/gamemodes/brother/traitor_bro.dm
@@ -9,6 +9,7 @@
 	required_players = 20 //yogs - just a minor change
 	title_icon = "ss13"
 
+
 	announce_span = "danger"
 	announce_text = "There are Syndicate agents and Blood Brothers on the station!\n\
 	<span class='danger'>Traitors</span>: Accomplish your objectives.\n\

--- a/code/game/gamemodes/brother/traitor_bro.dm
+++ b/code/game/gamemodes/brother/traitor_bro.dm
@@ -6,7 +6,7 @@
 	name = "traitor+brothers"
 	config_tag = "traitorbro"
 	restricted_jobs = list("AI", "Cyborg")
-	required_players = 8 //yogs - just a minor change
+	required_players = 20 //yogs - just a minor change
 	title_icon = "ss13"
 
 	announce_span = "danger"

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -81,7 +81,7 @@ GLOBAL_VAR(changeling_team_objective_type)
 	false_report_weight = 10
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Brig Physician") //YOGS - added hop and brig physician
-	required_players = 25
+	required_players = 20
 	required_enemies = 2
 	recommended_enemies = 4
 	reroll_friendly = 1

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -5,7 +5,7 @@
 	false_report_weight = 10
 	traitors_possible = 3 //hard limit on traitors if scaling is turned off
 	restricted_jobs = list("AI", "Cyborg")
-	required_players = 25
+	required_players = 20
 	required_enemies = 1	// how many of each type are required
 	recommended_enemies = 3
 	reroll_friendly = 1

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -41,7 +41,7 @@
 	false_report_weight = 10
 	restricted_jobs = list("Chaplain","AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Research Director", "Chief Engineer", "Chief Medical Officer", "Brig Physician") //Yogs: Added Brig Physician
 	protected_jobs = list()
-	required_players = 29
+	required_players = 24
 	required_enemies = 4
 	recommended_enemies = 4
 	enemy_minimum_age = 14

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -19,7 +19,7 @@
 	false_report_weight = 10
 	restricted_jobs = list("Security Officer", "Warden", "Detective", "AI", "Cyborg", "Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer", "Shaft Miner", "Mining Medic", "Brig Physician") //Yogs: Added Brig Physician
 	required_jobs = list(list("Captain"=1),list("Head of Personnel"=1),list("Head of Security"=1),list("Chief Engineer"=1),list("Research Director"=1),list("Chief Medical Officer"=1)) //Any head present
-	required_players = 30
+	required_players = 25
 	required_enemies = 2
 	recommended_enemies = 3
 	enemy_minimum_age = 14


### PR DESCRIPTION
# Document the changes in your pull request

changeling 25 -> 20
traitorchan 25 -> 20
bloodcult 29 -> 24 (same as clock cult)
traitorbro (traitors + blood brothers) 8 -> 20
wiz 34 -> 30
revolution 30 -> 25

# Why is this good for the game?

Our pop is a little on the low side recently, and I think these numbers better fit the server,

# Testing

none

# Wiki Documentation

do we track these on the wiki>

# Changelog

:cl:  

tweak: adjust some pop requirements for several antags

/:cl:
