### PR TITLE
[BOX] Library decal adjustments

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -26767,9 +26767,6 @@
 "gOa" = (
 /obj/effect/turf_decal/ramp_middle,
 /obj/structure/bookcase/random/fiction,
-/obj/effect/turf_decal/siding/wood/thin{
-	dir = 1
-	},
 /turf/open/floor/carpet,
 /area/library)
 "gOg" = (
@@ -39160,9 +39157,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/ramp_middle,
-/obj/effect/turf_decal/siding/wood/thin{
-	dir = 1
-	},
 /turf/open/floor/carpet,
 /area/library)
 "lmd" = (
@@ -63411,9 +63405,6 @@
 "uhU" = (
 /obj/effect/turf_decal/ramp_middle,
 /obj/structure/bookcase/random/adult,
-/obj/effect/turf_decal/siding/wood/thin{
-	dir = 1
-	},
 /turf/open/floor/carpet,
 /area/library)
 "uiF" = (

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -5933,6 +5933,9 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/siding/wood/thin,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/library)
 "aPQ" = (
@@ -70131,6 +70134,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"wFn" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/ramp_middle,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/siding/wood/thin,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
 "wFr" = (
 /obj/machinery/light_switch{
 	pixel_y = -25
@@ -118873,7 +118891,7 @@ alP
 aEH
 xjK
 aFu
-aPf
+wFn
 cZY
 aIt
 jQY

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -7,6 +7,7 @@
 	dir = 1
 	},
 /obj/structure/railing,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/library)
 "aad" = (
@@ -5190,6 +5191,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/wood/thin{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/library)
 "aLh" = (
@@ -5736,6 +5740,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/effect/turf_decal/siding/wood/corner/thin,
 /turf/open/floor/wood,
 /area/library)
 "aPd" = (
@@ -5767,24 +5772,21 @@
 /area/crew_quarters/fitness)
 "aPf" = (
 /obj/structure/railing,
-/obj/effect/turf_decal/stripes,
 /obj/effect/turf_decal/ramp_middle,
-/obj/effect/turf_decal/ramp_middle{
-	dir = 1
-	},
 /obj/effect/turf_decal/ramp_middle{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood,
 /area/library)
 "aPg" = (
 /obj/structure/bookcase{
 	name = "Forbidden Knowledge"
 	},
-/turf/open/floor/engine/cult,
+/turf/open/floor/plasteel/cult,
 /area/library)
 "aPi" = (
 /obj/structure/table/wood,
@@ -5793,7 +5795,7 @@
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
-/turf/open/floor/engine/cult,
+/turf/open/floor/plasteel/cult,
 /area/library)
 "aPm" = (
 /obj/structure/chair/stool,
@@ -5920,7 +5922,6 @@
 /area/hallway/primary/port)
 "aPP" = (
 /obj/structure/railing,
-/obj/effect/turf_decal/stripes,
 /obj/effect/turf_decal/ramp_middle{
 	dir = 8
 	},
@@ -5928,15 +5929,10 @@
 /obj/effect/turf_decal/ramp_middle{
 	dir = 1
 	},
-/obj/effect/turf_decal/ramp_middle{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood,
 /area/library)
 "aPQ" = (
@@ -5962,20 +5958,20 @@
 "aQr" = (
 /obj/machinery/light/small,
 /obj/machinery/vending/wardrobe/curator_wardrobe,
-/turf/open/floor/engine/cult,
+/turf/open/floor/plasteel/cult,
 /area/library)
 "aQs" = (
 /obj/structure/destructible/cult/tome,
 /obj/item/clothing/under/suit_jacket/red,
 /obj/item/book/codex_gigas,
-/turf/open/floor/engine/cult,
+/turf/open/floor/plasteel/cult,
 /area/library)
 "aQt" = (
 /obj/effect/landmark/blobstart,
 /obj/structure/chair/comfy/brown{
 	dir = 1
 	},
-/turf/open/floor/engine/cult,
+/turf/open/floor/plasteel/cult,
 /area/library)
 "aQx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -6214,7 +6210,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/engine/cult,
+/turf/open/floor/plasteel/cult,
 /area/library)
 "aRR" = (
 /obj/machinery/camera{
@@ -6907,13 +6903,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "aXX" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/ramp_middle,
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/wood,
 /area/library)
 "aYd" = (
@@ -10386,10 +10379,10 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/machinery/papershredder,
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
-/obj/machinery/papershredder,
 /turf/open/floor/wood,
 /area/library)
 "bBN" = (
@@ -10779,7 +10772,6 @@
 /area/science/mixing)
 "bFb" = (
 /obj/structure/table/wood,
-/obj/effect/turf_decal/siding/wood,
 /obj/item/deskbell/preset/library{
 	pixel_x = -9;
 	pixel_y = -3
@@ -10795,6 +10787,7 @@
 /obj/item/storage/pencil_holder/crew{
 	pixel_x = 8
 	},
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood,
 /area/library)
 "bFr" = (
@@ -11735,7 +11728,7 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -15552,6 +15545,7 @@
 	pixel_x = -4;
 	pixel_y = 8
 	},
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/library)
 "cKH" = (
@@ -16458,7 +16452,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "cZY" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -17484,9 +17478,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "dvd" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/effect/turf_decal/ramp_corner{
 	dir = 4
 	},
@@ -18579,15 +18570,15 @@
 /turf/open/floor/stone,
 /area/crew_quarters/bar)
 "dPy" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/structure/sign/painting{
 	persistence_id = "public";
 	pixel_x = -32
 	},
 /obj/machinery/camera{
 	c_tag = "Library East";
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner/thin{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -26774,15 +26765,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "gOa" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/effect/turf_decal/ramp_middle,
 /obj/effect/turf_decal/ramp_middle,
 /obj/structure/bookcase/random/fiction,
+/obj/effect/turf_decal/siding/wood/thin{
+	dir = 1
+	},
 /turf/open/floor/carpet,
 /area/library)
 "gOg" = (
@@ -27133,8 +27120,8 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "gTa" = (
-/obj/effect/turf_decal/siding/wood,
 /obj/machinery/photocopier,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood,
 /area/library)
 "gTb" = (
@@ -27441,10 +27428,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes{
-	dir = 9
-	},
-/obj/effect/turf_decal/ramp_middle,
 /obj/effect/turf_decal/ramp_middle{
 	dir = 4
 	},
@@ -30713,13 +30696,13 @@
 /turf/open/floor/carpet,
 /area/library)
 "idH" = (
-/obj/effect/turf_decal/siding/wood,
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen{
 	pixel_x = 4;
 	pixel_y = 2
 	},
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood,
 /area/library)
 "idL" = (
@@ -30987,12 +30970,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/security/prison/hallway)
-"ihg" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/library)
 "ihn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -32649,6 +32626,7 @@
 /obj/machinery/bookbinder{
 	pixel_y = 8
 	},
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/library)
 "iMC" = (
@@ -35179,10 +35157,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "jIq" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
+/obj/effect/turf_decal/siding/wood/thin{
+	dir = 10
 	},
-/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/library)
 "jIJ" = (
@@ -36270,8 +36247,8 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/locker)
 "khm" = (
-/obj/effect/turf_decal/stripes,
 /obj/structure/railing/corner,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood,
 /area/library)
 "khy" = (
@@ -37690,7 +37667,7 @@
 	},
 /obj/item/pen/invisible,
 /obj/item/toy/figure/curator,
-/turf/open/floor/engine/cult,
+/turf/open/floor/plasteel/cult,
 /area/library)
 "kKK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -38819,24 +38796,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"lgN" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/stripes,
-/obj/effect/turf_decal/ramp_middle,
-/obj/effect/turf_decal/ramp_middle{
-	dir = 1
-	},
-/obj/effect/turf_decal/ramp_middle{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
 "lhk" = (
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
@@ -39194,12 +39153,6 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "llW" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes{
-	dir = 5
-	},
 /obj/item/kirbyplants/random{
 	pixel_x = -5
 	},
@@ -39207,6 +39160,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/ramp_middle,
+/obj/effect/turf_decal/siding/wood/thin{
+	dir = 1
+	},
 /turf/open/floor/carpet,
 /area/library)
 "lmd" = (
@@ -40032,7 +39988,7 @@
 	pixel_x = -6;
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -41123,9 +41079,6 @@
 	},
 /obj/effect/landmark/start/assistant,
 /obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /obj/effect/turf_decal/ramp_corner{
@@ -42668,7 +42621,7 @@
 /obj/structure/chair/comfy/black{
 	dir = 8
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -42679,7 +42632,7 @@
 	pixel_x = 1;
 	pixel_y = 9
 	},
-/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood,
 /area/library)
 "mCc" = (
@@ -46660,9 +46613,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "nZg" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
 /obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/wood,
 /area/library)
@@ -48005,9 +47955,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "oyI" = (
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
 /obj/effect/turf_decal/ramp_middle,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -48391,6 +48338,7 @@
 	persistence_id = "public";
 	pixel_x = -32
 	},
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/library)
 "oHK" = (
@@ -49572,9 +49520,9 @@
 /area/quartermaster/office)
 "pfS" = (
 /obj/structure/table/wood,
-/obj/effect/turf_decal/siding/wood,
 /obj/item/camera_film,
 /obj/item/camera_film,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood,
 /area/library)
 "pgn" = (
@@ -49802,10 +49750,10 @@
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
-/obj/effect/turf_decal/siding/wood{
+/obj/machinery/light,
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
 	},
-/obj/machinery/light,
 /turf/open/floor/wood,
 /area/library)
 "piv" = (
@@ -54757,7 +54705,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "qVM" = (
-/obj/effect/turf_decal/siding/wood{
+/obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -56189,13 +56137,10 @@
 /turf/closed/wall/r_wall,
 /area/science/lab)
 "rym" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 8
-	},
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
 /obj/machinery/vending/coffee,
+/obj/effect/turf_decal/siding/wood/thin{
+	dir = 9
+	},
 /turf/open/floor/wood,
 /area/library)
 "ryJ" = (
@@ -60801,12 +60746,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"the" = (
-/obj/effect/turf_decal/stripes,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/wood,
-/area/library)
 "thk" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -61788,6 +61727,7 @@
 /area/crew_quarters/bar)
 "tBG" = (
 /obj/structure/railing,
+/obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
 /area/library)
 "tBZ" = (
@@ -63244,9 +63184,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "ucC" = (
-/obj/effect/turf_decal/siding/wood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood,
 /area/library)
 "ucF" = (
@@ -63469,15 +63409,11 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
 "uhU" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes{
-	dir = 1
-	},
-/obj/effect/turf_decal/ramp_middle,
 /obj/effect/turf_decal/ramp_middle,
 /obj/structure/bookcase/random/adult,
+/obj/effect/turf_decal/siding/wood/thin{
+	dir = 1
+	},
 /turf/open/floor/carpet,
 /area/library)
 "uiF" = (
@@ -66890,10 +66826,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "vvZ" = (
-/obj/effect/turf_decal/stripes,
 /obj/structure/railing/corner{
 	dir = 1
 	},
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood,
 /area/library)
 "vwa" = (
@@ -72761,8 +72697,8 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "xFp" = (
-/obj/effect/turf_decal/siding/wood,
 /obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/siding/wood/thin,
 /turf/open/floor/wood,
 /area/library)
 "xFt" = (
@@ -118690,7 +118626,7 @@ aEH
 anf
 aFu
 aPf
-ihg
+cZY
 exz
 aIt
 aLh
@@ -118946,8 +118882,8 @@ alP
 aEH
 xjK
 aFu
-lgN
-ihg
+aPf
+cZY
 aIt
 jQY
 aIt
@@ -119204,7 +119140,7 @@ wyd
 dBg
 vBC
 aPP
-ihg
+cZY
 aIt
 aES
 aIt
@@ -119979,7 +119915,7 @@ aJR
 aJR
 mJk
 vlM
-the
+ucC
 iNY
 oyI
 vlM


### PR DESCRIPTION
# Document the changes in your pull request
I changed some decals in the library to look better and be up-to-date:
- Removed hazard stripes
- Wood decals use the thin version rather than thick version
-- Fixed said wood decals using two overlapped "straight-lines" rather than the corner variant on corners
-- Fixed a few duplicate shadows
- Curator's back room now has spooky cult flooring instead of exposed plating!

# Why is this good for the game?
Industrial hazard stripes doesn't look good or make sense on wooden floor boards to me, and I like that we're shifting toward using thin decals instead of thicker ones on every room that features them, so good to have the library standardized too.

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/143908044/03285c1b-da88-40a3-875a-a1cb1c7c132e)

# Changelog
:cl:  
mapping: Adjusted decals and added some spooky flooring to the curator's backroom in the library on Box
/:cl:
