### PR TITLE
fix cable plane level and meteor spin icon with space lighting

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_main.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_main.dm
@@ -100,6 +100,9 @@
 /// from cosmetic items to restyle certain mobs, objects or organs: (atom/source, mob/living/trimmer, atom/movable/original_target, body_zone, restyle_type, style_speed)
 #define COMSIG_ATOM_RESTYLE "atom_restyle"
 
+/// Called on [/atom/SpinAnimation()] : (speed, loops, segments, angle)
+#define COMSIG_ATOM_SPIN_ANIMATION "atom_spin_animation"
+
 ///! from proc/get_rad_contents(): ()
 #define COMSIG_ATOM_RAD_PROBE "atom_rad_probe"
 	#define COMPONENT_BLOCK_RADIATION 1

--- a/code/__HELPERS/animations.dm
+++ b/code/__HELPERS/animations.dm
@@ -65,3 +65,53 @@
 	animate(transform = transforms[2], time = 0.1)
 	animate(transform = transforms[3], time = 0.2)
 	animate(transform = transforms[4], time = 0.3)
+
+
+/**
+ * Proc called when you want the atom to spin around the center of its icon (or where it would be if its transform var is translated)
+ * By default, it makes the atom spin forever and ever at a speed of 60 rpm.
+ *
+ * Arguments:
+ * * speed: how much it takes for the atom to complete one 360° rotation
+ * * loops: how many times do we want the atom to rotate
+ * * clockwise: whether the atom ought to spin clockwise or counter-clockwise
+ * * segments: in how many animate calls the rotation is split. Probably unnecessary, but you shouldn't set it lower than 3 anyway.
+ * * parallel: whether the animation calls have the ANIMATION_PARALLEL flag, necessary for it to run alongside concurrent animations.
+ */
+/atom/proc/SpinAnimation(speed = 1 SECONDS, loops = -1, clockwise = TRUE, segments = 3, parallel = TRUE)
+	if(!segments)
+		return
+	var/segment = 360/segments
+	if(!clockwise)
+		segment = -segment
+	SEND_SIGNAL(src, COMSIG_ATOM_SPIN_ANIMATION, speed, loops, segments, segment)
+	do_spin_animation(speed, loops, segments, segment, parallel)
+
+/atom/proc/DabAnimation(speed = 1, loops = 1, direction = 1 , hold_seconds = 0  , angle = 1 , stay = FALSE) // Hopek 2019  
+	// By making this in atom/proc everything in the game can potentially dab. You have been warned.
+	if(hold_seconds > 9999) // if you need to hold a dab for more than 2 hours intentionally let me know.
+		return
+	if(hold_seconds > 0)
+		hold_seconds = hold_seconds * 10 // Converts seconds to deciseconds 
+	if(angle == 1) //if angle is 1: random angle. Else take angle
+		angle = rand(25,50)
+	if(direction == 1) // direciton:: 1 for random pick, 2 for clockwise , 3 for anti-clockwise
+		direction = pick(2,3)
+	if(direction == 3) // if 3 then counter clockwise
+		angle = angle * -1
+	if(speed == 1) // if speed is 1 choose random speed from list
+		speed = rand(3,5)
+
+	// dab matrix here
+	var/matrix/DAB_COMMENCE = matrix(transform)
+	var/matrix/DAB_RETURN = matrix(transform)
+	DAB_COMMENCE.Turn(angle) // dab angle to matrix
+
+	// Dab animation 
+	animate(src, transform = DAB_COMMENCE, time = speed, loops ) // dab to hold angle
+	if(hold_seconds > 0)
+		sleep(hold_seconds) // time to hold the dab before going back
+	if(!stay) // if stay param is true dab doesn't return
+		animate(transform = DAB_RETURN, time = speed * 1.5, loops ) // reverse dab to starting position , slower
+		//doesn't have an object argument because this is "Stacking" with the animate call above
+		//3 billion% intentional

--- a/code/__HELPERS/matrices.dm
+++ b/code/__HELPERS/matrices.dm
@@ -2,60 +2,6 @@
 	. = new_angle - old_angle
 	Turn(.) //BYOND handles cases such as -270, 360, 540 etc. DOES NOT HANDLE 180 TURNS WELL, THEY TWEEN AND LOOK LIKE SHIT
 
-/atom/proc/SpinAnimation(speed = 1 SECONDS, loops = -1, clockwise = 1, segments = 3, parallel = TRUE)
-	if(!segments)
-		return
-	var/segment = 360/segments
-	if(!clockwise)
-		segment = -segment
-	var/list/matrices = list()
-	for(var/i in 1 to segments-1)
-		var/matrix/M = matrix(transform)
-		M.Turn(segment*i)
-		matrices += M
-	var/matrix/last = matrix(transform)
-	matrices += last
-
-	speed /= segments
-
-	if(parallel)
-		animate(src, transform = matrices[1], time = speed, loops , flags = ANIMATION_PARALLEL)
-	else
-		animate(src, transform = matrices[1], time = speed, loops)
-	for(var/i in 2 to segments) //2 because 1 is covered above
-		animate(transform = matrices[i], time = speed)
-		//doesn't have an object argument because this is "Stacking" with the animate call above
-		//3 billion% intentional
-
-/atom/proc/DabAnimation(speed = 1, loops = 1, direction = 1 , hold_seconds = 0  , angle = 1 , stay = FALSE) // Hopek 2019  
-	// By making this in atom/proc everything in the game can potentially dab. You have been warned.
-	if(hold_seconds > 9999) // if you need to hold a dab for more than 2 hours intentionally let me know.
-		return
-	if(hold_seconds > 0)
-		hold_seconds = hold_seconds * 10 // Converts seconds to deciseconds 
-	if(angle == 1) //if angle is 1: random angle. Else take angle
-		angle = rand(25,50)
-	if(direction == 1) // direciton:: 1 for random pick, 2 for clockwise , 3 for anti-clockwise
-		direction = pick(2,3)
-	if(direction == 3) // if 3 then counter clockwise
-		angle = angle * -1
-	if(speed == 1) // if speed is 1 choose random speed from list
-		speed = rand(3,5)
-
-	// dab matrix here
-	var/matrix/DAB_COMMENCE = matrix(transform)
-	var/matrix/DAB_RETURN = matrix(transform)
-	DAB_COMMENCE.Turn(angle) // dab angle to matrix
-
-	// Dab animation 
-	animate(src, transform = DAB_COMMENCE, time = speed, loops ) // dab to hold angle
-	if(hold_seconds > 0)
-		sleep(hold_seconds) // time to hold the dab before going back
-	if(!stay) // if stay param is true dab doesn't return
-		animate(transform = DAB_RETURN, time = speed * 1.5, loops ) // reverse dab to starting position , slower
-		//doesn't have an object argument because this is "Stacking" with the animate call above
-		//3 billion% intentional
-
 //Dumps the matrix data in format a-f
 /matrix/proc/tolist()
 	. = list()

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -88,18 +88,32 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 	icon_state = "small"
 	density = TRUE
 	anchored = TRUE
-	var/hits = 4
-	var/hitpwr = 2 //Level of ex_act to be called on hit.
-	var/dest
 	pass_flags = PASSTABLE
-	var/heavy = 0
+	
+	///The resilience of our meteor
+	var/hits = 4
+	///Level of ex_act to be called on hit.
+	var/hitpwr = EXPLODE_HEAVY
+	//Should we shake people's screens on impact
+	var/heavy = FALSE
+	///Sound to play when you hit something
 	var/meteorsound = 'sound/effects/meteorimpact.ogg'
+	///Our starting z level, prevents infinite meteors
 	var/z_original
-	var/threat = 0 // used for determining which meteors are most interesting
-	var/lifetime = DEFAULT_METEOR_LIFETIME
-	var/timerid = null
+	///Used for determining which meteors are most interesting
+	var/threat = 0
+
+	//Potential items to spawn when you die
 	var/list/meteordrop = list(/obj/item/stack/ore/iron)
+	///How much stuff to spawn when you die
 	var/dropamt = 2
+
+	///The thing we're moving towards, usually a turf
+	var/atom/dest
+	///Lifetime in seconds
+	var/lifetime = DEFAULT_METEOR_LIFETIME
+	
+	var/timerid = null
 
 /obj/effect/meteor/Move()
 	if(z != z_original || loc == dest)
@@ -134,6 +148,7 @@ GLOBAL_LIST_INIT(meteorsC, list(/obj/effect/meteor/dust)) //for space dust event
 	SpinAnimation()
 	timerid = QDEL_IN(src, lifetime)
 	chase_target(target)
+	update_appearance()
 
 /obj/effect/meteor/Bump(atom/A)
 	if(A)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -27,6 +27,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	desc = "A flexible, superconducting insulated cable for heavy-duty power transfer."
 	icon = 'icons/obj/power_cond/cables.dmi'
 	icon_state = "0-1"
+	plane = FLOOR_PLANE
 	layer = WIRE_LAYER //Above hidden pipes, GAS_PIPE_HIDDEN_LAYER
 	anchored = TRUE
 	obj_flags = CAN_BE_HIT | ON_BLUEPRINTS
@@ -89,7 +90,11 @@ By design, d1 is the smallest direction and d2 is the highest
 	cable_color = param_color || cable_color || pick(cable_colors)
 	if(cable_colors[cable_color])
 		cable_color = cable_colors[cable_color]
+	return INITIALIZE_HINT_LATELOAD
+
+/obj/structure/cable/LateInitialize()
 	update_appearance(UPDATE_ICON)
+	//is_fully_initialized = TRUE
 
 /obj/structure/cable/Destroy()					// called when a cable is deleted
 	if(powernet)


### PR DESCRIPTION
# Document the changes in your pull request
Cables had weird filter overlays on lattices out in space because they were on the wrong plane. that's fixed.
also meteors spun through space but their overlay didn't so there was a stiff colored outline on top of them.


fixed:
![dreamseeker_ziDHkzLEc6](https://github.com/yogstation13/Yogstation/assets/46236974/a249bcbe-d66d-4514-886a-96174702e862)
![dreamseeker_GhHF4VAm51](https://github.com/yogstation13/Yogstation/assets/46236974/ce222f86-4acf-4e89-a690-715d2974c4e2)

# Why is this good for the game?
Biome will cry less



# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: cables on the correct plane so they don't have weird lattice lighting filters
bugfix: meteors with space lighting overlays rotate with the meteors instead of being disjointed and unmoving
/:cl:
