### PR TITLE
updates seismic arm with minor dmc reference (and fixes big bug oversight)

### DIFF
--- a/code/datums/martial/reverbpalm.dm
+++ b/code/datums/martial/reverbpalm.dm
@@ -146,10 +146,12 @@
 	if(isanimal(target))
 		if(istype(target, /mob/living/simple_animal/hostile/megafauna/bubblegum))
 			var/mob/living/simple_animal/hostile/megafauna/bubblegum/B = target
+			var/turf/D = get_step(Q, turn(user.dir,180))
 			if(B.charging)
 				B.adjustBruteLoss(50)
 				B.charging = FALSE
-				target.visible_message(span_warning("[B] is caught and slammed into the dirt!"))
+				B.forceMove(D)
+				B.visible_message(span_warning("[B] is caught and thrown behind [user]!"))
 				playsound(target, 'sound/effects/explosion1.ogg', 60, 1)
 				shake_camera(user, 1, 2)
 				return

--- a/code/datums/martial/reverbpalm.dm
+++ b/code/datums/martial/reverbpalm.dm
@@ -86,7 +86,7 @@
 		return
 	if(H.a_intent == INTENT_DISARM)
 		rush(H)
-	if(H.a_intent == INTENT_HARM && isliving(target))
+	if(H.a_intent == INTENT_HARM && isliving(target) && (get_dist(H, target) <= 1))
 		suplex(H,target)
 	if(H.a_intent == INTENT_GRAB)
 		lariat(H)
@@ -137,7 +137,6 @@
 	COOLDOWN_START(src, next_suplex, COOLDOWN_SUPLEX)
 	footsies(target)
 	var/turf/Q = get_step(get_turf(user), turn(user.dir,180))
-	user.visible_message(span_warning("[user] outstretches [user.p_their()] arm and goes for a grab!"))
 	wakeup(target)
 	for(var/mob/living/L in Q.contents)
 		damagefilter(user, L, simpledam, persondam, borgdam)
@@ -145,6 +144,15 @@
 		target.forceMove(Z)
 	damagefilter(user, target, simpledam, persondam, borgdam)
 	if(isanimal(target))
+		if(istype(target, /mob/living/simple_animal/hostile/megafauna/bubblegum))
+			var/mob/living/simple_animal/hostile/megafauna/bubblegum/B = target
+			if(B.charging)
+				B.adjustBruteLoss(50)
+				B.charging = FALSE
+				target.visible_message(span_warning("[B] is caught and slammed into the dirt!"))
+				playsound(target, 'sound/effects/explosion1.ogg', 60, 1)
+				shake_camera(user, 1, 2)
+				return
 		if(target.stat == DEAD)
 			target.visible_message(span_warning("[target] crashes and explodes!"))
 			target.gib()

--- a/code/datums/martial/reverbpalm.dm
+++ b/code/datums/martial/reverbpalm.dm
@@ -149,7 +149,6 @@
 			var/turf/D = get_step(Q, turn(user.dir,180))
 			if(B.charging)
 				B.adjustBruteLoss(50)
-				B.charging = FALSE
 				B.forceMove(D)
 				B.visible_message(span_warning("[B] is caught and thrown behind [user]!"))
 				playsound(target, 'sound/effects/explosion1.ogg', 60, 1)


### PR DESCRIPTION
# Document the changes in your pull request

slamming bubblegum while she's charging will do 50 bonus damage to the base 20
also adds a proximity check to suplex because i might have forgotten to not let people get slam teleported telekinetically oops

# Why is this good for the game?

![fathersonbonding](https://github.com/yogstation13/Yogstation/assets/58535870/ebf6076a-9628-425e-b59c-b400288fcffc)

i think adding some reward to the big risk of getting close to bubblegum while charging is fine, plus i had this in mind since the seismic arm's conception and finally wanted to get it out of my head

# Testing

(all from melee range and not 7 meters away btw!)

damage from suplexing while in motion
![image](https://github.com/yogstation13/Yogstation/assets/58535870/152fac94-c296-4aec-85ed-f279505853a8)

damage normally 
![image](https://github.com/yogstation13/Yogstation/assets/58535870/3ee3ae2c-e054-43a9-81b7-7840b023c528)


# Changelog
:cl:  
bugfix: added proximity check to suplex  
tweak: seismic arm suplex bonus damage vs charging bubblegum  
/:cl:
