### PR TITLE
[BOX] Kitchen shutters change + blender removal

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -49336,6 +49336,16 @@
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
+"pcB" = (
+/obj/machinery/button/door{
+	id = "kitchen";
+	name = "Privacy Shutters Control";
+	pixel_x = -25;
+	pixel_y = 24;
+	req_access_txt = "28"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "pcF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -111892,7 +111902,7 @@ aAh
 aFt
 fgc
 gAp
-fKR
+pcB
 mPI
 xqh
 iix

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -5490,7 +5490,7 @@
 /area/maintenance/starboard/fore)
 "aNe" = (
 /obj/machinery/button/door{
-	id = "kitchenprivacy";
+	id = "kitchen";
 	name = "Privacy Shutters Control";
 	pixel_x = -5;
 	pixel_y = -25;
@@ -36995,7 +36995,7 @@
 	},
 /obj/structure/table,
 /obj/machinery/reagentgrinder/kitchen{
-	pixel_y = 6
+	pixel_y = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -38089,8 +38089,7 @@
 "kRZ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 6;
-	layer = 2.35;
-	
+	layer = 2.35
 	},
 /turf/closed/wall,
 /area/science/mixing)
@@ -42150,7 +42149,7 @@
 "mtr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchenprivacy";
+	id = "kitchen";
 	name = "privacy shutters"
 	},
 /turf/open/floor/plating,
@@ -48781,9 +48780,6 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "oPJ" = (
-/obj/machinery/reagentgrinder/kitchen{
-	pixel_y = 6
-	},
 /obj/structure/table,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -55773,8 +55769,7 @@
 /area/security/brig)
 "rrF" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
-	layer = 2.35;
-	
+	layer = 2.35
 	},
 /turf/closed/wall,
 /area/science/mixing)
@@ -60707,7 +60702,7 @@
 "thr" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder/kitchen{
-	pixel_y = 6
+	pixel_y = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -36995,7 +36995,7 @@
 	},
 /obj/structure/table,
 /obj/machinery/reagentgrinder/kitchen{
-	pixel_y = 8
+	pixel_y = 6
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -49336,16 +49336,6 @@
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
-"pcB" = (
-/obj/machinery/button/door{
-	id = "kitchen";
-	name = "Privacy Shutters Control";
-	pixel_x = -25;
-	pixel_y = 24;
-	req_access_txt = "28"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "pcF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -58917,6 +58907,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"sAn" = (
+/obj/machinery/button/door{
+	id = "kitchen";
+	name = "Privacy Shutters Control";
+	pixel_x = -25;
+	pixel_y = 24;
+	req_access_txt = "28"
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "sAr" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/components/unary/portables_connector,
@@ -60712,7 +60712,7 @@
 "thr" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder/kitchen{
-	pixel_y = 8
+	pixel_y = 6
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -111902,7 +111902,7 @@ aAh
 aFt
 fgc
 gAp
-pcB
+sAn
 mPI
 xqh
 iix

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -5490,7 +5490,7 @@
 /area/maintenance/starboard/fore)
 "aNe" = (
 /obj/machinery/button/door{
-	id = "kitchen";
+	id = "kitchenprivacy";
 	name = "Privacy Shutters Control";
 	pixel_x = -5;
 	pixel_y = -25;
@@ -26146,6 +26146,13 @@
 /obj/item/reagent_containers/food/condiment/enzyme{
 	layer = 5
 	},
+/obj/machinery/button/door{
+	id = "kitchen";
+	name = "Counter Shutters Control";
+	pixel_x = -27;
+	pixel_y = -5;
+	req_access_txt = "28"
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "gAq" = (
@@ -42149,7 +42156,7 @@
 "mtr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
+	id = "kitchenprivacy";
 	name = "privacy shutters"
 	},
 /turf/open/floor/plating,
@@ -58907,16 +58914,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"sAn" = (
-/obj/machinery/button/door{
-	id = "kitchen";
-	name = "Privacy Shutters Control";
-	pixel_x = -25;
-	pixel_y = 24;
-	req_access_txt = "28"
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "sAr" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/components/unary/portables_connector,
@@ -111902,7 +111899,7 @@ aAh
 aFt
 fgc
 gAp
-sAn
+fKR
 mPI
 xqh
 iix


### PR DESCRIPTION
# Document the changes in your pull request
~~- Adds another button for the shutters since the room is so big~~
- Deletes 1 of the 3 blenders they have
- Fixes an issue with the kitchen privacy button not lowering the western shutters
-- **Added a second button at the north end of the room that toggles only the counter shutters**
-- **The existing button now toggles only window shutters**

# Why is this good for the game?
A kitchen with two chefs and and two sets of hands and two of every machine does not need a third blender, I argue it's unecessary

~~And I thought the kitchen ought to have a second button since it's so far away from the counter, and the room is quite large anyways~~

So I've come to believe this may have been a mapping mistake since the bar/kitchen were redesigned! Once I added a second button, toggling ALL shutters at once seemed like overkill. So I tried splitting the two; the top one controls the counter shutters, and the bottom one controls the windows, and that felt much better!

The reason I think this may have been intended but never implemented, is that the bartender has the exact same setup! Hopefully cooks will have a better time controlling their shutters now.


# Testing
https://github.com/yogstation13/Yogstation/assets/143908044/09aa9779-a5db-4757-96b0-c977a5e4d233


# Wiki Documentation
We should really update those old ass map images on the wiki...

# Changelog
:cl:  
mapping: Added a second button to the kitchen on Box to toggle counter shutters
mapping: The privacy shutters in the kitchen on Box are now toggled with the bottom (already existing) button
mapping: Removed the third blender from the kitchen on Box
/:cl:
