### PR TITLE
Fixes "telecommunications mainframe" being invisible

### DIFF
--- a/code/game/machinery/telecomms/machines/allinone.dm
+++ b/code/game/machinery/telecomms/machines/allinone.dm
@@ -5,7 +5,7 @@
 
 /obj/machinery/telecomms/allinone
 	name = "telecommunications mainframe"
-	icon_state = "comm_server"
+	icon_state = "server"
 	desc = "A compact machine used for portable subspace telecommunications processing."
 	density = TRUE
 	use_power = NO_POWER_USE

--- a/code/game/machinery/telecomms/machines/allinone.dm
+++ b/code/game/machinery/telecomms/machines/allinone.dm
@@ -18,6 +18,8 @@
 
 /obj/machinery/telecomms/allinone/Initialize(mapload)
 	. = ..()
+	id = "Telecommunicatons Mainframe" //Does nothing, just prevents from showing NULL
+	network = "SyndiMain"
 	if (intercept)
 		freq_listening = list(FREQ_SYNDICATE)
 


### PR DESCRIPTION
# Document the changes in your pull request
Closes #19883
Pretty sure this is the sprite they intended for it to have

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/143908044/2c650968-1e13-4d50-ab7f-d06593cdb177)
![image](https://github.com/yogstation13/Yogstation/assets/143908044/bfb94921-98b6-42bb-bded-848d0217fde1)


# Changelog

:cl:  
bugfix: Fixed nuke op's telecomms machine being invisible
/:cl:
