### PR TITLE
AI eye icon visibility fix, and if you jump to an ai you just go to its eye because that's where they actually are

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -465,6 +465,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if (!istype(target) || (is_secret_level(target.z) && !client?.holder))
 		return
 
+	//shitcode override so that if you try to follow the AI, you'll get redirected to the AI eye where they're actually looking
+	if(isAI(target))
+		var/mob/living/silicon/ai/ai_target = target
+		if(ai_target.eyeobj)
+			target = ai_target.eyeobj
+	
 	var/icon/I = icon(target.icon,target.icon_state,target.dir)
 
 	var/orbitsize = (I.Width()+I.Height())*0.5
@@ -576,9 +582,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		ghost_others = client.prefs.read_preference(/datum/preference/choiced/ghost_others) //A quick update just in case this setting was changed right before calling the proc
 
 	if (!ghostvision)
-		see_invisible = SEE_INVISIBLE_LIVING
+		set_invis_see(SEE_INVISIBLE_LIVING)
 	else
-		see_invisible = SEE_INVISIBLE_OBSERVER
+		set_invis_see(SEE_INVISIBLE_OBSERVER)
 
 
 	updateghostimages()

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -21,6 +21,7 @@
 	. = ..()
 	GLOB.aiEyes += src
 	icon_state = "ai_camera[GLOB.ai_list.len % 3]" // Yogs -- multicoloured AI eyes
+	update_appearance()
 	update_ai_detect_hud()
 	setLoc(loc, TRUE)
 
@@ -153,25 +154,23 @@
 
 // This will move the AIEye. It will also cause lights near the eye to light up, if toggled.
 // This is handled in the proc below this one.
+/client/proc/AIMove(direction, mob/living/silicon/ai/user)
 
-/client/proc/AIMove(n, direct, mob/living/silicon/ai/user)
-
-	var/initial = initial(user.sprint)
-	var/max_sprint = 50
+	var/initial_sprint = initial(user.sprint)
 
 	if(user.cooldown && user.cooldown < world.timeofday) // 3 seconds
-		user.sprint = initial
+		user.sprint = initial_sprint
 
-	for(var/i = 0; i < max(user.sprint, initial); i += 20)
-		var/turf/step = get_turf(get_step(user.eyeobj, direct))
+	for(var/i = 0; i < max(user.sprint, initial_sprint); i += user.sprint)
+		var/turf/step = get_turf(get_step(user.eyeobj, direction))
 		if(step)
 			user.eyeobj.setLoc(step)
 
 	user.cooldown = world.timeofday + 5
 	if(user.acceleration)
-		user.sprint = min(user.sprint + 0.5, max_sprint)
+		user.sprint = min(user.sprint + 0.5, user.max_camera_sprint)
 	else
-		user.sprint = initial
+		user.sprint = initial_sprint
 
 	if(!user.tracking)
 		user.cameraFollow = null

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -110,7 +110,7 @@
 		return mob.remote_control.relaymove(mob, direct)
 
 	if(isAI(mob))
-		return AIMove(n,direct,mob)
+		return AIMove(direct,mob)
 
 	if(Process_Grab()) //are we restrained by someone's grip?
 		return


### PR DESCRIPTION
# Document the changes in your pull request

i've gotten numerous complaints that the ai eye isn't visible to ghosts so i fixed that, and made it so that orbiting an ai from the follow menu will take you to their eye rather than the server rack.

Unfortunately for the ai detecting multi-tool, i'm not sure if the blind spot viewing can be restored with the massive refactoring of how planes and visuals work, as it was created when planes were far more simple and you could just reach out and grab one, then modify the hell out of it until it was butchered and would still function. So pour one out for our little yellow friend.

# Why is this good for the game?
bugfix good

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/46236974/57cff5b6-7f06-40ab-864a-3b75214ba9dd)
AI is near
![image](https://github.com/yogstation13/Yogstation/assets/46236974/9bbcbc90-11a2-49a3-8456-364737000362)
AI is very close
![image](https://github.com/yogstation13/Yogstation/assets/46236974/776665c2-878e-497f-9879-4ff1defce0b0)
![image](https://github.com/yogstation13/Yogstation/assets/46236974/6c2d22bb-eb1f-41db-8664-c0ce310cea7a)


# Wiki Documentation

The ai detecting multi-tool can't show you the camera blindspots anymore and is just a hot/cold system with a green/yellow/red indicator for "ai is nowhere near", "ai is near", and "ai can see you"

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscdel: Ai-detecting multi-tool cannot show you blind spots anymore due to the rendering rework. Rip to a real one
bugfix: Ai cam location is visible to ghosts again and other entities that should be able to see it
/:cl:
