### PR TITLE
Fixes a quantum pipe problem that SOMEONE didn't correct on Yogstation.

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -61832,10 +61832,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/fore)


### PR DESCRIPTION
# Document the changes in your pull request
Changes exactly two pipes (an L and an I), replacing it with the far superior "T-pipe" (the Manifold), in Yogstation outside of EVA storage. Quantum Piping is also banned.

# Why is this good for the game?
Ventcrawlers can now properly ventcrawl. This also probably untangles a mess involving air and pipes.

# Testing
Does a single pipe REALLY need testing? The pipe was changed successfully.
![image](https://github.com/yogstation13/Yogstation/assets/106483611/046e9a6a-44a4-4c44-b8cf-678b9c7a875b)

# Changelog

:cl:
mapping: Yogstation's quantum pipe near EVA storage is now a manifold pipe.
/:cl:
