### PR TITLE
Fixes a bug where the break machinery objective wouldn't complete until deleted objects went through garbage collection

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1652,7 +1652,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	if(machines_to_break.len == 0)
 		return TRUE
 	for(var/obj/machinery/thing as anything in machines_to_break)
-		if(thing && istype(thing, target_obj_type))
+		if(thing && !QDELETED(thing) && istype(thing, target_obj_type))
 			return FALSE
 	return TRUE
 


### PR DESCRIPTION
If a thing gets qdeleted, it takes a while for it to actually count as null for the objective
this just checks if it's in the garbage collection queue

# Testing
Not really possible, just trust me

:cl:  
bugfix: Fixes a bug where the break machinery objective wouldn't complete until deleted objects went through garbage collection
/:cl:
