### PR TITLE
Reverts a small accidental change in #21499

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -35,7 +35,7 @@
 	RegisterSignal(src, COMSIG_COMPONENT_CLEAN_FACE_ACT, PROC_REF(clean_face))
 	AddComponent(/datum/component/personal_crafting)
 	AddElement(/datum/element/footstep, FOOTSTEP_MOB_HUMAN, 1, -6)
-	AddComponent(/datum/component/bloodysoles/feet)
+	AddComponent(/datum/component/bloodysoles/feet, FOOTPRINT_SPRITE_SHOES)
 	var/static/list/loc_connections = list(
 		COMSIG_ATOM_ENTERED = PROC_REF(on_entered),
 	)


### PR DESCRIPTION
Was a change from #21511 that got accidentally undone in #21499 since they both got merged like right next to each other and apparently conflicts don't exist


# Changelog

:cl:  

bugfix: Undoes accidental revert pertaining to bloody footprints

/:cl:
