### PR TITLE
Fixes the space pirate's data siphon disappearing when activated

### DIFF
--- a/code/game/machinery/telecomms/machines/allinone.dm
+++ b/code/game/machinery/telecomms/machines/allinone.dm
@@ -17,7 +17,7 @@
 	flags_1 = NODECONSTRUCT_1
 
 /obj/machinery/telecomms/allinone/Initialize(mapload)
-	. = ..()
+	. = ..()s
 	if (intercept)
 		freq_listening = list(FREQ_SYNDICATE)
 

--- a/code/game/machinery/telecomms/machines/allinone.dm
+++ b/code/game/machinery/telecomms/machines/allinone.dm
@@ -17,7 +17,7 @@
 	flags_1 = NODECONSTRUCT_1
 
 /obj/machinery/telecomms/allinone/Initialize(mapload)
-	. = ..()s
+	. = ..()
 	if (intercept)
 		freq_listening = list(FREQ_SYNDICATE)
 

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -190,7 +190,7 @@
 	STOP_PROCESSING(SSobj,src)
 
 /obj/machinery/shuttle_scrambler/update_icon_state()
-	icon_state = active ? "dominator-Blue" : "dominator"
+	icon_state = active ? "dominator-red" : "dominator"
 	return ..()
 
 /obj/machinery/shuttle_scrambler/Destroy()


### PR DESCRIPTION
# Document the changes in your pull request
Closes #21586
also I made it red instead of blue cause I thought it looked cool and evil, can change it back to blue on request of course

# Testing
https://github.com/yogstation13/Yogstation/assets/143908044/af8aebbc-3ac8-47ef-a970-a57a76ab0e5b

# Changelog
:cl:  
bugfix: Fixed the pirate data siphon going invisible when activated
/:cl:
