### PR TITLE
No more zombies in xenobio

### DIFF
--- a/code/game/objects/effects/spawners/mystery_box.dm
+++ b/code/game/objects/effects/spawners/mystery_box.dm
@@ -152,7 +152,7 @@
 	var/static/list/spooks = list('sound/hallucinations/growl1.ogg','sound/hallucinations/growl2.ogg','sound/hallucinations/growl3.ogg','sound/hallucinations/veryfar_noise.ogg','sound/hallucinations/wail.ogg')
 	armor = 20
 	speedmod = 1.6
-	changesource_flags = NONE //deliberate admin spawn only
+	changesource_flags = MIRROR_BADMIN //deliberate admin spawn only
 	var/heal_rate = 1
 	var/regen_cooldown = 0
 

--- a/code/game/objects/effects/spawners/mystery_box.dm
+++ b/code/game/objects/effects/spawners/mystery_box.dm
@@ -152,6 +152,7 @@
 	var/static/list/spooks = list('sound/hallucinations/growl1.ogg','sound/hallucinations/growl2.ogg','sound/hallucinations/growl3.ogg','sound/hallucinations/veryfar_noise.ogg','sound/hallucinations/wail.ogg')
 	armor = 20
 	speedmod = 1.6
+	changesource_flags = NONE //deliberate admin spawn only
 	var/heal_rate = 1
 	var/regen_cooldown = 0
 


### PR DESCRIPTION
both so people that want to grief don't start a zombie apocalypse
and those that don't want to aren't stuck as a zombie with claw hands

Charged black cores are annoying

:cl:  
bugfix: No more zombies in xenobio
/:cl:
