### PR TITLE
makes it so you can no longer use the seismic arm from within objects

### DIFF
--- a/code/datums/martial/reverbpalm.dm
+++ b/code/datums/martial/reverbpalm.dm
@@ -66,6 +66,10 @@
 
 /datum/martial_art/reverberating_palm/can_use(mob/living/carbon/human/H)
 	var/obj/item/bodypart/r_arm/robot/seismic/R = H.get_bodypart(BODY_ZONE_R_ARM)
+	var/turf/current = get_turf(H)
+	for(var/obj/outside in current.contents)
+		if(H in outside.contents)
+			return FALSE
 	if(R)
 		if(!istype(R, /obj/item/bodypart/r_arm/robot/seismic))
 			return FALSE

--- a/code/datums/martial/reverbpalm.dm
+++ b/code/datums/martial/reverbpalm.dm
@@ -66,10 +66,8 @@
 
 /datum/martial_art/reverberating_palm/can_use(mob/living/carbon/human/H)
 	var/obj/item/bodypart/r_arm/robot/seismic/R = H.get_bodypart(BODY_ZONE_R_ARM)
-	var/turf/current = get_turf(H)
-	for(var/obj/outside in current.contents)
-		if(H in outside.contents)
-			return FALSE
+	if(!isturf(H.loc))
+		return FALSE
 	if(R)
 		if(!istype(R, /obj/item/bodypart/r_arm/robot/seismic))
 			return FALSE


### PR DESCRIPTION
# Document the changes in your pull request

adds a check to using the seismic arm that makes it so you can't use it while inside things like mechs and bodybags for the sake of issue #21772 

# Testing
<!-- Describe what testing you did with this PR. Try to be thorough, especially if this is a larger project. -->
![dreamseeker_Ff3sPBgZ7h](https://github.com/yogstation13/Yogstation/assets/58535870/26b4247f-6ce4-454e-8899-8753a5a81b8f)


# Changelog

:cl:  

bugfix: fixed being able to seismic arm people from inside things
/:cl:
