### PR TITLE
Tweak mining medic jackets to have comparable armour to an unupgraded explorer suit

### DIFF
--- a/yogstation/code/modules/clothing/suits/labcoat.dm
+++ b/yogstation/code/modules/clothing/suits/labcoat.dm
@@ -2,13 +2,13 @@
 /obj/item/clothing/suit/toggle/labcoat/emt/explorer
 	name = "mining medic's jacket"
 	desc = "A protective jacket for medical emergencies on off-world planets. Has MM embossed into it."
-	armor = list(melee = 10, bullet = 10, laser = 0,energy = 0, bomb = 0, bio = 50, rad = 0, fire = 50, acid = 50)
+	armor = list(MELEE = 25, BULLET = 5, LASER = 5, ENERGY = 5, BOMB = 50, BIO = 100, RAD = 50, FIRE = 50, ACID = 50, WOUND = 10)
 	allowed = list(/obj/item/analyzer,/obj/item/multitool/tricorder,/obj/item/stack/medical,/obj/item/dnainjector,/obj/item/reagent_containers/dropper,/obj/item/reagent_containers/syringe,/obj/item/reagent_containers/autoinjector,/obj/item/healthanalyzer,/obj/item/flashlight/pen,/obj/item/reagent_containers/glass/bottle,/obj/item/reagent_containers/glass/beaker,/obj/item/reagent_containers/pill,/obj/item/storage/pill_bottle,/obj/item/paper,/obj/item/melee/classic_baton/telescopic,/obj/item/soap,/obj/item/sensor_device,/obj/item/tank/internals, /obj/item/hypospray)
 
 /obj/item/clothing/suit/toggle/labcoat/explorer
 	name = "mining medic's labcoat"
 	desc = "A protective labcoat for medical emergencies on off-world planets."
-	armor = list(melee = 10, bullet = 10, laser = 0,energy = 0, bomb = 0, bio = 50, rad = 0, fire = 50, acid = 50)
+	armor = list(MELEE = 25, BULLET = 5, LASER = 5, ENERGY = 5, BOMB = 50, BIO = 100, RAD = 50, FIRE = 50, ACID = 50, WOUND = 10)
 	allowed = list(/obj/item/analyzer,/obj/item/multitool/tricorder,/obj/item/stack/medical,/obj/item/dnainjector,/obj/item/reagent_containers/dropper,/obj/item/reagent_containers/syringe,/obj/item/reagent_containers/autoinjector,/obj/item/healthanalyzer,/obj/item/flashlight/pen,/obj/item/reagent_containers/glass/bottle,/obj/item/reagent_containers/glass/beaker,/obj/item/reagent_containers/pill,/obj/item/storage/pill_bottle,/obj/item/paper,/obj/item/melee/classic_baton/telescopic,/obj/item/soap,/obj/item/sensor_device,/obj/item/tank/internals, /obj/item/hypospray)
 	mob_overlay_icon = 'yogstation/icons/mob/clothing/suit/suit.dmi'
 	icon_state = "labcoat_mining"


### PR DESCRIPTION
literally exactly the same stats, but without the ability to upgrade

# Why is this good for the game?
They're expected to save miners that fucked up and died, they deserve at least some amount of armour
and shouldn't be expected to steal an explorer suit

:cl:  
tweak: Tweak mining medic jackets to have comparable armour to an unupgraded explorer suit
/:cl:
