### PR TITLE
Prevent dropping ABSTRACT items in VR

### DIFF
--- a/code/modules/VR/vr_human.dm
+++ b/code/modules/VR/vr_human.dm
@@ -20,6 +20,8 @@
 /mob/living/carbon/human/virtual_reality/Destroy()
 	revert_to_reality()
 	for(var/obj/item/I in get_all_contents())
+		if(I.item_flags & ABSTRACT)
+			continue
 		dropItemToGround(I, TRUE, TRUE)
 	return ..()
 


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Fixes #21797 

Likely more errors like this, but not game breaking

# Why is this good for the game?
<!-- Describe why you think this change is good for the game. This section is not required for bugfixes. -->

# Testing
<!-- Describe what testing you did with this PR. Try to be thorough, especially if this is a larger project. -->

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: Weapon internal magazines will no longer drop upon death in VR
/:cl:
