### PR TITLE
stops chapels and clerk office from double spawning

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -617,9 +617,9 @@ SUBSYSTEM_DEF(job)
 /datum/controller/subsystem/job/proc/irish_override()
 	var/datum/map_template/template = SSmapping.station_room_templates["Bar Irish"]
 
-	for(var/obj/effect/landmark/stationroom/box/bar/B in GLOB.bar_landmarks)
+	for(var/obj/effect/landmark/stationroom/box/bar/B in GLOB.landmarks_list)
 		template.load(B.loc, centered = FALSE)
-
+		qdel(B)
 
 /datum/controller/subsystem/job/proc/random_chapel_init()
 	try
@@ -664,9 +664,9 @@ SUBSYSTEM_DEF(job)
 			log_game("WARNING: CHAPEL RECOVERY FAILED! THERE WILL BE NO CHAPEL FOR THIS ROUND!")
 			return
 
-		for(var/obj/effect/landmark/stationroom/box/chapel/B in GLOB.chapel_landmarks)
+		for(var/obj/effect/landmark/stationroom/box/chapel/B in GLOB.landmarks_list)
 			template.load(B.loc, centered = FALSE)
-
+			qdel(B)
 	catch(var/exception/e)
 		message_admins("RUNTIME IN RANDOM_CHAPEL_INIT")
 		spawn_chapel()
@@ -681,9 +681,9 @@ SUBSYSTEM_DEF(job)
 	if(isnull(template))
 		message_admins("UNABLE TO SPAWN CHAPEL")
 
-	for(var/obj/effect/landmark/stationroom/box/chapel/B in GLOB.chapel_landmarks)
+	for(var/obj/effect/landmark/stationroom/box/chapel/B in GLOB.landmarks_list)
 		template.load(B.loc, centered = FALSE)
-
+		qdel(B)
 
 /datum/controller/subsystem/job/proc/random_clerk_init()
 	try
@@ -728,9 +728,9 @@ SUBSYSTEM_DEF(job)
 			log_game("WARNING: CLERK RECOVERY FAILED! THERE WILL BE NO CLERK SHOP FOR THIS ROUND!")
 			return
 
-		for(var/obj/effect/landmark/stationroom/box/clerk/B in GLOB.clerk_office_landmarks)
+		for(var/obj/effect/landmark/stationroom/box/clerk/B in GLOB.landmarks_list)
 			template.load(B.loc, centered = FALSE)
-
+			qdel(B)
 	catch(var/exception/e)
 		message_admins("RUNTIME IN RANDOM_CLERK_INIT")
 		spawn_clerk()
@@ -745,8 +745,9 @@ SUBSYSTEM_DEF(job)
 	if(isnull(template))
 		message_admins("UNABLE TO SPAWN CLERK")
 	
-	for(var/obj/effect/landmark/stationroom/box/clerk/B in GLOB.clerk_office_landmarks)
+	for(var/obj/effect/landmark/stationroom/box/clerk/B in GLOB.landmarks_list)
 		template.load(B.loc, centered = FALSE)
+		qdel(B)
 
 /datum/controller/subsystem/job/proc/handle_auto_deadmin_roles(client/C, rank)
 	if(!C?.holder)

--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -60,6 +60,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 		stack_trace("Station room spawner [src] at ([T.x], [T.y], [T.z]) has a null template.")
 	if(!template_name || template_name == EMPTY_SPAWN)
 		GLOB.stationroom_landmarks -= src
+		qdel(src)
 		return FALSE
 	GLOB.chosen_station_templates += template_name
 	var/datum/map_template/template = SSmapping.station_room_templates[template_name]
@@ -69,7 +70,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	template.load(T, centered = FALSE)
 	template.loaded++
 	GLOB.stationroom_landmarks -= src
-	//qdel(src)
+	qdel(src)
 	return TRUE
 
 // Proc to allow you to add conditions for choosing templates, instead of just randomly picking from the template list.
@@ -91,40 +92,22 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 			template_names = current_templates
 	return chosen_template
 
-/obj/effect/landmark/stationroom/box
-	///Should this landmark load a template during setup? You might not want to in the case of the chapel or clerk office that uses
-	///player preferences to determine which template loads on roundstart
-	var/load_on_init = TRUE
-
-/obj/effect/landmark/stationroom/box/load(template_name)
-	GLOB.stationroom_landmarks -= src
-	if(!load_on_init)
-		//don't actually load anything, we're going to do that ourselves
-		return TRUE
-	. = ..()
-
 /obj/effect/landmark/stationroom/box/bar
-	load_on_init = FALSE
 	template_names = list(
 		"Bar Trek", "Bar Spacious", "Bar Box", "Bar Casino", "Bar Citadel", 
 		"Bar Conveyor", "Bar Diner", "Bar Disco", "Bar Purple", "Bar Cheese", 
 		"Bar Clock", "Bar Arcade")
 
-/obj/effect/landmark/stationroom/box/bar/Initialize(mapload)
-	. = ..()
-	GLOB.bar_landmarks += src
+/obj/effect/landmark/stationroom/box/bar/load(template_name)
+	GLOB.stationroom_landmarks -= src
+	return TRUE
 
 /obj/effect/landmark/stationroom/box/clerk
-	load_on_init = FALSE
 	template_names = list("Clerk Box", "Clerk Pod", "Clerk Meta", "Clerk Gambling Hall")
 
-/obj/effect/landmark/stationroom/box/clerk/Initialize(mapload)
-	. = ..()
-	GLOB.clerk_office_landmarks += src
-
-// /obj/effect/landmark/stationroom/box/clerk/load(template_name)
-// 	GLOB.stationroom_landmarks -= src
-// 	return TRUE
+/obj/effect/landmark/stationroom/box/clerk/load(template_name)
+	GLOB.stationroom_landmarks -= src
+	return TRUE
 
 /obj/effect/landmark/stationroom/box/engine
 	template_names = list("Engine SM" = 40, "Engine Singulo And Tesla" = 20, "Engine Nuclear Reactor" = 20,"Engine TEG" = 20)
@@ -161,16 +144,11 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	template_names = list("Transfer 1", "Transfer 2", "Transfer 3", "Transfer 4", "Transfer 5", "Transfer 6", "Transfer 7", "Transfer 8", "Transfer 9", "Transfer 10")
 
 /obj/effect/landmark/stationroom/box/chapel
-	load_on_init = FALSE
 	template_names = list("Chapel 1", "Chapel 2")
 
-/obj/effect/landmark/stationroom/box/chapel/Initialize(mapload)
-	. = ..()
-	GLOB.chapel_landmarks += src
-
-// /obj/effect/landmark/stationroom/box/chapel/load(template_name)
-// 	GLOB.stationroom_landmarks -= src
-// 	return TRUE
+/obj/effect/landmark/stationroom/box/chapel/load(template_name)
+	GLOB.stationroom_landmarks -= src
+	return TRUE
 
 /obj/effect/landmark/stationroom/meta/engine
 	template_names = list("Meta SM" = 25, "Meta Nuclear Reactor" = 45, "Meta TEG" = 25) // tesla is loud as fuck and singulo doesn't make sense, so SM/reactor only


### PR DESCRIPTION
# Document the changes in your pull request

Woops midrounds joins were causing offices you get to choose to spawn to spawn again. I wonder who caused that to happen

# Why is this good for the game?
Nerfing chaplains getting more than one null rod and having too much faith

# Testing
i joined midround on my server and there wasn't 3 pews stacked


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: no more double clerk and chaplain workplace spawns
/:cl:
