### PR TITLE
Finally smooths the like 3 unsmoothed wall tiles next to rooms that get loaded in like chapel and clerk office every round

### DIFF
--- a/code/controllers/subsystem/atoms.dm
+++ b/code/controllers/subsystem/atoms.dm
@@ -1,4 +1,3 @@
-#define SUBSYSTEM_INIT_SOURCE "subsystem init"
 SUBSYSTEM_DEF(atoms)
 	name = "Atoms"
 	init_order = INIT_ORDER_ATOMS
@@ -43,11 +42,16 @@ SUBSYSTEM_DEF(atoms)
 	if(initialized == INITIALIZATION_INSSATOMS)
 		return
 
-	set_tracked_initalized(INITIALIZATION_INNEW_MAPLOAD, SUBSYSTEM_INIT_SOURCE)
+	// Generate a unique mapload source for this run of InitializeAtoms
+	var/static/uid = 0
+	uid = (uid + 1) % (SHORT_REAL_LIMIT - 1)
+	var/source = "subsystem init [uid]"
+	set_tracked_initalized(INITIALIZATION_INNEW_MAPLOAD, source)
 
 	// This may look a bit odd, but if the actual atom creation runtimes for some reason, we absolutely need to set initialized BACK
-	CreateAtoms(atoms, atoms_to_return)
-	clear_tracked_initalize(SUBSYSTEM_INIT_SOURCE)
+	CreateAtoms(atoms, atoms_to_return, source)
+	clear_tracked_initalize(source)
+	SSicon_smooth.free_deferred(source)
 
 	if(late_loaders.len)
 		for(var/I in 1 to late_loaders.len)
@@ -68,12 +72,13 @@ SUBSYSTEM_DEF(atoms)
 
 	testing("[queued_deletions.len] atoms were queued for deletion.")
 	queued_deletions.Cut()
+
 	// #ifdef PROFILE_MAPLOAD_INIT_ATOM
 	// rustg_file_write(json_encode(mapload_init_times), "[GLOB.log_directory]/init_times.json")
 	// #endif
 
 /// Actually creates the list of atoms. Exists soley so a runtime in the creation logic doesn't cause initalized to totally break
-/datum/controller/subsystem/atoms/proc/CreateAtoms(list/atoms, list/atoms_to_return = null)
+/datum/controller/subsystem/atoms/proc/CreateAtoms(list/atoms, list/atoms_to_return = null, mapload_source = null)
 	if (atoms_to_return)
 		LAZYINITLIST(created_atoms)
 
@@ -91,7 +96,12 @@ SUBSYSTEM_DEF(atoms)
 		for(var/I in 1 to atoms.len)
 			var/atom/A = atoms[I]
 			if(!(A.flags_1 & INITIALIZED_1))
-				CHECK_TICK
+				// Unrolled CHECK_TICK setup to let us enable/disable mapload based off source
+				if(TICK_CHECK)
+					clear_tracked_initalize(mapload_source)
+					stoplag()
+					if(mapload_source)
+						set_tracked_initalized(INITIALIZATION_INNEW_MAPLOAD, mapload_source)
 				PROFILE_INIT_ATOM_BEGIN()
 				InitAtom(A, TRUE, mapload_arg)
 				PROFILE_INIT_ATOM_END(A)
@@ -108,7 +118,11 @@ SUBSYSTEM_DEF(atoms)
 				#ifdef TESTING
 				++count
 				#endif
-				CHECK_TICK
+				if(TICK_CHECK)
+					clear_tracked_initalize(mapload_source)
+					stoplag()
+					if(mapload_source)
+						set_tracked_initalized(INITIALIZATION_INNEW_MAPLOAD, mapload_source)
 
 	testing("Initialized [count] atoms")
 
@@ -118,12 +132,18 @@ SUBSYSTEM_DEF(atoms)
 /datum/controller/subsystem/atoms/proc/map_loader_stop(source)
 	clear_tracked_initalize(source)
 
+/// Returns the source currently modifying SSatom's init behavior
+/datum/controller/subsystem/atoms/proc/get_initialized_source()
+	var/state_length = length(initialized_state)
+	if(!state_length)
+		return null
+	return initialized_state[state_length][1]
+
 /// Use this to set initialized to prevent error states where the old initialized is overriden, and we end up losing all context
 /// Accepts a state and a source, the most recent state is used, sources exist to prevent overriding old values accidentially
 /datum/controller/subsystem/atoms/proc/set_tracked_initalized(state, source)
 	if(!length(initialized_state))
 		base_initialized = initialized
-	
 	initialized_state += list(list(source, state))
 	initialized = state
 
@@ -141,9 +161,9 @@ SUBSYSTEM_DEF(atoms)
 		return
 	initialized = initialized_state[length(initialized_state)][2]
 
-/// Returns TRUE if anything is currently being initialized or needing to be deleted
+/// Returns TRUE if anything is currently being initialized
 /datum/controller/subsystem/atoms/proc/initializing_something()
-	return length(initialized_state)
+	return length(initialized_state) > 1
 
 /datum/controller/subsystem/atoms/Recover()
 	initialized = SSatoms.initialized
@@ -201,5 +221,3 @@ SUBSYSTEM_DEF(atoms)
 	var/initlog = InitLog()
 	if(initlog)
 		text2file(initlog, "[GLOB.log_directory]/initialize.log")
-
-#undef SUBSYSTEM_INIT_SOURCE

--- a/code/controllers/subsystem/icon_smooth.dm
+++ b/code/controllers/subsystem/icon_smooth.dm
@@ -9,8 +9,7 @@ SUBSYSTEM_DEF(icon_smooth)
 	var/list/blueprint_queue = list()
 	var/list/smooth_queue = list()
 	var/list/deferred = list()
-
-	var/map_loading = FALSE
+	var/list/deferred_by_source = list()
 
 /datum/controller/subsystem/icon_smooth/fire()
 	// We do not want to smooth icons of atoms whose neighbors are not initialized yet,
@@ -63,16 +62,30 @@ SUBSYSTEM_DEF(icon_smooth)
 
 	return SS_INIT_SUCCESS
 
+/// Releases a pool of delayed smooth attempts from a particular source
+/datum/controller/subsystem/icon_smooth/proc/free_deferred(source_to_free)
+	smooth_queue += deferred_by_source[source_to_free]
+	deferred_by_source -= source_to_free
+	if(!can_fire)
+		can_fire = TRUE
 
 /datum/controller/subsystem/icon_smooth/proc/add_to_queue(atom/thing)
 	if(thing.smoothing_flags & SMOOTH_QUEUED)
 		return
 	thing.smoothing_flags |= SMOOTH_QUEUED
+	// If we're currently locked into mapload BY something
+	// Then put us in a deferred list that we release when this mapload run is finished
+	if(initialized && length(SSatoms.initialized_state) && SSatoms.initialized == INITIALIZATION_INNEW_MAPLOAD)
+		var/source = SSatoms.get_initialized_source()
+		LAZYADD(deferred_by_source[source], thing)
+		return
 	smooth_queue += thing
 	if(!can_fire)
 		can_fire = TRUE
 
 /datum/controller/subsystem/icon_smooth/proc/remove_from_queues(atom/thing)
+	// Lack of removal from deferred_by_source is safe because the lack of SMOOTH_QUEUED will just free it anyway
+	// Hopefully this'll never cause a harddel (dies)
 	thing.smoothing_flags &= ~SMOOTH_QUEUED
 	smooth_queue -= thing
 	if(blueprint_queue)

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -4,8 +4,6 @@
 #define BUCKET_POS(timer) (((ROUND_UP((timer.timeToRun - timer.timer_subsystem.head_offset) / world.tick_lag)+1) % BUCKET_LEN) || BUCKET_LEN)
 /// Gets the maximum time at which timers will be invoked from buckets, used for deferring to secondary queue
 #define TIMER_MAX(timer_ss) (timer_ss.head_offset + TICKS2DS(BUCKET_LEN + timer_ss.practical_offset - 1))
-/// Max float with integer precision
-#define TIMER_ID_MAX (2**24)
 
 /**
  * # Timer Subsystem
@@ -740,4 +738,3 @@ SUBSYSTEM_DEF(timer)
 #undef BUCKET_LEN
 #undef BUCKET_POS
 #undef TIMER_MAX
-#undef TIMER_ID_MAX

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -138,6 +138,7 @@ GLOBAL_LIST_EMPTY(station_turfs)
 
 	if (smoothing_flags & (SMOOTH_CORNERS|SMOOTH_BITMASK))
 		QUEUE_SMOOTH(src)
+		QUEUE_SMOOTH_NEIGHBORS(src) //Yog code because there are some templates we load right into the map
 
 	visibilityChanged()
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -183,7 +183,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	default_slot = sanitize_integer(default_slot, 1, max_save_slots, initial(default_slot))
 	player_alt_titles = SANITIZE_LIST(player_alt_titles)
 
-	toggles = sanitize_integer(toggles, 0, ~0, initial(toggles)) // Yogs -- Fixes toggles not having >16 bits of flagspace
+	toggles = sanitize_integer(toggles, 0, SHORT_REAL_LIMIT-1, initial(toggles))
 	
 	key_bindings = sanitize_keybindings(key_bindings)
 


### PR DESCRIPTION
# Document the changes in your pull request

![image](https://github.com/yogstation13/Yogstation/assets/46236974/acbebbb9-aee1-4148-be73-56a2c076eb0b)

![dreamseeker_yymxNiGgtt](https://github.com/yogstation13/Yogstation/assets/46236974/757ac74c-7e1c-4d03-b2ad-327468850b4e)

# Why is this good for the game?
uninterrupted smoothing soothes my autism

# Testing
yes

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: turfs that smooth will spur their neighboring turfs to check their smoothing again when late loaded in
/:cl:
