### PR TITLE
Skin twister ided

### DIFF
--- a/yogstation/code/modules/jungleland/jungle_mobs.dm
+++ b/yogstation/code/modules/jungleland/jungle_mobs.dm
@@ -178,8 +178,8 @@
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "hits"
-	maxHealth = 320
-	health = 320
+	maxHealth = 285
+	health = 285
 	spacewalk = TRUE
 	melee_damage_lower = 30
 	melee_damage_upper = 55 // ouch


### PR DESCRIPTION
# Document the changes in your pull request
Skin twister health goes from 320 -> 285

# Why is this good for the game?
This mob is incredibly strong already, has an incredible 30-55 damage every hit, is remarkably fast, and to top it off, has a lot more health than the players themselves.
Combined with the fact they're designed to hit miners while in crit, and disguise as them after death can be a bit punishing.

So that is my case.
also I just witnessed 7 people get crushed by this single mob what in the goddamn

# Testing
Will do

# Changelog
:cl:  
tweak: Skin twister health reduced from 320 -> 285
/:cl: 

P.S. Ye I'm aware most of everything in jungleland is unfinished or broken, fixes are due to come as long as the server doesn't die