### PR TITLE
[BOX] Changes medbay doors unrestricted access

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -832,10 +832,6 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "afF" = (
-/obj/effect/turf_decal/arrows/white{
-	color = "#99ccff";
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
@@ -14402,6 +14398,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "ctu" = (
@@ -14648,13 +14645,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space/nearstation)
-"cwf" = (
-/obj/effect/turf_decal/arrows/white{
-	color = "#99ccff";
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
 "cwH" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -18832,9 +18822,6 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
 "dUl" = (
-/obj/effect/turf_decal/arrows/white{
-	color = "#99ccff"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -18843,6 +18830,10 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
+	},
+/obj/effect/turf_decal/arrows/white{
+	color = "#99ccff";
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -22038,6 +22029,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "eZD" = (
@@ -27654,6 +27646,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
+/obj/effect/mapping_helpers/airlock/unres,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "hcE" = (
@@ -34214,9 +34207,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "jpO" = (
-/obj/effect/turf_decal/arrows/white{
-	color = "#99ccff"
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
@@ -38089,8 +38079,7 @@
 "kRZ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6;
-	layer = 2.35;
-	
+	layer = 2.35
 	},
 /turf/closed/wall,
 /area/science/mixing)
@@ -40296,10 +40285,6 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "lLT" = (
-/obj/effect/turf_decal/arrows/white{
-	color = "#99ccff";
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -40307,6 +40292,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/arrows/white{
+	color = "#99ccff";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -44719,10 +44708,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "nnN" = (
-/obj/effect/turf_decal/arrows/white{
-	color = "#99ccff";
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
@@ -44734,6 +44719,10 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
+	},
+/obj/effect/turf_decal/arrows/white{
+	color = "#99ccff";
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -45066,12 +45055,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"nuL" = (
-/obj/effect/turf_decal/arrows/white{
-	color = "#99ccff"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
 "nuT" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -32
@@ -46932,12 +46915,6 @@
 	},
 /turf/open/space/basic,
 /area/ai_monitored/turret_protected/ai)
-"ogm" = (
-/obj/effect/turf_decal/arrows/white{
-	color = "#99ccff"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "ogV" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable/yellow{
@@ -47266,9 +47243,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "onr" = (
-/obj/effect/turf_decal/arrows/white{
-	color = "#99ccff"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
@@ -47276,6 +47250,10 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/arrows/white{
+	color = "#99ccff";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49790,13 +49768,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/starboard/aft)
-"pjc" = (
-/obj/effect/turf_decal/arrows/white{
-	color = "#99ccff";
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "pjh" = (
 /obj/structure/closet/lasertag/red,
 /turf/open/floor/plasteel,
@@ -54469,6 +54440,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
+/obj/effect/turf_decal/arrows/white{
+	color = "#99ccff";
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "qRq" = (
@@ -55773,8 +55748,7 @@
 /area/security/brig)
 "rrF" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	layer = 2.35;
-	
+	layer = 2.35
 	},
 /turf/closed/wall,
 /area/science/mixing)
@@ -63535,9 +63509,6 @@
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
 "ums" = (
-/obj/effect/turf_decal/arrows/white{
-	color = "#99ccff"
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
@@ -73101,6 +73072,10 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
+	},
+/obj/effect/turf_decal/arrows/white{
+	color = "#99ccff";
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -110632,11 +110607,11 @@ cru
 gAz
 lYh
 lYh
-nuL
+lYh
 qIz
 hbQ
 dUl
-ogm
+kub
 wSj
 dDw
 xuX
@@ -112688,11 +112663,11 @@ pVW
 rbH
 lYh
 lYh
-cwf
+lYh
 kcy
 krO
 lLT
-pjc
+kub
 hLI
 dDw
 dZg
@@ -112949,7 +112924,7 @@ rJo
 rjM
 phN
 nnN
-pjc
+kub
 kRm
 bvj
 bvj


### PR DESCRIPTION
# Document the changes in your pull request
This changes the silly arrows in the main medbay area and alters what doors have unrestricted access from the inside to allow patients to exit from both left and right entrances, rather than just the right one in a sort of "come in on the left, exit on the right" style.

# Why is this good for the game?
Helps those patients who just finished getting treated trying to exit on the left side, which since the sleeper/stasis bed are there, a **lot** of people try to do that. I get the system of a designated entrance and designated exit, but it doesn't always work like that.

People will come in from, and exit to both sides, and I've seen on too many occasions people annoyingly can't exit from one side, but can from another. I know it's not hard to follow basic directions, but this change is for convenience sake, as those directions are arbitrary, and aren't going to be respected or followed in real situations.

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/143908044/b9ef9e2a-6211-4c13-b451-5cf2418fca16)

# Changelog
:cl:  
mapping: Patients can now exit from both left and right doors on Box medbay
/:cl:
