### PR TITLE
Fixes regen cerulean extract getting null effect description

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -173,7 +173,7 @@ Regenerative extracts:
 	src.forceMove(user.loc)
 	var/obj/item/slimecross/X = new /obj/item/slimecross/regenerative(user.loc)
 	X.name = name
-	X.desc = desc
+	X.effect_desc = effect_desc
 	user.put_in_active_hand(X)
 	to_chat(user, span_notice("Some of the milky goo congeals in your hand!"))
 


### PR DESCRIPTION
# Document the changes in your pull request
Closes #21399 

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/143908044/8b592079-ed01-45fc-9b5f-49d1e47ad6c0)
![image](https://github.com/yogstation13/Yogstation/assets/143908044/d531b215-438a-400c-9123-e6b364a62b4a)

# Changelog
:cl:  
bugfix: Fixed regenerative cerulean's second extract getting a null description
/:cl: