### PR TITLE
Fixes bugs with blood type compatibility

### DIFF
--- a/code/datums/blood_types.dm
+++ b/code/datums/blood_types.dm
@@ -8,7 +8,7 @@
 
 /datum/blood_type/New()
 	. = ..()
-	compatible_types |= /datum/blood_type/universal
+	compatible_types |= typesof(/datum/blood_type/universal)
 
 /datum/blood_type/universal
 	name = "U"
@@ -30,7 +30,7 @@
 
 /datum/blood_type/b_minus
 	name = "B-"
-	compatible_types = list(/datum/blood_type/b_minus, /datum/blood_type/o_minus, /datum/blood_type/universal)
+	compatible_types = list(/datum/blood_type/b_minus, /datum/blood_type/o_minus)
 
 /datum/blood_type/b_plus
 	name = "B+"
@@ -42,7 +42,7 @@
 
 /datum/blood_type/ab_plus
 	name = "AB+"
-	compatible_types = list(/datum/blood_type/b_minus, /datum/blood_type/a_minus, /datum/blood_type/ab_minus, /datum/blood_type/o_minus)
+	compatible_types = list(/datum/blood_type/b_minus, /datum/blood_type/a_minus, /datum/blood_type/ab_minus, /datum/blood_type/o_minus, /datum/blood_type/b_plus, /datum/blood_type/a_plus, /datum/blood_type/ab_plus, /datum/blood_type/o_plus)
 
 /datum/blood_type/o_minus
 	name = "O-"


### PR DESCRIPTION
Subtypes of universal blood weren't included in universal compatibility
AB+ only could accept the blood types that AB- could, not any of the + blood types

:cl:  
bugfix: Fixes bugs with blood type compatibility
/:cl:
