### PR TITLE
birdboat meat is no longer invisible

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/goose.dm
+++ b/code/modules/mob/living/simple_animal/hostile/goose.dm
@@ -9,7 +9,7 @@
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
 	speak_chance = 0
 	turns_per_move = 5
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat = 2)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab = 2)
 	response_help = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm = "kicks"


### PR DESCRIPTION
Birdboat, when butchered, gave invisible meat. This fixes that.


# Testing
current result ![image](https://github.com/yogstation13/Yogstation/assets/122807629/832364b6-d955-42c8-95bf-8848634b7015)
here a bald man has butchered birdboat to provide plain raw meat ![image](https://github.com/yogstation13/Yogstation/assets/122807629/7c090851-7d8b-44fd-a3cb-de103325b7ab)

:cl:  ktlwjec
bugfix: Birdboat gives meat when butchered.
/:cl: