### PR TITLE
Makes the night vision quirk work again

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -164,10 +164,9 @@
 
 /datum/quirk/night_vision/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/item/organ/eyes/eyes = H.getorgan(/obj/item/organ/eyes)
-	if(!eyes || eyes.lighting_cutoff)
+	if(!istype(H)) //sanity check
 		return
-	eyes.Insert(H) //refresh their eyesight and vision
+	H.update_sight()//refresh their eyesight and vision
 
 /datum/quirk/photographer
 	name = "Photographer"

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1258,6 +1258,8 @@
 ///Update the lighting plane and sight of this mob (sends COMSIG_MOB_UPDATE_SIGHT)
 /mob/proc/update_sight()
 	SHOULD_CALL_PARENT(TRUE)
+	if(HAS_TRAIT(src, TRAIT_NIGHT_VISION))
+		lighting_cutoff = max(lighting_cutoff, 6)
 	SEND_SIGNAL(src, COMSIG_MOB_UPDATE_SIGHT)
 	sync_lighting_plane_cutoff()
 


### PR DESCRIPTION
It wasn't updated to the most recent version of night vision, so it did nothing

# Testing
with and without the quirk (might need to cost more than 2)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/fbbbb569-9925-4703-a38e-c54a0e5aadd4)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/f4a54870-46d5-4e99-9a95-f16d33a8796c)

:cl:  
bugfix: Makes the night vision quirk work again
/:cl:
