### PR TITLE
Fixes cargo shuttle blast doors/buttons

### DIFF
--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -168,7 +168,7 @@
 
 /obj/machinery/button/connect_to_shuttle(mapload, obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
 	if(id)
-		id = "[port.shuttle_id]_[id]"
+		id = "[id]"
 		setup_device()
 
 /obj/machinery/button/attack_hand(mob/user)

--- a/code/game/machinery/doors/poddoor.dm
+++ b/code/game/machinery/doors/poddoor.dm
@@ -189,4 +189,4 @@
 		. += "<span class='[span_notice("The maintenance panel is [panel_open ? "opened" : "closed"].")]"
 		
 /obj/machinery/door/poddoor/connect_to_shuttle(mapload, obj/docking_port/mobile/port, obj/docking_port/stationary/dock)
-	id = "[port.shuttle_id]_[id]"
+	id = "[id]"


### PR DESCRIPTION
# Document the changes in your pull request
Closes #21444
Big thanks to redmoogle for helping me find exactly what the issue was

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/143908044/9d24718a-538c-467a-92f6-17190f5a03f8)
Might need to do more testing in a bit to check the code I've left behind is dead weight or not

# Changelog
:cl:
bugfix: Fixed cargo shuttle blast doors not opening properly
/:cl:
