### PR TITLE
[ADMIN] Updates petty filter

### DIFF
--- a/config/pretty_filter.txt
+++ b/config/pretty_filter.txt
@@ -43,5 +43,8 @@ n[i1!\\\/]+g(?:g|l+[e3]+t)=BAN ME ADMINS!
 One day while Andy was masturbating=BAN ME ADMINS!
 XEzwgBD=BAN ME ADMINS!
 
+#Regex for tyranny without the y
+tra+nn+y+=BAN ME ADMINS!
+
 \b(?:https?:\/\/)?(?:www|i)?\.?(?!yogstation\.net|github\.com)\w{4,128}\.\w{2}\.?\w{0,2}\b\S*=[Link Removed]
 [^ -ÿ]+=​

--- a/config/pretty_filter.txt
+++ b/config/pretty_filter.txt
@@ -44,7 +44,7 @@ One day while Andy was masturbating=BAN ME ADMINS!
 XEzwgBD=BAN ME ADMINS!
 
 #Regex for tyranny without the y
-tra+nn+y+=BAN ME ADMINS!
+tra+n+y+=BAN ME ADMINS!
 
 \b(?:https?:\/\/)?(?:www|i)?\.?(?!yogstation\.net|github\.com)\w{4,128}\.\w{2}\.?\w{0,2}\b\S*=[Link Removed]
 [^ -ÿ]+=​


### PR DESCRIPTION
# Document the changes in your pull request
Added tyranny without the y so people who aren't great at typing won't say something that lands them in trouble

# Testing
Tested several times to make sure I got this regex shenaniganery right, it should be working as intended
Three examples:
![image](https://github.com/yogstation13/Yogstation/assets/143908044/788f11aa-3168-4f22-9bb1-c2421468c536)


# Changelog
:cl: 
experimental: Updated the petty filter, please make a bug report if you get a 0.1 rule reminder in your chat for saying something normal
/:cl:
