### PR TITLE
fixes a bug where emissive bodyparts showed as white in the character menu

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1086,7 +1086,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 					accessory_overlay.color = forced_colour
 			standing += accessory_overlay
 
-			if(S.emissive && !(HAS_TRAIT(H, TRAIT_HUSK)))
+			if(S.emissive && !(HAS_TRAIT(H, TRAIT_HUSK)) && !istype(H, /mob/living/carbon/human/dummy))//don't put emissives on dummy mobs as they're used for the preference menu, which doesn't draw emissives properly
 				var/mutable_appearance/emissive_accessory_overlay = emissive_appearance(S.icon, "placeholder", H)
 
 				//A little rename so we don't have to use tail_lizard or tail_human when naming the sprites.


### PR DESCRIPTION
# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/6c726311-1161-40d2-8f83-02d461f23107)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/fc245860-9b4c-4499-ae8b-5766968c8c1f)

:cl:  
bugfix: fixes a bug where emissive bodyparts showed as white in the character menu
/:cl:
