### PR TITLE
Fixes clothes that don't cover your hands protecting your hands from electric shock

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -513,7 +513,7 @@
 			else
 				return
 		else if(user.has_status_effect(/datum/status_effect/hallucination) && ishuman(user) && prob(1) && !operating)
-			if(user.getarmor(user.held_index_to_body_zone(user.active_hand_index), ELECTRIC) < 100)
+			if(user.getarmor(user.held_index_to_hand(user.active_hand_index), ELECTRIC) < 100)
 				new /datum/hallucination/shock(user)
 				return
 	var/allowed = (obj_flags & CMAGGED) ? cmag_allowed(user) : allowed(user)

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -284,7 +284,7 @@
 	if(!shockcd)
 		if(ismob(user))
 			var/mob/living/M = user
-			M.electrocute_act(15,"Energy Barrier", zone=user.held_index_to_body_zone(user.active_hand_index)) // you touched it with your hand
+			M.electrocute_act(15,"Energy Barrier", zone=user.held_index_to_hand(user.active_hand_index)) // you touched it with your hand
 			shockcd = TRUE
 			addtimer(CALLBACK(src, PROC_REF(cooldown)), 5)
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -37,10 +37,11 @@
 		return "r"
 	return "l"
 
-/mob/proc/held_index_to_body_zone(i)
+/// Returns HAND_LEFT or HAND_RIGHT based on whether the left or right hand is selected
+/mob/proc/held_index_to_hand(i)
 	if(!(i % 2))
-		return BODY_ZONE_R_ARM
-	return BODY_ZONE_L_ARM
+		return HAND_RIGHT
+	return HAND_LEFT
 
 //Check we have an organ for this hand slot (Dismemberment), Only relevant for humans
 /mob/proc/has_hand_for_held_index(i)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -383,7 +383,7 @@
 		if(!(BP.emp_act(severity, emp_message) & EMP_PROTECT_SELF))
 			emp_message = FALSE // if the EMP was successful, don't spam the chat with more messages
 
-/mob/living/carbon/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, zone = BODY_ZONE_R_ARM, override = FALSE, tesla_shock = FALSE, illusion = FALSE, stun = TRUE, gib = FALSE)
+/mob/living/carbon/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, zone = HANDS, override = FALSE, tesla_shock = FALSE, illusion = FALSE, stun = TRUE, gib = FALSE)
 	if(tesla_shock && (flags_1 & TESLA_IGNORE_1))
 		return FALSE
 	if(HAS_TRAIT(src, TRAIT_SHOCKIMMUNE))

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -1,53 +1,40 @@
 /mob/living/carbon/human/getarmor(def_zone, type)
-	var/armorval = 0
-	var/organnum = 0
-
 	if(def_zone)
-		if(isbodypart(def_zone))
-			var/obj/item/bodypart/bp = def_zone
-			if(bp)
-				return checkarmor(def_zone, type)
-		var/obj/item/bodypart/affecting = get_bodypart(check_zone(def_zone))
-		if(affecting)
-			return checkarmor(affecting, type)
+		if(isnum(def_zone)) // allows using bodypart bitflags instead of zones
+			return checkarmor(def_zone, type)
+		var/obj/item/bodypart/affecting = isbodypart(def_zone) ? def_zone : get_bodypart(check_zone(def_zone))
+		return checkarmor(affecting.body_part, type)
 		//If a specific bodypart is targetted, check how that bodypart is protected and return the value.
 
 	//If you don't specify a bodypart, it checks ALL your bodyparts for protection, and averages out the values
-	for(var/X in bodyparts)
-		var/obj/item/bodypart/BP = X
-		armorval += min(checkarmor(BP, type), 100) // hey no you can't do that
+	var/armorval = 0
+	var/organnum = 0
+	for(var/obj/item/bodypart/limb as anything in bodyparts)
+		armorval += min(checkarmor(limb.body_part, type), 100) // hey no you can't do that
 		organnum++
 	return (armorval/max(organnum, 1))
 
 
-/mob/living/carbon/human/proc/checkarmor(obj/item/bodypart/def_zone, d_type)
-	if(!d_type)
+/mob/living/carbon/human/proc/checkarmor(bodypart_flag, armor_flag)
+	if(!armor_flag)
 		return 0
 	var/protection = 0
 	var/list/body_parts = list(head, wear_mask, wear_suit, w_uniform, back, gloves, shoes, belt, s_store, glasses, ears, wear_id, wear_neck) //Everything but pockets. Pockets are l_store and r_store. (if pockets were allowed, putting something armored, gloves or hats for example, would double up on the armor)
-	for(var/bp in body_parts)
-		if(!bp)
-			continue
-		if(bp && istype(bp , /obj/item/clothing))
-			var/obj/item/clothing/C = bp
-			if(def_zone.body_part & C.body_parts_covered)
-				protection += C.armor.getRating(d_type)
-			else if(C.body_parts_partial_covered & def_zone.body_part)
-				protection += C.armor.getRating(d_type) * 0.5
-	protection += physiology.armor.getRating(d_type)
+	for(var/obj/item/clothing/cover in body_parts)
+		if(bodypart_flag & cover.body_parts_covered)
+			protection += cover.armor.getRating(armor_flag)
+		else if(bodypart_flag & cover.body_parts_partial_covered)
+			protection += cover.armor.getRating(armor_flag) * 0.5
+	protection += physiology.armor.getRating(armor_flag)
 	return protection
 
 ///Get all the clothing on a specific body part
-/mob/living/carbon/human/proc/clothingonpart(obj/item/bodypart/def_zone)
+/mob/living/carbon/human/proc/clothingonpart(bodypart_flag)
 	var/list/covering_part = list()
 	var/list/body_parts = list(head, wear_mask, wear_suit, w_uniform, back, gloves, shoes, belt, s_store, glasses, ears, wear_id, wear_neck) //Everything but pockets. Pockets are l_store and r_store. (if pockets were allowed, putting something armored, gloves or hats for example, would double up on the armor)
-	for(var/bp in body_parts)
-		if(!bp)
-			continue
-		if(bp && istype(bp , /obj/item/clothing))
-			var/obj/item/clothing/C = bp
-			if(def_zone.body_part & C.body_parts_covered)
-				covering_part += C
+	for(var/obj/item/clothing/cover in body_parts)
+		if(bodypart_flag & cover.body_parts_covered)
+			covering_part += cover
 	return covering_part
 
 /mob/living/carbon/human/on_hit(obj/projectile/P)
@@ -505,7 +492,7 @@
 
 
 //Added a safety check in case you want to shock a human mob directly through electrocute_act.
-/mob/living/carbon/human/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, zone = BODY_ZONE_R_ARM, override = FALSE, tesla_shock = FALSE, illusion = FALSE, stun = TRUE, gib = FALSE)
+/mob/living/carbon/human/electrocute_act(shock_damage, obj/source, siemens_coeff = 1, zone = HANDS, override = FALSE, tesla_shock = FALSE, illusion = FALSE, stun = TRUE, gib = FALSE)
 	if(!override)
 		siemens_coeff *= physiology.siemens_coeff
 	. = ..()

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -58,7 +58,7 @@
 /obj/item/energy_katana/pickup(mob/living/carbon/human/user)
 	. = ..()
 	if(!is_ninja(user)) //stolen directly from the bloody bastard sword
-		if(user.electrocute_act(15, src, 1, user.held_index_to_body_zone(user.active_hand_index))) // you tried to grab it with this hand, so we'll shock it
+		if(user.electrocute_act(15, src, 1, user.held_index_to_hand(user.active_hand_index))) // you tried to grab it with this hand, so we'll shock it
 			to_chat(user, span_userdanger("[src] shocks you!"))
 			user.emote("scream")
 			user.dropItemToGround(src, TRUE)

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -346,7 +346,7 @@
 //dist_check - set to only shock mobs within 1 of source (vendors, airlocks, etc.)
 //zone_override - allows checking a specific body part for shock protection instead of the hands
 //No animations will be performed by this proc.
-/proc/electrocute_mob(mob/living/carbon/victim, power_source, obj/source, siemens_coeff = 1, dist_check = FALSE, zone = BODY_ZONE_R_ARM)
+/proc/electrocute_mob(mob/living/carbon/victim, power_source, obj/source, siemens_coeff = 1, dist_check = FALSE, zone = HANDS)
 	if(!istype(victim) || ismecha(victim.loc))
 		return FALSE //feckin mechs are dumb
 

--- a/code/modules/surgery/bodyparts/_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/_bodyparts.dm
@@ -19,7 +19,7 @@
 	var/body_zone //BODY_ZONE_CHEST, BODY_ZONE_L_ARM, etc , used for def_zone
 	var/aux_zone // used for hands
 	var/aux_layer
-	var/body_part = null //bitflag used to check which clothes cover this bodypart
+	var/body_part = NONE //bitflag used to check which clothes cover this bodypart
 	var/use_digitigrade = NOT_DIGITIGRADE //Used for alternate legs, useless elsewhere
 	var/list/embedded_objects = list()
 	var/held_index = 0 //are we a hand? if so, which one!
@@ -460,7 +460,7 @@
 	// quick re-check to see if bare_wound_bonus applies, for the benefit of log_wound(), see about getting the check from check_wounding_mods() somehow
 	if(ishuman(owner))
 		var/mob/living/carbon/human/human_wearer = owner
-		var/list/clothing = human_wearer.clothingonpart(src)
+		var/list/clothing = human_wearer.clothingonpart(body_part)
 		for(var/i in clothing)
 			var/obj/item/clothing/clothes_check = i
 			// unlike normal armor checks, we tabluate these piece-by-piece manually so we can also pass on appropriate damage the clothing's limbs if necessary
@@ -524,7 +524,7 @@
 		if(H?.physiology?.armor?.wound)//if there is any innate wound armor (poly or genetics)
 			armor_ablation += H.physiology.armor.getRating(WOUND)
 
-		var/list/clothing = H.clothingonpart(src)
+		var/list/clothing = H.clothingonpart(body_part)
 		for(var/c in clothing)
 			var/obj/item/clothing/C = c
 			// unlike normal armor checks, we tabluate these piece-by-piece manually so we can also pass on appropriate damage the clothing's limbs if necessary

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/power_suck.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/power_suck.dm
@@ -31,7 +31,7 @@
 		draining = FALSE
 		return
 
-	var/blocked = H.getarmor(H.held_index_to_body_zone(H.active_hand_index), ELECTRIC)
+	var/blocked = H.getarmor(H.held_index_to_hand(H.active_hand_index), ELECTRIC)
 	siemens_coefficient *= (100 - blocked) / 100
 	if(blocked >= 100)
 		to_chat(H, span_info("NOTICE: [H.gloves] prevent electrical contact - CONSUME protocol aborted."))


### PR DESCRIPTION
Fixes clothes that cover arms but not hands still counting as protecting hands against electric shock.

Also lets `getarmor()` use bodypart flags instead of zones, which allows checking multiple limbs at once or checking just hands/feet/etc instead of the whole bodypart.

:cl:  
bugfix: Fixed clothes that don't cover your hands protecting your hands from electric shock
/:cl:
