### PR TITLE
Partially reverts #31612 with the proper fix, lets you reload donksoft weapons.

### DIFF
--- a/code/__DEFINES/ammo.dm
+++ b/code/__DEFINES/ammo.dm
@@ -25,7 +25,6 @@
 #define CALIBER_BREACH "breaching"  	    // 12 Gauge (Breaching Shotgun)
 #define CALIBER_CANNON "100mm"		        // Cannonball (Hand Cannon)
 #define CALIBER_FOAM "foam_force"           // Foam darts (Toy Guns)
-#define CALIBER_FOAM_RIOT "foam_force_riot" // Riot darts (Syndicate Toy Guns)
 #define CALIBER_GATLING "gatling"   	    // Gatling (Osprey Minigun) (Don't ask)
 #define CALIBER_SPEAR "speargun"            // Spear (Speargun)
 

--- a/code/modules/projectiles/ammunition/reusable/foam.dm
+++ b/code/modules/projectiles/ammunition/reusable/foam.dm
@@ -60,7 +60,6 @@
 
 /obj/item/ammo_casing/reusable/foam_dart/riot
 	name = "riot foam dart"
-	caliber = CALIBER_FOAM_RIOT
 	desc = "Whose smart idea was it to use toys as crowd control? Ages 18 and up."
 	projectile_type = /obj/projectile/bullet/reusable/foam_dart/riot
 	icon_state = "foamdart_riot"

--- a/code/modules/projectiles/boxes_magazines/external/toy.dm
+++ b/code/modules/projectiles/boxes_magazines/external/toy.dm
@@ -1,7 +1,14 @@
 /obj/item/ammo_box/magazine/toy
 	name = "foam force META magazine"
 	ammo_type = /obj/item/ammo_casing/reusable/foam_dart	
-	caliber = list(CALIBER_FOAM, CALIBER_FOAM_RIOT)
+	caliber = CALIBER_FOAM
+	var/hugbox = FALSE
+
+/obj/item/ammo_box/magazine/toy/attempt_load(obj/item/A, mob/user, silent, replace_spent)
+	if(istype(A, /obj/item/ammo_casing/reusable/foam_dart/riot) && hugbox)
+		to_chat(user, span_danger("The dart seems to be blocked from entering by a bright orange piece of plastic! How annoying."))
+		return
+	..()
 
 /obj/item/ammo_box/magazine/toy/smg
 	name = "foam force SMG magazine"
@@ -31,7 +38,7 @@
 /obj/item/ammo_box/magazine/toy/smgm45
 	name = "donksoft SMG magazine"
 	icon_state = "c20r45-toy"
-	caliber = list(CALIBER_FOAM, CALIBER_FOAM_RIOT)
+	caliber = CALIBER_FOAM
 	ammo_type = /obj/item/ammo_casing/reusable/foam_dart
 	max_ammo = 20
 
@@ -46,7 +53,6 @@
 /obj/item/ammo_box/magazine/toy/m762
 	name = "donksoft box magazine"
 	icon_state = "a762-toy"
-	caliber = list(CALIBER_FOAM, CALIBER_FOAM_RIOT)
 	ammo_type = /obj/item/ammo_casing/reusable/foam_dart
 	max_ammo = 50
 
@@ -60,13 +66,13 @@
 
 //Hugboxed mags for roundstart vendors.
 /obj/item/ammo_box/magazine/toy/smg/hugbox
-	caliber = CALIBER_FOAM
+	hugbox = TRUE
 
 /obj/item/ammo_box/magazine/toy/pistol/hugbox
-	caliber = CALIBER_FOAM
+	hugbox = TRUE
 
 /obj/item/ammo_box/magazine/toy/m762/hugbox
-	caliber = CALIBER_FOAM
+	hugbox = TRUE
 
 /obj/item/ammo_box/magazine/toy/smgm45/hugbox
-	caliber = CALIBER_FOAM
+	hugbox = TRUE

--- a/code/modules/projectiles/boxes_magazines/external/toy.dm
+++ b/code/modules/projectiles/boxes_magazines/external/toy.dm
@@ -4,6 +4,11 @@
 	caliber = CALIBER_FOAM
 	var/hugbox = FALSE
 
+/obj/item/ammo_box/magazine/toy/Initialize(mapload)
+	. = ..()
+	if(hugbox) //noob
+		name = "safety-first [name]"
+
 /obj/item/ammo_box/magazine/toy/attempt_load(obj/item/A, mob/user, silent, replace_spent)
 	if(istype(A, /obj/item/ammo_casing/reusable/foam_dart/riot) && hugbox)
 		to_chat(user, span_danger("The dart seems to be blocked from entering by a bright orange piece of plastic! How annoying."))

--- a/code/modules/projectiles/boxes_magazines/internal/toy.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/toy.dm
@@ -1,14 +1,21 @@
 /obj/item/ammo_box/magazine/internal/shot/toy
 	ammo_type = /obj/item/ammo_casing/reusable/foam_dart
-	caliber = list(CALIBER_FOAM, CALIBER_FOAM_RIOT)
+	caliber = CALIBER_FOAM
 	max_ammo = 4
+	var/hugbox = FALSE
 
 /obj/item/ammo_box/magazine/internal/shot/toy/crossbow
 	max_ammo = 5
 
 /obj/item/ammo_box/magazine/internal/shot/toy/hugbox
-	ammo_type = /obj/item/ammo_casing/reusable/foam_dart
-	caliber = CALIBER_FOAM
+	hugbox = TRUE
 
 /obj/item/ammo_box/magazine/internal/shot/toy/crossbow/hugbox
-	caliber = CALIBER_FOAM
+	hugbox = TRUE
+
+/obj/item/ammo_box/magazine/internal/shot/toy/attempt_load(obj/item/A, mob/user, silent, replace_spent)
+	if(istype(A, /obj/item/ammo_casing/reusable/foam_dart/riot) && hugbox)
+		to_chat(user, span_danger("The dart seems to be blocked from entering by a bright orange piece of plastic! How annoying."))
+		return
+	..()
+	

--- a/code/modules/projectiles/guns/ballistic/toy.dm
+++ b/code/modules/projectiles/guns/ballistic/toy.dm
@@ -133,7 +133,7 @@
 	desc = "A weapon favored by many overactive children. Ages 8 and up. This one feels noticably less fun..."
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/toy/crossbow/hugbox
 
-obj/item/gun/ballistic/automatic/l6_saw/toy/unrestricted/hugbox
+/obj/item/gun/ballistic/automatic/l6_saw/toy/unrestricted/hugbox
 	desc = "A heavily modified toy light machine gun, designated 'L6 SAW'. Ages 8 and up. This one feels noticably less fun..."
 	mag_type = /obj/item/ammo_box/magazine/toy/m762/hugbox
 


### PR DESCRIPTION
# Document the changes in your pull request

caliber variable does not support list()

closes https://github.com/yogstation13/Yogstation/issues/21612

# Why is this good for the game?
bugfixing. Also makes the names of these magazines say "safety first" so you aren't confused when you can't put it in.

# Testing
I was able to load normal foam force darts into the hugbox variety but unable to load riot darts into the hugbox variety.
![dreamseeker_T7eyXCQ2GK](https://github.com/yogstation13/Yogstation/assets/5091394/18c7e9d7-84d5-41d7-8c68-b5a2e292a158)
I was however able to load riot darts into the non-hugbox variety.

# Changelog

:cl:  
bugfix: you can now reload donksoft toys properly
/:cl:
