### PR TITLE
Tweaks power X-02 power armor upon request from lassih

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -1201,7 +1201,7 @@
 	hardsuit_type = "advpa1"
 	strip_delay = 100
 	equip_delay_other = 100
-	armor = list(MELEE = 50, BULLET = 10, LASER = 25, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 10, WOUND = 0, ELECTRIC = 100)
+	armor = list(MELEE = 50, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 10, WOUND = 0, ELECTRIC = 100)
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	resistance_flags = FIRE_PROOF | LAVA_PROOF | ACID_PROOF
 
@@ -1213,7 +1213,7 @@
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/powerarmor_advanced
 	hardsuit_type = "advancedpa1"
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/gun/energy/kinetic_accelerator, /obj/item/kinetic_crusher, /obj/item/pickaxe, /obj/item/pickaxe/drill/jackhammer, /obj/item/shield/riot/goliath, /obj/item/shield/riot/roman)
-	armor = list(MELEE = 50, BULLET = 10, LASER = 25, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 10, WOUND = 0, ELECTRIC = 100)
+	armor = list(MELEE = 50, BULLET = 10, LASER = 10, ENERGY = 0, BOMB = 0, BIO = 0, RAD = 0, FIRE = 0, ACID = 10, WOUND = 0, ELECTRIC = 100)
 	slowdown = 0
 	strip_delay = 180
 	equip_delay_other = 180
@@ -1222,11 +1222,11 @@
 
 /obj/item/clothing/suit/space/hardsuit/powerarmor_advanced/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/armor_plate,10,/obj/item/stack/sheet/animalhide/weaver_chitin, list(MELEE = 0.5, BULLET = 3, LASER = 0.5, ENERGY = 2.5, BOMB = 5, BIO = 10, RAD = 8, FIRE = 10, ACID = 9, WOUND = 0.1))
+	AddComponent(/datum/component/armor_plate,10,/obj/item/stack/sheet/animalhide/weaver_chitin, list(MELEE = 2, BULLET = 0.5, LASER = 0.5, ENERGY = 1.5, BOMB = 5, BIO = 10, RAD = 8, FIRE = 10, ACID = 9, WOUND = 0.1))
 
 /obj/item/clothing/head/helmet/space/hardsuit/powerarmor_advanced/Initialize(mapload)
 	. = ..()
-	AddComponent(/datum/component/armor_plate,10,/obj/item/stack/sheet/animalhide/weaver_chitin, list(MELEE = 0.5, BULLET = 3, LASER = 0.5, ENERGY = 2.5, BOMB = 5, BIO = 10, RAD = 8, FIRE = 10, ACID = 9, WOUND = 0.1))
+	AddComponent(/datum/component/armor_plate,10,/obj/item/stack/sheet/animalhide/weaver_chitin, list(MELEE = 2, BULLET = 0.5, LASER = 0.5, ENERGY = 1.5, BOMB = 5, BIO = 10, RAD = 8, FIRE = 10, ACID = 9, WOUND = 0.1))
 
 /obj/item/clothing/head/helmet/space/hardsuit/syndi/debug // reused code so I dont have to make new procs
 	name = "debug hardsuit helmet"


### PR DESCRIPTION
![image](https://github.com/yogstation13/Yogstation/assets/108117184/bdad2a23-6621-4f98-95fc-b6564e85c928)

Greatly reduces laser, bullet, and energy armour when fully plated, but increases melee armour

Now it'll end at
70 melee, 15 bullet, 15 laser, 15 energy
instead of
55 melee, 40 bullet, 30 laser, 25 energy

# Why is this good for the game?
Miner armour shouldn't have good bullet, laser, or energy defense, while it should have really good melee defense
Their armour should be suited to their job, not for other endeavours


:cl:  
tweak: Tweaks power X-02 power armor to have better stats for miners
/:cl:
