### PR TITLE
Jaunters once again activate in non-belt slots

### DIFF
--- a/code/datums/components/chasm.dm
+++ b/code/datums/components/chasm.dm
@@ -118,8 +118,7 @@
 				return CHASM_REGISTER_SIGNALS
 		if(ishuman(dropped_thing))
 			var/mob/living/carbon/human/victim = dropped_thing
-			if(istype(victim.belt, /obj/item/wormhole_jaunter))
-				var/obj/item/wormhole_jaunter/jaunter = victim.belt
+			for(var/obj/item/wormhole_jaunter/jaunter in victim.get_all_contents())
 				var/turf/chasm = get_turf(victim)
 				var/fall_into_chasm = jaunter.chasm_react(victim)
 				if(!fall_into_chasm)


### PR DESCRIPTION
# Document the changes in your pull request

https://github.com/yogstation13/Yogstation/pull/21221 reverted it back to belt to match TG

# Changelog

:cl:  
bugfix: jaunters activate automatically in non-belt slots again
/:cl:
