### PR TITLE
Fixes being unable to select a clan as bloodsucker

### DIFF
--- a/code/modules/antagonists/bloodsuckers/structures/bloodsucker_coffin.dm
+++ b/code/modules/antagonists/bloodsuckers/structures/bloodsucker_coffin.dm
@@ -6,7 +6,7 @@
 		else
 			to_chat(owner, "This [claimed.name] has already been claimed by another.")
 		return FALSE
-	if(!LAZYFIND(GLOB.the_station_areas, current_area))
+	if(!LAZYFIND(GLOB.the_station_areas, current_area.type))
 		claimed.balloon_alert(owner.current, "not part of station!")
 		return
 	// This is my Lair


### PR DESCRIPTION
# Testing
tested it while testing the hecata necromancy pr, hisa can vouch for me

:cl:  
bugfix: Fixes being unable to select a clan as bloodsucker
/:cl:
