### PR TITLE
Removes MMIs and positronic brains from medical techfab

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -11,7 +11,7 @@
 	construction_time = 75
 	build_path = /obj/item/mmi
 	category = list("Control Interfaces", "Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/posibrain
 	name = "Positronic Brain"
@@ -22,7 +22,7 @@
 	construction_time = 75
 	build_path = /obj/item/mmi/posibrain
 	category = list("Control Interfaces", "Medical Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL | DEPARTMENTAL_FLAG_SCIENCE
+	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/bluespacebeaker
 	name = "Bluespace Beaker"

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -404,7 +404,7 @@
 	build_path = /obj/item/organ/eyes/robotic/xray
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
-
+w
 /datum/design/cyberimp_xray
 	name = "X-Ray Eyes"
 	desc = "These cybernetic eyes will give you X-Ray-vision. Blinking is futile."

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -404,7 +404,7 @@
 	build_path = /obj/item/organ/eyes/robotic/xray
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
-w
+
 /datum/design/cyberimp_xray
 	name = "X-Ray Eyes"
 	desc = "These cybernetic eyes will give you X-Ray-vision. Blinking is futile."


### PR DESCRIPTION
# Document the changes in your pull request
As title says

# Why is this good for the game?
Makes no sense to me for medical to have robotics/science items since they can't do anything with them
Also results in these items becoming more rare and more valuable, which is good because they should be

# Testing
yep
![image](https://github.com/yogstation13/Yogstation/assets/143908044/cda83778-fadf-4ad4-9068-6c64e6133acd)


# Changelog
:cl:  
tweak: MMIs and positronic brains can no longer be printed from the medical techfab
/:cl:
