### PR TITLE
Fixes a bug with ghost roles being able to get picked as antags

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -147,8 +147,9 @@
 	var/list/living_crew = list()
 
 	for(var/mob/Player in GLOB.mob_list)
-		if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) && !isbrain(Player) && Player.client)
+		if(Player.mind && Player.stat != DEAD && !isnewplayer(Player) && !isbrain(Player) && Player.client && (Player.mind.assigned_role in GLOB.crew_positions))
 			living_crew += Player
+
 	var/malc = CONFIG_GET(number/midround_antag_life_check)
 	if(living_crew.len / GLOB.joined_player_list.len <= malc) //If a lot of the player base died, we start fresh
 		message_admins("Convert_roundtype failed due to too many dead people. Limit is [malc * 100]% living crew")

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -204,8 +204,10 @@ GLOBAL_LIST_INIT(security_positions, original_security_positions | alt_security_
 GLOBAL_LIST_INIT(nonhuman_positions, original_nonhuman_positions | alt_nonhuman_positions)
 GLOBAL_LIST_INIT(civilian_positions, original_civilian_positions | alt_civilian_positions)
 
+GLOBAL_LIST_INIT(crew_positions, command_positions | engineering_positions | medical_positions | science_positions | supply_positions | security_positions | civilian_positions | nonhuman_positions)
+
 GLOBAL_LIST_INIT(exp_jobsmap, list(
-	EXP_TYPE_CREW = list("titles" = command_positions | engineering_positions | medical_positions | science_positions | supply_positions | security_positions | civilian_positions | nonhuman_positions), // crew positions
+	EXP_TYPE_CREW = list("titles" = crew_positions),
 	EXP_TYPE_COMMAND = list("titles" = command_positions),
 	EXP_TYPE_ENGINEERING = list("titles" = engineering_positions),
 	EXP_TYPE_MEDICAL = list("titles" = medical_positions),


### PR DESCRIPTION
closes: #21747

any time a round would mulligan, it would just throw everyone living in the antag pot
at no point would it check if the player was a ghost role or not
it also doesn't check if the living players are already antags, but that's not likely to happen :clueless:

# Why is this good for the game?
(it's a bugfix, but it could also be considered a design choice)
A number of ghost roles are heavily restricted in what they're capable of doing
giving them antag is both wasting the players antag rep, and causing the round to be boring, as the antag can't interact with the station

# Testing
gotta, though i imagine it will prove difficult

:cl:  
bugfix: Fixes a bug with ghost roles being able to get picked as antags
/:cl:
