### PR TITLE
Makes cryopodding remove the person from antag teams

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -308,6 +308,12 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 /obj/machinery/cryopod/proc/despawn_occupant()
 	var/mob/living/mob_occupant = occupant
 	if(mob_occupant.mind && mob_occupant.mind.assigned_role)
+		// Removes from team antag teams to avoid influencing gameplay
+		var/datum/antagonist/antag = mob_occupant.mind.has_antag_datum()
+		if(antag)
+			var/datum/team/antag_team = antag.get_team()
+			if(antag_team)
+				antag_team.remove_member(mob_occupant.mind)
 		//Handle job slot/tater cleanup.
 		var/job = mob_occupant.mind.assigned_role
 		SSjob.FreeRole(job)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -309,7 +309,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	var/mob/living/mob_occupant = occupant
 	if(mob_occupant.mind && mob_occupant.mind.assigned_role)
 		// Removes from team antag teams to avoid influencing gameplay
-		var/datum/antagonist/antag = mob_occupant.mind.has_antag_datum()
+		var/datum/antagonist/antag = mob_occupant.mind.has_antag_datum(/datum/antagonist)
 		if(antag)
 			var/datum/team/antag_team = antag.get_team()
 			if(antag_team)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -309,11 +309,11 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 	var/mob/living/mob_occupant = occupant
 	if(mob_occupant.mind && mob_occupant.mind.assigned_role)
 		// Removes from team antag teams to avoid influencing gameplay
-		var/datum/antagonist/antag = mob_occupant.mind.has_antag_datum(/datum/antagonist)
-		if(antag)
-			var/datum/team/antag_team = antag.get_team()
-			if(antag_team)
-				antag_team.remove_member(mob_occupant.mind)
+		for(var/datum/antagonist/antag as anything in mob_occupant.mind.antag_datums)
+			if(antag && istype(antag))
+				var/datum/team/antag_team = antag.get_team()
+				if(antag_team)
+					antag_team.remove_member(mob_occupant.mind)
 		//Handle job slot/tater cleanup.
 		var/job = mob_occupant.mind.assigned_role
 		SSjob.FreeRole(job)


### PR DESCRIPTION
# Why is this good for the game?
a blood brother can't control if their ally cryos
this makes it so they aren't screwed over

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/9ffd5578-776a-4422-8999-205ceca37af0)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/596819f0-feb6-4e1d-8f76-be6042833928)


:cl:  
bugfix: Blood brothers no longer instantly redtext if their ally cryoes
/:cl:
