### PR TITLE
lava fishin'

### DIFF
--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -29,6 +29,7 @@
 	refresh_light()
 	if(!smoothing_flags)
 		update_appearance()
+	AddComponent(/datum/component/fishable/lava)
 
 /turf/open/lava/update_overlays()
 	. = ..()

--- a/yogstation/code/datums/components/fishable.dm
+++ b/yogstation/code/datums/components/fishable.dm
@@ -75,7 +75,7 @@
 		/obj/item/shovel,
 		/obj/item/shard,
 		/obj/item/pickaxe,
-		/obj/item/stack/sheet/mineral/sandstone
+		/obj/item/stack/sheet/mineral/sandstone,
 		/obj/item/stack/sheet/mineral/coal
 	)
 	common_loot = list(

--- a/yogstation/code/datums/components/fishable.dm
+++ b/yogstation/code/datums/components/fishable.dm
@@ -82,7 +82,7 @@
 		/mob/living/simple_animal/hostile/asteroid/gutlunch,
 		/obj/item/stack/sheet/bone,
 		/mob/living/simple_animal/hostile/asteroid/goliath,
-		/obj/item/stack/sheet/animalhide/goliath_hide
+		/obj/item/stack/sheet/animalhide/goliath_hide,
 		/obj/item/claymore/ruin,
 		/obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_leaf,
 		/obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_cap,

--- a/yogstation/code/datums/components/fishable.dm
+++ b/yogstation/code/datums/components/fishable.dm
@@ -81,7 +81,6 @@
 	common_loot = list(
 		/mob/living/simple_animal/hostile/asteroid/gutlunch,
 		/obj/item/stack/sheet/bone,
-		/mob/living/simple_animal/hostile/asteroid/goliath,
 		/obj/item/stack/sheet/animalhide/goliath_hide,
 		/obj/item/claymore/ruin,
 		/obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_leaf,
@@ -99,15 +98,17 @@
 		/obj/item/clothing/shoes/magboots/syndie,
 		/obj/item/clothing/head/helmet/chaplain,
 		/obj/item/clothing/suit/armor/riot/chaplain,
-		/obj/item/claymore,
+		/obj/item/nullrod/claymore,
 		/obj/item/banner/cargo,
+		/obj/structure/closet/crate/necropolis, //empty chest its a joke :)
 		/obj/item/book/manual/ashwalker
 
 	)
 	rare_loot = list(
 		/mob/living/simple_animal/hostile/mining_drone,
+		/mob/living/simple_animal/hostile/asteroid/goliath,
 		/obj/item/stack/sheet/mineral/mythril,
-		/obj/structure/closet/crate/necropolis, //empty chest its a joke :)
+		/obj/structure/closet/crate/necropolis/tendril, //populated chest
 		/obj/item/book_of_babel,
 		/obj/item/bedsheet/cult,
 		/obj/item/assembly/signaler/anomaly/bluespace,

--- a/yogstation/code/datums/components/fishable.dm
+++ b/yogstation/code/datums/components/fishable.dm
@@ -8,7 +8,6 @@
 	dupe_mode = COMPONENT_DUPE_UNIQUE
 	var/datum/fishing_loot/loot = new /datum/fishing_loot/water
 
-
 /datum/component/fishable/Initialize()
 	if(!istype(parent, /turf))
 		return COMPONENT_INCOMPATIBLE
@@ -18,7 +17,7 @@
 		FISHING_LOOT_JUNK = min(max(0,50 - fishing_power),25),
 		FISHING_LOOT_COMMON = min(fishing_power / 5,50),
 		FISHING_LOOT_UNCOMMON = min(fishing_power / 10,33),
-		FISHING_LOOT_RARE = min(fishing_power / 20,25)
+		FISHING_LOOT_RARE = min(fishing_power / 20,25) 
 		)
 
 	var/chosen_rank = pickweight(chance)
@@ -33,9 +32,12 @@
 			return pick(loot.rare_loot)
 	return FISHING_LOOT_NOTHING
 
+//lava fishing
+
+/datum/component/fishable/lava
+	loot = new /datum/fishing_loot/lava
 
 //LOOT TABLES
-
 /datum/fishing_loot
 	var/list/junk_loot
 	var/list/common_loot
@@ -53,7 +55,7 @@
 		/obj/item/reagent_containers/food/snacks/fish/salmon,
 		/obj/item/reagent_containers/food/snacks/fish/bass,
 		/obj/item/reagent_containers/food/snacks/bait/worm/leech
-		)
+	)
 	uncommon_loot = list(
 		/obj/item/reagent_containers/food/snacks/fish/goldfish/giant,
 		/obj/item/reagent_containers/food/snacks/fish/shrimp,
@@ -67,3 +69,49 @@
 		/obj/item/clothing/head/soft/fishfear/legendary,
 		/mob/living/simple_animal/hostile/retaliate/gator
 	)
+/datum/fishing_loot/lava
+	junk_loot = list(
+		/obj/item/clothing/shoes/workboots/mining,
+		/obj/item/shovel,
+		/obj/item/shard,
+		/obj/item/pickaxe,
+		/obj/item/stack/sheet/mineral/sandstone
+		/obj/item/stack/sheet/mineral/coal
+	)
+	common_loot = list(
+		/mob/living/simple_animal/hostile/asteroid/gutlunch,
+		/obj/item/stack/sheet/bone,
+		/mob/living/simple_animal/hostile/asteroid/goliath,
+		/obj/item/stack/sheet/animalhide/goliath_hide
+		/obj/item/claymore/ruin,
+		/obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_leaf,
+		/obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_cap,
+		/obj/item/reagent_containers/food/snacks/grown/ash_flora/mushroom_stem,
+		/obj/item/reagent_containers/food/snacks/grown/ash_flora/cactus_fruit
+
+	)
+	uncommon_loot = list(
+		/obj/item/survivalcapsule,
+		/obj/item/stack/sheet/ruinous_metal,
+		/obj/item/stack/tile/brass,
+		/obj/item/stack/sheet/mineral/plasma,
+		/obj/item/stack/sheet/bluespace_crystal,
+		/obj/item/clothing/shoes/magboots/syndie,
+		/obj/item/clothing/head/helmet/chaplain,
+		/obj/item/clothing/suit/armor/riot/chaplain,
+		/obj/item/claymore,
+		/obj/item/banner/cargo,
+		/obj/item/book/manual/ashwalker
+
+	)
+	rare_loot = list(
+		/mob/living/simple_animal/hostile/mining_drone,
+		/obj/item/stack/sheet/mineral/mythril,
+		/obj/structure/closet/crate/necropolis, //empty chest its a joke :)
+		/obj/item/book_of_babel,
+		/obj/item/bedsheet/cult,
+		/obj/item/assembly/signaler/anomaly/bluespace,
+		/obj/item/stack/sheet/mineral/abductor
+		)
+		
+		


### PR DESCRIPTION
we fishin' today boys!

# Document the changes in your pull request

Adds the possibility to fish in lava. Includes a special ash themed lootpool that goes as follow:
Junk:
- mining boots;
- shovel;
- pickaxe;
- sandstone;
- coal.

Common:
- Living gutlunch;
- bone;
- goliath hide;
- rusted claymore;
- mushroom leaf;
- mushroom stem;
- cactus fruit.

Uncommon:
- bluespace capsule;
- necropolis chest (empty it's a prank);
- ruinous metal;
- brass;
- plasma sheet;
- bluespace crystal;
- syndicate magboots;
- crusader helmet;
- crusader armor;
- holy claymore (nullrod version);
- cargo banner;
- ashwalker cooking manual.

Rare:
- mining drone;
- mythril;
- -Living goliath;
- necropolis chest;
- book of babel;
- cult bedsheet;
- bluespace anomaly core;
- alien alloy.


# Why is this good for the game?

more shit to do. 

# Testing

Tested all features on a personnal server. 
![image](https://github.com/yogstation13/Yogstation/assets/56667232/f54cba93-c73e-468d-8996-11d745b2f26f)


# Spriting

none

# Wiki Documentation

we dont have a fishing wiki page.

# Changelog

added lava fishing

:cl:  
rscadd: added lava fishing.
/:cl:
