### PR TITLE
Reduces the chance for rare and joke title screens

### DIFF
--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -23,8 +23,8 @@ SUBSYSTEM_DEF(title)
 	var/list/joke_provisional_title_screens = flist("[global.config.directory]/title_screens/images/joke/")
 	var/list/rare_provisional_title_screens = flist("[global.config.directory]/title_screens/images/rare/")
 	var/list/title_screens = list()
-	var/use_rare_screens = prob(5)		// 1% Chance for Rare Screens in /rare
-	var/use_joke_screens = prob(20) 	// 20% Chance for Joke Screens in /joke
+	var/use_rare_screens = prob(1)		// 1% Chance for Rare Screens in /rare
+	var/use_joke_screens = prob(10) 	// 10% Chance for Joke Screens in /joke
 
 	if(SSevents.holidays && SSevents.holidays[APRIL_FOOLS])
 		use_joke_screens = TRUE


### PR DESCRIPTION
Reduces rare back to 1% from 5%
Reduces joke to 10% from 20%

# Why is this good for the game?
They're special because of how rare they are, when there's roughly a 1/4 chance for a special title screen, they don't feel nearly as special

:cl:  
tweak: Reduces the chance for rare and joke title screens
/:cl:
