### PR TITLE
[ASTEROID] Solves prisoners/wardens not being able to access a fridge in perma

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -896,13 +896,13 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "ahZ" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Prison Cafeteria";
 	dir = 4;
 	network = list("ss13","prison")
 	},
+/obj/structure/closet/secure_closet/freezer/fridge/open,
 /turf/open/floor/plasteel/white,
 /area/security/prison)
 "aib" = (


### PR DESCRIPTION
# Document the changes in your pull request
It's now unlocked, boom problem solved (Box does this so why not)

Closes #20562

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/143908044/02288ace-9577-4049-8d8b-08b494c699ad)


# Wiki Documentation
I'll get around to it eventually

# Changelog
:cl:  
mapping: Fixed an issue where prisoners/warden couldn't access the top fridge in perma on Asteroid
/:cl:
