### PR TITLE
Fixes chat being unavailable while server is initializing

### DIFF
--- a/code/modules/tgchat/to_chat.dm
+++ b/code/modules/tgchat/to_chat.dm
@@ -65,7 +65,7 @@
 	trailing_newline = TRUE,
 	confidential = FALSE
 )
-	if(isnull(Master) || !Master.current_runlevel)
+	if(isnull(Master) || !Master.current_runlevel || !MC_RUNNING(SSchat.init_stage))
 		to_chat_immediate(target, html, type, text, avoid_highlighting, allow_linkify)
 		return
 	


### PR DESCRIPTION
# Document the changes in your pull request

one line change, lets to_chat_immediate actually get called if SSchat is not intiailized to handle regular to_chat()

# Why is this good for the game?
now you can talk and see the server loading!

# Testing
![dreamseeker_ohugTR9vUV](https://github.com/yogstation13/Yogstation/assets/5091394/604dba14-7e40-410d-8141-640aa0019c18)


# Changelog

:cl:  
bugfix: to_chat_immediate is now properly called so you see stuff loading/chat during initialization
/:cl:
