### PR TITLE
Tweak megafauna projectile flags

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -262,6 +262,7 @@ Difficulty: Very Hard
 	speed = 2
 	eyeblur = 0
 	damage_type = BRUTE
+	armor_flag = BOMB
 	pass_flags = PASSTABLE
 
 /obj/projectile/colossus/on_hit(atom/target, blocked = FALSE)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/stalwart.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/stalwart.dm
@@ -342,6 +342,7 @@
 	speed = 4
 	eyeblur = 0
 	damage_type = BRUTE
+	armor_flag = MELEE
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 	color = "#00e1ff"
 	light_range = 2
@@ -356,6 +357,7 @@
 	speed = 6
 	eyeblur = 0
 	damage_type = BRUTE
+	armor_flag = MELEE
 	pass_flags = PASSTABLE
 	color = "#4851ce"
 	light_range = 2
@@ -370,6 +372,7 @@
 	speed = 5
 	eyeblur = 0
 	damage_type = BRUTE
+	armor_flag = MELEE
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 	color = "#9a9fdb"
 	light_range = 2
@@ -384,6 +387,7 @@
 	speed = 10
 	eyeblur = 0
 	damage_type = BRUTE
+	armor_flag = BOMB
 	pass_flags = PASSTABLE
 	light_range = 6
 	light_power = 10


### PR DESCRIPTION
Colossus projectiles resolve against bomb

Regular stalwart projectiles resolve against melee
While the volatile orb resolves against bomb

# Why is this good for the game?
Miners are given loads of melee and bomb armour for their job, the fauna they're expected to deal with checking for bullet armour means either they do a load of damage, or miners are given armour that lets them handle it, and they bring it on station to powergame.

:cl:  
tweak: Tweaks some megafauna projectiles to resolve against melee or bomb armour instead of bullet
/:cl:
