### PR TITLE
Fixes a bug where mid-round traitors could be told to break whiteship or freeminer machines if they are on the Z level at the time

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1619,6 +1619,8 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 			continue
 		if(!istype(get_area(machine), /area))
 			continue
+		if(istype(get_area(machine), /area/shuttle))
+			continue //no whiteship machines
 		eligible_machines |= machine
 
 	eligible_machines = shuffle(eligible_machines)


### PR DESCRIPTION
closes: #21521

# Testing
this one's sorta finnicky to test 

:cl:  
bugfix: Traitors can no longer roll whiteship or freeminer machines for the destroy objective
/:cl:
