### PR TITLE
Gives teleport implants to all syndicate ghost roles so they cannot leave their z-level

### DIFF
--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -168,12 +168,14 @@
 	backpack_contents = list(
 		/obj/item/modular_computer/tablet/preset/syndicate=1
 		)
+	implants = list(/obj/item/implant/teleporter/syndicate_lavaland)
 
 /datum/outfit/lavaland_syndicate/comms/subordinate
 	name = "Space Syndicate Comms Agent"
 	r_hand = /obj/item/kitchen/knife/combat
 	back = /obj/item/storage/backpack
 	backpack_contents = null
+	implants = list(/obj/item/implant/teleporter/syndicate_listening_post)
 
 /datum/outfit/lavaland_syndicate/comms/lieutenant
 	name = "Space Syndicate Comms Agent Lieutenant"
@@ -185,7 +187,8 @@
 		/obj/item/modular_computer/tablet/preset/syndicate=1,
 		/obj/item/gun/ballistic/revolver/ultrasecure=1
 		)
-
+	implants = list(/obj/item/implant/teleporter/syndicate_listening_post)
+	
 /obj/item/clothing/mask/chameleon/gps/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/gps, "Encrypted Signal")

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -168,14 +168,18 @@
 	backpack_contents = list(
 		/obj/item/modular_computer/tablet/preset/syndicate=1
 		)
-	implants = list(/obj/item/implant/teleporter/syndicate_lavaland)
+	implants = list(
+	/obj/item/implant/teleporter/syndicate_lavaland,
+	/obj/item/implant/weapons_auth)
 
 /datum/outfit/lavaland_syndicate/comms/subordinate
 	name = "Space Syndicate Comms Agent"
 	r_hand = /obj/item/kitchen/knife/combat
 	back = /obj/item/storage/backpack
 	backpack_contents = null
-	implants = list(/obj/item/implant/teleporter/syndicate_listening_post)
+	implants = list(
+	/obj/item/implant/teleporter/syndicate_listening_post,
+	/obj/item/implant/weapons_auth)
 
 /datum/outfit/lavaland_syndicate/comms/lieutenant
 	name = "Space Syndicate Comms Agent Lieutenant"
@@ -187,8 +191,10 @@
 		/obj/item/modular_computer/tablet/preset/syndicate=1,
 		/obj/item/gun/ballistic/revolver/ultrasecure=1
 		)
-	implants = list(/obj/item/implant/teleporter/syndicate_listening_post)
-	
+	implants = list(
+	/obj/item/implant/teleporter/syndicate_listening_post,
+	/obj/item/implant/weapons_auth)
+
 /obj/item/clothing/mask/chameleon/gps/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/gps, "Encrypted Signal")

--- a/yogstation/code/game/objects/items/implants/implant_teleporter.dm
+++ b/yogstation/code/game/objects/items/implants/implant_teleporter.dm
@@ -117,6 +117,15 @@
 	usewhitelist = TRUE
 	retrievalmessage = "Agent retrieval complete."
 
+/obj/item/implant/teleporter/syndicate_lavaland
+	pointofreturn = /area/ruin/powered/syndicate_lava_base
+	usewhitelist = TRUE
+	retrievalmessage = "Agent retrieval complete."
+
+/obj/item/implant/teleporter/syndicate_listening_post
+	pointofreturn = /area/ruin/space/has_grav/listeningstation
+	usewhitelist = TRUE
+	retrievalmessage = "Agent retrieval complete."
 /obj/item/implant/teleporter/demon
 	pointofreturn = /area/ruin/powered/sinden
 	usewhitelist = TRUE


### PR DESCRIPTION
# Document the changes in your pull request

These guys should not be leaving their z-level

# Why is this good for the game?

This sometimes comes up and is very annoying, just a double-check to make sure nobody does what they shouldn't.

# Testing

I did not test this, however following the other code (copied from the other ghost roles who do this) I believe it to be fine, can test if needed.

# Changelog


:cl:  
rscadd: Adds those anti-leaving-z-level implants to all syndicate ghost roles.

/:cl:
