### PR TITLE
Reworks the cursed ice hiking boots

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
@@ -281,7 +281,7 @@ Difficulty: Extremely Hard
 /obj/item/clothing/shoes/winterboots/ice_boots/speedy
 	name = "cursed ice hiking boots"
 	desc = "A pair of winter boots contractually made by a devil, they cannot be taken off once put on."
-	slowdown = SHOES_SLOWDOWN - 1
+	slowdown = SHOES_SLOWDOWN - 0.3
 
 /obj/item/clothing/shoes/winterboots/ice_boots/speedy/Initialize(mapload)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
@@ -295,7 +295,7 @@ Difficulty: Extremely Hard
 	if((slot & ITEM_SLOT_FEET) && ishuman(user))
 		owner = user
 
-/obj/item/clothing/shoes/winterboots/ice_boots/process(delta_time)
+/obj/item/clothing/shoes/winterboots/ice_boots/speedy/process(delta_time)
 	if(prob(10) && owner && (owner.get_item_by_slot(ITEM_SLOT_FEET) == src))
 		if(!W)
 			W = new(src)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/demonic_frost_miner.dm
@@ -281,11 +281,27 @@ Difficulty: Extremely Hard
 /obj/item/clothing/shoes/winterboots/ice_boots/speedy
 	name = "cursed ice hiking boots"
 	desc = "A pair of winter boots contractually made by a devil, they cannot be taken off once put on."
-	slowdown = SHOES_SLOWDOWN - 0.3
+	slowdown = SHOES_SLOWDOWN - 0.5
+	var/obj/vehicle/ridden/scooter/wheelys/W
+	var/mob/living/carbon/human/owner
 
 /obj/item/clothing/shoes/winterboots/ice_boots/speedy/Initialize(mapload)
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT(type))
+	START_PROCESSING(SSobj, src)
+
+/obj/item/clothing/shoes/winterboots/ice_boots/speedy/equipped(mob/user, slot)
+	. = ..()
+	if((slot & ITEM_SLOT_FEET) && ishuman(user))
+		owner = user
+
+/obj/item/clothing/shoes/winterboots/ice_boots/process(delta_time)
+	if(prob(10) && owner && (owner.get_item_by_slot(ITEM_SLOT_FEET) == src))
+		if(!W)
+			W = new(src)
+		if(!W.has_buckled_mobs())
+			W.forceMove(get_turf(owner))
+			W.buckle_mob(owner)
 
 /obj/item/pickaxe/drill/jackhammer/demonic
 	name = "demonic jackhammer"


### PR DESCRIPTION
Now it has a random chance every tick to force the user to use wheelies
it still makes the user pretty damn fast otherwise, but less so

# Why is this good for the game?
free insane speed is really strong, and them being unremovable isn't a curse, it's a boon when the shoes are so good
they still make you go fast, now they're just suitably cursed

# Testing
gotta

:cl:  
tweak: Reworks the cursed ice hiking boots
/:cl:
