### PR TITLE
meatballs in food boxes are raw instead of cooked

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1087,7 +1087,7 @@
 /obj/item/storage/box/ingredients/italian/PopulateContents()
 	for(var/i in 1 to 3)
 		new /obj/item/reagent_containers/food/snacks/grown/tomato(src)
-		new /obj/item/reagent_containers/food/snacks/meatball(src) //YOGS - bigotry rule
+		new /obj/item/reagent_containers/food/snacks/raw_meatball(src) //YOGS - bigotry rule
 	new /obj/item/reagent_containers/food/drinks/bottle/wine(src)
 
 /obj/item/storage/box/ingredients/vegetarian
@@ -1110,7 +1110,7 @@
 		new /obj/item/reagent_containers/food/snacks/grown/potato(src)
 		new /obj/item/reagent_containers/food/snacks/grown/tomato(src)
 		new /obj/item/reagent_containers/food/snacks/grown/corn(src)
-	new /obj/item/reagent_containers/food/snacks/meatball(src) //YOGS - bigotry rule
+	new /obj/item/reagent_containers/food/snacks/raw_meatball(src) //YOGS - bigotry rule
 
 /obj/item/storage/box/ingredients/fruity
 	theme_name = "fruity"
@@ -1166,7 +1166,7 @@
 	new /obj/item/reagent_containers/food/snacks/carpmeat(src)
 	new /obj/item/reagent_containers/food/snacks/meat/slab/xeno(src)
 	new /obj/item/reagent_containers/food/snacks/meat/slab/corgi(src)
-	new /obj/item/reagent_containers/food/snacks/meatball(src) //YOGS - bigotry rule
+	new /obj/item/reagent_containers/food/snacks/raw_meatball(src) //YOGS - bigotry rule
 
 /obj/item/storage/box/ingredients/exotic
 	theme_name = "exotic"


### PR DESCRIPTION
changes the meatballs in three ingredient boxes from cooked to raw

# Why is this good for the game?
allows them to be used for other stuff too, such as patties. also i think it looks weird when you get a box full of raw meat and then this random meatball cooked

# Testing
yes

:cl:  ktlwjec
tweak: Meatballs in ingredient boxes start off raw.
/:cl: