### PR TITLE
Makes preternis night vision consume power

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
@@ -21,6 +21,16 @@
 	// This variable is the actual night vision strength
 	var/light_cutoff = LIGHTING_CUTOFF_HIGH
 
+/obj/item/organ/eyes/robotic/preternis/Insert(mob/living/carbon/M, special, drop_if_replaced, initialising)
+	. = ..()
+	if(ishuman(owner))
+		var/mob/living/carbon/human/H = owner
+		original_eye_color = H.eye_color
+	
+/obj/item/organ/eyes/robotic/preternis/Remove(mob/living/carbon/M, special)
+	nv_off()
+	. = ..()
+
 /obj/item/organ/eyes/robotic/preternis/ui_action_click()
 	if(damage > low_threshold || (powered && owner.nutrition <= NUTRITION_LEVEL_HUNGRY))
 		//no nightvision if your eyes are low on power, whether internal or external

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
@@ -59,10 +59,10 @@
 	. = ..()
 	if(!owner)
 		return
-	if(HAS_TRAIT(owner, TRAIT_POWERHUNGRY) && !powered)
+	if((HAS_TRAIT(owner, TRAIT_POWERHUNGRY) || (owner.mob_biotypes & MOB_ROBOTIC)) && !powered)
 		powered = TRUE
 		to_chat(owner, span_notice("A battery icon disappears from your vision as your [src] switch to external power."))
-	if(!HAS_TRAIT(owner, TRAIT_POWERHUNGRY) && powered) //these eyes depend on being inside a preternis for power
+	if(!(HAS_TRAIT(owner, TRAIT_POWERHUNGRY) || (owner.mob_biotypes & MOB_ROBOTIC)) && powered) //these eyes depend on being inside a preternis for power
 		powered = FALSE
 		to_chat(owner, span_boldwarning("Your [src] flash warnings that they've lost their power source, and are running on emergency power!"))
 	if(powered)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
@@ -32,7 +32,6 @@
 
 /obj/item/organ/eyes/robotic/preternis/proc/nv_on()
 	night_vision = TRUE
-	sight_flags = initial(sight_flags)
 	color_cutoffs = colour_cutoff_list.Copy()
 	lighting_cutoff = light_cutoff
 	if(ishuman(owner))
@@ -45,7 +44,6 @@
 
 /obj/item/organ/eyes/robotic/preternis/proc/nv_off()
 	night_vision = FALSE
-	sight_flags = initial(sight_flags)
 	color_cutoffs = null
 	lighting_cutoff = null
 	if(ishuman(owner) && original_eye_color)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
@@ -69,11 +69,13 @@
 		//when powered, they recharge by healing
 		owner.adjustOrganLoss(ORGAN_SLOT_EYES,-0.5)
 		if(night_vision)
-			owner.adjust_nutrition(-0.5) //consumes power to stay charged
+			owner.adjust_nutrition(-1) //consumes power to stay charged
 			if(owner.nutrition <= NUTRITION_LEVEL_HUNGRY)
 				nv_off() //if low on power, turn off
 	else if(night_vision)
 		owner.adjustOrganLoss(ORGAN_SLOT_EYES,0.5) //to simulate running out of power, they take damage
+		if(damage > low_threshold)
+			nv_off() //if low on power, turn off
 	
 /obj/item/organ/eyes/robotic/preternis/examine(mob/user)
 	. = ..()

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
@@ -59,10 +59,10 @@
 	. = ..()
 	if(!owner)
 		return
-	if((owner.mob_biotypes & MOB_ROBOTIC) && !powered)
+	if(HAS_TRAIT(owner, TRAIT_POWERHUNGRY) && !powered)
 		powered = TRUE
 		to_chat(owner, span_notice("A battery icon disappears from your vision as your [src] switch to external power."))
-	if(!(owner.mob_biotypes & MOB_ROBOTIC) && powered) //these eyes depend on being inside a preternis for power
+	if(!HAS_TRAIT(owner, TRAIT_POWERHUNGRY) && powered) //these eyes depend on being inside a preternis for power
 		powered = FALSE
 		to_chat(owner, span_boldwarning("Your [src] flash warnings that they've lost their power source, and are running on emergency power!"))
 	if(powered)


### PR DESCRIPTION
Preternis eyes will now consume power while their night vision is in use
Preternis eyes will only take damage in non powerhungry species when nightvision is turned on
They'll also be able to be put in an ethereal without losing power too

# Why is this good for the game?
preternis eyes are particularly strong as they give free night vision with no downside
they used to eventually turn off if used enough, but that was changed at some point a while ago

This re-adds that by making them consume power while in use, and shutting down when the host gets particularly hungry

Also, making them only degrade when night vision is actively being used by non powerhungry species lets them actually have some use for those species

# Testing
gotta

:cl:  
tweak: Preternis eyes now also care about if a species is powerhungry instead of only robotic
tweak: Preternis eyes night vision now consumes power from powerhungry species
tweak: Preternis eyes only take damage in non powerhungry species when nightvision is turned on
/:cl:
