### PR TITLE
Adds disposals to cargo shuttle blacklist

### DIFF
--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -12,8 +12,8 @@
 	var/can_approve_requests = TRUE
 	var/contraband = FALSE
 	var/safety_warning = "For safety reasons, the automated supply shuttle \
-		cannot transport live organisms, human remains, classified nuclear weaponry \
-		or homing beacons. Additionally, remove any privately ordered crates from the shuttle."
+		cannot transport live organisms, human remains, classified nuclear weaponry, \
+		homing beacons or pneumatic disposal segments. Additionally, remove any privately ordered crates from the shuttle."
 	var/blockade_warning = "Bluespace instability detected. Shuttle movement impossible."
 	var/self_paid = FALSE
 

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -26,7 +26,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/structure/extraction_point,
 		/obj/machinery/syndicatebomb,
 		/obj/item/hilbertshotel,
-		/obj/structure/closet/bluespace // yogs - nope nice try
+		/obj/structure/closet/bluespace, // yogs - nope nice try
 		/obj/structure/disposalpipe,
 		/obj/structure/disposaloutlet, // connect outlet to bin, knock outlet onto shuttle, send it, enter bin
 		/obj/structure/receiving_pad // holoparasite

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -29,7 +29,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/structure/closet/bluespace, // yogs - nope nice try
 		/obj/structure/disposalpipe,
 		/obj/structure/disposaloutlet, // connect outlet to bin, knock outlet onto shuttle, send it, enter bin
-		/obj/structure/receiving_pad // holoparasite
+		/obj/machinery/disposal
 	)))
 
 /obj/docking_port/mobile/supply

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -27,6 +27,9 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/machinery/syndicatebomb,
 		/obj/item/hilbertshotel,
 		/obj/structure/closet/bluespace // yogs - nope nice try
+		/obj/structure/disposalpipe,
+		/obj/structure/disposaloutlet, // connect outlet to bin, knock outlet onto shuttle, send it, enter bin
+		/obj/structure/receiving_pad // holoparasite
 	)))
 
 /obj/docking_port/mobile/supply


### PR DESCRIPTION
# Document the changes in your pull request
Added all disposals stuff to cargo shuttle's blacklist
Totally not stealing TG's fix for this

Closes #21600 

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/143908044/7f8cf182-f421-4b4c-8d4c-89b81eadc75e)
![image](https://github.com/yogstation13/Yogstation/assets/143908044/414076c0-3b17-4ddd-a605-d85f10c8c6c2)


# Changelog
:cl:  
bugfix: Fixed being able to enter centcom via disposals
/:cl:
