### PR TITLE
Multi-Z radio messages

### DIFF
--- a/code/game/machinery/telecomms/broadcasting.dm
+++ b/code/game/machinery/telecomms/broadcasting.dm
@@ -125,8 +125,7 @@
 		levels = lvls
 	else
 	//Yogs end, technically, I guess
-		var/turf/T = get_turf_global(source) // yogs - get_turf_global instead of get_turf
-		levels = list(T.z)
+		levels = SSmapping.get_connected_levels(get_turf_global(source)) // yogs - get_turf_global instead of get_turf
 
 /datum/signal/subspace/vocal/copy()
 	var/datum/signal/subspace/vocal/copy = new(source, frequency, virt, language)

--- a/code/game/machinery/telecomms/machines/broadcaster.dm
+++ b/code/game/machinery/telecomms/machines/broadcaster.dm
@@ -35,7 +35,7 @@ GLOBAL_VAR_INIT(message_delay, 0) // To make sure restarting the recentmessages 
 
 	var/turf/T = get_turf(src)
 	if (T)
-		signal.levels |= T.z
+		signal.levels |= SSmapping.get_connected_levels(T)
 
 	var/signal_message = "[signal.frequency]:[signal.data["message"]]:[signal.data["name"]]"
 	if(signal_message in GLOB.recentmessages)

--- a/code/game/machinery/telecomms/machines/message_server.dm
+++ b/code/game/machinery/telecomms/machines/message_server.dm
@@ -175,7 +175,7 @@
 	data = init_data
 	var/turf/T = get_turf(source)
 	if(T)
-		levels = list(T.z)
+		levels = SSmapping.get_connected_levels(T)
 	else
 		levels = list(2) 
 	if(!("reject" in data))

--- a/code/game/machinery/telecomms/machines/relay.dm
+++ b/code/game/machinery/telecomms/machines/relay.dm
@@ -21,9 +21,9 @@
 
 /obj/machinery/telecomms/relay/receive_information(datum/signal/subspace/signal, obj/machinery/telecomms/machine_from)
 	// Add our level and send it back
-	var/turf/T = get_turf(src)
-	if(can_send(signal) && T)
-		signal.levels |= T.z
+	var/turf/relay_turf = get_turf(src)
+	if(can_send(signal) && relay_turf)
+		signal.levels |= SSmapping.get_connected_levels(relay_turf)
 
 // Checks to see if it can send/receive.
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -302,7 +302,7 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	// Okay, the signal was never processed, send a mundane broadcast.
 	signal.data["compression"] = 0
 	signal.transmission_method = TRANSMISSION_RADIO
-	signal.levels = list(T.z)
+	signal.levels = SSmapping.get_connected_levels(T)
 	signal.broadcast()
 
 /obj/item/radio/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, list/message_mods = list())


### PR DESCRIPTION
# Document the changes in your pull request

Radio messages can now be properly received from connected z-levels without a relay.

Basically finishes porting tgstation/tgstation#76360 which was half-ported in a separate PR.

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/93578146/9b3d8c74-b445-4dd4-a0a8-dfd5d97565d3)

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: Radio messages work across connected z-levels
/:cl:
