### PR TITLE
Readds some unintentionally missing tables and bar sign from the den of sin ruin

### DIFF
--- a/_maps/RandomRuins/JungleRuins/jungleland_jungle_sinden.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungleland_jungle_sinden.dmm
@@ -499,7 +499,7 @@
 /turf/open/floor/mineral/titanium,
 /area/ruin/powered/sinden)
 "DQ" = (
-/obj/structure/table/wood/fancy/exoticpurple,
+/obj/structure/table/wood/fancy/purple,
 /turf/open/floor/carpet/purple,
 /area/ruin/powered/sinden)
 "ED" = (
@@ -521,7 +521,7 @@
 /turf/open/floor/mineral/titanium,
 /area/ruin/powered/sinden)
 "Ha" = (
-/obj/structure/sign/barsign,
+/obj/machinery/barsign,
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/ruin/powered/sinden)
 "Hf" = (
@@ -656,7 +656,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/table/wood/fancy/exoticpurple,
 /obj/item/paper_bin,
 /obj/item/pen,
 /turf/open/floor/carpet/purple,


### PR DESCRIPTION
# Document the changes in your pull request
So I noticed some missing stuff
![image](https://github.com/yogstation13/Yogstation/assets/143908044/b766cd20-9f45-4518-8b7d-d57f0f73a92d)
and I looked back on #21352 just to make sure, and yep stuff do be missing

Definitely broke from the icon smoothing PR, just type paths that were changed without this ruin being accounted for

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/143908044/b9acfc05-125b-4840-a614-a08e7ddad98f)
![image](https://github.com/yogstation13/Yogstation/assets/143908044/4548ff26-6a55-48f0-90a5-f0600c4e4126)


# Wiki Documentation
Sometime...

# Changelog
:cl:  
mapping: Readded some missing tables and a bar sign from the den of sin ruin in jungleland
/:cl:
