### PR TITLE
Hopefully fixes whiteship and shuttle atmos by readding the CHANGETURF_DEFER_CHANGE flag

### DIFF
--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -50,10 +50,10 @@ All ShuttleMove procs go here
 	//Destination turf changes
 	//Baseturfs is definitely a list or this proc wouldnt be called
 	var/shuttle_depth = depth_to_find_baseturf(/turf/baseturf_skipover/shuttle)
-	
+
 	if(!shuttle_depth)
 		CRASH("A turf queued to move via shuttle somehow had no skipover in baseturfs. [src]([type]):[loc]")
-	newT.CopyOnTop(src, 1, shuttle_depth, TRUE, CHANGETURF_DEFER_CHANGE)
+	newT.CopyOnTop(src, 1, shuttle_depth, TRUE)
 	SEND_SIGNAL(src, COMSIG_TURF_ON_SHUTTLE_MOVE, newT)
 	
 	return TRUE
@@ -67,7 +67,7 @@ All ShuttleMove procs go here
 	var/shuttle_depth = depth_to_find_baseturf(/turf/baseturf_skipover/shuttle)
 
 	if(shuttle_depth)
-		oldT.ScrapeAway(shuttle_depth)
+		oldT.ScrapeAway(shuttle_depth, CHANGETURF_DEFER_CHANGE)
 
 	if(rotation)
 		shuttleRotate(rotation) //see shuttle_rotate.dm


### PR DESCRIPTION
# Document the changes in your pull request
If this still manages to break on live i'll try something else


# Why is this good for the game?
the employees will love the free air provided on each flight

# Testing
I flew the whiteship around to a few docks and the atmos never borked



# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: shuttle atmos shouldn't get left behind on takeoff
/:cl:
