### PR TITLE
Fixes invisible synth storage circuit board, makes mass driver board purple

### DIFF
--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -163,15 +163,6 @@
 		/obj/item/stack/cable_coil = 2,
 		/obj/item/stock_parts/manipulator = 5)
 
-/obj/item/circuitboard/machine/synth_pod
-	name = "Synthetic Storage Unit (Machine Board)"
-	icon_state = "engineering"
-	build_path = /obj/machinery/synth_pod
-	req_components = list(
-		/obj/item/stock_parts/micro_laser = 2,
-		/obj/item/stack/cable_coil = 2,
-		/obj/item/stock_parts/manipulator = 2)
-
 /obj/item/circuitboard/machine/decontamination_unit
 	name = "Decontamination Storage Unit (Machine Board)"
 	greyscale_colors = CIRCUIT_COLOR_ENGINEERING
@@ -744,7 +735,7 @@
 	needs_anchored = FALSE
 // yogs start - abductor chem dispenser
 /obj/item/circuitboard/machine/chem_dispenser/abductor
-	name = "Reagent Synthetizer (Abductor Machine Board)"
+	name = "Reagent Synthetizer (Machine Board)"
 	icon_state = "abductor_mod"
 	build_path = /obj/machinery/chem_dispenser/abductor
 	def_components = list(/obj/item/stock_parts/cell = /obj/item/stock_parts/cell/high)
@@ -867,7 +858,7 @@
 		/obj/item/stack/sheet/glass = 1)
 
 /obj/item/circuitboard/machine/protolathe/department/medical
-	name = "Departmental Protolathe (Machine Board) - Medical"
+	name = "Departmental Protolathe - Medical (Machine Board)"
 	greyscale_colors = CIRCUIT_COLOR_MEDICAL
 	build_path = /obj/machinery/rnd/production/protolathe/department/medical
 
@@ -1034,7 +1025,7 @@
 	build_path = /obj/machinery/processor/slime
 
 /obj/item/circuitboard/machine/protolathe/department/science
-	name = "Departmental Protolathe (Machine Board) - Science"
+	name = "Departmental Protolathe - Science (Machine Board)"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/rnd/production/protolathe/department/science
 
@@ -1139,12 +1130,28 @@
 		/obj/item/reagent_containers/glass/beaker = 2)
 
 /obj/item/circuitboard/machine/plort
-	name = "Machine Design (Plort Redemption Machine)"
+	name = "Plort Redemption Machine (Machine Board)"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/plortrefinery
 	req_components = list(
 		/obj/item/stock_parts/manipulator = 3,
 		/obj/item/stack/cable_coil = 2)
+
+/obj/item/circuitboard/machine/synth_pod
+	name = "Synthetic Storage Unit (Machine Board)"
+	greyscale_colors = CIRCUIT_COLOR_SCIENCE
+	build_path = /obj/machinery/synth_pod
+	req_components = list(
+		/obj/item/stock_parts/micro_laser = 2,
+		/obj/item/stack/cable_coil = 2,
+		/obj/item/stock_parts/manipulator = 2)
+
+/obj/item/circuitboard/machine/mass_driver
+	name = "Mass Driver (Machine Board)"
+	greyscale_colors = CIRCUIT_COLOR_SCIENCE
+	build_path = /obj/machinery/mass_driver
+	req_components = list(
+		/obj/item/stock_parts/capacitor = 1)
 
 //Security
 
@@ -1368,7 +1375,7 @@
 	req_components = list()
 
 /obj/item/circuitboard/machine/protolathe/department/cargo
-	name = "Departmental Protolathe (Machine Board) - Cargo"
+	name = "Departmental Protolathe - Cargo (Machine Board)"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/rnd/production/protolathe/department/cargo
 
@@ -1389,7 +1396,7 @@
 		/obj/item/stack/cable_coil = 5)
 
 /obj/item/circuitboard/machine/techfab/department/cargo
-	name = "\improper Departmental Techfab (Machine Board) - Cargo"
+	name = "\improper Departmental Techfab - Cargo (Machine Board)"
 	greyscale_colors = CIRCUIT_COLOR_SUPPLY
 	build_path = /obj/machinery/rnd/production/techfab/department/cargo
 
@@ -1476,9 +1483,3 @@
 	req_components = list(
 		/obj/item/stock_parts/capacitor = 3,
 		/obj/item/stock_parts/micro_laser = 1)
-
-/obj/item/circuitboard/machine/mass_driver
-	name = "Mass Driver"
-	build_path = /obj/machinery/mass_driver
-	req_components = list(
-		/obj/item/stock_parts/capacitor = 1)


### PR DESCRIPTION
# Document the changes in your pull request
- Fixed synthetic storage unit being invisible (wasn't coded for GAGS)
- Made mass driver purple (I forgot to do it when I added it)
- Standardized board names

Closes #21781

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/143908044/4aaca4fb-da43-441c-b635-d80f87dfb570)
![image](https://github.com/yogstation13/Yogstation/assets/143908044/8a8eeae4-1c1b-4263-82c1-3401c01f652c)

# Changelog
:cl:  
bugfix: Fixed synthetic storage unit circuit boards being invisible
spellcheck: Standardized some circuit board names
/:cl:
