### PR TITLE
Fixes fusion reactions not working in the atmospherics simulator computer

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -316,9 +316,6 @@
 	return fusion_react(air, holder)
 
 /proc/fusion_react(datum/gas_mixture/air, datum/holder)
-	var/turf/open/location = get_holder_turf(holder)
-	if(!location)
-		return NO_REACTION
 	if(!air.analyzer_results)
 		air.analyzer_results = new
 	var/list/cached_scan_results = air.analyzer_results
@@ -366,6 +363,7 @@
 		air.adjust_moles(GAS_NITRIUM, FUSION_TRITIUM_MOLES_USED*(reaction_energy*-FUSION_TRITIUM_CONVERSION_COEFFICIENT))
 
 	if(reaction_energy)
+		var/turf/open/location = get_holder_turf(holder)
 		if(location)
 			var/particle_chance = ((PARTICLE_CHANCE_CONSTANT)/(reaction_energy-PARTICLE_CHANCE_CONSTANT)) + 1//Asymptopically approaches 100% as the energy of the reaction goes up.
 			if(prob(PERCENT(particle_chance)))

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -582,9 +582,9 @@
 /obj/machinery/portable_atmospherics/canister/fusion_test/create_gas()
 	air_contents.set_moles(GAS_TRITIUM, 10)
 	air_contents.set_moles(GAS_PLASMA, 500)
-	air_contents.set_moles(GAS_H2, 500)
+	air_contents.set_moles(GAS_CO2, 500)
 	air_contents.set_moles(GAS_NITROUS, 100)
-	air_contents.set_temperature(10000)
+	air_contents.set_temperature(FUSION_TEMPERATURE_THRESHOLD)
 
 /// Canister 1 Kelvin below the fusion point. Contains far too much plasma. Only good for adding more fuel to ongoing fusion reactions.
  /obj/machinery/portable_atmospherics/canister/fusion_test_2
@@ -596,7 +596,7 @@
 	air_contents.set_moles(GAS_PLASMA, 15000)
 	air_contents.set_moles(GAS_CO2, 1500)
 	air_contents.set_moles(GAS_NITROUS, 100)
-	air_contents.set_temperature(9999)
+	air_contents.set_temperature(FUSION_TEMPERATURE_THRESHOLD - 1)
 
 /// Canister at the perfect conditions to start and continue fusion for a long time.
 /obj/machinery/portable_atmospherics/canister/fusion_test_3
@@ -620,7 +620,7 @@
 	air_contents.set_moles(GAS_PLASMA, 4500)
 	air_contents.set_moles(GAS_CO2, 1500)
 	air_contents.set_moles(GAS_DILITHIUM, 2000)
-	air_contents.set_temperature(10000)
+	air_contents.set_temperature(FUSION_TEMPERATURE_THRESHOLD - 1)
 
 /// A canister that is 1 Kelvin away from doing the stimball reaction.
 /obj/machinery/portable_atmospherics/canister/stimball_test

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -70,6 +70,7 @@
 #define TRAIT_SOURCE_UNIT_TESTS "unit_tests"
 
 #include "anchored_mobs.dm"
+#include "atmos_tests.dm"
 #include "baseturfs.dm"
 #include "component_tests.dm"
 #include "dcs_check_list_arguments.dm"

--- a/code/modules/unit_tests/atmos_tests.dm
+++ b/code/modules/unit_tests/atmos_tests.dm
@@ -1,10 +1,10 @@
 /datum/unit_test/fusion_reaction/Run()
 	var/datum/gas_mixture/fusion_test_mix = new
 
-	air_contents.set_moles(GAS_TRITIUM, 1000)
-	air_contents.set_moles(GAS_PLASMA, 4500)
-	air_contents.set_moles(GAS_CO2, 1500)
-	air_contents.set_moles(GAS_DILITHIUM, 2000)
+	fusion_test_mix.set_moles(GAS_TRITIUM, 1000)
+	fusion_test_mix.set_moles(GAS_PLASMA, 4500)
+	fusion_test_mix.set_moles(GAS_CO2, 1500)
+	fusion_test_mix.set_moles(GAS_DILITHIUM, 2000)
 	fusion_test_mix.set_temperature(FUSION_TEMPERATURE_THRESHOLD - 1)
 
 	if(fusion_test_mix.react() != REACTING)

--- a/code/modules/unit_tests/atmos_tests.dm
+++ b/code/modules/unit_tests/atmos_tests.dm
@@ -1,0 +1,12 @@
+/datum/unit_test/fusion_reaction/Run()
+	var/datum/gas_mixture/fusion_test_mix = new
+
+	air_contents.set_moles(GAS_TRITIUM, 1000)
+	air_contents.set_moles(GAS_PLASMA, 4500)
+	air_contents.set_moles(GAS_CO2, 1500)
+	air_contents.set_moles(GAS_DILITHIUM, 2000)
+	fusion_test_mix.set_temperature(FUSION_TEMPERATURE_THRESHOLD - 1)
+
+	if(fusion_test_mix.react() != REACTING)
+		TEST_FAIL("Fusion reaction was unable to start!")
+	qdel(fusion_test_mix)


### PR DESCRIPTION
Fusion reactions work in the atmospherics simulator again. Also adds a unit test for fusion reactions.

![image](https://github.com/yogstation13/Yogstation/assets/93578146/ad9fb391-2092-443f-bf23-8618126cde91)


:cl:  
rscadd: Added a unit test for fusion reactions
bugfix: Fixed fusion reactions not working in the atmospherics simulator computer
/:cl:
