### PR TITLE
Fixes invisible carpets and clockwork grilles

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -326,6 +326,12 @@
 	desc = "A strangely-shaped grille."
 	broken_type = /obj/structure/grille/ratvar/broken
 
+	// These don't smooth
+	base_icon_state = null
+	smoothing_flags = NONE
+	smoothing_groups = null
+	canSmoothWith = null
+
 /obj/structure/grille/ratvar/Initialize(mapload)
 	. = ..()
 	if(broken)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -326,7 +326,7 @@
 	desc = "A strangely-shaped grille."
 	broken_type = /obj/structure/grille/ratvar/broken
 
-	// These don't smooth
+	// These ones are too cool to smooth
 	base_icon_state = null
 	smoothing_flags = NONE
 	smoothing_groups = null

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -170,6 +170,7 @@
 	desc = "Soft velvet carpeting. Feels good between your toes."
 	icon = 'icons/turf/floors/carpet.dmi'
 	icon_state = "carpet-255"
+	base_icon_state = "carpet"
 	flags_1 = NONE
 	bullet_bounce_sound = null
 	footstep = FOOTSTEP_CARPET
@@ -184,54 +185,63 @@
 /turf/open/indestructible/carpet/black
 	icon = 'icons/turf/floors/carpet_black.dmi'
 	icon_state = "carpet_black-255"
+	base_icon_state = "carpet_black"
 	smoothing_groups = SMOOTH_GROUP_TURF_OPEN + SMOOTH_GROUP_CARPET_BLACK
 	canSmoothWith = SMOOTH_GROUP_CARPET_BLACK
 
 /turf/open/indestructible/carpet/blue
 	icon = 'icons/turf/floors/carpet_blue.dmi'
 	icon_state = "carpet_blue-255"
+	base_icon_state = "carpet_blue"
 	smoothing_groups = SMOOTH_GROUP_TURF_OPEN + SMOOTH_GROUP_CARPET_BLUE
 	canSmoothWith = SMOOTH_GROUP_CARPET_BLUE
 
 /turf/open/indestructible/carpet/cyan
 	icon = 'icons/turf/floors/carpet_cyan.dmi'
 	icon_state = "carpet_cyan-255"
+	base_icon_state = "carpet_cyan"
 	smoothing_groups = SMOOTH_GROUP_TURF_OPEN + SMOOTH_GROUP_CARPET_CYAN
 	canSmoothWith = SMOOTH_GROUP_CARPET_CYAN
 
 /turf/open/indestructible/carpet/green
 	icon = 'icons/turf/floors/carpet_green.dmi'
 	icon_state = "carpet_green-255"
+	base_icon_state = "carpet_green"
 	smoothing_groups = SMOOTH_GROUP_TURF_OPEN + SMOOTH_GROUP_CARPET_GREEN
 	canSmoothWith = SMOOTH_GROUP_CARPET_GREEN
 
 /turf/open/indestructible/carpet/orange
 	icon = 'icons/turf/floors/carpet_orange.dmi'
 	icon_state = "carpet_orange-255"
+	base_icon_state = "carpet_orange"
 	smoothing_groups = SMOOTH_GROUP_TURF_OPEN + SMOOTH_GROUP_CARPET_ORANGE
 	canSmoothWith = SMOOTH_GROUP_CARPET_ORANGE
 
 /turf/open/indestructible/carpet/purple
 	icon = 'icons/turf/floors/carpet_purple.dmi'
 	icon_state = "carpet_purple-255"
+	base_icon_state = "carpet_purple"
 	smoothing_groups = SMOOTH_GROUP_TURF_OPEN + SMOOTH_GROUP_CARPET_PURPLE
 	canSmoothWith = SMOOTH_GROUP_CARPET_PURPLE
 
 /turf/open/indestructible/carpet/red
 	icon = 'icons/turf/floors/carpet_red.dmi'
 	icon_state = "carpet_red-255"
+	base_icon_state = "carpet_red"
 	smoothing_groups = SMOOTH_GROUP_TURF_OPEN + SMOOTH_GROUP_CARPET_RED
 	canSmoothWith = SMOOTH_GROUP_CARPET_RED
 
 /turf/open/indestructible/carpet/royalblack
 	icon = 'icons/turf/floors/carpet_royalblack.dmi'
 	icon_state = "carpet_royalblack-255"
+	base_icon_state = "carpet_royalblack"
 	smoothing_groups = SMOOTH_GROUP_TURF_OPEN + SMOOTH_GROUP_CARPET_ROYAL_BLACK
 	canSmoothWith = SMOOTH_GROUP_CARPET_ROYAL_BLACK
 
 /turf/open/indestructible/carpet/royalblue
 	icon = 'icons/turf/floors/carpet_royalblue.dmi'
 	icon_state = "carpet_royalblue-255"
+	base_icon_state = "carpet_royalblue"
 	smoothing_groups = SMOOTH_GROUP_TURF_OPEN + SMOOTH_GROUP_CARPET_ROYAL_BLUE
 	canSmoothWith = SMOOTH_GROUP_CARPET_ROYAL_BLUE
 


### PR DESCRIPTION
# Document the changes in your pull request
Slot machines were just fixed, so this fully closes #21533

What was wrong with the carpets?
Only the invincible ones had this issue, they didn't have a base_icon_state set so the smoothing system, upon running the code, would promptly sunder them into nullspace.

Cog grilles?
Normal grilles use smoothing and they're a subtype of those. These ones do not use smoothing however, so the code panicked and didn't know what to do with em.

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/143908044/ae2a6ffc-7fff-43d2-8871-05e61b09cb52)
![image](https://github.com/yogstation13/Yogstation/assets/143908044/b8cada9b-012a-4d6b-a750-527b356cd033)


# Changelog
:cl: 
bugfix: Fixed invincible carpets looking like a black void (see goat king's arena)
bugfix: Fixed cog grilles looking like smiling tables
/:cl:
