### PR TITLE
[PORT] Ports Stun Baton Eyecandy | Glows and Sparks from TG

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -44,6 +44,7 @@
 	set_light_on(!light_on)
 	return
 
+
 /obj/item/melee/baton/get_cell()
 	return cell
 

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -33,6 +33,16 @@
 	var/preload_cell_type
 	///used for passive discharge
 	var/cell_last_used = 0
+	light_range = 1.5
+	light_system = MOVABLE_LIGHT
+	light_on = FALSE
+	light_color = LIGHT_COLOR_ORANGE
+	light_power = 0.5
+
+/// Toggles the stun baton's light
+/obj/item/melee/baton/proc/toggle_light(mob/user)
+	set_light_on(!light_on)
+	return
 
 /obj/item/melee/baton/get_cell()
 	return cell
@@ -76,6 +86,7 @@
 		if(status && cell.charge < hitcost)
 			//we're below minimum, turn off
 			status = FALSE
+			set_light_on(FALSE)
 			update_appearance(UPDATE_ICON)
 			playsound(loc, "sparks", 75, 1, -1)
 			STOP_PROCESSING(SSobj, src) // no more charge? stop checking for discharge
@@ -135,6 +146,8 @@
 		status = !status
 		to_chat(user, span_notice("[src] is now [status ? "on" : "off"]."))
 		playsound(loc, "sparks", 75, 1, -1)
+		toggle_light(user)
+		do_sparks(1, TRUE, src)
 		cell_last_used = 0
 		if(status)
 			START_PROCESSING(SSobj, src)
@@ -306,3 +319,5 @@
 	desc = "A new power management circuit which enables stun batons to instantly stun, at the cost of double power usage."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "cyborg_upgrade3"
+
+


### PR DESCRIPTION
Full credit goes to the original PR located here https://github.com/tgstation/tgstation/pull/81449

# Document the changes in your pull request

Adds a small light to stun batons when they are turned on, along with some sparks.

# Why is this good for the game?

looks cool.

# Testing

![image](https://github.com/yogstation13/Yogstation/assets/75333826/6e6e7289-c35f-4352-941e-7486d878a126)


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd:  Ports baton light up from TG

/:cl:
