### PR TITLE
Cargo shuttle now properly says it will arrive in 30 seconds instead of 1 minute

### DIFF
--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -148,7 +148,14 @@
 				investigate_log("[key_name(usr)] sent the supply shuttle away.", INVESTIGATE_CARGO)
 			else
 				investigate_log("[key_name(usr)] called the supply shuttle.", INVESTIGATE_CARGO)
-				say("The supply shuttle has been called and will arrive in [SSshuttle.supply.timeLeft(600)] minutes.")
+				var/call_time = SSshuttle.supply.timeLeft(10) //how many seconds
+				var/unit = "seconds"
+				if(call_time >= 60) //if more than 60 seconds,
+					call_time = SSshuttle.supply.timeLeft(600) //go to minutes instead
+					unit = "minute"
+					if(call_time > 1) //handles more than 1 minute
+						unit = "minutes"
+				say("The supply shuttle has been called and will arrive in [call_time] [unit].")
 				SSshuttle.moveShuttle("supply", "supply_home", TRUE)
 			. = TRUE
 		if("loan")


### PR DESCRIPTION
# Document the changes in your pull request

https://github.com/yogstation13/Yogstation/pull/16062 halved the time from 1 minute to 30 seconds but Theos never updated the actual console to support saying times that are less than 1 minute.

# Why is this good for the game?
Now it doesn't say "1 minute" because it's rounding up
# Testing

![image](https://github.com/yogstation13/Yogstation/assets/5091394/d498febd-c877-488d-b56d-13ef66818f3d)

# Changelog

:cl:  
bugfix: Cargo shuttle call displays the correct time
/:cl:
