### PR TITLE
Liquid plasma rivers cool down heat exchange pipes instead of heating them

### DIFF
--- a/code/game/turfs/open/lava.dm
+++ b/code/game/turfs/open/lava.dm
@@ -23,6 +23,10 @@
 	var/mask_icon = 'icons/turf/floors.dmi'
 	/// The icon state that covers the lava bits of our turf
 	var/mask_state = "lava-lightmask"
+	/// The temperature this lava will heat or cool radiator pipes to
+	var/lava_temperature = 5000
+	/// The heat capacity of the lava, used by heat exchange pipes
+	var/lava_heat_capacity = 700000
 
 /turf/open/lava/Initialize(mapload)
 	. = ..()
@@ -155,10 +159,10 @@
 	return TRUE
 
 /turf/open/lava/GetHeatCapacity()
-	. = 700000
+	return lava_heat_capacity
 
 /turf/open/lava/GetTemperature()
-	. = 5000
+	return lava_temperature
 
 /turf/open/lava/TakeTemperature(temp)
 

--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -172,6 +172,7 @@
 	light_range = 3
 	light_power = 0.75
 	light_color = LIGHT_COLOR_PURPLE
+	lava_temperature = 73 // cold, not hot
 
 /turf/open/lava/plasma/attackby(obj/item/I, mob/user, params)
 	var/obj/item/reagent_containers/glass/C = I


### PR DESCRIPTION
# Document the changes in your pull request

Liquid plasma tiles cool down gases in heat exchange pipes instead of heating them, like lava tiles but cold instead of hot.

# Why is this good for the game?
Pretty sure this was an oversight, liquid plasma is meant to be the cold version of lava for icemoon but it still heats gases in heat exchange pipes to the same temperature.

# Testing
It's very cold

# Wiki Documentation

Might be worth mentioning on the guide to atmos that heat exchange pipes can be used on lava or liquid plasma tiles as heating or cooling respectively.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Liquid plasma tiles cool down gas in radiator loops instead of heating them
/:cl:
