### PR TITLE
Fix chapel tiles, broken grille sprites, and layering ordering that biome has been asking me for

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -132,7 +132,6 @@
 #define HIGH_TURF_LAYER 2.03
 #define LATTICE_LAYER 2.04
 #define DISPOSAL_PIPE_LAYER 2.042
-#define WIRE_LAYER 2.044
 #define GLASS_FLOOR_LAYER 2.046
 #define TRAM_RAIL_LAYER 2.047
 #define ABOVE_OPEN_TURF_LAYER 2.049
@@ -144,6 +143,7 @@
 #define BULLET_HOLE_LAYER 2.06
 #define ABOVE_NORMAL_TURF_LAYER 2.08
 #define GAS_PIPE_HIDDEN_LAYER 2.35 //layer = initial(layer) + piping_layer / 1000 in atmospherics/update_icon() to determine order of pipe overlap
+#define WIRE_LAYER 2.43 //Yog Biome request
 #define WIRE_BRIDGE_LAYER 2.44
 #define WIRE_TERMINAL_LAYER 2.45
 #define GAS_SCRUBBER_LAYER 2.46

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -305,7 +305,7 @@
 	return null
 
 /obj/structure/grille/broken // Pre-broken grilles for map placement
-	icon_state = "brokengrille"
+	icon_state = "grille_broken"
 	density = FALSE
 	broken = TRUE
 	rods_amount = 1

--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -48,22 +48,21 @@
 	C.play_tool_sound(src, 80)
 	return remove_tile(user, silent, (C.tool_behaviour == TOOL_SCREWDRIVER))
 
-/turf/open/floor/wood/remove_tile(mob/user, silent = FALSE, make_tile = TRUE)
+/turf/open/floor/wood/remove_tile(mob/user, silent = FALSE, make_tile = TRUE, force_plating)
 	if(broken || burnt)
-		broken = 0
-		burnt = 0
+		broken = FALSE
+		burnt = FALSE
 		if(user && !silent)
 			to_chat(user, span_notice("You remove the broken planks."))
 	else
 		if(make_tile)
 			if(user && !silent)
 				to_chat(user, span_notice("You unscrew the planks."))
-			if(floor_tile)
-				new floor_tile(src)
+			spawn_tile()
 		else
 			if(user && !silent)
 				to_chat(user, span_notice("You forcefully pry off the planks, destroying them in the process."))
-	return make_plating()
+	return make_plating(force_plating)
 
 /turf/open/floor/wood/parquet
 	icon_state = "wood-parquet"

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -27,7 +27,8 @@ By design, d1 is the smallest direction and d2 is the highest
 	desc = "A flexible, superconducting insulated cable for heavy-duty power transfer."
 	icon = 'icons/obj/power_cond/cables.dmi'
 	icon_state = "0-1"
-	plane = FLOOR_PLANE
+	///Yogs, Biome wanted cables above pipes
+	//plane = FLOOR_PLANE
 	layer = WIRE_LAYER //Above hidden pipes, GAS_PIPE_HIDDEN_LAYER
 	anchored = TRUE
 	obj_flags = CAN_BE_HIT | ON_BLUEPRINTS

--- a/code/modules/recycling/disposal/construction.dm
+++ b/code/modules/recycling/disposal/construction.dm
@@ -57,6 +57,14 @@
 		else
 			icon_state = "condisposal"
 
+// Extra layer handling
+/obj/structure/disposalconstruct/update_icon()
+	. = ..()
+	if(!is_pipe())
+		return
+
+	layer = anchored ? initial(pipe_type.layer) : initial(layer)
+
 /obj/structure/disposalconstruct/proc/get_disposal_dir()
 	if(!is_pipe())
 		return NONE

--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -10,7 +10,8 @@
 	dir = NONE			// dir will contain dominant direction for junction pipes
 	max_integrity = 200
 	armor = list(MELEE = 25, BULLET = 10, LASER = 10, ENERGY = 100, BOMB = 0, BIO = 100, RAD = 100, FIRE = 90, ACID = 30)
-	layer = DISPOSAL_PIPE_LAYER			// slightly lower than wires and other pipes
+	plane = FLOOR_PLANE
+	layer = DISPOSAL_PIPE_LAYER // slightly lower than wires and other pipes
 	flags_1 = RAD_PROTECT_CONTENTS_1 | RAD_NO_CONTAMINATE_1
 	var/dpdir = NONE					// bitmask of pipe directions
 	var/initialize_dirs = NONE			// bitflags of pipe directions added on init, see \code\_DEFINES\pipe_construction.dm

--- a/yogstation/code/datums/ruins/station.dm
+++ b/yogstation/code/datums/ruins/station.dm
@@ -4,7 +4,6 @@
 
 /datum/map_template/ruin/station/box
 	prefix = "_maps/RandomRuins/StationRuins/BoxStation/"
-	should_place_on_top = FALSE
 
 /datum/map_template/ruin/station/box/engine
 	id = "engine_sm"


### PR DESCRIPTION
# Document the changes in your pull request

Templates loaded on certain maps wouldn't have plating under them and instead have raw space. Broken grilles weren't showing up on the map editor, and cables are now on top of pipes, which are on top of disposal pipes

# Changelog

:cl:  
bugfix: Box Chapel tiles had no plating under them so crow barring them would send you straight to god
bugfix: Broken grille sprites back. They just wanted to grille for Pete's sake
tweak: Organized the spaghetti layering of atmos pipes, disposal pipes, and cables. 
/:cl:
