### PR TITLE
HFR gas byproducts now uses scaled_production instead of fuel_consumption, and now scaled alongside with gas produced from moderator, code refactor

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -254,8 +254,8 @@
 
 	var/add_remove_amount = round(scaled_production, 0.01) // gases on the same tier are produced at normal rate
 	for(var/gas_id in fuel.primary_products)
-			internal_fusion.adjust_moles(gas_id, add_remove_amount)
-			delta_fuel_list[gas_id] += add_remove_amount
+		internal_fusion.adjust_moles(gas_id, add_remove_amount)
+		delta_fuel_list[gas_id] += add_remove_amount
 
 	if(power_level < 1)
 		return // can't produce any gases, don't need to continue

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -252,18 +252,19 @@
 		internal_fusion.adjust_moles(gas_id, -remove_amount)
 		delta_fuel_list[gas_id] -= remove_amount
 
+	var/add_remove_amount = round(scaled_production, 0.01) // gases on the same tier are produced at normal rate
+	for(var/gas_id in fuel.primary_products)
+			internal_fusion.adjust_moles(gas_id, add_remove_amount)
+			delta_fuel_list[gas_id] += add_remove_amount
+
 	if(power_level < 1)
 		return // can't produce any gases, don't need to continue
 
 	// Each recipe provides a tier list of six output gases.
 	// Which gases are produced depend on what the fusion level is.
 	var/list/tier = fuel.secondary_products
-	var/add_remove_amount = round(scaled_production, 0.01) // gases on the same tier are produced at normal rate
 	moderator_internal.adjust_moles(tier[power_level], add_remove_amount)
 	delta_mod_list[tier[power_level]] += add_remove_amount
-	for(var/gas_id in fuel.primary_products)
-		internal_fusion.adjust_moles(gas_id, add_remove_amount)
-		delta_fuel_list[gas_id] += add_remove_amount
 	if(power_level < 6)
 		moderator_internal.adjust_moles(tier[power_level + 1], round(scaled_production * 0.5, 0.01)) // gases on the above tier are produced at reduced rate
 		delta_mod_list[tier[power_level + 1]] += round(scaled_production * 0.5, 0.01)

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -251,10 +251,6 @@
 		var/remove_amount = round(min(fuel_list[gas_id], fuel_consumption), 0.01)
 		internal_fusion.adjust_moles(gas_id, -remove_amount)
 		delta_fuel_list[gas_id] -= remove_amount
-	for(var/gas_id in fuel.primary_products)
-		var/add_amount = round(fuel_consumption * 0.5, 0.01)
-		internal_fusion.adjust_moles(gas_id, add_amount)
-		delta_fuel_list[gas_id] += add_amount
 
 	if(power_level < 1)
 		return // can't produce any gases, don't need to continue
@@ -262,8 +258,12 @@
 	// Each recipe provides a tier list of six output gases.
 	// Which gases are produced depend on what the fusion level is.
 	var/list/tier = fuel.secondary_products
-	moderator_internal.adjust_moles(tier[power_level], round(scaled_production, 0.01)) // gases on the same tier are produced at normal rate
-	delta_mod_list[tier[power_level]] += round(scaled_production, 0.01)
+	var/add_remove_amount = round(scaled_production, 0.01) // gases on the same tier are produced at normal rate
+	moderator_internal.adjust_moles(tier[power_level], add_remove_amount)
+	delta_mod_list[tier[power_level]] += add_remove_amount
+	for(var/gas_id in fuel.primary_products)
+		internal_fusion.adjust_moles(gas_id, add_remove_amount)
+		delta_fuel_list[gas_id] += add_remove_amount
 	if(power_level < 6)
 		moderator_internal.adjust_moles(tier[power_level + 1], round(scaled_production * 0.5, 0.01)) // gases on the above tier are produced at reduced rate
 		delta_mod_list[tier[power_level + 1]] += round(scaled_production * 0.5, 0.01)


### PR DESCRIPTION


# Document the changes in your pull request
HFR gas byproducts now uses scaled_production instead of fuel_consumption, and now scaled alongside with gas produced from moderator, code refactor

# Why is this good for the game?
QoL
Byproducts uses ``fuel_consumption``  to produce gas which is weird and it produces very little amount of gas because of the var has been calculated to small numbers, it should be using ``scaled_production`` instead which is more accurate and can produce decent amount of gas. 

# Testing
Observing the HFR monitor i did notice that the byproducts increased when reaching certain fusion level 


# Wiki Documentation
no wiki

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: HFR gas byproducts now uses scaled_production instead of fuel_consumption, and now scaled alongside with gas produced from moderator, code refactor
/:cl:
