### PR TITLE
makes it so perma always starts with the lights on

### DIFF
--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -916,9 +916,11 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Prison Wing"
 	icon_state = "sec_prison"
 	minimap_color = "#530505"
+	lights_always_start_on = TRUE
 
 /area/security/prison/hallway
 	name = "Prison Wing Hallway"
+	lights_always_start_on = TRUE
 
 /area/security/processing
 	name = "Labor Shuttle Dock"

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -920,7 +920,6 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 /area/security/prison/hallway
 	name = "Prison Wing Hallway"
-	lights_always_start_on = TRUE
 
 /area/security/processing
 	name = "Labor Shuttle Dock"


### PR DESCRIPTION
# Document the changes in your pull request
makes it so perma always starts with the lights on

# Why is this good for the game?
if the lights start off (which they tend to, since i cant recall a single time the perma lights werent off when i've gotten perma'd since the new perma was added) they are likely to STAY off, which sucks for the inhabitants as they have to wander around basically blind, and gives sec a massive advantage as they can use NVGs which allows sec to see prisoners while prisoners cant see sec.
i like bein able to fuckin see in my perma

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/122653864/f828ca52-3af0-4387-b57e-78b1952ba1c8)
im the only person, started as chap, perma lights were on

# Changelog

:cl:  
mapping: Protests from the Prisoner's Rights Society has forced NT's hand into making perma's lights always start on.
/:cl:
