### PR TITLE
clamps agent id age

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -661,7 +661,7 @@ update_label("John Doe", "Clowny")
 
 			var/newAge = input(user, "Choose the ID's age:\n([AGE_MIN]-[AGE_MAX])", "Agent card age") as num|null
 			if(newAge)
-				registered_age = max(round(text2num(newAge)), 0)
+				registered_age = clamp(round(text2num(newAge)), AGE_MIN, AGE_MAX)
 
 			registered_name = input_name
 			assignment = target_occupation


### PR DESCRIPTION

# Document the changes in your pull request

closes https://github.com/yogstation13/Yogstation/issues/21802

already clamped your age above 0 so im assuming it's intended to clamp it

# Why is this good for the game?
no more accidentally putting 42069 as your age

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/5091394/4299d8f4-f72c-45db-bd9a-b4d5ce102d2c)
![image](https://github.com/yogstation13/Yogstation/assets/5091394/e4ce62fa-439b-473c-923b-b26678b885e3)

# Changelog

:cl:  
bugfix: agent id age can only be set to realistic age numbers now
/:cl:
