### PR TITLE
Powered ruins properly start with lights on if they have a lightswitch

### DIFF
--- a/code/game/area/areas/ruins/_ruins.dm
+++ b/code/game/area/areas/ruins/_ruins.dm
@@ -21,3 +21,4 @@
 
 /area/ruin/powered
 	requires_power = FALSE
+	lights_always_start_on = TRUE


### PR DESCRIPTION
# Testing

gotta

:cl:  
bugfix: Powered ruins properly start with lights on if they have a lightswitch
/:cl:
