### PR TITLE
Removes one of the comms agents from the space listening station

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -2147,6 +2147,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/airlock)
+"EW" = (
+/obj/structure/sign/poster/official/no_erp{
+	desc = "This poster reminds the crew that Eroticism, Rape and Pornography are banned on Syndicate stations.";
+	pixel_y = -32
+	},
+/obj/item/bedsheet/syndie,
+/obj/structure/bed,
+/turf/open/floor/plasteel/grimy,
+/area/ruin/space/has_grav/listeningstation/quarters)
 "Fl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -2247,18 +2256,6 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation/engineering)
-"He" = (
-/obj/structure/sign/poster/official/no_erp{
-	desc = "This poster reminds the crew that Eroticism, Rape and Pornography are banned on Syndicate stations.";
-	pixel_y = -32
-	},
-/obj/item/bedsheet/syndie,
-/obj/structure/bed,
-/obj/effect/mob_spawn/human/lavaland_syndicate/comms/space/lieutenant{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ruin/space/has_grav/listeningstation/quarters)
 "Hy" = (
 /obj/machinery/computer/med_data/syndie{
 	dir = 8;
@@ -2407,8 +2404,8 @@
 /obj/docking_port/stationary{
 	dwidth = 6;
 	height = 7;
-	shuttle_id = "listeningpost";
 	name = "Listening Post Dock";
+	shuttle_id = "listeningpost";
 	width = 15
 	},
 /turf/template_noop,
@@ -4175,7 +4172,7 @@ OV
 Su
 tH
 ah
-He
+EW
 az
 NO
 "}


### PR DESCRIPTION

# Document the changes in your pull request

Removes one of the comm agent spawns from the space listening station
# Why is this good for the game?
So we have entirely too many comms agents, incase you didn't know. This station previously spawned 2, which is already 2 much (1 is annoying on its own), but it's made worse by the fact that there can also be a planetary syndicate base, which would've given you up to 3 comms agents.

Nowadays comms agents serve more as a "haha im just a funny guy here to be pals and annoy the fuck out of everyone" role, instead of the "create disarray and provide syndicate agents with recon" role, which probably wouldn’t be as bad if we couldn’t have 3 in a single rohnd
# Testing
<!-- Describe what testing you did with this PR. Try to be thorough, especially if this is a larger project. -->

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
mapping: remove one of the comms agents from the space listening post
/:cl:
