### PR TITLE
Fixes water cookies tasting like /datum/reagent/water like what the hell really man how do you do that

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/consuming.dm
+++ b/code/modules/research/xenobiology/crossbreeding/consuming.dm
@@ -150,7 +150,7 @@ Consuming extracts:
 	name = "metallic cookie"
 	desc = "A shiny grey cookie. Hard to the touch."
 	icon_state = "metal"
-	taste = /datum/reagent/copper
+	taste = "sweet iron"
 
 /obj/item/slime_cookie/metal/do_effect(mob/living/M, mob/user)
 	M.apply_status_effect(/datum/status_effect/metalcookie)

--- a/code/modules/research/xenobiology/crossbreeding/consuming.dm
+++ b/code/modules/research/xenobiology/crossbreeding/consuming.dm
@@ -136,7 +136,7 @@ Consuming extracts:
 	name = "water cookie"
 	desc = "A transparent blue cookie. Constantly dripping wet."
 	icon_state = "blue"
-	taste = /datum/reagent/water
+	taste = "clear spring water"
 
 /obj/item/slime_cookie/blue/do_effect(mob/living/M, mob/user)
 	M.apply_status_effect(/datum/status_effect/watercookie)


### PR DESCRIPTION
# Document the changes in your pull request
![image](https://github.com/yogstation13/Yogstation/assets/143908044/2ba747c2-ce04-4487-9c50-5858803d3bce)

idunno what this guy was thinking trynna be slick coding it like that
no other cookie has its `taste` set like that like c'mon man really

# Testing
yeah
![image](https://github.com/yogstation13/Yogstation/assets/143908044/00127eda-96aa-43ab-b065-726f02e4585b)


# Changelog
:cl: 
bugfix: Fixed water cookies tasting like /datum/reagent/water and metallic cookies tasting like /datum/reagent/copper
/:cl:
