### PR TITLE
Observing players partially contribute to gamemode

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -1,7 +1,7 @@
 ///An unreadied player counts for this much compared to a readied one
 #define UNREADIED_PLAYER_MULTIPLIER 0.75
 ///An observer player counts this much compared to a readied one
-#define OBSERVER_PLAYER_MULTIPLIER 0.33
+#define OBSERVER_PLAYER_MULTIPLIER 0.25
 
 #define NUKE_RESULT_FLUKE 0
 #define NUKE_RESULT_NUKE_WIN 1

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -1,7 +1,7 @@
 ///An unreadied player counts for this much compared to a readied one
 #define UNREADIED_PLAYER_MULTIPLIER 0.75
 ///An observer player counts this much compared to a readied one
-#define OBSERVER_PLAYER_MULTIPLIER 0.5
+#define OBSERVER_PLAYER_MULTIPLIER 0.33
 
 #define NUKE_RESULT_FLUKE 0
 #define NUKE_RESULT_NUKE_WIN 1

--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -1,5 +1,7 @@
 ///An unreadied player counts for this much compared to a readied one
 #define UNREADIED_PLAYER_MULTIPLIER 0.75
+///An observer player counts this much compared to a readied one
+#define OBSERVER_PLAYER_MULTIPLIER 0.5
 
 #define NUKE_RESULT_FLUKE 0
 #define NUKE_RESULT_NUKE_WIN 1

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -81,9 +81,9 @@
 		if(player.client.holder) //Admins don't count towards unreadied or observing player count
 			continue
 
-		if((player.ready == PLAYER_NOT_READY))
+		if(player.ready == PLAYER_NOT_READY)
 			unreadiedPlayers++
-		else if((player.ready == PLAYER_READY_TO_OBSERVE))
+		else if(player.ready == PLAYER_READY_TO_OBSERVE)
 			ghostPlayers++
 
 	if(!GLOB.Debug2)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -70,13 +70,24 @@
 /datum/game_mode/proc/can_start()
 	var/playerC = 0
 	var/unreadiedPlayers = 0
+	var/ghostPlayers = 0
 	for(var/mob/dead/new_player/player in GLOB.player_list)
-		if(player.client && (player.ready == PLAYER_READY_TO_PLAY))
+		if(!player.client)
+			continue
+
+		if(player.ready == PLAYER_READY_TO_PLAY)
 			playerC++
-		else if(player.client && (player.ready == PLAYER_NOT_READY) && !player.client.holder) //Admins don't count :)
+
+		if(player.client.holder) //Admins don't count towards unreadied or observing player count
+			continue
+
+		if((player.ready == PLAYER_NOT_READY))
 			unreadiedPlayers++
+		else if((player.ready == PLAYER_READY_TO_OBSERVE))
+			ghostPlayers++
+
 	if(!GLOB.Debug2)
-		var/adjustedPlayerCount = round(playerC + (unreadiedPlayers * UNREADIED_PLAYER_MULTIPLIER), 1)
+		var/adjustedPlayerCount = round(playerC + (unreadiedPlayers * UNREADIED_PLAYER_MULTIPLIER) + (ghostPlayers * OBSERVER_PLAYER_MULTIPLIER), 1)
 		log_game("Round can_start() with [adjustedPlayerCount] adjusted count, versus [playerC] regular player count. Requirement: [required_players] Gamemode: [name]")
 		if(adjustedPlayerCount < required_players || (maximum_players >= 0 && playerC > maximum_players))
 			return FALSE


### PR DESCRIPTION
Makes observing players equivalent to 0.25 of a player when picking a gamemode
This is compared to 1.0 for regular players
and 0.75 for unreadied players

# Why is this good for the game?
We're currently suffering from lowpop, people who instantly observe might be fishing for ghost roles or something
Having ghosts factor into gamemode, even slightly, might affect the game mode picked, and as such, affect player retention (not constant traitor)

I have it incredibly low at 0.25 so they aren't likely to make a difference all that often, but if there's enough of them, it'll add up

# Testing
i sorta can't

:cl:  
tweak: Observing players partially contribute to gamemode
/:cl:
