### PR TITLE
stops non-existent mail from halting shuttle

### DIFF
--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -148,13 +148,13 @@
 	recipient_ref = WEAKREF(recipient)
 
 	var/mob/living/body = recipient.current
-	var/list/goodies = generic_goodies
+	var/list/goodies = generic_goodies.Copy()
 
 	var/datum/job/this_job = SSjob.GetJob(recipient.assigned_role)
 	if(this_job)
 		if(this_job.paycheck_department && department_colors[this_job.paycheck_department])
 			color = department_colors[this_job.paycheck_department]
-		var/list/job_goodies = this_job.get_mail_goodies()
+		var/list/job_goodies = this_job.get_mail_goodies().Copy()
 		if(LAZYLEN(job_goodies))
 			// certain roles and jobs (prisoner) do not receive generic gifts.
 			if(this_job.exclusive_mail_goodies)
@@ -168,7 +168,7 @@
 			if(goodies[item] <= 0)	 //remove everything with a weight below 0
 				goodies -= item
 
-	if(!goodies) //if everything was removed for some reason
+	if(!length(goodies)) //if everything was removed for some reason
 		return FALSE 
 
 	for(var/iterator in 1 to goodie_count)
@@ -377,4 +377,3 @@
 				debug_info += " - [initial(goodie.name)]: [goodie_weight] ([(goodie_weight / job_goodies_weight) * 100]%)\n"
 	
 	to_chat(src, examine_block(debug_info))
-

--- a/code/game/objects/items/mail.dm
+++ b/code/game/objects/items/mail.dm
@@ -154,7 +154,8 @@
 	if(this_job)
 		if(this_job.paycheck_department && department_colors[this_job.paycheck_department])
 			color = department_colors[this_job.paycheck_department]
-		var/list/job_goodies = this_job.get_mail_goodies().Copy()
+		var/list/job_goodies = this_job.get_mail_goodies()
+		job_goodies = job_goodies.Copy()
 		if(LAZYLEN(job_goodies))
 			// certain roles and jobs (prisoner) do not receive generic gifts.
 			if(this_job.exclusive_mail_goodies)


### PR DESCRIPTION
# Document the changes in your pull request

https://github.com/yogstation13/Yogstation/pull/16855

This PR modifies the GLOBAL mail goodies list if you have the loser trait EVERY time you get mail generated

if this happens enough times you will completely delete the global mail goodies list

the check for checking the empty goodies list was incorrect and would try to spawn mail without a type path

this breaks the cargo shuttle and it will never arrive

this fixes all of it

# Changelog

:cl:  
bugfix: bad mail wont stop shuttle anymore
/:cl:
