### PR TITLE
fixes custom shuttles

### DIFF
--- a/code/modules/shuttle/shuttle_creation/shuttle_creator.dm
+++ b/code/modules/shuttle/shuttle_creation/shuttle_creator.dm
@@ -180,7 +180,7 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 		to_chat(user, "<span class='warning'>Invalid shuttle, restarting bluespace systems...</span>")
 		return FALSE
 
-	var/datum/map_template/shuttle/new_shuttle = new /datum/map_template/shuttle()
+	//var/datum/map_template/shuttle/new_shuttle = new /datum/map_template/shuttle()
 
 	var/obj/docking_port/mobile/port = new /obj/docking_port/mobile(get_turf(target))
 	var/obj/docking_port/stationary/stationary_port = new /obj/docking_port/stationary(get_turf(target))
@@ -227,10 +227,10 @@ GLOBAL_LIST_EMPTY(custom_shuttle_machines)		//Machines that require updating (He
 			if(length(curT.baseturfs) < 2)
 				continue
 			//Add the shuttle base shit to the shuttle
-			curT.baseturfs.Insert(3, /turf/baseturf_skipover/shuttle)
+			curT.insert_baseturf(3, /turf/baseturf_skipover/shuttle)
 			port.shuttle_areas[cur_area] = TRUE
 
-	port.linkup(new_shuttle, stationary_port)
+	port.linkup(stationary_port)
 
 	port.movement_force = list("KNOCKDOWN" = 0, "THROW" = 0)
 	port.initiate_docking(stationary_port)


### PR DESCRIPTION
# Document the changes in your pull request

we got baseturf wrappers but custom shutters werent using them. also this isnt the right way to link to a dock anymore

# Why is this good for the game?
lets you actually use custom shuttles now!

# Testing
![dreamseeker_Su1pdH6Mz7](https://github.com/yogstation13/Yogstation/assets/5091394/8cbdd204-00c6-4cdd-bfd3-6877d13279a4)

# Changelog

:cl:  
bugfix: custom shuttles no longer glitch out on takeoff
/:cl:
