### PR TITLE
Fixes(?) meatspike frame not needing to be anchored when finishing

### DIFF
--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -15,6 +15,9 @@
 	if(default_unfasten_wrench(user, I))
 		return
 	else if(istype(I, /obj/item/stack/rods))
+		if(!anchored)
+			to_chat(user, span_warning("[src] must be anchored first!"))
+			return
 		var/obj/item/stack/rods/R = I
 		if(R.get_amount() >= 4)
 			R.use(4)


### PR DESCRIPTION
# Document the changes in your pull request
So I was testing to see if there were issues with meatspike frames, and discovered it COULD be wrenched down, but didn't care if it was anchored or not when finishing the frame with rods
I think this is a bugfix? Seems like an oversight so I'll call it that, but feel free to correct me if I'm wrong ig

# Testing

https://github.com/yogstation13/Yogstation/assets/143908044/211bf9bf-0fbb-4b9e-a038-2316cfb71b23

![image](https://github.com/yogstation13/Yogstation/assets/143908044/ac1cd6d8-18e2-42e5-ae48-6b32a1fd9a48)


# Changelog

:cl:  
bugfix: Fixed meatspike frames not checking if they're anchored or not when finishing
/:cl:
