### PR TITLE
Makes our master far less dumpy in private

### DIFF
--- a/code/__DEFINES/subsystems.dm
+++ b/code/__DEFINES/subsystems.dm
@@ -173,7 +173,8 @@
 #define INIT_ORDER_PATH				-50
 #define INIT_ORDER_DISCORD			-60
 #define INIT_ORDER_EXPLOSIONS		-69
-#define INIT_ORDER_STATPANELS 		-98
+#define INIT_ORDER_STATPANELS 		-97
+#define INIT_ORDER_INIT_PROFILER 	-98 //Near the end, logs the costs of initialize
 #define INIT_ORDER_DEMO				-99 // To avoid a bunch of changes related to initialization being written, do this last
 #define INIT_ORDER_CHAT				-100 //Should be last to ensure chat remains smooth during init.
 

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -474,8 +474,8 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 		var/newdrift = ((REALTIMEOFDAY - init_timeofday) - (world.time - init_time)) / world.tick_lag
 		tickdrift = max(0, MC_AVERAGE_FAST(tickdrift, newdrift))
 		var/starting_tick_usage = TICK_USAGE
-
-		if(newdrift - olddrift >= CONFIG_GET(number/drift_dump_threshold))
+		//Yog: profile dumping was throttling lower performance computers, so we're going to have it disabled by default but you can enable it via config flags
+		if(newdrift - olddrift >= CONFIG_GET(number/drift_dump_threshold) && CONFIG_GET(flag/auto_profile))
 			AttemptProfileDump(CONFIG_GET(number/drift_profile_delay))
 		olddrift = newdrift
 

--- a/code/controllers/subsystem/init_profiler.dm
+++ b/code/controllers/subsystem/init_profiler.dm
@@ -1,0 +1,28 @@
+#define INIT_PROFILE_NAME "init_profiler.json"
+
+///Subsystem exists so we can separately log init time costs from the costs of general operation
+///Hopefully this makes sorting out what causes problems when easier
+SUBSYSTEM_DEF(init_profiler)
+	name = "Init Profiler"
+	init_order = INIT_ORDER_INIT_PROFILER
+	init_stage = INITSTAGE_MAX
+	flags = SS_NO_FIRE
+
+/datum/controller/subsystem/init_profiler/Initialize()
+	if(CONFIG_GET(flag/auto_profile))
+		write_init_profile()
+	return SS_INIT_SUCCESS
+
+/datum/controller/subsystem/init_profiler/proc/write_init_profile()
+	var/current_profile_data = world.Profile(PROFILE_REFRESH, format = "json")
+	CHECK_TICK
+
+	if(!length(current_profile_data)) //Would be nice to have explicit proc to check this
+		stack_trace("Warning, profiling stopped manually before dump.")
+	var/prof_file = file("[GLOB.log_directory]/[INIT_PROFILE_NAME]")
+	if(fexists(prof_file))
+		fdel(prof_file)
+	WRITE_FILE(prof_file, current_profile_data)
+	world.Profile(PROFILE_CLEAR) //Now that we're written this data out, dump it. We don't want it getting mixed up with our current round data
+
+#undef INIT_PROFILE_NAME

--- a/config/config.txt
+++ b/config/config.txt
@@ -422,6 +422,16 @@ DEFAULT_VIEW 19x15
 ## You probably shouldn't ever be changing this, but it's here if you want to.
 DEFAULT_VIEW_SQUARE 15x15
 
+
+## Enable automatic profiling - Byond 513.1506 and newer only.
+#AUTO_PROFILE
+
+## Threshold (in deciseconds) for real time between ticks before we start dumping profiles
+DRIFT_DUMP_THRESHOLD 40
+
+## How long to wait (in deciseconds) after a profile dump before logging another tickdrift sourced one
+DRIFT_PROFILE_DELAY 150
+
 ## Comment this out if you want to use the SQL based mentor system, the legacy system uses mentors.txt.
 ## You need to set up your database to use the SQL based system.
 ## This flag is automatically enabled if SQL_ENABLED isn't

--- a/config/private_default.txt
+++ b/config/private_default.txt
@@ -86,9 +86,8 @@ VOICE_ANNOUNCE_DIR ../Yogstation.net/voice_announce_tmp
 ## Enable the demo subsystem
 #DEMOS_ENABLED
 
-## Starlight for exterior walls and breaches. Uncomment for starlight!
-## This is disabled by default to make testing quicker, should be enabled on production servers or testing servers messing with lighting
-#STARLIGHT
+## Enable automatic profiling - Byond 513.1506 and newer only.
+#AUTO_PROFILE
 
 
 ## Assets can opt-in to caching their results into `tmp`.

--- a/config/private_server.txt
+++ b/config/private_server.txt
@@ -97,6 +97,9 @@ VOICE_ANNOUNCE_DIR data/voice_announcements
 ## Enable the demo subsystem
 DEMOS_ENABLED
 
+## Enable automatic profiling - Byond 513.1506 and newer only.
+AUTO_PROFILE
+
 ## Starlight for exterior walls and breaches. Uncomment for starlight!
 ## This is disabled by default to make testing quicker, should be enabled on production servers or testing servers messing with lighting
 STARLIGHT

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -422,6 +422,7 @@
 #include "code\controllers\subsystem\garbage.dm"
 #include "code\controllers\subsystem\icon_smooth.dm"
 #include "code\controllers\subsystem\idlenpcpool.dm"
+#include "code\controllers\subsystem\init_profiler.dm"
 #include "code\controllers\subsystem\input.dm"
 #include "code\controllers\subsystem\ipintel.dm"
 #include "code\controllers\subsystem\job.dm"


### PR DESCRIPTION
# Document the changes in your pull request
![image](https://github.com/yogstation13/Yogstation/assets/46236974/a6a439dd-b013-4265-ab98-fb26f67dccd8)
![image](https://github.com/yogstation13/Yogstation/assets/46236974/5fc8392d-7535-4787-a218-e132e6c3dd7b)

I'm using the auto_profile config flag as a catch-all for profile dumping. The live server can seemingly handle it without issue, so i'm leaving it enabled and including the init profiling. However when run locally on personal machines, the profiler can hog your cpu trying to dump profile data. So that's going to be off by default unless enabled intentionally.


# Testing
Private server no longer had the profiling json unless i specifically enabled the config, just like the Demos flag

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: auto_profile config flag added to the private default and private server config files
tweak: private servers aren't dumpy unless you specifically request them to be 
tweak: main yog server will be extra dumpy because we can handle it
/:cl:
