### PR TITLE
Removes minimum pop requirement from icemeta

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -22,7 +22,6 @@ map yogstation
 endmap
 
 map icemeta
-	minplayers 25
 	votable
 endmap
 


### PR DESCRIPTION
yet another pr that breaks feature freeze for the sake of lowpop "help"

# Why is this good for the game?
Map variety is incredibly important for a lot of people, with lowpop, the only maps that can be selected are gax and box
if box can be rolled at 2 players, ice meta should be able to also

:cl:  
tweak: Removes minimum pop requirement from icemeta
/:cl:
