### PR TITLE
Tweaks the backrooms to not give the server 114% free lag

### DIFF
--- a/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_generator.dm
+++ b/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_generator.dm
@@ -275,7 +275,10 @@
 /datum/map_generator/dungeon_generator/maintenance/backrooms //this is an entire Z level, so we need to be mindful of how many machines and mobs we spawn
 
 	//since there are no firelocks, the place needs to be impossible to space
-	weighted_possible_floor_types = list(/turf/open/floor/plasteel/dark/indestructible = 1, /turf/open/floor/plating/indestructible = 5)
+	weighted_open_turf_types = list(
+		/turf/open/floor/plating/indestructible = 10, 
+		/turf/open/floor/plasteel/dark/indestructible = 1,
+		)
 	weighted_closed_turf_types = list(/turf/closed/indestructible = 1)
 
 	room_theme_path = /datum/dungeon_room_theme/maintenance/backrooms

--- a/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_generator.dm
+++ b/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_generator.dm
@@ -272,7 +272,7 @@
 ////////////////////////////////////////////////////////////////
 //------------Generator specifically for the Z level----------//
 ////////////////////////////////////////////////////////////////
-/datum/map_generator/dungeon_generator/maintenance/backrooms //this is an entire Z level, so we need to be mindful of how many machines and mobs we spawn
+/datum/map_generator/dungeon_generator/maintenance/backrooms
 
 	//since there are no firelocks, the place needs to be hard to space and replenish air automatically
 	weighted_open_turf_types = list(
@@ -280,6 +280,7 @@
 		/turf/open/floor/plating/rust/backrooms = 1,
 		)
 
+	//removes firelocks and apcs as the area is large enough that it annihilates the server if it has a bunch of firelocks
 	include_firelocks = FALSE
 	include_apcs = FALSE
 

--- a/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_generator.dm
+++ b/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_generator.dm
@@ -273,5 +273,12 @@
 //------------Generator specifically for the Z level----------//
 ////////////////////////////////////////////////////////////////
 /datum/map_generator/dungeon_generator/maintenance/backrooms //this is an entire Z level, so we need to be mindful of how many machines and mobs we spawn
+
+	//since there are no firelocks, the place needs to be impossible to space
+	weighted_possible_floor_types = list(/turf/open/floor/plasteel/dark/indestructible = 1, /turf/open/floor/plating/indestructible = 5)
+	weighted_closed_turf_types = list(/turf/closed/indestructible = 1)
+
+	room_theme_path = /datum/dungeon_room_theme/maintenance/backrooms
+
 	include_firelocks = FALSE
 	include_apcs = FALSE

--- a/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_generator.dm
+++ b/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_generator.dm
@@ -274,20 +274,19 @@
 ////////////////////////////////////////////////////////////////
 /datum/map_generator/dungeon_generator/maintenance/backrooms //this is an entire Z level, so we need to be mindful of how many machines and mobs we spawn
 
-	//since there are no firelocks, the place needs to be impossible to space
+	//since there are no firelocks, the place needs to be hard to space and replenish air automatically
 	weighted_open_turf_types = list(
-		/turf/open/floor/plating/indestructible = 10, 
-		/turf/open/floor/plating/rust/indestructible = 1,
+		/turf/open/floor/plating/backrooms = 10, 
+		/turf/open/floor/plating/rust/backrooms = 1,
 		)
-	weighted_closed_turf_types = list(/turf/closed/indestructible = 1)
 
 	include_firelocks = FALSE
 	include_apcs = FALSE
 
-/turf/open/floor/plating/rust/indestructible
-	baseturfs = /turf/open/floor/plating/indestructible
+/turf/open/floor/plating/rust/backrooms
+	baseturfs = /turf/open/floor/plating/backrooms
 	planetary_atmos = TRUE // prevent spacing backrooms
 
-/turf/open/floor/plating/indestructible
-	baseturfs = /turf/open/floor/plating/indestructible
+/turf/open/floor/plating/backrooms
+	baseturfs = /turf/open/floor/plating/backrooms
 	planetary_atmos = TRUE // prevent spacing backrooms

--- a/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_generator.dm
+++ b/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_generator.dm
@@ -281,8 +281,6 @@
 		)
 	weighted_closed_turf_types = list(/turf/closed/indestructible = 1)
 
-	room_theme_path = /datum/dungeon_room_theme/maintenance/backrooms
-
 	include_firelocks = FALSE
 	include_apcs = FALSE
 

--- a/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_generator.dm
+++ b/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_generator.dm
@@ -277,7 +277,7 @@
 	//since there are no firelocks, the place needs to be impossible to space
 	weighted_open_turf_types = list(
 		/turf/open/floor/plating/indestructible = 10, 
-		/turf/open/floor/plasteel/dark/indestructible = 1,
+		/turf/open/floor/plating/rust/indestructible = 1,
 		)
 	weighted_closed_turf_types = list(/turf/closed/indestructible = 1)
 
@@ -285,3 +285,11 @@
 
 	include_firelocks = FALSE
 	include_apcs = FALSE
+
+/turf/open/floor/plating/rust/indestructible
+	baseturfs = /turf/open/floor/plating/indestructible
+	planetary_atmos = TRUE // prevent spacing backrooms
+
+/turf/open/floor/plating/indestructible
+	baseturfs = /turf/open/floor/plating/indestructible
+	planetary_atmos = TRUE // prevent spacing backrooms

--- a/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_generator.dm
+++ b/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_generator.dm
@@ -6,14 +6,21 @@
 	weighted_closed_turf_types = list(/turf/closed/wall = 5, /turf/closed/wall/rust = 2 )
 	room_datum_path = /datum/dungeon_room/maintenance
 	room_theme_path = /datum/dungeon_room_theme/maintenance
+
+	///Boolean, whether or not firelocks are added to the maintenance
+	var/include_firelocks = TRUE
+	///Boolean, wether or not apcs are added to the maintenance
+	var/include_apcs = TRUE
 	
 	//var/list/used_spawn_points = list()
 
 /datum/map_generator/dungeon_generator/maintenance/build_dungeon()
 	. = ..()
-	add_firelocks()
-	add_apcs()
-	wire_apcs()
+	if(include_firelocks)
+		add_firelocks()
+	if(include_apcs)
+		add_apcs()
+		wire_apcs()
 	add_maint_loot()
 
 /datum/map_generator/dungeon_generator/maintenance/proc/add_firelocks()
@@ -261,3 +268,10 @@
 		//what the fuck how did you get here
 		brazil = TRUE
 	return "blocked directions: [blocked_directions], against a wall: [against_wall], in a one tile hallway: [blocking_passage], brazil: [brazil]"
+
+////////////////////////////////////////////////////////////////
+//------------Generator specifically for the Z level----------//
+////////////////////////////////////////////////////////////////
+/datum/map_generator/dungeon_generator/maintenance/backrooms //this is an entire Z level, so we need to be mindful of how many machines and mobs we spawn
+	include_firelocks = FALSE
+	include_apcs = FALSE

--- a/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_room_theme.dm
+++ b/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_room_theme.dm
@@ -10,3 +10,23 @@
 	weighted_possible_door_types = list(/obj/machinery/door/airlock/maintenance_hatch = 1)
 	feature_weight = 80
 	mob_spawn_chance = 50
+
+/datum/dungeon_room_theme/maintenance/backrooms
+	room_type = ROOM_TYPE_RANDOM
+	room_danger_level = ROOM_RATING_SAFE | ROOM_RATING_HOSTILE
+
+	weighted_possible_floor_types = list(/turf/open/floor/plasteel/dark/indestructible = 5, /turf/open/floor/plating/indestructible = 5)
+	weighted_possible_window_types = list(/turf/closed/indestructible/opsglass = 1)
+	window_weight = 10
+
+	weighted_possible_door_types = list(/obj/machinery/door/airlock/maintenance_hatch = 1)
+	feature_weight = 80
+	mob_spawn_chance = 50
+
+/turf/open/floor/plasteel/dark/indestructible
+	baseturfs = /turf/open/floor/plating/indestructible
+
+/turf/open/floor/plating/indestructible
+	baseturfs = /turf/open/floor/plating/indestructible
+	planetary_atmos = TRUE
+	made_baseturf = TRUE // prevent spacing backrooms

--- a/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_room_theme.dm
+++ b/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_room_theme.dm
@@ -28,5 +28,4 @@
 
 /turf/open/floor/plating/indestructible
 	baseturfs = /turf/open/floor/plating/indestructible
-	planetary_atmos = TRUE
-	made_baseturf = TRUE // prevent spacing backrooms
+	planetary_atmos = TRUE // prevent spacing backrooms

--- a/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_room_theme.dm
+++ b/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_room_theme.dm
@@ -10,22 +10,3 @@
 	weighted_possible_door_types = list(/obj/machinery/door/airlock/maintenance_hatch = 1)
 	feature_weight = 80
 	mob_spawn_chance = 50
-
-/datum/dungeon_room_theme/maintenance/backrooms
-	room_type = ROOM_TYPE_RANDOM
-	room_danger_level = ROOM_RATING_SAFE | ROOM_RATING_HOSTILE
-
-	weighted_possible_floor_types = list(/turf/open/floor/plasteel/dark/indestructible = 5, /turf/open/floor/plating/indestructible = 5)
-	weighted_possible_window_types = list(/turf/closed/indestructible/opsglass = 1)
-	window_weight = 10
-
-	weighted_possible_door_types = list(/obj/machinery/door/airlock/maintenance_hatch = 1)
-	feature_weight = 80
-	mob_spawn_chance = 50
-
-/turf/open/floor/plasteel/dark/indestructible
-	baseturfs = /turf/open/floor/plating/indestructible
-
-/turf/open/floor/plating/indestructible
-	baseturfs = /turf/open/floor/plating/indestructible
-	planetary_atmos = TRUE // prevent spacing backrooms

--- a/code/game/area/areas/procedurally_generated_areas/maintenance.dm
+++ b/code/game/area/areas/procedurally_generated_areas/maintenance.dm
@@ -168,4 +168,6 @@
 
 /area/procedurally_generated/maintenance/the_backrooms
 	name = "The Backrooms"
+	requires_power = FALSE
+	map_generator = /datum/map_generator/dungeon_generator/maintenance/backrooms
 	


### PR DESCRIPTION
i've tweaked it so it doesn't spawn apcs/wires/firelocks
i've also replaced the turf with indestructible ones that use planetary atmos, so the place is pretty much immune to spacing

# Why is this good for the game?
it was spawning too many machines and making SSmachines cry

# Testing
i've confirmed the turf replacements and the lack of spawning, however for some reason the backrooms themselves aren't spawning because rust_g is missing things
testing on the live server however proved highly fruitful
![image](https://github.com/yogstation13/Yogstation/assets/108117184/0d8d8d64-4ef6-4493-a5bb-96f932f1cd12)


:cl:  
experimental: Tweaks the backrooms to not give the server 114% free lag
/:cl:
