### PR TITLE
Vending machines no longer spark when their UI is open

### DIFF
--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -10,10 +10,19 @@
 	add_duds(1)
 	..()
 
+/datum/wires/vending/interact(mob/user)
+	var/obj/machinery/vending/V = holder
+	if(!issilicon(user) && V.seconds_electrified && V.shock(user, 100)) // Just incase
+		return
+
+	return ..()
+
 /datum/wires/vending/interactable(mob/user)
 	var/obj/machinery/vending/V = holder
-	if(!issilicon(user) && V.seconds_electrified && V.shock(user, 100))
-		return FALSE
+	if(!issilicon(user) && V.seconds_electrified)
+		var/mob/living/carbon/carbon_user = user
+		if (!istype(carbon_user) || carbon_user.should_electrocute(src))
+			return FALSE
 	if(V.panel_open)
 		return TRUE
 
@@ -56,6 +65,7 @@
 				V.seconds_electrified = MACHINE_NOT_ELECTRIFIED
 			else
 				V.seconds_electrified = MACHINE_ELECTRIFIED_PERMANENT
+				V.shock(usr, 100)
 		if(WIRE_IDSCAN)
 			V.scan_id = mend
 		if(WIRE_SPEAKER)


### PR DESCRIPTION
# Document the changes in your pull request

Fixes: #18976

interactable didnt check distance; this was copied from airlock code
# Testing
![image](https://github.com/yogstation13/Yogstation/assets/20369082/23197b6e-6041-4932-9e27-5541adafd1de)

didnt spark when I walked away

# Changelog

:cl:  
bugfix: Shocked vending machines no longer spark when you walk away
/:cl:
