### PR TITLE
Fixes preterni being unable to take RDS

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -350,7 +350,7 @@
 
 /datum/quirk/insanity/check_quirk(datum/preferences/prefs)
 	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
-	var/disallowed_trait = (initial(species_type.inherent_biotypes) & MOB_ROBOTIC)
+	var/disallowed_trait = !(initial(species_type.inherent_biotypes) & ALL_NON_ROBOTIC)
 
 	if(disallowed_trait)
 		return "You are not illogical."


### PR DESCRIPTION
# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/2d8133a2-d82e-42f6-ac33-5d3d45f8ea04)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/bdb443e7-2919-4184-a13d-91ee061e68a8)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/4881a978-9d11-45db-af32-1b5ab0a28e7d)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/acb91bb1-e7fb-48d4-b417-d84f6d8a4572)


:cl:  
bugfix: Fixes preterni being unable to take RDS
/:cl:
