### PR TITLE
Lizards, polysmorphs, and skeletons now actually make clacky step noises.

### DIFF
--- a/code/datums/elements/footstep.dm
+++ b/code/datums/elements/footstep.dm
@@ -148,8 +148,8 @@
 	//cache for sanic speed (lists are references anyways)
 	var/static/list/footstep_sounds = GLOB.footstep
 
-	if (((source.wear_suit?.body_parts_covered | source.w_uniform?.body_parts_covered) & FEET) || (source.shoes && !istype(source.shoes, /obj/item/clothing/shoes/xeno_wraps)))
-		// we are wearing shoes
+	if (((source.wear_suit?.body_parts_covered | source.w_uniform?.body_parts_covered) & FEET) || (source.shoes && !istype(source.shoes, /obj/item/clothing/shoes/xeno_wraps)) || (source.dna.species.barefoot_step_sound == FOOTSTEP_MOB_SHOE))
+		// we are wearing shoes or have shoes for feet
 
 		var/shoestep_type = prepared_steps[FOOTSTEP_MOB_SHOE]
 		playsound(source.loc, pick(footstep_sounds[shoestep_type][1]),
@@ -157,16 +157,27 @@
 			TRUE,
 			footstep_sounds[shoestep_type][3] + e_range + range_adjustment, falloff_distance = 1, vary = sound_vary)
 	else
-		var/barefoot_type = prepared_steps[FOOTSTEP_MOB_BAREFOOT]
+		var/barefoot_type = prepared_steps[source.dna.species.barefoot_step_sound]
 		if(source.dna.species.special_step_sounds)
 			playsound(source.loc, pick(source.dna.species.special_step_sounds), 50, TRUE, falloff_distance = 1, vary = sound_vary)
 		else
-			var/static/list/bare_footstep_sounds = GLOB.barefootstep
-
-			playsound(source.loc, pick(bare_footstep_sounds[barefoot_type][1]),
-				bare_footstep_sounds[barefoot_type][2] * volume * volume_multiplier,
-				TRUE,
-				bare_footstep_sounds[barefoot_type][3] + e_range + range_adjustment, falloff_distance = 1, vary = sound_vary)
+			switch(source.dna.species.barefoot_step_sound)
+				if(FOOTSTEP_MOB_BAREFOOT)
+					playsound(source.loc, pick(GLOB.barefootstep[barefoot_type][1]),
+						GLOB.barefootstep[barefoot_type][2] * volume * volume_multiplier,
+						TRUE,
+						GLOB.barefootstep[barefoot_type][3] + e_range + range_adjustment, falloff_distance = 1, vary = sound_vary)
+				if(FOOTSTEP_MOB_CLAW)
+					playsound(source.loc, pick(GLOB.clawfootstep[barefoot_type][1]),
+						GLOB.clawfootstep[barefoot_type][2] * volume * volume_multiplier,
+						TRUE,
+						GLOB.clawfootstep[barefoot_type][3] + e_range + range_adjustment, falloff_distance = 1, vary = sound_vary)
+				else	//Emergency backup shoe step sound if it's not either of these other two types for some reason
+					playsound(source.loc, pick(GLOB.footstep[prepared_steps[FOOTSTEP_MOB_SHOE]][1]),
+						GLOB.footstep[prepared_steps[FOOTSTEP_MOB_SHOE]][2] * volume * volume_multiplier,
+						TRUE,
+						GLOB.footstep[prepared_steps[FOOTSTEP_MOB_SHOE]][3] + e_range + range_adjustment, falloff_distance = 1, vary = sound_vary)
+					
 
 ///Prepares a footstep for machine walking
 /datum/element/footstep/proc/play_simplestep_machine(atom/movable/source, atom/oldloc, direction, forced, list/old_locs, momentum_change)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -121,6 +121,8 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	var/inert_mutation 	= DWARFISM
 	///used to set the mobs deathsound on species change
 	var/deathsound
+	///Barefoot step sound
+	var/barefoot_step_sound = FOOTSTEP_MOB_BAREFOOT
 	///Sounds to override barefeet walking
 	var/list/special_step_sounds
 	///How loud to play the step override

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -19,6 +19,7 @@
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	attack_verb = "slash"
 	attack_effect = ATTACK_EFFECT_CLAW
+	barefoot_step_sound = FOOTSTEP_MOB_CLAW
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -15,6 +15,7 @@
 	mutanttongue = /obj/item/organ/tongue/bone/plasmaman
 	mutantliver = /obj/item/organ/liver/plasmaman
 	mutantstomach = /obj/item/organ/stomach/plasmaman
+	barefoot_step_sound = FOOTSTEP_MOB_CLAW
 	brutemod = 1.3 //Rattle me bones, but less because plasma bones are very hard
 	burnmod = 0.9 //Plasma is a surprisingly good insulator if not around oxygen
 	heatmod = 1.5 //Don't let the plasma actually heat up though

--- a/code/modules/mob/living/carbon/human/species_types/polysmorphs.dm
+++ b/code/modules/mob/living/carbon/human/species_types/polysmorphs.dm
@@ -34,6 +34,7 @@
 	mutanttail = /obj/item/organ/tail/polysmorph
 	mutantlungs = /obj/item/organ/lungs/xeno
 	attack_verb = "slash"
+	barefoot_step_sound = FOOTSTEP_MOB_CLAW
 	attack_effect = ATTACK_EFFECT_CLAW
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'

--- a/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -9,6 +9,7 @@
 	inherent_traits = list(TRAIT_RESISTHEAT,TRAIT_NOBREATH,TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_RADIMMUNE,TRAIT_GENELESS,TRAIT_PIERCEIMMUNE,TRAIT_NOHUNGER,TRAIT_EASYDISMEMBER,TRAIT_LIMBATTACHMENT,TRAIT_FAKEDEATH, TRAIT_CALCIUM_HEALER)
 	inherent_biotypes = MOB_UNDEAD|MOB_HUMANOID
 	mutanttongue = /obj/item/organ/tongue/bone
+	barefoot_step_sound = FOOTSTEP_MOB_CLAW
 	damage_overlay_type = ""//let's not show bloody wounds or burns over bones.
 	wings_icon = "Skeleton"
 	disliked_food = NONE


### PR DESCRIPTION
I WASNT INSANE THEY DID USE THE NORMAL BAREFOOT SOUND THE WHOLE TIME AHHHHH

Anyways, this actually allows species to have claw footstep noises. I didn't touch all the other override step noises for stuff like IPC and preternis, this just (currently) applies to lizards, polys, and all skeletal individuals.


# Why is this good for the game?

I've been gaslit that they used different sound the whole time and I'm sure everyone else was.

# Testing

I don't know how to make videos with sound but I did test all the species with special footstep types and they work fine, i can make one later or something if it's that much of an issue.


# Changelog

:cl:  

tweak: Lizards, polysmorphs, and skeletons now actually make claw noises like everyone always said they did. This also indirectly makes them louder.
/:cl:
