### PR TITLE
Fixes a bunch of runtimes and fixes job occupations failing to load and punting you into a random job

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -213,6 +213,11 @@ SUBSYSTEM_DEF(ticker)
 	to_chat(world, span_boldannounce("Starting game..."))
 	var/init_start = world.timeofday
 		//Create and announce mode
+		
+	//quickly load all the unloaded characters so it looks like we've had them loaded the entire time
+	for(var/mob/dead/new_player/player in GLOB.player_list)
+		player.force_load_character()
+
 	var/list/datum/game_mode/runnable_modes
 	if(GLOB.master_mode == "random" || GLOB.master_mode == "secret")
 		runnable_modes = config.get_runnable_modes()

--- a/code/datums/wounds/scars/_scars.dm
+++ b/code/datums/wounds/scars/_scars.dm
@@ -147,7 +147,7 @@
 		if((human_victim.wear_mask && (human_victim.wear_mask.flags_inv & HIDEFACE)) || (human_victim.head && (human_victim.head.flags_inv & HIDEFACE)))
 			return FALSE
 	else if(limb.scars_covered_by_clothes)
-		var/num_covers = LAZYLEN(human_victim.clothingonpart(limb))
+		var/num_covers = LAZYLEN(human_victim.clothingonpart(limb.body_part))
 		if(num_covers + get_dist(viewer, victim) >= visibility)
 			return FALSE
 

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -439,8 +439,8 @@
 	..()
 
 /obj/item/card/mining_point_card/examine(mob/user)
-	..()
-	to_chat(user, "There's [points] point\s on the card.")
+	. = ..()
+	. += "There's [points] point\s on the card."
 
 ///Conscript kit
 /obj/item/card/mining_access_card

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -122,12 +122,7 @@
 			to_chat(usr, span_notice("The game is still loading. Please wait a bit before editing your character."))
 			return
 		var/datum/preferences/preferences = client.prefs
-		if(!preferences.loaded_character)
-			var/success = preferences.load_character()
-			if(!success)
-				preferences.randomise_appearance_prefs() //let's create a random character then - rather than a fat, bald and naked man.
-				preferences.save_character() //let's save this new random character so it doesn't keep generating new ones.
-				preferences.loaded_character = TRUE
+		force_load_character()
 		preferences.current_window = PREFERENCE_TAB_CHARACTER_PREFERENCES
 		preferences.update_static_data(usr)
 		preferences.ui_interact(usr)
@@ -435,13 +430,6 @@
 
 /mob/dead/new_player/proc/create_character(transfer_after)
 	spawning = TRUE
-	var/datum/preferences/preferences = client.prefs
-	if(!preferences.loaded_character)
-		var/success = preferences.load_character()
-		if(!success)
-			preferences.randomise_appearance_prefs() //let's create a random character then - rather than a fat, bald and naked man.
-			preferences.save_character() //let's save this new random character so it doesn't keep generating new ones.
-			preferences.loaded_character = TRUE
 	close_spawn_windows()
 	//mind.active = FALSE //we wish to transfer the key manually
 
@@ -546,6 +534,19 @@
 			message_admins("[src.ckey] just got booted back to lobby with no jobs enabled, but antag rolling enabled. Likely antag rolling abuse.")
 
 		return FALSE //This is the only case someone should actually be completely blocked from antag rolling as well
+	return TRUE
+
+/mob/dead/new_player/proc/force_load_character()
+	if(!client)
+		return
+	var/datum/preferences/preferences = client.prefs
+	if(preferences.loaded_character) //no need
+		return
+	var/success = preferences.load_character()
+	if(!success)
+		preferences.randomise_appearance_prefs() //let's create a random character then - rather than a fat, bald and naked man.
+		preferences.save_character() //let's save this new random character so it doesn't keep generating new ones.
+		preferences.loaded_character = TRUE
 	return TRUE
 
 #undef RESET_HUD_INTERVAL

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -151,7 +151,7 @@
 	. = ..()
 	if(HAS_TRAIT(stomach_owner, TRAIT_POWERHUNGRY))
 		stomach_owner.nutrition = stored_charge
-	RegisterSignal(stomach_owner, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, PROC_REF(charge))
+	RegisterSignal(stomach_owner, COMSIG_PROCESS_BORGCHARGER_OCCUPANT, PROC_REF(charge), override = TRUE)
 
 /obj/item/organ/stomach/cell/Remove(mob/living/carbon/stomach_owner, special)
 	. = ..()


### PR DESCRIPTION
 Document the changes in your pull request

We should load your job preferences before the game picks your job i think

also fixes a bunch of annoying runtimes i found while finding this

# Why is this good for the game?
bug fixes are good for player retention


# Changelog

:cl:  
bugfix: job occupations won't delete themselves and you won't be put into random jobs if you haven't loaded your character
bugfix: mining points card says the correct description
bugfix: scars check for the correct body part flag instead of the body part itself
/:cl:
