### PR TITLE
Fix blend_cutoff_colors runtimes relating to update_vision

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -314,6 +314,13 @@
 #define	REAGENTS_METABOLISM 0.4	//How many units of reagent are consumed per tick, by default.
 #define REAGENTS_EFFECT_MULTIPLIER (REAGENTS_METABOLISM / 0.4)	// By defining the effect multiplier this way, it'll exactly adjust all effects according to how they originally were with the 0.4 metabolism
 
+// Eye protection
+#define FLASH_PROTECTION_HYPER_SENSITIVE -2
+#define FLASH_PROTECTION_SENSITIVE -1
+#define FLASH_PROTECTION_NONE 0
+#define FLASH_PROTECTION_FLASH 1
+#define FLASH_PROTECTION_WELDER 2
+
 // Roundstart trait system
 
 #define MAX_QUIRKS 6 //The maximum amount of quirks one character can have at roundstart

--- a/code/__HELPERS/colors.dm
+++ b/code/__HELPERS/colors.dm
@@ -40,6 +40,10 @@
 /// But paired down and modified to work for our color range
 /// Accepts the color cutoffs as two 3 length list(0-100,...) arguments
 /proc/blend_cutoff_colors(list/first_color, list/second_color)
+	// These runtimes usually mean that either the eye or the glasses have an incorrect color_cutoffs
+	ASSERT(first_color?.len == 3, "First color must be a 3 length list, received [json_encode(first_color)]")
+	ASSERT(second_color?.len == 3, "Second color must be a 3 length list, received [json_encode(second_color)]")
+	
 	var/list/output = new /list(3)
 
 	// Invert the colors, multiply to "darken" (actually lights), then uninvert to get back to what we want

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -11,22 +11,21 @@
 	materials = list(/datum/material/glass = 250)
 	var/vision_flags = 0
 	var/invis_view = SEE_INVISIBLE_LIVING	//admin only for now
-	var/invis_override = 0 //Override to allow glasses to set higher than normal see_invis
-	var/list/icon/current = list() //the current hud icons
-	var/vision_correction = 0 //does wearing these glasses correct some of our vision defects?
-	var/glass_colour_type //colors your vision when worn
-
+	/// Override to allow glasses to set higher than normal see_invis
+	var/invis_override = 0
 	/// A percentage of how much rgb to "max" on the lighting plane
 	/// This lets us brighten darkness without washing out bright color
 	var/lighting_cutoff = null
 	/// Similar to lighting_cutoff, except it has individual r g and b components in the same 0-100 scale
 	var/list/color_cutoffs = null
-// Potentially replace glass_color_type with a setup that colors lighting by dropping segments of different componets
-// Like the current idea, but applied without the mass cutoff (maybe? somehow?)
-// That or just a light color to the lighting plane, that'd work too
-// Enough to make it visible but not so much that it's a pain
-
-// That, or just make stuff that uses lighting_cutoff have colored offsets and all, like you were planning
+	/// The current hud icons
+	var/list/icon/current = list()
+	/// Colors your vision when worn
+	var/glass_colour_type
+	/// Whether or not vision coloring is forcing
+	var/forced_glass_color = FALSE
+	//does wearing these glasses correct some of our vision defects?
+	var/vision_correction = 0
 
 /obj/item/clothing/glasses/suicide_act(mob/living/carbon/user)
 	user.visible_message(span_suicide("[user] is stabbing \the [src] into [user.p_their()] eyes! It looks like [user.p_theyre()] trying to commit suicide!"))

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -317,7 +317,7 @@ GLOBAL_LIST_EMPTY(aide_list)
 
 /obj/effect/wisp/proc/update_user_sight(mob/user)
 	SIGNAL_HANDLER
-	user.sight |= sight_flags
+	user.add_sight(sight_flags)
 	if(!isnull(color_cutoffs))
 		user.lighting_color_cutoffs = blend_cutoff_colors(user.lighting_color_cutoffs, color_cutoffs)
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -596,7 +596,7 @@
 			set_invis_see(min(glasses.invis_view, see_invisible))
 		if(!isnull(glasses.lighting_cutoff))
 			lighting_cutoff = max(lighting_cutoff, glasses.lighting_cutoff)
-		if(!isnull(glasses.color_cutoffs))
+		if(length(glasses.color_cutoffs))
 			lighting_color_cutoffs = blend_cutoff_colors(lighting_color_cutoffs, glasses.color_cutoffs)
 
 

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -176,6 +176,7 @@
 	name = "undead eyes"
 	desc = "Somewhat counterintuitively, these half-rotten eyes actually have superior vision to those of a living human."
 	color_cutoffs = list(25, 35, 5)
+	lighting_cutoff = LIGHTING_CUTOFF_HIGH
 
 //innate nightvision eyes
 /obj/item/organ/eyes/alien
@@ -183,12 +184,14 @@
 	desc = "It turned out they had them after all!"
 	sight_flags = SEE_MOBS
 	color_cutoffs = list(25, 5, 42)
+	lighting_cutoff = LIGHTING_CUTOFF_HIGH
 
 /obj/item/organ/eyes/shadow
 	name = "burning red eyes"
 	desc = "Even without their shadowy owner, looking at these eyes gives you a sense of dread."
 	icon_state = "burning_eyes"
 	color_cutoffs = list(20, 10, 40)
+	lighting_cutoff = LIGHTING_CUTOFF_HIGH
 
 ///Robotic
 /obj/item/organ/eyes/robotic

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -172,26 +172,23 @@
 	medium_light_cutoff = list(0, 20, 35)
 	high_light_cutoff = list(0, 40, 50)
 
+/obj/item/organ/eyes/zombie
+	name = "undead eyes"
+	desc = "Somewhat counterintuitively, these half-rotten eyes actually have superior vision to those of a living human."
+	color_cutoffs = list(25, 35, 5)
+
 //innate nightvision eyes
 /obj/item/organ/eyes/alien
 	name = "alien eyes"
 	desc = "It turned out they had them after all!"
 	sight_flags = SEE_MOBS
 	color_cutoffs = list(25, 5, 42)
-	lighting_cutoff = LIGHTING_CUTOFF_HIGH
-
-/obj/item/organ/eyes/zombie
-	name = "undead eyes"
-	desc = "Somewhat counterintuitively, these half-rotten eyes actually have superior vision to those of a living human."
-	color_cutoffs = list(25, 35, 5)
-	lighting_cutoff = LIGHTING_CUTOFF_HIGH
 
 /obj/item/organ/eyes/shadow
 	name = "burning red eyes"
 	desc = "Even without their shadowy owner, looking at these eyes gives you a sense of dread."
 	icon_state = "burning_eyes"
 	color_cutoffs = list(20, 10, 40)
-	lighting_cutoff = LIGHTING_CUTOFF_HIGH
 
 ///Robotic
 /obj/item/organ/eyes/robotic
@@ -243,7 +240,7 @@
 	sight_flags = SEE_MOBS
 	// We're gonna downshift green and blue a bit so darkness looks yellow
 	color_cutoffs = list(25, 8, 5)
-	flash_protect = -1
+	flash_protect = FLASH_PROTECTION_SENSITIVE
 
 /obj/item/organ/eyes/robotic/flashlight
 	name = "flashlight eyes"
@@ -279,7 +276,7 @@
 /obj/item/organ/eyes/robotic/shield
 	name = "shielded robotic eyes"
 	desc = "These reactive micro-shields will protect you from welders and flashes without obscuring your vision."
-	flash_protect = 2
+	flash_protect = FLASH_PROTECTION_WELDER
 
 /obj/item/organ/eyes/robotic/shield/emp_act(severity)
 	return


### PR DESCRIPTION
# Document the changes in your pull request

Nothing changes from a gameplay perspective, I just don't think we're supposed to be using the lighting cutoffs like that anymore with the new rendering system. Thanks @AlvCyktor for being problematic
![xX6r0fzTun](https://github.com/yogstation13/Yogstation/assets/46236974/69e8b998-3d0a-4c7c-8097-a3b973966920)


# Why is this good for the game?
less runtimes

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/46236974/34cfabfb-bcfe-44a5-960f-2f0269b1ad6f)
still seems to work right

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: index_out_of_bounds fixed on blend_cutoff_colors
/:cl:
