### PR TITLE
Gives some old roles new PDAs and cleans out some using the old ones

### DIFF
--- a/code/game/gamemodes/clown_ops/clown_ops.dm
+++ b/code/game/gamemodes/clown_ops/clown_ops.dm
@@ -37,6 +37,7 @@
 	l_pocket = /obj/item/pinpointer/nuke/syndicate
 	r_pocket = /obj/item/bikehorn
 	id = /obj/item/card/id/syndicate
+	belt = /obj/item/modular_computer/tablet/pda/preset/basic/clown
 	backpack_contents = list(/obj/item/kitchen/knife/combat/survival,\
 		/obj/item/reagent_containers/spray/waterflower/lube)
 	implants = list(/obj/item/implant/sad_trombone)

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -672,7 +672,7 @@
 	STR.silent = TRUE
 
 /obj/item/storage/backpack/duffelbag/clown/syndie/PopulateContents()
-	new /obj/item/pda/clown(src)
+	new /obj/item/modular_computer/tablet/pda/preset/basic/syndicate/clown(src)
 	new /obj/item/clothing/under/rank/clown(src)
 	new /obj/item/clothing/shoes/clown_shoes(src)
 	new /obj/item/clothing/mask/gas/clown_hat(src)

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -772,7 +772,6 @@
 	new /obj/item/storage/backpack/chameleon/syndicate(src)
 	new /obj/item/radio/headset/chameleon/syndicate(src)
 	new /obj/item/stamp/chameleon/syndicate(src)
-	new /obj/item/pda/chameleon/syndicate(src)
 
 /obj/item/storage/box/syndie_kit/chameleon/plasmaman
 	real_name = "chameleon kit"
@@ -788,7 +787,6 @@
 	new /obj/item/storage/backpack/chameleon/syndicate(src)
 	new /obj/item/radio/headset/chameleon/syndicate(src)
 	new /obj/item/stamp/chameleon/syndicate(src)
-	new /obj/item/pda/chameleon/syndicate(src)
 
 //5*(2*4) = 5*8 = 45, 45 damage if you hit one person with all 5 stars.
 //Not counting the damage it will do while embedded (2*4 = 8, at 15% chance)
@@ -841,7 +839,7 @@
 	new /obj/item/radio/headset/headset_cent/empty(src)
 	new /obj/item/clothing/glasses/sunglasses(src)
 	new /obj/item/storage/backpack/satchel(src)
-	new /obj/item/pda/heads(src)
+	new /obj/item/modular_computer/tablet/pda/preset/basic/bureaucrat(src)
 	new /obj/item/clipboard(src)
 	new /obj/item/implanter/mindshield(src)
 
@@ -856,7 +854,6 @@
 	new /obj/item/storage/backpack/chameleon/broken(src)
 	new /obj/item/radio/headset/chameleon/broken(src)
 	new /obj/item/stamp/chameleon/broken(src)
-	new /obj/item/pda/chameleon/broken(src)
 	// No chameleon laser, they can't randomise for //REASONS//
 
 /obj/item/storage/box/syndie_kit/bee_grenades

--- a/code/modules/antagonists/traitor/equipment/contractor.dm
+++ b/code/modules/antagonists/traitor/equipment/contractor.dm
@@ -183,8 +183,8 @@
 
 	uniform = /obj/item/clothing/under/chameleon
 	suit = /obj/item/clothing/suit/chameleon
-	back = /obj/item/storage/backpack
-	belt = /obj/item/pda/chameleon
+	back = /obj/item/storage/backpack/chameleon
+	belt = /obj/item/modular_computer/tablet/pda/preset/basic/syndicate
 	mask = /obj/item/clothing/mask/cigarette/syndicate
 	shoes = /obj/item/clothing/shoes/chameleon/noslip
 	ears = /obj/item/radio/headset/chameleon

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -333,7 +333,7 @@
 /datum/outfit/centcom_clown
 	name = "Code Banana ERT"
 	id = /obj/item/card/id/centcom
-	belt = /obj/item/pda/clown
+	belt = /obj/item/modular_computer/tablet/pda/preset/basic/clown
 	ears = /obj/item/radio/headset/headset_cent
 	uniform = /obj/item/clothing/under/rank/clown
 	back = /obj/item/storage/backpack/clown

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -172,7 +172,7 @@
 	l_pocket = /obj/item/melee/transforming/energy/sword/saber
 	l_hand = /obj/item/storage/secure/briefcase
 	id = /obj/item/card/id/syndicate
-	belt = /obj/item/pda/heads
+	belt = /obj/item/modular_computer/tablet/pda/preset/basic/syndicate
 
 /datum/outfit/assassin/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	var/obj/item/clothing/under/U = H.w_uniform

--- a/code/modules/jobs/job_types/centcom.dm
+++ b/code/modules/jobs/job_types/centcom.dm
@@ -16,7 +16,7 @@
 	belt = /obj/item/gun/energy/e_gun
 	l_pocket = /obj/item/pen
 	back = /obj/item/storage/backpack/satchel
-	r_pocket = /obj/item/pda/heads
+	r_pocket = /obj/item/modular_computer/tablet/pda/preset/basic/bureaucrat
 	l_hand = /obj/item/clipboard
 	id = /obj/item/card/id/centcom
 	backpack_contents = list(/obj/item/restraints/handcuffs/cable/zipties=1, /obj/item/stamp/cent = 1,)

--- a/code/modules/modular_computers/computers/item/pda/pda_presets.dm
+++ b/code/modules/modular_computers/computers/item/pda/pda_presets.dm
@@ -137,6 +137,6 @@
 /obj/item/modular_computer/tablet/pda/preset/basic/bureaucrat/Initialize(mapload)
 	starting_files |= list(
 		new /datum/computer_file/program/crew_manifest,
-		new /datum/computer_file/program/alarm_monitor // Captain I noticed you may have a few fires around
+		new /datum/computer_file/program/paperwork_printer
 	)	
 	. = ..()

--- a/code/modules/modular_computers/computers/item/pda/pda_presets.dm
+++ b/code/modules/modular_computers/computers/item/pda/pda_presets.dm
@@ -111,12 +111,32 @@
 
 //for inside one of the nukie lockers
 /obj/item/modular_computer/tablet/pda/preset/basic/syndicate
-	desc = "A standard issue PDA often given to syndicate agents."
+	desc = "Based off Nanotrasen's PDAs, this one has been reverse-engineered and loaded with illegal software provided by the Syndicate."
 
 /obj/item/modular_computer/tablet/pda/preset/basic/syndicate/Initialize(mapload)
 	. = ..()
 	obj_flags |= EMAGGED //starts emagged
 	starting_files |= list(
 		new /datum/computer_file/program/bomberman
+	)
+
+// The worst thing mankind can fathom - used in clown ops and nukie clown costume
+/obj/item/modular_computer/tablet/pda/preset/basic/syndicate/clown
+	desc = "A hilariously terrifying PDA reverse-engineered by the Syndicate, given to their most unhinged operatives."
+	finish_color = "pink"
+	pen_type = /obj/item/toy/crayon/rainbow
+
+/obj/item/modular_computer/tablet/pda/preset/basic/syndicate/clown/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/slippery, 120, NO_SLIP_WHEN_WALKING)
+
+/obj/item/modular_computer/tablet/pda/preset/basic/bureaucrat
+	desc = "A standard issue PDA issued to certain Nanotrasen personnel to help with inspections."
+	finish_color = "green" // Rockin the company colors
+
+/obj/item/modular_computer/tablet/pda/preset/basic/bureaucrat/Initialize(mapload)
+	starting_files |= list(
+		new /datum/computer_file/program/crew_manifest,
+		new /datum/computer_file/program/alarm_monitor // Captain I noticed you may have a few fires around
 	)	
-	
+	. = ..()

--- a/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
+++ b/code/modules/modular_computers/file_system/programs/paperworkprinter.dm
@@ -8,7 +8,7 @@
 	requires_ntnet = FALSE
 	size = 4
 	tgui_id = "NtosPaperworkPrinter"
-	program_icon = "clipboard-list"
+	program_icon = "file"
 
 /datum/computer_file/program/paperwork_printer/ui_static_data(mob/user)
 	var/list/data = get_header_data()

--- a/yogstation/code/modules/antagonists/infiltrator/outfit.dm
+++ b/yogstation/code/modules/antagonists/infiltrator/outfit.dm
@@ -1,4 +1,4 @@
-/datum/outfit/infiltrator
+/datum/outfit/infiltrator // RIP
 	name = "Syndicate Infiltrator"
 
 	uniform = /obj/item/clothing/under/chameleon/syndicate
@@ -8,7 +8,7 @@
 	ears = /obj/item/radio/headset/chameleon/syndicate
 	id = /obj/item/card/id/syndicate
 	mask = /obj/item/clothing/mask/chameleon/syndicate
-	belt = /obj/item/pda/chameleon/syndicate
+	belt = /obj/item/modular_computer/tablet/pda/preset/basic/syndicate
 	box = /obj/item/storage/box/survival/engineer
 	backpack_contents = list(/obj/item/kitchen/knife/combat/survival=1,\
 		/obj/item/gun/ballistic/automatic/pistol=1)


### PR DESCRIPTION
# Document the changes in your pull request
Aight so I wanted to remove contractors spawning in with old PDAs (a bit of a giveaway to metagamers and so on) and ended up bringing a few more roles up to date PDA-wise! Can atomize if need be.
Basically:
- Contractors, chameleon kits, etc no longer have the (old) chameleon PDAs
- CentCom inspectors now spawn with modern PDAs (RIP bluespace paper printer) preloaded with a crew manifest and paperwork printer
- Clown ops and the uplink clown costume now have a variant of syndicate (emagged) PDAs that are also slippery HONK
- Changed the paper printer app icon from:
![image](https://github.com/yogstation13/Yogstation/assets/143908044/cbe0b2cf-121c-4e6f-ae43-3873f1eea8fd) --> ![image](https://github.com/yogstation13/Yogstation/assets/143908044/9a151baf-7e86-4ccf-925d-b51dba70751d)
because it was identical to the crew manifest, and didn't look good

and ye thas about it

# Why is this good for the game?
I was always incredibly bugged by centcom inspectors and contractor supports spawning with the outdated PDA. This will bring a lot of modern roles in line with modern PDAs, makes more sense considering those old PDAs are antiques IC too.

# Testing
Inspector PDA
![image](https://github.com/yogstation13/Yogstation/assets/143908044/222a2704-be1e-4dbe-9269-cf89bd48408e)
![image](https://github.com/yogstation13/Yogstation/assets/143908044/7fd8beeb-2733-404b-a9cd-0156333e5934)
![image](https://github.com/yogstation13/Yogstation/assets/143908044/c3153af5-9f7f-4913-bab0-ca9de22cacba)
Syndicate clown PDA
![image](https://github.com/yogstation13/Yogstation/assets/143908044/d239762c-be92-4b51-a905-09f4fd9f5e19)
Contractor support has modern syndie PDA
![image](https://github.com/yogstation13/Yogstation/assets/143908044/d7df7203-819d-4799-9a50-f3276452d4c6)
![image](https://github.com/yogstation13/Yogstation/assets/143908044/b0f852af-fe38-469b-869e-23a9990ebdf6)
Chameleon kit without old cham PDA
![image](https://github.com/yogstation13/Yogstation/assets/143908044/cd61412a-836c-4bd1-a811-a01d5dd2d5b9)

# Wiki Documentation
Might be some stuff I have to change, I'll look into it

# Changelog
:cl: 
rscadd: CentCom inspectors and clown ops now have their own PDA presets
tweak: CentCom inspectors, contractor supports, chameleon kits, etc. no longer spawn with old PDAs - now have modern ones
spellcheck: Changed nukie PDA flavor text
/:cl:
