### PR TITLE
Fixes pulsating tumors not having a GPS signal

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -210,8 +210,14 @@ obj/structure/elite_tumor/proc/return_elite()
 
 /obj/structure/elite_tumor/Initialize(mapload)
 	. = ..()
-	//AddComponent(/datum/component/gps, "Menacing Signal")
+	AddComponent(/datum/component/gps, "Menacing Signal")
 	START_PROCESSING(SSobj, src)
+
+/obj/item/gps/internal/elite
+	icon_state = null
+	gpstag = "Menacing Signal"
+	desc = "Something strange sleeps beneath the planet."
+	invisibility = 100
 
 /obj/structure/elite_tumor/Destroy()
 	STOP_PROCESSING(SSobj, src)


### PR DESCRIPTION
# Document the changes in your pull request
Closes #21776

something may be off with either the uncommenting or the other block I added
might need to test more to find out if one is redundant, but tl;dr it works

P.S. I couldn't replicate the GPS thing in the issue, GPS names seem to work fine for me

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/143908044/1a265364-6b9f-4de1-95bb-affed22bd8c0)
![image](https://github.com/yogstation13/Yogstation/assets/143908044/0691eb15-95d3-4e40-940f-28fb74caad9a)

# Changelog
:cl:  
bugfix: Fixed pulsating tumors not having a GPS signal
/:cl:
