### PR TITLE
Filing cabinets can now accept tapes

### DIFF
--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -1,3 +1,6 @@
+// Way to many types to just leave as a instance variable
+GLOBAL_LIST_INIT(filingcabinet_types, typecacheof(list(/obj/item/paper, /obj/item/folder, /obj/item/photo, /obj/item/documents, /obj/item/clipboard, /obj/item/tape)))
+
 /* Filing cabinets!
  * Contains:
  *		Filing Cabinets
@@ -71,7 +74,7 @@
 	update_appearance(UPDATE_ICON)
 	if(mapload)
 		for(var/obj/item/I in loc)
-			if(istype(I, /obj/item/paper) || istype(I, /obj/item/folder) || istype(I, /obj/item/photo))
+			if(is_type_in_typecache(I, GLOB.filingcabinet_types))
 				I.forceMove(src)
 
 /obj/structure/filingcabinet/deconstruct(disassembled = TRUE)
@@ -89,7 +92,7 @@
 		else
 			name = initial(name)
 		return
-	if(istype(P, /obj/item/paper) || istype(P, /obj/item/folder) || istype(P, /obj/item/photo) || istype(P, /obj/item/documents) || istype(P, /obj/item/clipboard))
+	if(is_type_in_typecache(P, GLOB.filingcabinet_types))
 		if(!user.transferItemToLoc(P, src))
 			return
 		to_chat(user, span_notice("You put [P] in [src]."))

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -1,6 +1,3 @@
-// Way to many types to just leave as a instance variable
-GLOBAL_LIST_INIT(filingcabinet_types, typecacheof(list(/obj/item/paper, /obj/item/folder, /obj/item/photo, /obj/item/documents, /obj/item/clipboard, /obj/item/tape)))
-
 /* Filing cabinets!
  * Contains:
  *		Filing Cabinets
@@ -20,6 +17,9 @@ GLOBAL_LIST_INIT(filingcabinet_types, typecacheof(list(/obj/item/paper, /obj/ite
 	icon_state = "filingcabinet"
 	density = TRUE
 	anchored = TRUE
+
+	/// List of allowed item types
+	var/allowed_types = list(/obj/item/paper, /obj/item/folder, /obj/item/photo, /obj/item/documents, /obj/item/clipboard, /obj/item/tape)
 
 /obj/structure/filingcabinet/chestdrawer
 	name = "chest drawer"
@@ -74,7 +74,7 @@ GLOBAL_LIST_INIT(filingcabinet_types, typecacheof(list(/obj/item/paper, /obj/ite
 	update_appearance(UPDATE_ICON)
 	if(mapload)
 		for(var/obj/item/I in loc)
-			if(is_type_in_typecache(I, GLOB.filingcabinet_types))
+			if(is_type_in_list(I, allowed_types))
 				I.forceMove(src)
 
 /obj/structure/filingcabinet/deconstruct(disassembled = TRUE)
@@ -92,7 +92,7 @@ GLOBAL_LIST_INIT(filingcabinet_types, typecacheof(list(/obj/item/paper, /obj/ite
 		else
 			name = initial(name)
 		return
-	if(is_type_in_typecache(P, GLOB.filingcabinet_types))
+	if(is_type_in_list(P, allowed_types))
 		if(!user.transferItemToLoc(P, src))
 			return
 		to_chat(user, span_notice("You put [P] in [src]."))


### PR DESCRIPTION
# Document the changes in your pull request

Cleans up the item code for filling cabinets
Fixes: #21728


# Testing
![image](https://github.com/yogstation13/Yogstation/assets/20369082/fc2d07f7-3fc9-41be-bb37-1cb4f9b3c95e)

use call proc to do `Initialize(mapload = TRUE)`
![image](https://github.com/yogstation13/Yogstation/assets/20369082/08b25bb4-1c37-4a87-98d9-d4556b0547c6)

# Changelog

:cl:  
tweak: Filing cabinets can accept tape now
/:cl:
