### PR TITLE
Followup tweak to venus human trap weedkiller damage + pull

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -131,6 +131,7 @@
 /mob/living/simple_animal/hostile/venus_human_trap/Initialize(mapload)
 	. = ..()
 	AddElement(/datum/element/life_draining, damage_overtime = 5, check_damage_callback = CALLBACK(src, PROC_REF(kudzu_need)))
+	remove_verb(src, /mob/living/verb/pulled) //no dragging the poor sap into the depths of the vines never to be seen again
 
 /mob/living/simple_animal/hostile/venus_human_trap/Life(seconds_per_tick = SSMOBS_DT, times_fired)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -107,8 +107,6 @@
 	melee_damage_upper = 25
 	a_intent = INTENT_HARM
 	attack_sound = 'sound/weapons/bladeslice.ogg'
-	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
-	unsuitable_atmos_damage = 0
 	sight = SEE_SELF|SEE_MOBS|SEE_OBJS|SEE_TURFS
 	// Real green, cause of course
 	lighting_cutoff_red = 10

--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -107,6 +107,7 @@
 	melee_damage_upper = 25
 	a_intent = INTENT_HARM
 	attack_sound = 'sound/weapons/bladeslice.ogg'
+	atmos_requirements = list("min_oxy" = 1, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	sight = SEE_SELF|SEE_MOBS|SEE_OBJS|SEE_TURFS
 	// Real green, cause of course
 	lighting_cutoff_red = 10

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -265,7 +265,7 @@
 /datum/reagent/toxin/plantbgone/reaction_mob(mob/living/M, methods=TOUCH, reac_volume)
 	if(istype(M, /mob/living/simple_animal/hostile/venus_human_trap))
 		var/mob/living/simple_animal/hostile/venus_human_trap/planty = M
-		planty.weedkiller(reac_volume)
+		planty.weedkiller(reac_volume * 2)
 	if(methods & VAPOR)
 		if(iscarbon(M))
 			var/mob/living/carbon/C = M


### PR DESCRIPTION
When i tweaked how weedkiller worked on venus human traps, i only really tested to make sure it worked, not if it was properly effective
It's proven to be too weak now that they regenerate health by default

Also removes pulling, as it's too easy for them to hide bodies

They're a midround nuisance that can be spawned by traitors, they aren't supposed to be as dangerous as the blob

:cl:  
tweak: Weedkiller does 2x damage to venus human traps than before
tweak: Venus human traps can no longer pull
tweak: venus human traps now require a pressurized environment
/:cl:
