### PR TITLE
Moves two xeno spawns out of public areas

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -70649,6 +70649,7 @@
 /area/maintenance/starboard/aft)
 "vif" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/locker)
 "vig" = (
@@ -78953,7 +78954,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
 	},
-/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel,
 /area/engine/atmos/hfr)
 "xLQ" = (

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -29920,8 +29920,12 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/mix)
 "hRt" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/bar,
 /obj/effect/landmark/xeno_spawn,
-/turf/open/floor/wood/parquet,
+/turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "hRx" = (
 /obj/effect/turf_decal/tile/red/opposingcorners,
@@ -109605,7 +109609,7 @@ wcU
 aql
 hKi
 jTj
-sGs
+hRt
 exZ
 aql
 ioB
@@ -110635,7 +110639,7 @@ qWa
 col
 hQg
 hOm
-hRt
+aFd
 aFd
 cFS
 aFd


### PR DESCRIPTION
# Document the changes in your pull request
I was looking into closing #14118
Round ID shows it was on Box
![image](https://github.com/yogstation13/Yogstation/assets/143908044/9210fa5e-d33c-4404-a428-2dd7aafbbb79)

So I check box for a xeno spawn as described. Nothing there.
Alright so to make sure I check every xeno spawn on the map to make sure I'm not trippin, then I find this in the bar
![image](https://github.com/yogstation13/Yogstation/assets/143908044/3a1bb799-671f-4145-b0ee-7abda88c9122)

And I don't think it's supposed to be like that. If it is? It shouldn't; that's too public of a place to spawn. So I moved it into the bartender's backroom.

So...closes #14118 I guess?

And I did the same for a xeno spawn on asteroid which was in the middle of the HFR room - moved to the bathroom.

# Why is this good for the game?
Xeno spawns in public are not good

# Testing
O_O uh...yeah

# Changelog
:cl: 
mapping: Fixed two xeno spawn locations being in public areas
/:cl:
