### PR TITLE
[LORE] Replaces hyperspace with bluespace

### DIFF
--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -103,7 +103,7 @@
 	id = "empty-shell"
 	suffix = "emptyshell.dmm"
 	name = "Empty Shell"
-	description = "Cosy, rural property available for young professional couple. Only twelve parsecs from the nearest hyperspace lane!"
+	description = "Cosy, rural property available for young professional couple. Only twelve parsecs from the nearest gigabeacon!"
 
 /datum/map_template/ruin/space/gas_the_lizards
 	id = "gas-the-lizards"

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -99,7 +99,7 @@
 ////////////////////////////Single-area shuttles////////////////////////////
 
 /area/shuttle/transit
-	name = "Hyperspace"
+	name = "Bluespace"
 	desc = "Weeeeee"
 	static_lighting = FALSE
 	base_lighting_alpha = 255

--- a/code/game/turfs/open/space/transit.dm
+++ b/code/game/turfs/open/space/transit.dm
@@ -1,5 +1,5 @@
 /turf/open/space/transit
-	name = "\proper hyperspace"
+	name = "\proper bluespace"
 	desc = "What is this, light-speed? We need to go to plaid speed!"  // spaceballs was a great movie
 	icon_state = "black"
 	dir = SOUTH

--- a/code/modules/holodeck/turfs.dm
+++ b/code/modules/holodeck/turfs.dm
@@ -89,18 +89,18 @@
 	icon_state = SPACE_ICON_STATE // so realistic
 	. = ..()
 
-/turf/open/floor/holofloor/hyperspace
-	name = "\proper hyperspace"
+/turf/open/floor/holofloor/bluespace
+	name = "\proper bluespace"
 	icon = 'icons/turf/space.dmi'
 	icon_state = "speedspace_ns_1"
 	bullet_bounce_sound = null
 	tiled_dirt = FALSE
 
-/turf/open/floor/holofloor/hyperspace/Initialize(mapload)
+/turf/open/floor/holofloor/bluespace/Initialize(mapload)
 	icon_state = "speedspace_ns_[(x + 5*y + (y%2+1)*7)%15+1]"
 	. = ..()
 
-/turf/open/floor/holofloor/hyperspace/ns/Initialize(mapload)
+/turf/open/floor/holofloor/bluespace/ns/Initialize(mapload)
 	. = ..()
 	icon_state = "speedspace_ns_[(x + 5*y + (y%2+1)*7)%15+1]"
 

--- a/code/modules/shuttle/ripple.dm
+++ b/code/modules/shuttle/ripple.dm
@@ -1,6 +1,6 @@
 /obj/effect/abstract/ripple
-	name = "hyperspace ripple"
-	desc = "Something is coming through hyperspace, you can see the \
+	name = "bluespace ripple"
+	desc = "Something is coming through bluespace, you can see the \
 		visual disturbances. It's probably best not to be on top of these \
 		when whatever is tunneling comes through."
 	icon = 'icons/effects/effects.dmi'


### PR DESCRIPTION
# Document the changes in your pull request
Replaces every player-facing mention of hyperspace with bluespace

# Why is this good for the game?
There was a discussion about this in lore-public, and I believe I'm not the only one who agrees that hyperspace travel doesn't really fit in with the lore we're trying to create. Therefore: bluespace.

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/143908044/8860a048-fea4-460f-aac6-4717f903ca28)

# Wiki Documentation
Do the same there

# Changelog
:cl:  
tweak: "Hyperspace" no longer exists and never did, FTL travel is achieved by tunneling through bluespace
/:cl:
