### PR TITLE
Maybe fixes a bug with disposal pipes qdeleting people

### DIFF
--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -45,10 +45,10 @@
 // pipe is deleted
 // ensure if holder is present, it is expelled
 /obj/structure/disposalpipe/Destroy()
-	var/obj/structure/disposalholder/H = locate() in src
-	if(H)
-		H.active = FALSE
-		expel(H, get_turf(src), 0)
+	for(var/obj/structure/disposalholder/H as anything in src)
+		if(istype(H))
+			H.active = FALSE
+			expel(H, get_turf(src), 0)
 	QDEL_NULL(stored)
 	return ..()
 


### PR DESCRIPTION
possibly happens because it only expels a single disposal holder, so if multiple overlap when a pipe is deconstructed, it only expels one and the other is qdeleted

# Testing
15 cats going in
![image](https://github.com/yogstation13/Yogstation/assets/108117184/f9f49c9d-9dfa-47a1-b5ea-153b4b2502a7)
15 cats coming out
![image](https://github.com/yogstation13/Yogstation/assets/108117184/f114f19c-2760-4d38-8150-fe608154ba25)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/ae917ef0-3d2d-4786-a9c5-abb7ee308f77)

:cl:  
bugfix: Maybe fixes a bug with disposal pipes qdeleting people
/:cl:
