### PR TITLE
Fixes quirks STILL being reset randomly along with jobs + reverts 21541 and partially 21653

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -11,13 +11,7 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	var/list/quirks = list()		//Assoc. list of all roundstart quirk datum types; "name" = /path/
 	var/list/quirk_points = list()	//Assoc. list of quirk names and their "point cost"; positive numbers are good traits, and negative ones are bad
 	var/list/quirk_objects = list()	//A list of all quirk objects in the game, since some may process
-	var/list/quirk_blacklist = list() //A list a list of quirks that can not be used with each other. Format: list(quirk1,quirk2),list(quirk3,quirk4)
-
-/datum/controller/subsystem/processing/quirks/Initialize(timeofday)
-	if(!quirks.len)
-		SetupQuirks()
-
-	quirk_blacklist = list(
+	var/static/list/quirk_blacklist = list( //A list a list of quirks that can not be used with each other. Format: list(quirk1,quirk2),list(quirk3,quirk4)
 		list("Blind","Nearsighted"),
 		list("Jolly","Depression","Apathetic","Hypersensitive"),
 		list("Ageusia","Vegetarian","Deviant Tastes"),
@@ -30,7 +24,11 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 		list("Prosthetic Limb (Left Leg)","Paraplegic"),
 		list("Prosthetic Limb (Right Leg)","Paraplegic"),
 		list("Prosthetic Limb","Paraplegic")
-	)
+	) 
+
+/datum/controller/subsystem/processing/quirks/Initialize(timeofday)
+	if(!quirks.len)
+		SetupQuirks()
 	return SS_INIT_SUCCESS
 
 //basically a lazily loaded list of quirks, never access .quirks directly.

--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -33,6 +33,12 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	)
 	return SS_INIT_SUCCESS
 
+//basically a lazily loaded list of quirks, never access .quirks directly.
+/datum/controller/subsystem/processing/quirks/proc/get_quirks()
+	if(!quirks.len)
+		SetupQuirks()
+	return quirks
+
 /datum/controller/subsystem/processing/quirks/proc/SetupQuirks()
 	// Sort by Positive, Negative, Neutral; and then by name
 	var/list/quirk_list = sortList(subtypesof(/datum/quirk), /proc/cmp_quirk_asc)
@@ -86,8 +92,10 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	// If moods are globally enabled, or this guy does indeed have his mood pref set to Enabled
 	var/ismoody = (!CONFIG_GET(flag/disable_human_mood) || (prefs.read_preference(/datum/preference/toggle/mood_enabled)))
 
+	var/list/all_quirks = get_quirks() //forces a load of the quirks if they aren't setup already
+
 	for (var/quirk_name in quirks)
-		var/datum/quirk/quirk = SSquirks.quirks[quirk_name]
+		var/datum/quirk/quirk = all_quirks[quirk_name]
 		if (isnull(quirk))
 			continue
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -213,10 +213,6 @@ SUBSYSTEM_DEF(ticker)
 	to_chat(world, span_boldannounce("Starting game..."))
 	var/init_start = world.timeofday
 		//Create and announce mode
-		
-	//quickly load all the unloaded characters so it looks like we've had them loaded the entire time
-	for(var/mob/dead/new_player/player in GLOB.player_list)
-		player.force_load_character()
 
 	var/list/datum/game_mode/runnable_modes
 	if(GLOB.master_mode == "random" || GLOB.master_mode == "secret")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -79,10 +79,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	/// If set to TRUE, will update character_profiles on the next ui_data tick.
 	var/tainted_character_profiles = FALSE
 
-	/// var to tell the game if we actually have a loaded character or if we need to load one, doesnt care if your loaded character is valid or not
-	var/loaded_character = FALSE
-
-
 	///removed, kept here for migration in 'legacy_mood_migration.dm'
 	///DO NOT USE THIS!
 	var/yogtoggles
@@ -123,7 +119,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	var/loaded_preferences_successfully = load_preferences()
 	if(loaded_preferences_successfully)
-		return
+		if(load_character())
+			return
 	//we couldn't load character data so just randomize the character appearance + name
 	randomise_appearance_prefs()		//let's create a random character then - rather than a fat, bald and naked man.
 	if(C)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -293,7 +293,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	all_quirks = SSquirks.filter_invalid_quirks(all_quirks, src)
 	validate_quirks()
 
-	loaded_character = TRUE
 	return TRUE
 
 /datum/preferences/proc/save_character()

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -122,7 +122,6 @@
 			to_chat(usr, span_notice("The game is still loading. Please wait a bit before editing your character."))
 			return
 		var/datum/preferences/preferences = client.prefs
-		force_load_character()
 		preferences.current_window = PREFERENCE_TAB_CHARACTER_PREFERENCES
 		preferences.update_static_data(usr)
 		preferences.ui_interact(usr)
@@ -534,19 +533,6 @@
 			message_admins("[src.ckey] just got booted back to lobby with no jobs enabled, but antag rolling enabled. Likely antag rolling abuse.")
 
 		return FALSE //This is the only case someone should actually be completely blocked from antag rolling as well
-	return TRUE
-
-/mob/dead/new_player/proc/force_load_character()
-	if(!client)
-		return
-	var/datum/preferences/preferences = client.prefs
-	if(preferences.loaded_character) //no need
-		return
-	var/success = preferences.load_character()
-	if(!success)
-		preferences.randomise_appearance_prefs() //let's create a random character then - rather than a fat, bald and naked man.
-		preferences.save_character() //let's save this new random character so it doesn't keep generating new ones.
-		preferences.loaded_character = TRUE
 	return TRUE
 
 #undef RESET_HUD_INTERVAL


### PR DESCRIPTION
# Document the changes in your pull request

I was thinking too hard about this. If quirks don't exist, we simply load them.

My solution was overblown and stopped players from accessing their characters arbitrarily.

Should also stop jobs being exploded because of an unloaded character.

Ports https://github.com/tgstation/tgstation/pull/61492

# Testing
<!-- Describe what testing you did with this PR. Try to be thorough, especially if this is a larger project. -->

# Changelog

:cl:  
bugfix: quirks should finally stop resetting for real, along with your jobs since your character is loaded properly.
/:cl:
