### PR TITLE
Fixes quirks exploding

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -79,6 +79,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	/// If set to TRUE, will update character_profiles on the next ui_data tick.
 	var/tainted_character_profiles = FALSE
 
+	/// var to tell the game if we actually have a loaded character or if we need to load one, doesnt care if your loaded character is valid or not
+	var/loaded_character = FALSE
+
 
 	///removed, kept here for migration in 'legacy_mood_migration.dm'
 	///DO NOT USE THIS!
@@ -120,8 +123,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	var/loaded_preferences_successfully = load_preferences()
 	if(loaded_preferences_successfully)
-		if(load_character())
-			return
+		return
 	//we couldn't load character data so just randomize the character appearance + name
 	randomise_appearance_prefs()		//let's create a random character then - rather than a fat, bald and naked man.
 	if(C)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -289,6 +289,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	all_quirks = SSquirks.filter_invalid_quirks(all_quirks, src)
 	validate_quirks()
 
+	loaded_character = TRUE
 	return TRUE
 
 /datum/preferences/proc/save_character()

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -120,6 +120,7 @@
 	if(href_list["show_preferences"])
 		if(!SSquirks.initialized)
 			to_chat(usr, span_notice("The game is still loading. Please wait a bit before editing your character."))
+			return
 		var/datum/preferences/preferences = client.prefs
 		if(!preferences.loaded_character)
 			var/success = preferences.load_character()

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -434,6 +434,13 @@
 
 /mob/dead/new_player/proc/create_character(transfer_after)
 	spawning = TRUE
+	var/datum/preferences/preferences = client.prefs
+	if(!preferences.loaded_character)
+		var/success = preferences.load_character()
+		if(!success)
+			preferences.randomise_appearance_prefs() //let's create a random character then - rather than a fat, bald and naked man.
+			preferences.save_character() //let's save this new random character so it doesn't keep generating new ones.
+			preferences.loaded_character = TRUE
 	close_spawn_windows()
 	//mind.active = FALSE //we wish to transfer the key manually
 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -118,7 +118,15 @@
 		relevant_cap = max(hpc, epc)
 
 	if(href_list["show_preferences"])
+		if(!SSquirks.initialized)
+			to_chat(usr, span_notice("The game is still loading. Please wait a bit before editing your character."))
 		var/datum/preferences/preferences = client.prefs
+		if(!preferences.loaded_character)
+			var/success = preferences.load_character()
+			if(!success)
+				preferences.randomise_appearance_prefs() //let's create a random character then - rather than a fat, bald and naked man.
+				preferences.save_character() //let's save this new random character so it doesn't keep generating new ones.
+				preferences.loaded_character = TRUE
 		preferences.current_window = PREFERENCE_TAB_CHARACTER_PREFERENCES
 		preferences.update_static_data(usr)
 		preferences.ui_interact(usr)


### PR DESCRIPTION
# Document the changes in your pull request

If you join the game before quirk SS initializes, it will check your quirks against an empty quirk list, deleting all of the.

this lazyloads your character for when you need it, and wont let you load them until ssquirks is done
# Testing

![ESDCpW8nDZ](https://github.com/yogstation13/Yogstation/assets/5091394/30bbeb61-46ed-4c24-ad98-d6d7cb1df084)
still got my quirks

# Changelog

:cl:  
bugfix: quirks won't delete themselves from your characters if you load in fast anymore
/:cl:
