### PR TITLE
Fixes bamboo walls and floors looking like VOID

### DIFF
--- a/code/game/turfs/closed/wall/mineral_walls.dm
+++ b/code/game/turfs/closed/wall/mineral_walls.dm
@@ -165,6 +165,7 @@
 	desc = "A wall with a bamboo finish."
 	icon = 'icons/turf/walls/bamboo_wall.dmi'
 	icon_state = "wall-0"
+	base_icon_state = "bamboo_wall"
 	sheet_type = /obj/item/stack/sheet/mineral/bamboo
 	hardness = 60
 	smoothing_flags = SMOOTH_BITMASK

--- a/code/game/turfs/open/floor/fancy_floor.dm
+++ b/code/game/turfs/open/floor/fancy_floor.dm
@@ -227,7 +227,8 @@
 /turf/open/floor/bamboo
 	desc = "A bamboo mat with a decorative trim."
 	icon = 'icons/turf/floors/bamboo_mat.dmi'
-	icon_state = "bamboo"
+	icon_state = "mat-255"
+	base_icon_state = "mat"
 	floor_tile = /obj/item/stack/tile/bamboo
 	smoothing_flags = SMOOTH_BITMASK
 	smoothing_groups = SMOOTH_GROUP_TURF_OPEN + SMOOTH_GROUP_BAMBOO_FLOOR


### PR DESCRIPTION
# Document the changes in your pull request
Icons just weren't set right since the big smoothing PR, should be working good now

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/143908044/15f980b3-d693-4864-92ea-5552387be4b5)

:cl:  
bugfix: Fixed bamboo walls and floors looking like a black void
/:cl:
