### PR TITLE
Gives preternis eyes a notice when they're too low on power to activate nightvision

### DIFF
--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
@@ -32,9 +32,6 @@
 	. = ..()
 
 /obj/item/organ/eyes/robotic/preternis/ui_action_click()
-	if(damage > low_threshold || (powered && owner.nutrition <= NUTRITION_LEVEL_HUNGRY))
-		//no nightvision if your eyes are low on power, whether internal or external
-		return
 	if (night_vision)
 		nv_off()
 	else
@@ -79,10 +76,12 @@
 		if(night_vision)
 			owner.adjust_nutrition(-1) //consumes power to stay charged
 			if(owner.nutrition <= NUTRITION_LEVEL_HUNGRY)
+				to_chat(owner, span_boldwarning("Your [src] flash warnings that they've disabled night vision to save power!"))
 				nv_off() //if low on power, turn off
 	else if(night_vision)
 		owner.adjustOrganLoss(ORGAN_SLOT_EYES,0.5) //to simulate running out of power, they take damage
 		if(damage > low_threshold)
+			to_chat(owner, span_boldwarning("Your [src] flash warnings that they've disabled night vision to save power!"))
 			nv_off() //if low on power, turn off
 	
 /obj/item/organ/eyes/robotic/preternis/examine(mob/user)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
@@ -32,6 +32,10 @@
 	. = ..()
 
 /obj/item/organ/eyes/robotic/preternis/ui_action_click()
+	if(damage > low_threshold || (powered && owner.nutrition <= NUTRITION_LEVEL_HUNGRY))
+		to_chat(owner, span_warning("Your [src] flash warnings that they've disabled night vision to save power!"))
+		//no nightvision if your eyes are low on power, whether internal or external
+		return
 	if (night_vision)
 		nv_off()
 	else


### PR DESCRIPTION
# Why is this good for the game?
someone might think the ability is broken or bugged without a chat notice

# Testing
it's just to_chat lines

:cl:  
tweak: Gives preternis eyes a notice when they're too low on power to activate nightvision
/:cl:
