### PR TITLE
stops you from closing candle boxes

### DIFF
--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -20,6 +20,7 @@
 	var/icon_type = "donut"
 	var/spawn_type = null
 	var/fancy_open = FALSE
+	var/can_toggle = TRUE //some things are always open like candles
 
 /obj/item/storage/fancy/PopulateContents()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
@@ -42,8 +43,9 @@
 			. += "There are [contents.len <= 0 ? "no" : "[contents.len]"] [icon_type]s left."
 
 /obj/item/storage/fancy/attack_self(mob/user)
-	fancy_open = !fancy_open
-	update_appearance(UPDATE_ICON)
+	if(can_toggle)
+		fancy_open = !fancy_open
+		update_appearance(UPDATE_ICON)
 	return ..()
 
 /obj/item/storage/fancy/Exited()
@@ -152,6 +154,8 @@
 	slot_flags = ITEM_SLOT_BELT
 	spawn_type = /obj/item/candle
 	fancy_open = TRUE
+	can_toggle = FALSE
+
 
 /obj/item/storage/fancy/candle_box/attack_self(mob_user)
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

some fancy boxes don't actually have closed states, candle box being one of them. so this stops you from closing them

closes https://github.com/yogstation13/Yogstation/issues/21766

why not add a closed sprite? because part of the charm of the sprite is that you can see the candles. we would need to double the sprites with the flap or do some overlay stuff. interacting with it at all is going to open it anyway.

# Why is this good for the game?
it will stop going invisible

# Testing
*holds very visible candle box in front of you*

# Changelog

:cl:  
bugfix: candle boxes won't turn invisible anymore when used inhand as they cannot be closed
/:cl:
