### PR TITLE
Fixes light step's prevention of leaving footprints

### DIFF
--- a/code/game/objects/effects/decals/cleanable.dm
+++ b/code/game/objects/effects/decals/cleanable.dm
@@ -89,7 +89,7 @@
 //This is on /cleanable because fuck this ancient mess
 /obj/effect/decal/cleanable/proc/on_entered(datum/source, atom/movable/AM)
 	SIGNAL_HANDLER
-	if(iscarbon(AM) && blood_state && bloodiness > 40)
+	if(iscarbon(AM) && blood_state && bloodiness > 40 && !HAS_TRAIT(AM, TRAIT_LIGHT_STEP))
 		SEND_SIGNAL(AM, COMSIG_STEP_ON_BLOOD, src)
 		update_icon()
 


### PR DESCRIPTION
I hate leaving footprints that's THE reason I play with it and I want my cleanliness back dammit!



# Testing

Dragged the mojas and a monkey through the blood to make sure it worked normally, I had light step and walked through each pool first without leaving prints.

![image](https://github.com/yogstation13/Yogstation/assets/43766432/16b386e9-5042-4737-874c-ba1f15076698)


# Changelog


:cl:  

bugfix: Light step now stops your shoes from getting dirty again

/:cl:
