### PR TITLE
Adds canister bombs

### DIFF
--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -35,8 +35,6 @@
 	var/timing = FALSE
 	var/restricted = FALSE
 	req_access = list()
-	//a singletank bomb te explode the canister
-	var/obj/item/tank/single_tank
 
 	//list of canister types for relabeling
 	var/static/list/label2types = list(
@@ -320,8 +318,8 @@
 	var/light_state = get_pressure_state(air_contents?.return_pressure())
 	if(light_state) //happens when pressure is below 10kpa which means no light
 		. += mutable_appearance(icon, light_state)
-	if(single_tank)
-		. += single_tank
+	if(holding.bomb_status)
+		. += holding
 
 ///return the icon_state component for the canister's indicator light based on its current pressure reading
 /obj/machinery/portable_atmospherics/canister/proc/get_pressure_state(air_pressure)
@@ -373,29 +371,6 @@
 		to_chat(user, span_notice("You cannot slice [src] apart when it isn't broken."))
 
 	return TRUE
-
-//attaching or droping the singletank bomb
-/obj/machinery/portable_atmospherics/canister/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/tank)) 
-		if(!(stat & BROKEN))
-			var/obj/item/tank/T = W
-			if(T.bomb_status)
-				if(!user.transferItemToLoc(T, src))
-					return ..()
-				single_tank = T
-				update_appearance(UPDATE_ICON)
-				user.balloon_alert(user, "[single_tank.name] attached!")
-				add_fingerprint(user)
-				return
-		return ..()
-	else if ((W.tool_behaviour == TOOL_WRENCH) && single_tank)
-		W.play_tool_sound(src)
-		single_tank.forceMove(drop_location())
-		single_tank = null
-		update_appearance(UPDATE_ICON)
-		return
-	else
-		return ..()
 
 /obj/machinery/portable_atmospherics/canister/obj_break(damage_flag)
 	. = ..()

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -312,6 +312,8 @@
 		. += "can-open"
 	if(holding)
 		. += "can-tank"
+		if(holding.bomb_status)
+			. += holding
 	if(connected_port)
 		. += "can-connector"
 

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -1,6 +1,6 @@
 #define CAN_DEFAULT_RELEASE_PRESSURE (ONE_ATMOSPHERE)
-#define CANISTER_EXPLOSION_PRESSURE   (40.*ONE_ATMOSPHERE) //maybe needs tweaking
-#define CANISTER_EXPLOSION_SCALE      (6.*ONE_ATMOSPHERE)
+#define CANISTER_EXPLOSION_PRESSURE   (200.*ONE_ATMOSPHERE) //maybe needs tweaking
+#define CANISTER_EXPLOSION_SCALE      (10.*ONE_ATMOSPHERE)
 
 /obj/machinery/portable_atmospherics/canister
 	name = "canister"
@@ -320,6 +320,8 @@
 	var/light_state = get_pressure_state(air_contents?.return_pressure())
 	if(light_state) //happens when pressure is below 10kpa which means no light
 		. += mutable_appearance(icon, light_state)
+	if(single_tank)
+		. += single_tank
 
 ///return the icon_state component for the canister's indicator light based on its current pressure reading
 /obj/machinery/portable_atmospherics/canister/proc/get_pressure_state(air_pressure)
@@ -390,15 +392,10 @@
 		W.play_tool_sound(src)
 		single_tank.forceMove(drop_location())
 		single_tank = null
+		update_appearance(UPDATE_ICON)
 		return
 	else
 		return ..()
-
-/obj/machinery/portable_atmospherics/canister/update_overlays()
-	. = ..()
-	if(single_tank)
-		. += single_tank.icon_state
-		. += single_tank.overlays
 
 /obj/machinery/portable_atmospherics/canister/obj_break(damage_flag)
 	. = ..()

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -35,6 +35,8 @@
 	var/timing = FALSE
 	var/restricted = FALSE
 	req_access = list()
+	//a singletank bomb te explode the canister
+	var/obj/item/tank/single_tank
 
 	//list of canister types for relabeling
 	var/static/list/label2types = list(
@@ -369,6 +371,34 @@
 		to_chat(user, span_notice("You cannot slice [src] apart when it isn't broken."))
 
 	return TRUE
+
+//attaching or droping the singletank bomb
+/obj/machinery/portable_atmospherics/canister/attackby(obj/item/W, mob/user, params)
+	if(istype(W, /obj/item/tank)) 
+		if(!(stat & BROKEN))
+			var/obj/item/tank/T = W
+			if(T.bomb_status)
+				if(!user.transferItemToLoc(T, src))
+					return ..()
+				single_tank = T
+				update_appearance(UPDATE_ICON)
+				user.balloon_alert(user, "[single_tank.name] attached!")
+				add_fingerprint(user)
+				return
+		return ..()
+	else if ((W.tool_behaviour == TOOL_WRENCH) && single_tank)
+		W.play_tool_sound(src)
+		single_tank.forceMove(drop_location())
+		single_tank = null
+		return
+	else
+		return ..()
+
+/obj/machinery/portable_atmospherics/canister/update_overlays()
+	. = ..()
+	if(single_tank)
+		. += single_tank.icon_state
+		. += single_tank.overlays
 
 /obj/machinery/portable_atmospherics/canister/obj_break(damage_flag)
 	. = ..()

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -312,15 +312,12 @@
 		. += "can-open"
 	if(holding)
 		. += "can-tank"
-		if(holding.bomb_status)
-			. += holding
 	if(connected_port)
 		. += "can-connector"
-
 	var/light_state = get_pressure_state(air_contents?.return_pressure())
 	if(light_state) //happens when pressure is below 10kpa which means no light
 		. += mutable_appearance(icon, light_state)
-	if(holding.bomb_status)
+	if(holding?.bomb_status)
 		. += holding
 
 ///return the icon_state component for the canister's indicator light based on its current pressure reading


### PR DESCRIPTION
# Document the changes in your pull request

makes canisters explode when they break if they have 200000Kpa or higher pressure and makes single tank bombs attachable to them so the canister can detonate by itself.

# Why is this good for the game?
<!-- Describe why you think this change is good for the game. This section is not required for bugfixes. -->
gives more depth and possibilities to some jobs


# Testing
<details> 
  <summary>tested</summary>
  
[2024-02-29 19-38-18.webm](https://github.com/yogstation13/Yogstation/assets/74709370/db34cc29-3f3c-497e-a4ce-a4e3d5492bf5)

  a tiny bit laggy
</details>

# Wiki Documentation
canisters exploding with high pressure and single tank attachable to them


# Changelog


:cl:  
rscadd: canister bombs now explode when broken if they have enough pressure
rscadd: makes single tank bombs attachable to canisters

/:cl:
