### PR TITLE
Fixes preternis cores not showing up if wearing something not covering the chest + jumpsuit alt mode fix

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -443,7 +443,7 @@ BLIND     // can't see anything
 			adjusted = DIGIALT_STYLE
 		if(DIGIALT_STYLE)
 			adjusted = DIGITIGRADE_STYLE
-	if(adjusted == NORMAL_STYLE || adjusted == DIGIALT_STYLE) //Yogs End
+	if(adjusted == ALT_STYLE || adjusted == DIGIALT_STYLE) //Yogs End
 		if(fitted != FEMALE_UNIFORM_TOP)
 			fitted = NO_FEMALE_UNIFORM
 		if(!alt_covers_chest) // for the special snowflake suits that expose the chest when adjusted (and also the arms, realistically)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -925,7 +925,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 			bodyparts_to_add -= "preternis_eye"
 
 	if("preternis_core" in mutant_bodyparts)
-		if(H.w_uniform || H.wear_suit)
+		if(!get_location_accessible(H, BODY_ZONE_CHEST))
 			bodyparts_to_add -= "preternis_core"
 
 	if("pod_hair" in mutant_bodyparts)


### PR DESCRIPTION
found the second bug while fixing the first

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/c2a513b6-7bf4-4d44-9df7-896ec209ba14)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/f7239f38-0965-4fdb-bef9-537c601cc500)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/aa9829ab-7069-42bf-8748-ef03c9ae24b9)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/dd1d0555-004b-48db-a38c-3272d51ad08e)

:cl:  
bugfix: fixes preternis cores not showing up if wearing a suit or jacket that doesn't cover the chest
bugfix: fixes alt jumpsuit modes having inverted chest covering than the sprite implies
/:cl:
