### PR TITLE
fix decal being transparent when applied with decal painter

### DIFF
--- a/code/game/objects/items/airlock_painter.dm
+++ b/code/game/objects/items/airlock_painter.dm
@@ -439,7 +439,7 @@
  * * target - The turf being painted to
 */
 /obj/item/airlock_painter/decal/proc/paint_floor(turf/open/floor/target)
-	target.AddElement(/datum/element/decal, 'icons/turf/decals.dmi', stored_decal_total, stored_dir, null, null, alpha, color, null, FALSE, null)
+	target.AddElement(/datum/element/decal, 'icons/turf/decals.dmi', stored_decal_total, stored_dir, null, null, default_alpha, color, null, FALSE, null)
 
 /**
  * Return the final icon_state for the given decal options


### PR DESCRIPTION
# Document the changes in your pull request
fix decal being transparent when applied with decal painter



# Testing
this was using the base alpha 211 instead of 255, i changed it back. This was caused by iconsmooth pr
![image](https://github.com/yogstation13/Yogstation/assets/89688125/6cb01d17-33cb-47e5-9550-456fe04fd893)






# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

bugfix: fix decal being transparent when applied with decal painter
/:cl:
