### PR TITLE
Fixes mention of Weyland-Yutani existing 

### DIFF
--- a/code/game/objects/items/manuals.dm
+++ b/code/game/objects/items/manuals.dm
@@ -10,7 +10,7 @@
 /obj/item/book/manual/ripley_build_and_repair
 	name = "APLU \"Ripley\" Construction and Operation Manual"
 	icon_state ="book"
-	author = "Weyland-Yutani Corp"
+	author = "Sano-Waltfield Industries"
 	title = "APLU \"Ripley\" Construction and Operation Manual"
 	dat = {"<html>
 				<head>
@@ -24,7 +24,7 @@
 				</head>
 				<body>
 				<center>
-				<b style='font-size: 12px;'>Weyland-Yutani - Building Better Worlds</b>
+				<b style='font-size: 12px;'>Sano-Waltfield - Forging Better Futures</b>
 				<h1>Autonomous Power Loader Unit \"Ripley\"</h1>
 				</center>
 				<h2>Specifications:</h2>


### PR DESCRIPTION
# Document the changes in your pull request
Replaces mentions of Weyland-Yutani(????) with Sano-Waltfield in a probably never-used book regarding ripley mech repair

# Why is this good for the game?
Corporation that doesn't exist < corporation that does
Also might be copyrighted idk 
![image](https://github.com/yogstation13/Yogstation/assets/143908044/8de0b87f-11d1-458c-ada6-d6aa076e452e)

# Testing
Now with added totally unique slogan (I'm open to suggestions)
![image](https://github.com/yogstation13/Yogstation/assets/143908044/838d2eaf-ceed-4ec5-84c5-226e82455007)

# Changelog
:cl:  
spellcheck: Fixed mention of Weyland-Yutani appearing in the ripley mech repair manual
/:cl:
