### PR TITLE
Fixes mouse cheese eating

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -239,7 +239,7 @@ GLOBAL_VAR_INIT(mouse_killed, 0)
 /mob/living/simple_animal/mouse/proc/cheese_up()
 	regen_health(15)
 	if(cheesed)
-		cheese_time = cheese_time + 3 MINUTES
+		cheese_time += 3 MINUTES
 		return
 	cheesed = TRUE
 	resize = 2
@@ -248,7 +248,7 @@ GLOBAL_VAR_INIT(mouse_killed, 0)
 	maxHealth = 30
 	health = maxHealth
 	to_chat(src, span_userdanger("You ate cheese! You are now stronger, bigger and faster!"))
-	cheese_time = cheese_time + 3 MINUTES
+	cheese_time = world.time + 3 MINUTES
 
 /mob/living/simple_animal/mouse/proc/cheese_down()
 	cheesed = FALSE


### PR DESCRIPTION
# Document the changes in your pull request

Fixes: #20010 

it was caused by cheesed comparing itself to world.time without adding world.time to the initial time

# Testing

https://github.com/yogstation13/Yogstation/assets/20369082/80c69848-ef9d-4f4d-93a6-bae5bb825329


# Changelog

:cl:  
bugfix: Mice cheese powers last more than 1 nanosecond
/:cl:
