### PR TITLE
Fixes the lack of Cuban Pete as lobby music

### DIFF
--- a/yogstation/code/controllers/subsystem/ticker.dm
+++ b/yogstation/code/controllers/subsystem/ticker.dm
@@ -5,6 +5,7 @@
 	//Add/remove songs from this list individually, rather than multiple at once. This makes it easier to judge PRs that change the list, since PRs that change it up heavily are less likely to meet broad support
 	//Add a comment after the song link in the format [Artist - Name]
 	var/list/songs = list(
+		"https://www.youtube.com/watch?v=jA4u5Pur5KA",						// Cuban Pete - Jim Carrey
 		"https://www.youtube.com/watch?v=lIrum6iFz6U", 						// Electric Light Orchestra - Mr. Blue Sky
 		"https://www.youtube.com/watch?v=Ae2N5310MXE",						// SolusLunes - Endless Space
 		"https://www.youtube.com/watch?v=WEhS9Y9HYjU", 						// Noel Harrison - The Windmills of Your Mind

--- a/yogstation/code/controllers/subsystem/ticker.dm
+++ b/yogstation/code/controllers/subsystem/ticker.dm
@@ -5,7 +5,7 @@
 	//Add/remove songs from this list individually, rather than multiple at once. This makes it easier to judge PRs that change the list, since PRs that change it up heavily are less likely to meet broad support
 	//Add a comment after the song link in the format [Artist - Name]
 	var/list/songs = list(
-		"https://www.youtube.com/watch?v=jA4u5Pur5KA",						// Cuban Pete - Jim Carrey
+		"https://www.youtube.com/watch?v=jA4u5Pur5KA",						// Jim Carrey - Cuban Pete
 		"https://www.youtube.com/watch?v=lIrum6iFz6U", 						// Electric Light Orchestra - Mr. Blue Sky
 		"https://www.youtube.com/watch?v=Ae2N5310MXE",						// SolusLunes - Endless Space
 		"https://www.youtube.com/watch?v=WEhS9Y9HYjU", 						// Noel Harrison - The Windmills of Your Mind


### PR DESCRIPTION
# Document the changes in your pull request

Fixes Cuban Pete not being apart of the lobby music.

# Why is this good for the game?
This is a very serious, game-altering bug that our maintainers and coders have refused to fix, so I have chosen to do so myself. Cuban Pete was the greatest scientist and griffer of all time, it only makes sense that we pay tribute to him in one of mankind's earliest and most innovative forms of art: song. To do anything less is a disgrace to all of SS13, and the fact that this bug remained unfixed for so long is frankly appalling.

btw we should probably cull the amount of these songs whos links dont work anymore

# Testing

soon..

# Changelog

:cl:  
bugfix: Fixes Cuban Pete, sung by Jim Carrey, not being apart of the lobby music.
/:cl:
