### PR TITLE
Fixes not being able to attach goliath hide to APLU exosuits

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1283,7 +1283,7 @@ GLOBAL_VAR_INIT(year_integer, text2num(year)) // = 2013???
 // Matter resupply and upgrades for mounted RCDs
 /obj/mecha/proc/matter_resupply(obj/item/I, mob/user)
 	for(var/obj/item/mecha_parts/mecha_equipment/rcd/R in equipment)
-		R.internal_rcd.attackby(I, user)
+		. = R.internal_rcd.attackby(I, user)
 		if(QDELETED(I))
 			return
 

--- a/code/game/mecha/mecha_defense.dm
+++ b/code/game/mecha/mecha_defense.dm
@@ -213,8 +213,8 @@
 		return
 	
 	if(istype(W, /obj/item/stack) || istype(W, /obj/item/rcd_ammo) || istype(W, /obj/item/rcd_upgrade))
-		matter_resupply(W, user)
-		return
+		if(matter_resupply(W, user))
+			return
 
 	if(istype(W, /obj/item/mecha_parts))
 		var/obj/item/mecha_parts/P = W


### PR DESCRIPTION
![image](https://github.com/yogstation13/Yogstation/assets/93578146/39bba256-a210-40be-9501-4ae4d494370e)

:cl:  
bugfix: Goliath hide plates can be attached to APLU mechs again
/:cl:
