### PR TITLE
Gives traitors a chance to not get an escape objective

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -162,10 +162,12 @@
 			if(minorObjective)
 				add_objective(minorObjective)
 		if(!(locate(/datum/objective/escape) in objectives))
-			var/datum/objective/escape/escape_objective = new
-			escape_objective.owner = owner
-			add_objective(escape_objective)
-			return
+			if(prob(70)) //doesn't always need to escape
+				var/datum/objective/escape/escape_objective = new
+				escape_objective.owner = owner
+				add_objective(escape_objective)
+			else
+				forge_single_human_objective()
 
 /datum/antagonist/traitor/proc/forge_ai_objectives()
 	var/objective_count = 0


### PR DESCRIPTION
Adds a 30% chance that instead of being given the basic escape objective, the traitor is given an additonal regular objective

# Why is this good for the game?
The stress of needing to escape outside of custody can cause traitors to be exceedingly quiet
Hijack and Glorious death are the opposite and force traitors to do things that are basically the loudest possible
This adds a chance for a traitor to just not have to care where they end up so long as their objectives are done
This lets them die, or be caught, or even still be on the station, it doesn't matter (steal still completes if the traitor dies and has the item on their corpse i'm pretty sure)

This gives them a sense of freedom to not need to worry about the future that glorious death brings, without forcing them to do crazy things, or letting them ignore the server rules, enabling them to kill everyone on the station with a tesloose or plasma flood

# Testing
gotta

:cl:  
tweak: Gives a 30% chance for traitors to get another objective instead of being told to escape
/:cl:
