### PR TITLE
Makes certain mutant bodyparts emissive

### DIFF
--- a/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -61,6 +61,7 @@
 	var/dimension_y = 32
 	var/limbs_id // The limbs id supplied for full-body replacing features.
 	var/center = FALSE	//Should we center the sprite?
+	var/emissive = FALSE //is this emissive?
 
 //////////////////////
 // Hair Definitions //
@@ -857,6 +858,7 @@
 /datum/sprite_accessory/ipc_screens
 	icon = 'icons/mob/ipc_accessories.dmi'
 	color_src = EYECOLOR
+	emissive = TRUE
 
 /datum/sprite_accessory/ipc_screens/blue
 	name = "Blue"
@@ -875,6 +877,7 @@
 /datum/sprite_accessory/ipc_screens/blank
 	name = "Null"
 	icon_state = "blank"
+	emissive = FALSE
 
 /datum/sprite_accessory/ipc_screens/console
 	name = "Console"
@@ -2242,6 +2245,7 @@
 	center = TRUE
 	dimension_y = 34
 	locked = TRUE
+	emissive = TRUE
 
 /datum/sprite_accessory/wings_open/ethereal
 	name = "Ethereal"
@@ -2249,6 +2253,7 @@
 	dimension_x = 46
 	center = TRUE
 	dimension_y = 34
+	emissive = TRUE
 
 /datum/sprite_accessory/wings/etherealdetails
 	name = "Etherealdetails"
@@ -2258,6 +2263,7 @@
 	dimension_y = 34
 	locked = TRUE
 	color_src = null
+	emissive = TRUE
 
 /datum/sprite_accessory/wings_open/etherealdetails
 	name = "Etherealdetails"
@@ -2266,6 +2272,7 @@
 	center = TRUE
 	dimension_y = 34
 	color_src = null
+	emissive = TRUE
 
 /datum/sprite_accessory/wings/elytra
 	name = "Elytra"
@@ -2275,6 +2282,7 @@
 	dimension_y = 32
 	locked = TRUE
 	color_src = EYECOLOR
+	emissive = TRUE
 
 /datum/sprite_accessory/wings_open/elytra
 	name = "Elytra"
@@ -2283,6 +2291,7 @@
 	center = TRUE
 	dimension_y = 32
 	color_src = EYECOLOR
+	emissive = TRUE
 
 /datum/sprite_accessory/frills
 	icon = 'icons/mob/mutant_bodyparts.dmi'
@@ -2598,6 +2607,7 @@
 /datum/sprite_accessory/ethereal_mark
 	icon = 'icons/mob/mutant_bodyparts.dmi'
 	color_src = EYECOLOR
+	emissive = TRUE
 
 /datum/sprite_accessory/ethereal_mark/eyes
 	name = "Eyes"
@@ -2717,6 +2727,7 @@
 /datum/sprite_accessory/preternis_eye
 	icon = 'icons/mob/mutant_bodyparts.dmi'
 	color_src = EYECOLOR
+	emissive = TRUE
 
 /datum/sprite_accessory/preternis_eye/one
 	name = "Standard"
@@ -2754,6 +2765,7 @@
 /datum/sprite_accessory/preternis_core
 	icon = 'icons/mob/mutant_bodyparts.dmi'
 	color_src = EYECOLOR
+	emissive = TRUE
 
 /datum/sprite_accessory/preternis_core/core
 	name = "Core"

--- a/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -858,6 +858,7 @@
 /datum/sprite_accessory/ipc_screens
 	icon = 'icons/mob/ipc_accessories.dmi'
 	color_src = EYECOLOR
+	emissive = TRUE
 
 /datum/sprite_accessory/ipc_screens/blue
 	name = "Blue"
@@ -876,6 +877,7 @@
 /datum/sprite_accessory/ipc_screens/blank
 	name = "Null"
 	icon_state = "blank"
+	emissive = FALSE
 
 /datum/sprite_accessory/ipc_screens/console
 	name = "Console"

--- a/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -858,7 +858,6 @@
 /datum/sprite_accessory/ipc_screens
 	icon = 'icons/mob/ipc_accessories.dmi'
 	color_src = EYECOLOR
-	emissive = TRUE
 
 /datum/sprite_accessory/ipc_screens/blue
 	name = "Blue"
@@ -877,7 +876,6 @@
 /datum/sprite_accessory/ipc_screens/blank
 	name = "Null"
 	icon_state = "blank"
-	emissive = FALSE
 
 /datum/sprite_accessory/ipc_screens/console
 	name = "Console"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -916,6 +916,10 @@ GLOBAL_LIST_EMPTY(features_by_species)
 		if((H.wear_mask && (H.wear_mask.flags_inv & HIDEEYES)) || (H.head && (H.head.flags_inv & HIDEEYES)) || !HD)
 			bodyparts_to_add -= "preternis_eye"
 
+	if("preternis_core" in mutant_bodyparts)
+		if(H.w_uniform || (H.wear_suit && (H.wear_suit.flags_inv & HIDEJUMPSUIT)))
+			bodyparts_to_add -= "preternis_core"
+
 	if("pod_hair" in mutant_bodyparts)
 		if((H.wear_mask && (H.wear_mask.flags_inv & HIDEHAIR)) || (H.head && (H.head.flags_inv & HIDEHAIR)) || !HD || HD.status == BODYPART_ROBOTIC)
 			bodyparts_to_add -= "pod_hair"
@@ -1041,7 +1045,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			if(!S || S.icon_state == "none")
 				continue
 
-			var/mutable_appearance/accessory_overlay = mutable_appearance(S.icon, layer = -layer)
+			var/mutable_appearance/accessory_overlay 
+			accessory_overlay = mutable_appearance(S.icon)
 
 			//A little rename so we don't have to use tail_lizard or tail_human when naming the sprites.
 			if(bodypart == "tail_lizard" || bodypart == "tail_human" || bodypart == "tail_polysmorph")
@@ -1081,6 +1086,43 @@ GLOBAL_LIST_EMPTY(features_by_species)
 				else
 					accessory_overlay.color = forced_colour
 			standing += accessory_overlay
+
+			if(S.emissive)
+				var/mutable_appearance/emissive_accessory_overlay 
+				emissive_accessory_overlay  = emissive_appearance(S.icon, "placeholder", H)
+				//A little rename so we don't have to use tail_lizard or tail_human when naming the sprites.
+				if(S.gender_specific)
+					emissive_accessory_overlay.icon_state = "[g]_[bodypart]_[S.icon_state]_[layertext]"
+				else
+					emissive_accessory_overlay.icon_state = "m_[bodypart]_[S.icon_state]_[layertext]"
+
+				if(S.center)
+					emissive_accessory_overlay = center_image(emissive_accessory_overlay, S.dimension_x, S.dimension_y)
+
+				if(!(HAS_TRAIT(H, TRAIT_HUSK)))
+					if(!forced_colour)
+						switch(S.color_src)
+							if(MUTCOLORS)
+								if(H.dna.check_mutation(HULK))			//HULK GO FIRST
+									emissive_accessory_overlay.color = "#00aa00"
+								else if(fixed_mut_color)													//Then fixed color if applicable
+									emissive_accessory_overlay.color = fixed_mut_color
+								else																		//Then snowflake color
+									emissive_accessory_overlay.color = H.dna.features["mcolor"]
+							if(HAIR)
+								if(hair_color == "mutcolor")
+									emissive_accessory_overlay.color = H.dna.features["mcolor"]
+								else if(hair_color == "fixedmutcolor")
+									emissive_accessory_overlay.color = fixed_mut_color
+								else
+									emissive_accessory_overlay.color = H.hair_color
+							if(FACEHAIR)
+								emissive_accessory_overlay.color = H.facial_hair_color
+							if(EYECOLOR)
+								emissive_accessory_overlay.color = H.eye_color
+					else
+						emissive_accessory_overlay.color = forced_colour
+				standing += emissive_accessory_overlay
 
 			if(S.hasinner)
 				var/mutable_appearance/inner_accessory_overlay = mutable_appearance(S.icon, layer = -layer)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -917,7 +917,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			bodyparts_to_add -= "preternis_eye"
 
 	if("preternis_core" in mutant_bodyparts)
-		if(H.w_uniform || (H.wear_suit && (H.wear_suit.flags_inv & HIDEJUMPSUIT)))
+		if(H.w_uniform || H.wear_suit)
 			bodyparts_to_add -= "preternis_core"
 
 	if("pod_hair" in mutant_bodyparts)
@@ -1046,7 +1046,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 				continue
 
 			var/mutable_appearance/accessory_overlay 
-			accessory_overlay = mutable_appearance(S.icon)
+			accessory_overlay = mutable_appearance(S.icon, layer = -layer)
 
 			//A little rename so we don't have to use tail_lizard or tail_human when naming the sprites.
 			if(bodypart == "tail_lizard" || bodypart == "tail_human" || bodypart == "tail_polysmorph")
@@ -1087,9 +1087,10 @@ GLOBAL_LIST_EMPTY(features_by_species)
 					accessory_overlay.color = forced_colour
 			standing += accessory_overlay
 
-			if(S.emissive)
+			if(S.emissive && !(HAS_TRAIT(H, TRAIT_HUSK)))
 				var/mutable_appearance/emissive_accessory_overlay 
 				emissive_accessory_overlay  = emissive_appearance(S.icon, "placeholder", H)
+
 				//A little rename so we don't have to use tail_lizard or tail_human when naming the sprites.
 				if(S.gender_specific)
 					emissive_accessory_overlay.icon_state = "[g]_[bodypart]_[S.icon_state]_[layertext]"
@@ -1099,29 +1100,28 @@ GLOBAL_LIST_EMPTY(features_by_species)
 				if(S.center)
 					emissive_accessory_overlay = center_image(emissive_accessory_overlay, S.dimension_x, S.dimension_y)
 
-				if(!(HAS_TRAIT(H, TRAIT_HUSK)))
-					if(!forced_colour)
-						switch(S.color_src)
-							if(MUTCOLORS)
-								if(H.dna.check_mutation(HULK))			//HULK GO FIRST
-									emissive_accessory_overlay.color = "#00aa00"
-								else if(fixed_mut_color)													//Then fixed color if applicable
-									emissive_accessory_overlay.color = fixed_mut_color
-								else																		//Then snowflake color
-									emissive_accessory_overlay.color = H.dna.features["mcolor"]
-							if(HAIR)
-								if(hair_color == "mutcolor")
-									emissive_accessory_overlay.color = H.dna.features["mcolor"]
-								else if(hair_color == "fixedmutcolor")
-									emissive_accessory_overlay.color = fixed_mut_color
-								else
-									emissive_accessory_overlay.color = H.hair_color
-							if(FACEHAIR)
-								emissive_accessory_overlay.color = H.facial_hair_color
-							if(EYECOLOR)
-								emissive_accessory_overlay.color = H.eye_color
-					else
-						emissive_accessory_overlay.color = forced_colour
+				if(!forced_colour)
+					switch(S.color_src)
+						if(MUTCOLORS)
+							if(H.dna.check_mutation(HULK))			//HULK GO FIRST
+								emissive_accessory_overlay.color = "#00aa00"
+							else if(fixed_mut_color)													//Then fixed color if applicable
+								emissive_accessory_overlay.color = fixed_mut_color
+							else																		//Then snowflake color
+								emissive_accessory_overlay.color = H.dna.features["mcolor"]
+						if(HAIR)
+							if(hair_color == "mutcolor")
+								emissive_accessory_overlay.color = H.dna.features["mcolor"]
+							else if(hair_color == "fixedmutcolor")
+								emissive_accessory_overlay.color = fixed_mut_color
+							else
+								emissive_accessory_overlay.color = H.hair_color
+						if(FACEHAIR)
+							emissive_accessory_overlay.color = H.facial_hair_color
+						if(EYECOLOR)
+							emissive_accessory_overlay.color = H.eye_color
+				else
+					emissive_accessory_overlay.color = forced_colour
 				standing += emissive_accessory_overlay
 
 			if(S.hasinner)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1045,8 +1045,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			if(!S || S.icon_state == "none")
 				continue
 
-			var/mutable_appearance/accessory_overlay 
-			accessory_overlay = mutable_appearance(S.icon, layer = -layer)
+			var/mutable_appearance/accessory_overlay = mutable_appearance(S.icon, layer = -layer)
 
 			//A little rename so we don't have to use tail_lizard or tail_human when naming the sprites.
 			if(bodypart == "tail_lizard" || bodypart == "tail_human" || bodypart == "tail_polysmorph")
@@ -1088,8 +1087,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			standing += accessory_overlay
 
 			if(S.emissive && !(HAS_TRAIT(H, TRAIT_HUSK)))
-				var/mutable_appearance/emissive_accessory_overlay 
-				emissive_accessory_overlay  = emissive_appearance(S.icon, "placeholder", H)
+				var/mutable_appearance/emissive_accessory_overlay = emissive_appearance(S.icon, "placeholder", H)
 
 				//A little rename so we don't have to use tail_lizard or tail_human when naming the sprites.
 				if(S.gender_specific)


### PR DESCRIPTION
Makes
Ethereal eyes and wings (not particularly relevant since they glow)
Preternis eyes, core, and wings
IPC screen
all emissive

# Why is this good for the game?
Gives certain species cool effects using the new darkness system

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/efa100d5-8b00-4918-8e99-4396024cabee)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/a0c960b8-5547-40dc-af5d-6fbf8e46b83f)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/5ce9a23a-13b8-4def-8751-0702ab49c9c3)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/4dd2d069-ee53-4066-8c55-1e0a70222ed2)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/184a1124-a52a-4f89-8237-235ad7d4f3a3)

only bug is that the character preference menu shows emissives incorrectly, and i have no clue how to fix that
![image](https://github.com/yogstation13/Yogstation/assets/108117184/b74f6d98-baa6-4861-b1b0-b4fb7e0ca089)


:cl:  
rscadd: Certain species bodyparts now glow in the dark
/:cl:
