### PR TITLE
Fixes a missing plasma input vent (oops)

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_syndicate.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_syndicate.dmm
@@ -1870,10 +1870,6 @@
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/machinery/light_switch{
-	pixel_y = 28;
-	pixel_x = 14
-	},
 /turf/open/floor/carpet/red,
 /area/ruin/syndicate_icemoon/command)
 "lD" = (
@@ -7454,6 +7450,10 @@
 	},
 /obj/structure/closet/secure_closet/syndicate/captain,
 /obj/item/storage/toolbox/syndicate/real,
+/obj/machinery/light_switch{
+	pixel_y = 28;
+	pixel_x = -6
+	},
 /turf/open/floor/carpet/red,
 /area/ruin/syndicate_icemoon/command)
 "SZ" = (

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_syndicate.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_syndicate.dmm
@@ -6011,7 +6011,6 @@
 /area/icemoon/surface/outdoors)
 "Jy" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	dir = 8;
 	target_temperature = 80
 	},
 /turf/open/floor/plating,
@@ -7566,9 +7565,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/ruin/syndicate_icemoon/dorms)
 "TS" = (
-/obj/machinery/atmospherics/components/unary/tank/nitrogen{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/tank/nitrogen,
 /turf/open/floor/plating,
 /area/ruin/syndicate_icemoon/medical)
 "TW" = (

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_syndicate.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_syndicate.dmm
@@ -1871,7 +1871,8 @@
 	pixel_y = 26
 	},
 /obj/machinery/light_switch{
-	pixel_y = 28
+	pixel_y = 28;
+	pixel_x = 14
 	},
 /turf/open/floor/carpet/red,
 /area/ruin/syndicate_icemoon/command)
@@ -3311,6 +3312,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/syndicate_icemoon/warehouse)
 "ud" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 1
+	},
 /turf/open/floor/engine/plasma,
 /area/ruin/syndicate_icemoon/reactor)
 "ue" = (
@@ -5807,6 +5811,10 @@
 	},
 /obj/effect/turf_decal/siding/red{
 	dir = 10
+	},
+/obj/machinery/light_switch{
+	pixel_y = -28;
+	pixel_x = 8
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/ruin/syndicate_icemoon/command)


### PR DESCRIPTION
I ACCIDENTALLY LOST THE PLASMA INPUT VENT
also moves a lightswitch by like 8 pixels and adds another

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: OOPS I DROPPED THE PLASMA INPUT VENT
/:cl:
