### PR TITLE
Fixes goat king arena portal

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/kinggoatarena.dmm
+++ b/_maps/RandomRuins/SpaceRuins/kinggoatarena.dmm
@@ -131,7 +131,7 @@
 /obj/effect/portal/permanent/one_way/multi/entry{
 	id = "goatarena";
 	teleport_channel = "free";
-	desc = "Echoes of a thousand bleats and the faint smells of farm and gold seem to emanate from this portal. Do you dare enter?"
+	desc = "Echoes of a thousand bleats and the faint smell of farm seem to emanate from this portal. Do you dare enter?"
 	name = "Ingress"
 	},
 /turf/open/indestructible/carpet,

--- a/_maps/RandomRuins/SpaceRuins/kinggoatarena.dmm
+++ b/_maps/RandomRuins/SpaceRuins/kinggoatarena.dmm
@@ -131,7 +131,7 @@
 /obj/effect/portal/permanent/one_way/multi/entry{
 	id = "goatarena";
 	teleport_channel = "free";
-	desc = "Echoes of a thousand bleats and the faint smell of farm seem to emanate from this portal. Do you dare enter?"
+	desc = "Echoes of a thousand bleats and the faint smell of farm seem to emanate from this portal. Do you dare enter?";
 	name = "Ingress";
 	},
 /turf/open/indestructible/carpet,

--- a/_maps/RandomRuins/SpaceRuins/kinggoatarena.dmm
+++ b/_maps/RandomRuins/SpaceRuins/kinggoatarena.dmm
@@ -132,7 +132,7 @@
 	id = "goatarena";
 	teleport_channel = "free";
 	desc = "Echoes of a thousand bleats and the faint smell of farm seem to emanate from this portal. Do you dare enter?"
-	name = "Ingress"
+	name = "Ingress";
 	},
 /turf/open/indestructible/carpet,
 /area/ruin/powered/kinggoat_arena)

--- a/_maps/RandomRuins/SpaceRuins/kinggoatarena.dmm
+++ b/_maps/RandomRuins/SpaceRuins/kinggoatarena.dmm
@@ -131,7 +131,7 @@
 /obj/effect/portal/permanent/one_way/multi/entry{
 	id = "goatarena";
 	teleport_channel = "free";
-	desc = "The echoes of a thousand bleats and a faint smell of wool seem to emanate from this portal. Do you dare enter?"
+	desc = "Echoes of a thousand bleats and the faint smells of farm and gold seem to emanate from this portal. Do you dare enter?"
 	name = "Ingress"
 	},
 /turf/open/indestructible/carpet,

--- a/_maps/RandomRuins/SpaceRuins/kinggoatarena.dmm
+++ b/_maps/RandomRuins/SpaceRuins/kinggoatarena.dmm
@@ -131,7 +131,8 @@
 /obj/effect/portal/permanent/one_way/multi/entry{
 	id = "goatarena";
 	teleport_channel = "free";
-	name = "goat arena portal"
+	desc = "The echoes of a thousand bleats and a faint smell of wool seem to emanate from this portal. Do you dare enter?"
+	name = "Ingress"
 	},
 /turf/open/indestructible/carpet,
 /area/ruin/powered/kinggoat_arena)
@@ -196,7 +197,7 @@
 /area/ruin/powered/kinggoat_arena)
 "T" = (
 /obj/machinery/door/airlock/gold/glass{
-	desc = "Once you go in the portal past this door there is no going back...";
+	desc = "A small engraving on the door reads: <i>Once you go in the portal past this door there is no going back...</i>";
 	name = "POINT OF NO RETURN"
 	},
 /turf/open/indestructible/carpet,
@@ -205,7 +206,8 @@
 /obj/effect/portal/permanent/one_way/multi/exit{
 	id = "goatarena";
 	teleport_channel = "free";
-	name = "goat arena portal";
+	desc = "You can barely make out what's on the other side: Freedom, something you hope to see again."
+	name = "Egress";
 	alpha = 0
 	},
 /turf/open/indestructible/carpet{

--- a/_maps/RandomRuins/SpaceRuins/kinggoatarena.dmm
+++ b/_maps/RandomRuins/SpaceRuins/kinggoatarena.dmm
@@ -206,7 +206,7 @@
 /obj/effect/portal/permanent/one_way/multi/exit{
 	id = "goatarena";
 	teleport_channel = "free";
-	desc = "You can barely make out what's on the other side: Freedom, something you hope to see again."
+	desc = "You can barely make out what's on the other side: Freedom, something you hope to see again.";
 	name = "Egress";
 	alpha = 0
 	},

--- a/_maps/RandomRuins/SpaceRuins/kinggoatarena.dmm
+++ b/_maps/RandomRuins/SpaceRuins/kinggoatarena.dmm
@@ -128,10 +128,10 @@
 	},
 /area/ruin/powered/kinggoat_arena)
 "E" = (
-/obj/effect/portal/permanent/one_way/keep{
-	id = "king goat arena";
-	name = "king goat arena portal";
-	teleport_channel = "free"
+/obj/effect/portal/permanent/one_way/multi/entry{
+	id = "goatarena";
+	teleport_channel = "free";
+	name = "goat arena portal"
 	},
 /turf/open/indestructible/carpet,
 /area/ruin/powered/kinggoat_arena)
@@ -202,10 +202,11 @@
 /turf/open/indestructible/carpet,
 /area/ruin/powered/kinggoat_arena)
 "V" = (
-/obj/effect/portal/permanent/one_way/destroy{
-	id = "king goat arena";
-	name = "king goat arena portal";
-	teleport_channel = "free"
+/obj/effect/portal/permanent/one_way/multi/exit{
+	id = "goatarena";
+	teleport_channel = "free";
+	name = "goat arena portal";
+	alpha = 0
 	},
 /turf/open/indestructible/carpet{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"


### PR DESCRIPTION
# Why is this good for the game?
I haven't a damn clue what's wrong but normal permanent one way portals don't want to work
and yet, the portals on centcom, a subtype of a subtype of said permanent one way portals do work

call it a bandaid fix whatever, this fixes it

# Testing

https://github.com/yogstation13/Yogstation/assets/143908044/0bc32a2e-05de-4c13-9e22-a1a626a0a19a


# Changelog
:cl:  
bugfix: Fixed the portal in goat king arena not working
/:cl:
