### PR TITLE
Update simple mob appearance on death

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -339,13 +339,15 @@
 		//a manner as to cause a call to death() again
 		del_on_death = FALSE
 		qdel(src)
-	else
-		health = 0
-		icon_state = icon_dead
-		if(flip_on_death)
-			transform = transform.Turn(180)
-		density = FALSE
-		..()
+		return
+	
+	health = 0
+	icon_state = icon_dead
+	if(flip_on_death)
+		transform = transform.Turn(180)
+	density = FALSE
+	update_appearance()
+	return	..()
 
 /mob/living/simple_animal/proc/CanAttack(atom/the_target)
 	if(see_invisible < the_target.invisibility)


### PR DESCRIPTION
literally just to fix this because @TehLadyK keeps bugging me about it
![image](https://github.com/yogstation13/Yogstation/assets/46236974/7733e05f-c945-407e-9a6b-3efd535eea6a)

there
![dreamseeker_wZo1vRFUAD](https://github.com/yogstation13/Yogstation/assets/46236974/d7779c7b-4c55-4efc-b343-2f2797ebd341)
hope you're happy about the dolphins hurt in the creation of this pr

# Changelog

:cl:  
bugfix: simple mobs call update_appearance on death which will update overlays applied to them
/:cl:
