### PR TITLE
hopefully fix adminwho by skipping nulls in the admin list

### DIFF
--- a/yogstation/code/datums/world_topic.dm
+++ b/yogstation/code/datums/world_topic.dm
@@ -31,6 +31,8 @@ GLOBAL_VAR_INIT(mentornoot, FALSE)
 	var/list/admin_keys = list()
 	for(var/adm in GLOB.permissions.admins)
 		var/client/C = adm
+		if(isnull(C)) //Yog we're having issues with null holders breaking adminwho, so let's skip nulls
+			continue
 		if(input["adminchannel"])
 			admin_keys += "[C][C.holder.fakekey ? "(Stealth)" : ""][C.is_afk() ? "(AFK)" : ""]"
 		else if(!C.holder.fakekey)


### PR DESCRIPTION
# Document the changes in your pull request

we should probably switch to GLOB.admins like tg instead of GLOB.permissions.admins, but for the time being this should fix the issue
![image](https://github.com/yogstation13/Yogstation/assets/46236974/1ce1d8ba-b790-4bc4-97c6-df53b1c115ba)


# Why is this good for the game?
people don't think they're safe from admins

# Testing
can't test privately because i don't have the whole admin system backend with mentors and maintainers who are like pseudo admins

# Changelog

:cl:  
bugfix: fix adminwho by skipping null clients in the admin list
/:cl:
