### PR TITLE
Healium now heals oxy damage

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1548,6 +1548,7 @@
 		M.adjust_jitter_up_to(2, 10)
 	else if(M.bodytemperature < T0C)
 		heal_factor *= (100 + max(T0C - M.bodytemperature, 200)) / 100 // if you're asleep, you get healed faster when you're cold (up to 3x at 73 kelvin)
+	M.adjustOxyLoss(-10*heal_factor*REM)
 	M.adjustFireLoss(-7*heal_factor*REM)
 	M.adjustToxLoss(-5*heal_factor*REM)
 	M.adjustBruteLoss(-5*heal_factor*REM)


### PR DESCRIPTION

# Document the changes in your pull request
Healium now heals oxy damage

# Why is this good for the game?
Oxyloss is very important, giving healium to medical should help docs recovering patients with oxyloss problem faster and for the case when all cryoxadone are gone healium could act as a backup when restoring oxyloss. Disclaimer: this only works well for cryotube because you can be asleep and cold for it to boost healing efficiency, you wont be able to use healium alone to counter oxyloss

# Testing
The one line code worked, helping me staying alive from my bloodloss


# Wiki Documentation
Healium now heals oxy damage

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: Healium now heals oxy damage
/:cl:
