### PR TITLE
removes snowflake title screen pixel offset handling

### DIFF
--- a/code/controllers/subsystem/title.dm
+++ b/code/controllers/subsystem/title.dm
@@ -56,7 +56,6 @@ SUBSYSTEM_DEF(title)
 
 	if(splash_turf)
 		splash_turf.icon = icon
-		splash_turf.handle_generic_titlescreen_sizes()
 
 	return SS_INIT_SUCCESS
 

--- a/code/game/turfs/closed/indestructible.dm
+++ b/code/game/turfs/closed/indestructible.dm
@@ -60,24 +60,6 @@ INITIALIZE_IMMEDIATE(/turf/closed/indestructible/splashscreen)
 	SStitle.splash_turf = src
 	if(SStitle.icon)
 		icon = SStitle.icon
-		handle_generic_titlescreen_sizes()
-
-///helper proc that will center the screen if the icon is changed to a generic width, to make admins have to fudge around with pixel_x less. returns null
-/turf/closed/indestructible/splashscreen/proc/handle_generic_titlescreen_sizes()
-	var/icon/size_check = icon(SStitle.icon, icon_state)
-	var/width = size_check.Width()
-	if(width == 480) // 480x480 is nonwidescreen
-		pixel_x = 0
-	else if(width == 608) // 608x480 is widescreen
-		pixel_x = -64
-
-/turf/closed/indestructible/splashscreen/vv_edit_var(var_name, var_value)
-	. = ..()
-	if(.)
-		switch(var_name)
-			if(NAMEOF(src, icon))
-				SStitle.icon = icon
-				handle_generic_titlescreen_sizes()
 
 /turf/closed/indestructible/riveted
 	icon = 'icons/turf/walls/riveted.dmi'


### PR DESCRIPTION
# Document the changes in your pull request

Added in #21221 to handle weird titlescreens from tg, but unneeded here and only caused one of the joke title screens to be offset oddly.

# Why is this good for the game?

makes us look more professional.

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/5091394/4cb18fe6-bf35-4f6b-8515-5b2e5738887c)

# Changelog

:cl:  
bugfix: clown throwing pie at sec officer title screen is no longer offset incorrectly
/:cl:
