### PR TITLE
Fix maroon organ objective mulligan

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1709,8 +1709,11 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 
 /datum/objective/maroon_organ/find_target(dupe_search_range, blacklist)
 	. = ..()
+	finalize()
+
+/datum/objective/maroon_organ/finalize()
 	if(!target)
-		return
+		return FALSE
 
 	// This will always be a carbon with organs, because of is_valid_target()
 	var/mob/living/carbon/carbon_target = target.current
@@ -1719,7 +1722,9 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 		if(istype(thing, /obj/item/organ/brain)) //make sure it doesn't pick the brain
 			eligible_organs -= thing
 	original_organ = pick(eligible_organs)
-	update_explanation_text()
+	if(original_organ)
+		update_explanation_text()
+		return TRUE
 
 /datum/objective/maroon_organ/update_explanation_text()
 	if(target && original_organ)
@@ -1730,6 +1735,8 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	. = ..()
 
 /datum/objective/maroon_organ/admin_edit(mob/admin)
+	admin_simple_target_pick(admin)
+	finalize()
 	update_explanation_text()
 	return
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1730,7 +1730,6 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	. = ..()
 
 /datum/objective/maroon_organ/admin_edit(mob/admin)
-	finalize()
 	update_explanation_text()
 	return
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1707,10 +1707,10 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 		var/mob/living/carbon/possible_carbon_target = possible_target.current
 		return LAZYLEN(possible_carbon_target.internal_organs)
 
-/datum/objective/maroon_organ/finalize()
-	find_target()
+/datum/objective/maroon_organ/find_target(dupe_search_range, blacklist)
+	. = ..()
 	if(!target)
-		return FALSE
+		return
 
 	// This will always be a carbon with organs, because of is_valid_target()
 	var/mob/living/carbon/carbon_target = target.current
@@ -1719,9 +1719,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 		if(istype(thing, /obj/item/organ/brain)) //make sure it doesn't pick the brain
 			eligible_organs -= thing
 	original_organ = pick(eligible_organs)
-	if(original_organ)
-		update_explanation_text()
-		return TRUE
+	update_explanation_text()
 
 /datum/objective/maroon_organ/update_explanation_text()
 	if(target && original_organ)

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -198,13 +198,8 @@
 			destroy_objective.owner = owner
 			destroy_objective.find_target()
 			add_objective(destroy_objective)
-		else if(prob(20))
-			var/datum/objective/maroon_organ/organ_objective = new
-			organ_objective.owner = owner
-			organ_objective.finalize()
-			add_objective(organ_objective)
 		else
-			var/N = pick(/datum/objective/assassinate/cloned, /datum/objective/assassinate/once, /datum/objective/assassinate, /datum/objective/maroon)
+			var/N = pick(/datum/objective/assassinate/cloned, /datum/objective/assassinate/once, /datum/objective/assassinate, /datum/objective/maroon, /datum/objective/maroon_organ)
 			var/datum/objective/kill_objective = new N
 			kill_objective.owner = owner
 			kill_objective.find_target()


### PR DESCRIPTION
It calls find_target when mulliganned
maroon organ used a snowflake proc

<sup><sup><sup><sup><sup>i blame ynot, i just copy pasted the code from his pr </sup></sup></sup></sup></sup>

# Testing
gotta

:cl:  
bugfix: Fixes a bug where maroon organ objective wouldn't mulligan properly
/:cl:
