### PR TITLE
Fixes certain tgui menus blocking inputs if you're too fast

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -94,7 +94,7 @@ GLOBAL_LIST_INIT(blacklisted_builds, list(
 			return
 
 	var/stl = CONFIG_GET(number/second_topic_limit)
-	if (!holder && stl)
+	if (!holder && stl && href_list["window_id"] != "statbrowser")
 		var/second = round(world.time, 10)
 		if (!topiclimiter)
 			topiclimiter = new(LIMITER_SIZE)


### PR DESCRIPTION
It basically removes the per-second rate limit from topics that aren't the stat panel
-no one uses the stat panel so much they'd need more than 15 clicks a second
-there's still a per-minute limit so people can't use something like the genetics menu to ddos the game
-i copied this fix from tg

it'll mostly fix telepathy and genetics

# Testing
i tested it, took a screenshot, but then copied a new thing into my pastebin over the screenshot, i can take a new screenshot if you really care

:cl:  
bugfix: Fixes certain tgui menus blocking inputs if you're too fast
/:cl:
