### PR TITLE
Removes the slaughter demon spawner from battle royale

### DIFF
--- a/yogstation/code/game/gamemodes/battle_royale/loot.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/loot.dm
@@ -379,7 +379,6 @@ GLOBAL_LIST_INIT(battleroyale_utility, list(//bombs, explosives, anything that's
 		/obj/item/storage/backpack/duffelbag/syndie/c4 = -3, //C4 Is kind of useless when you have AA
 		/obj/item/battleroyale/itemspawner/construct = -3,
 		/obj/item/book/granter/action/spell/forcewall = -3,
-		/obj/item/antag_spawner/slaughter_demon = -3, //why the hell not
 		/obj/item/antag_spawner/slaughter_demon/laughter = -3, //people still get disqualified, but they at least get to come back
 		/obj/item/storage/backpack/holding = -3,
 		/obj/effect/spawner/lootdrop/stronggene = -3,


### PR DESCRIPTION
# Why is this good for the game?
slaughter demons drop hearts that can grant bloodcrawl, which give a win by default to anyone that eats it
if two people get bloodcrawl, they can force a round to never end
laughter demon doesn't have that problem as it doesn't drop the heart on death

# Testing
no need, it's just deleting a line from a list, also it's damn near impossible to test anyways

:cl:  
rscdel: Removes the slaughter demon spawner from battle royale
/:cl:
