### PR TITLE
Makes the clarke tied for fastest mech in the game

### DIFF
--- a/code/game/mecha/working/clarke.dm
+++ b/code/game/mecha/working/clarke.dm
@@ -6,8 +6,8 @@
 	max_temperature = 65000
 	max_integrity = 200
 	step_in = 1.25
-	fast_pressure_step_in = 1.25
-	slow_pressure_step_in = 1.8
+	fast_pressure_step_in = 1.5
+	slow_pressure_step_in = 2
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	light_power = 7
 	deflect_chance = 10


### PR DESCRIPTION
Tg moves faster than we do and this was ported from tg so of course it oved faster than every other mech in the game :)
Now it just moves as fast as the original fastest mech in the game (ripley mk-1) with a step_in of 1.5 in low pressure and 2 in high pressure. For reference, odysseus is 2, sidewinder is 2.5, gygax (and ripley mk-II and mk-III in high pressure) is 3.

# Why is this good for the game?

Tg balance bad

# Testing
Number change


# Wiki Documentation

Mech moves same speed as ripley mk-I

# Changelog


:cl:  

tweak: The clarke is now tied for fastest mech in the game with the ripley mk-I

/:cl:
