### PR TITLE
Raise the HFR's healium healing threshold from 66.66% to 90%.

### DIFF
--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -347,7 +347,7 @@
 				linked_output.airs[1].adjust_moles(GAS_FREON, scaled_production * 1.15)
 				induce_hallucination(500, delta_time)
 			if(moderator_list[GAS_HEALIUM] > 100)
-				if(critical_threshold_proximity > 400)
+				if(critical_threshold_proximity > 90)
 					critical_threshold_proximity = max(critical_threshold_proximity - (moderator_list[GAS_HEALIUM] / 100 * delta_time ), 0)
 					var/remove_amount = round(min(moderator_internal.get_moles(GAS_HEALIUM), scaled_production * 20), 0.01)
 					moderator_internal.adjust_moles(GAS_HEALIUM, -remove_amount)
@@ -373,7 +373,7 @@
 				induce_hallucination(900, delta_time, force=TRUE)
 				linked_output.airs[1].adjust_moles(GAS_ANTINOB, clamp(dirty_production_rate / 0.045, 0, 10) * delta_time)
 			if(moderator_list[GAS_HEALIUM] > 100)
-				if(critical_threshold_proximity > 400)
+				if(critical_threshold_proximity > 90)
 					critical_threshold_proximity = max(critical_threshold_proximity - (moderator_list[GAS_HEALIUM] / 100 * delta_time), 0)
 					var/remove_amount = round(min(moderator_internal.get_moles(GAS_HEALIUM), scaled_production * 20), 0.01)
 					delta_mod_list[GAS_HEALIUM] -= remove_amount

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -1,4 +1,4 @@
-/**
+/*
  * Main Fusion processes
  * process() Organizes all other calls, and is the best starting point for top-level logic.
  * fusion_process() handles all the main fusion reaction logic and consequences (lightning, radiation, particles) from an active fusion reaction.

--- a/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
+++ b/code/modules/atmospherics/machinery/components/fusion/hfr_main_processes.dm
@@ -1,4 +1,4 @@
-/*
+/**
  * Main Fusion processes
  * process() Organizes all other calls, and is the best starting point for top-level logic.
  * fusion_process() handles all the main fusion reaction logic and consequences (lightning, radiation, particles) from an active fusion reaction.


### PR DESCRIPTION


# Document the changes in your pull request
Raise the HFR's healium healing threshold from 66.66% to 90%.

# Why is this good for the game?
Allows HFR to be healed before reaching dangerous state which probally wouldnt be good, and allows HFR to be healed to 90% quick and instead healing to 66,66% and then slowly climb to 100%

# Testing
yes it worked



# Wiki Documentation
no wiki :(

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: Raise the HFR's healium healing threshold from 66.66% to 90%.
/:cl:
