### PR TITLE
Fixes the server not restarting at the end of a round

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -353,7 +353,7 @@ SUBSYSTEM_DEF(ticker)
 		place.power_change()
 
 
-	INVOKE_ASYNC(src, PROC_REF(rock_paper_scissors_puzzle))
+	INVOKE_ASYNC(GLOBAL_PROC, GLOBAL_PROC_REF(rock_paper_scissors_puzzle))
 	return TRUE
 
 /datum/controller/subsystem/ticker/proc/PostSetup()

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -353,7 +353,7 @@ SUBSYSTEM_DEF(ticker)
 		place.power_change()
 
 
-	rock_paper_scissors_puzzle()
+	INVOKE_ASYNC(src, PROC_REF(rock_paper_scissors_puzzle))
 	return TRUE
 
 /datum/controller/subsystem/ticker/proc/PostSetup()


### PR DESCRIPTION
Current culprit is this proc call
it calls it just before the return statement
it asks 3 people to respond to a tgui prompt, but without a timeout it can just never end
meaning setup() never finishes returning, and that fire() call never finishes

it was also added by the ai rework pr
the last time we encountered this problem was last time the pr was testmerged

# Testing
lol, lmao, good fuckin luck confirming or denying it

:cl:  
bugfix: fixes the server not restarting at the end of a round
/:cl:
