### PR TITLE
Updates mining medic jumpsuit to use proper armour defines

### DIFF
--- a/yogstation/code/modules/clothing/under/jobs/civilian.dm
+++ b/yogstation/code/modules/clothing/under/jobs/civilian.dm
@@ -30,5 +30,5 @@
 	can_adjust = 0
 	sensor_mode = 3
 	random_sensor = 0
-	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 15, rad = 0)
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 15, RAD = 0, FIRE = 0, ACID = 0, WOUND = 5)
 	mutantrace_variation = MUTANTRACE_VARIATION

--- a/yogstation/code/modules/clothing/under/jobs/civilian.dm
+++ b/yogstation/code/modules/clothing/under/jobs/civilian.dm
@@ -30,5 +30,5 @@
 	can_adjust = FALSE
 	sensor_mode = 3
 	random_sensor = FALSE
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 15, RAD = 0, FIRE = 0, ACID = 0, WOUND = 5)
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 15, RAD = 0, FIRE = 80, ACID = 0, WOUND = 5)
 	mutantrace_variation = MUTANTRACE_VARIATION

--- a/yogstation/code/modules/clothing/under/jobs/civilian.dm
+++ b/yogstation/code/modules/clothing/under/jobs/civilian.dm
@@ -27,8 +27,8 @@
 	name = "recovery medic's jumpsuit"
 	icon_state = "recovery"
 	item_state = "recovery"
-	can_adjust = 0
+	can_adjust = FALSE
 	sensor_mode = 3
-	random_sensor = 0
+	random_sensor = FALSE
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 15, RAD = 0, FIRE = 0, ACID = 0, WOUND = 5)
 	mutantrace_variation = MUTANTRACE_VARIATION

--- a/yogstation/code/modules/clothing/under/jobs/civilian.dm
+++ b/yogstation/code/modules/clothing/under/jobs/civilian.dm
@@ -30,5 +30,5 @@
 	can_adjust = FALSE
 	sensor_mode = 3
 	random_sensor = FALSE
-	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 15, RAD = 0, FIRE = 80, ACID = 0, WOUND = 5)
+	armor = list(MELEE = 0, BULLET = 0, LASER = 0,ENERGY = 0, BOMB = 0, BIO = 15, RAD = 0, FIRE = 80, ACID = 0, WOUND = 10)
 	mutantrace_variation = MUTANTRACE_VARIATION

--- a/yogstation/code/modules/jobs/job_types/brig_physician.dm
+++ b/yogstation/code/modules/jobs/job_types/brig_physician.dm
@@ -54,7 +54,7 @@
 	glasses = /obj/item/clothing/glasses/hud/health/sunglasses
 	shoes = /obj/item/clothing/shoes/jackboots
 	digitigrade_shoes = /obj/item/clothing/shoes/xeno_wraps/jackboots
-	uniform = /obj/item/clothing/under/yogs/rank/miner/medic
+	uniform = /obj/item/clothing/under/yogs/rank/physician/white
 	uniform_skirt = /obj/item/clothing/under/yogs/rank/physician/white/skirt
 	suit = /obj/item/clothing/suit/toggle/labcoat/emt/physician
 	l_hand = /obj/item/storage/firstaid/regular


### PR DESCRIPTION
Just a minor maintain thing

(it also doesn't have the 80 fire armour that miner jumpsuit has for some reason, but i didn't add that because it would make it strictly better than other suits for brig phys)

:cl:  
bugfix: fixes mining medic jumpsuit from having 5 less wound armour than every other basic jumpsuit
bugfix: brig phys now spawns with the brig phys jumpsuit rather than the mining medic one
tweak: gives mining medic jumpsuit the same armour as miner's jumpsuit
/:cl:
