### PR TITLE
Makes the reactor monitor UI a bit better

### DIFF
--- a/tgui/packages/tgui/interfaces/NtosReactorStats.js
+++ b/tgui/packages/tgui/interfaces/NtosReactorStats.js
@@ -1,14 +1,16 @@
 import { useBackend } from '../backend';
 import { NtosWindow } from '../layouts';
-import { Button, ProgressBar, Section, Table } from '../components';
-import { ReactorStatsSection } from './ReactorComputer';
+import { Box, Button, ProgressBar, Section, Stack, Table } from '../components';
+import { ReactorHistory, ReactorStats } from './ReactorComputer';
 
 export const NtosReactorStats = (props, context) => {
+  const { act, data } = useBackend(context);
   return (
     <NtosWindow
       resizable
-      width={440}
-      height={650}>
+      width={400}
+      height={528}
+      theme={data.theme}>
       <NtosWindow.Content>
         <NtosReactorMonitorContent />
       </NtosWindow.Content>
@@ -24,16 +26,16 @@ export const NtosReactorMonitorContent = (props, context) => {
     );
   }
   return (
-    <Section
-      title="Reactor Monitor"
-      buttons={(
+    <>
+      <ReactorStats
+        section_buttons={(
         <Button
           icon="arrow-left"
           content="Back"
           onClick={() => act('PRG_clear')} />
-      )}>
-        <ReactorStatsSection />
-    </Section>
+        )} />
+      <ReactorHistory/>
+    </>
   );
 };
 

--- a/tgui/packages/tgui/interfaces/NtosReactorStats.js
+++ b/tgui/packages/tgui/interfaces/NtosReactorStats.js
@@ -34,7 +34,7 @@ export const NtosReactorMonitorContent = (props, context) => {
           content="Back"
           onClick={() => act('PRG_clear')} />
         )} />
-      <ReactorHistory/>
+      <ReactorHistory />
     </>
   );
 };

--- a/tgui/packages/tgui/interfaces/NtosReactorStats.js
+++ b/tgui/packages/tgui/interfaces/NtosReactorStats.js
@@ -1,6 +1,6 @@
 import { useBackend } from '../backend';
 import { NtosWindow } from '../layouts';
-import { Box, Button, ProgressBar, Section, Stack, Table } from '../components';
+import { Button, ProgressBar, Section, Table } from '../components';
 import { ReactorHistory, ReactorStats } from './ReactorComputer';
 
 export const NtosReactorStats = (props, context) => {

--- a/tgui/packages/tgui/interfaces/ReactorComputer.js
+++ b/tgui/packages/tgui/interfaces/ReactorComputer.js
@@ -1,6 +1,6 @@
 import { useBackend, useLocalState } from '../backend';
 import { Window } from '../layouts';
-import { Box, Button, Chart, Flex, ProgressBar, Section, Tabs, Slider } from '../components';
+import { Box, Button, Chart, Flex, ProgressBar, Section, Tabs, Slider, LabeledList, Stack } from '../components';
 import { FlexItem } from '../components/Flex';
 import { formatSiUnit } from '../format';
 
@@ -9,29 +9,96 @@ export const ReactorComputer = (props, context) => {
   return (
     <Window
       resizable
-      width={360}
-      height={540}>
-      <Window.Content fitted>
-        <Tabs>
-          <Tabs.Tab
-            selected={tabIndex === 1}
-            onClick={() => setTabIndex(1)}>
-            Status
-          </Tabs.Tab>
-          <Tabs.Tab
-            selected={tabIndex === 2}
-            onClick={() => setTabIndex(2)}>
-            Control
-          </Tabs.Tab>
-        </Tabs>
-        {tabIndex === 1 && <ReactorStatsSection />}
-        {tabIndex === 2 && <ReactorControlRodControl />}
+      width={400}
+      height={588}>
+      <Window.Content>
+        <ReactorStats/>
+        <ReactorControl/>
+        <ReactorHistory/>
       </Window.Content>
     </Window>
   );
 };
 
-export const ReactorStatsSection = (props, context) => {
+export const ReactorStats = (props, context) => {
+  const { act, data } = useBackend(context);
+  const { section_buttons } = props;
+  return (
+    <Section title="Legend:" buttons={section_buttons}>
+      <LabeledList>
+        <LabeledList.Item label="Integrity">
+          <ProgressBar
+            value={data.integrity / 100}
+            ranges={{
+              good: [0.90, Infinity],
+              average: [0.5, 0.90],
+              bad: [-Infinity, 0.5],
+            }}>
+            {data.integrity}%
+          </ProgressBar>
+        </LabeledList.Item>
+        <LabeledList.Item label="Reactor Power">
+          <ProgressBar
+            value={data.power}
+            minValue={0}
+            maxValue={10000000}
+            color="yellow">
+            {formatSiUnit(data.power, 0, "W")}
+          </ProgressBar>
+        </LabeledList.Item>
+        <LabeledList.Item label="Reactor Pressure">
+          <ProgressBar
+            value={data.kpa}
+            minValue={0}
+            maxValue={10000}
+            color="white" >
+            {formatSiUnit(data.kpa*1000, 1, "Pa")}
+          </ProgressBar>
+        </LabeledList.Item>
+        <LabeledList.Item label="Coolant Temperature">
+          <ProgressBar
+            value={data.coolantInput}
+            minValue={0}
+            maxValue={1500}
+            color="blue">
+            {data.coolantInput} K
+          </ProgressBar>
+        </LabeledList.Item>
+        <LabeledList.Item label="Outlet Temperature">
+          <ProgressBar
+            value={data.coolantOutput}
+            minValue={0}
+            maxValue={1500}
+            color="orange">
+            {data.coolantOutput} K
+          </ProgressBar>
+        </LabeledList.Item>
+        <LabeledList.Item label="Core Temperature">
+          <ProgressBar
+            value={data.coreTemp}
+            minValue={0}
+            maxValue={1500}
+            color="bad">
+            {data.coreTemp} K
+          </ProgressBar>
+        </LabeledList.Item>
+        <LabeledList.Item label="Criticality (K)">
+          <ProgressBar
+            value={data.k / 5}
+            ranges={{
+              good: [-Infinity, 0.4],
+              average: [0.4, 0.6],
+              bad: [0.6, Infinity],
+            }}>
+            {data.k}
+          </ProgressBar>
+        </LabeledList.Item>
+      </LabeledList>
+    </Section>
+  );
+};
+
+export const ReactorHistory = (props, context) => {
   const { act, data } = useBackend(context);
   const powerData = data.powerData.map((value, i) => [i, value]);
   const kpaData = data.kpaData.map((value, i) => [i, value]);
@@ -39,70 +106,8 @@ export const ReactorStatsSection = (props, context) => {
   const tempInputData = data.tempInputData.map((value, i) => [i, value]);
   const tempOutputData = data.tempOutputData.map((value, i) => [i, value]);
   return (
-    <Box height="100%">
-      <Section title="Legend:">
-        Integrity:
-        <ProgressBar
-          value={data.integrity / 100}
-          ranges={{
-            good: [0.90, Infinity],
-            average: [0.5, 0.90],
-            bad: [-Infinity, 0.5],
-          }}>
-          {data.integrity}%
-        </ProgressBar>
-        Reactor Power:
-        <ProgressBar
-          value={data.power}
-          minValue={0}
-          maxValue={10000000}
-          color="yellow">
-          {formatSiUnit(data.power, 0, "W")}
-        </ProgressBar>
-        Reactor Pressure:
-        <ProgressBar
-          value={data.kpa}
-          minValue={0}
-          maxValue={10000}
-          color="white" >
-          {formatSiUnit(data.kpa*1000, 1, "Pa")}
-        </ProgressBar>
-        Coolant temperature:
-        <ProgressBar
-          value={data.coolantInput}
-          minValue={0}
-          maxValue={1500}
-          color="blue">
-          {data.coolantInput} K
-        </ProgressBar>
-        Outlet temperature:
-        <ProgressBar
-          value={data.coolantOutput}
-          minValue={0}
-          maxValue={1500}
-          color="orange">
-          {data.coolantOutput} K
-        </ProgressBar>
-        Core temperature:
-        <ProgressBar
-          value={data.coreTemp}
-          minValue={0}
-          maxValue={1500}
-          color="bad">
-          {data.coreTemp} K
-        </ProgressBar>
-        Neutrons per generation (K):
-        <ProgressBar
-          value={data.k / 5}
-          ranges={{
-            good: [-Infinity, 0.4],
-            average: [0.4, 0.6],
-            bad: [0.6, Infinity],
-          }}>
-          {data.k}
-        </ProgressBar>
-      </Section>
-      <Section fill title="Reactor Statistics:" height="200px">
+    <>
+      <Section fill title="Reactor Statistics:" height="200px" mt={1}>
         <Chart.Line
           fillPositionedParent
           data={powerData}
@@ -139,11 +144,11 @@ export const ReactorStatsSection = (props, context) => {
           strokeColor="rgba(255, 129, 25 , 1)"
           fillColor="rgba(255, 129, 25 , 0.1)" />
       </Section>
-    </Box>
+    </>
   );
 };
 
-export const ReactorControlRodControl = (props, context) => {
+export const ReactorControl = (props, context) => {
   const { act, data } = useBackend(context);
   const control_rods = data.control_rods;
   const k = data.k;
@@ -151,65 +156,54 @@ export const ReactorControlRodControl = (props, context) => {
   const fuel_rods = data.rods.length;
   const shutdown_temp = data.shutdownTemp;
   return (
-    <Box height="100%">
-      <Section fill title="Power Management:" height="96px">
-        {'Reactor Power: '}
-        <Button
-          disabled={
-            (data.coreTemp > shutdown_temp && data.active) ||
-            (fuel_rods <= 0 && !data.active) ||
-            k > 0
-          }
-          icon={data.active ? 'power-off' : 'times'}
-          content={data.active ? 'On' : 'Off'}
-          selected={data.active}
-          onClick={() => act('power')}
-        />
+    <>
+      <Section title="Controls:">
+        <LabeledList>
+          <LabeledList.Item label="Reactor Power">
+            <Button
+              disabled={
+                (data.coreTemp > shutdown_temp && data.active) ||
+                (fuel_rods <= 0 && !data.active) ||
+                k > 0
+              }
+              icon={data.active ? 'power-off' : 'times'}
+              content={data.active ? 'On' : 'Off'}
+              selected={data.active}
+              onClick={() => act('power')}
+            />
+          </LabeledList.Item>
+          <LabeledList.Item label="Control Rod Insertion">
+            <ProgressBar
+              value={(control_rods / 100 * 100) * 0.01}
+              ranges={{
+                good: [0.7, Infinity],
+                average: [0.4, 0.7],
+                bad: [-Infinity, 0.4],
+              }} />
+          </LabeledList.Item>
+          <LabeledList.Item label="Target Criticality">
+            <Slider
+              value={Math.round(desiredK*10)/10}
+              fillValue={Math.round(k*10)/10}
+              minValue={0}
+              maxValue={5}
+              step={0.1}
+              stepPixelSize={5}
+              onDrag={(e, value) => act('input', {
+                target: value,
+              })} />
+          </LabeledList.Item>
+        </LabeledList>
       </Section>
-      <Section fill title="Control Rod Management:" height="100%">
-        Control Rod Insertion:
-        <ProgressBar
-          value={(control_rods / 100 * 100) * 0.01}
-          ranges={{
-            good: [0.7, Infinity],
-            average: [0.4, 0.7],
-            bad: [-Infinity, 0.4],
-          }} />
-        <br />
-        Neutrons per generation (K):
-        <br />
-        <ProgressBar
-          value={(k / 5 * 100) * 0.01}
-          ranges={{
-            good: [-Infinity, 0.4],
-            average: [0.4, 0.6],
-            bad: [0.6, Infinity],
-          }}>
-          {k}
-        </ProgressBar>
-        <br />
-        Target criticality:
-        <br />
-        <Slider
-          value={Math.round(desiredK*10)/10}
-          fillValue={Math.round(k*10)/10}
-          minValue={0}
-          maxValue={5}
-          step={0.1}
-          stepPixelSize={5}
-          onDrag={(e, value) => act('input', {
-            target: value,
-          })} />
-      </Section>
-    </Box>
+    </>
   );
 };
 
-export const ReactorFuelControl = (props, context) => {
+export const ReactorFuel = (props, context) => {
   const { act, data } = useBackend(context);
   const shutdown_temp = data.shutdownTemp;
   return (
-    <Section title="Fuel Rod Management" height="100%">
+    <Section title="Fuel Rod Management">
       {data.rods.length > 0 ? (
         <Box>
           <Flex direction="column">

--- a/tgui/packages/tgui/interfaces/ReactorComputer.js
+++ b/tgui/packages/tgui/interfaces/ReactorComputer.js
@@ -12,9 +12,9 @@ export const ReactorComputer = (props, context) => {
       width={400}
       height={588}>
       <Window.Content>
-        <ReactorStats/>
-        <ReactorControl/>
-        <ReactorHistory/>
+        <ReactorStats />
+        <ReactorControl />
+        <ReactorHistory />
       </Window.Content>
     </Window>
   );
@@ -106,45 +106,43 @@ export const ReactorHistory = (props, context) => {
   const tempInputData = data.tempInputData.map((value, i) => [i, value]);
   const tempOutputData = data.tempOutputData.map((value, i) => [i, value]);
   return (
-    <>
-      <Section fill title="Reactor Statistics:" height="200px" mt={1}>
-        <Chart.Line
-          fillPositionedParent
-          data={powerData}
-          rangeX={[0, powerData.length - 1]}
-          rangeY={[0, Math.max(15000000, ...data.powerData)]}
-          strokeColor="rgba(255, 215,0, 1)"
-          fillColor="rgba(255, 215, 0, 0.1)" />
-        <Chart.Line
-          fillPositionedParent
-          data={kpaData}
-          rangeX={[0, kpaData.length - 1]}
-          rangeY={[0, Math.max(10000, ...data.kpaData)]}
-          strokeColor="rgba(255,250,250, 1)"
-          fillColor="rgba(255,250,250, 0.1)" />
-        <Chart.Line
-          fillPositionedParent
-          data={tempCoreData}
-          rangeX={[0, tempCoreData.length - 1]}
-          rangeY={[0, Math.max(1800, ...data.tempCoreData)]}
-          strokeColor="rgba(255, 0, 0 , 1)"
-          fillColor="rgba(255, 0, 0 , 0.1)" />
-        <Chart.Line
-          fillPositionedParent
-          data={tempInputData}
-          rangeX={[0, tempInputData.length - 1]}
-          rangeY={[0, Math.max(1800, ...data.tempInputData)]}
-          strokeColor="rgba(127, 179, 255 , 1)"
-          fillColor="rgba(127, 179, 255 , 0.1)" />
-        <Chart.Line
-          fillPositionedParent
-          data={tempOutputData}
-          rangeX={[0, tempOutputData.length - 1]}
-          rangeY={[0, Math.max(1800, ...data.tempOutputData)]}
-          strokeColor="rgba(255, 129, 25 , 1)"
-          fillColor="rgba(255, 129, 25 , 0.1)" />
-      </Section>
-    </>
+    <Section fill title="Reactor Statistics:" height="200px" mt={1}>
+      <Chart.Line
+        fillPositionedParent
+        data={powerData}
+        rangeX={[0, powerData.length - 1]}
+        rangeY={[0, Math.max(15000000, ...data.powerData)]}
+        strokeColor="rgba(255, 215,0, 1)"
+        fillColor="rgba(255, 215, 0, 0.1)" />
+      <Chart.Line
+        fillPositionedParent
+        data={kpaData}
+        rangeX={[0, kpaData.length - 1]}
+        rangeY={[0, Math.max(10000, ...data.kpaData)]}
+        strokeColor="rgba(255,250,250, 1)"
+        fillColor="rgba(255,250,250, 0.1)" />
+      <Chart.Line
+        fillPositionedParent
+        data={tempCoreData}
+        rangeX={[0, tempCoreData.length - 1]}
+        rangeY={[0, Math.max(1800, ...data.tempCoreData)]}
+        strokeColor="rgba(255, 0, 0 , 1)"
+        fillColor="rgba(255, 0, 0 , 0.1)" />
+      <Chart.Line
+        fillPositionedParent
+        data={tempInputData}
+        rangeX={[0, tempInputData.length - 1]}
+        rangeY={[0, Math.max(1800, ...data.tempInputData)]}
+        strokeColor="rgba(127, 179, 255 , 1)"
+        fillColor="rgba(127, 179, 255 , 0.1)" />
+      <Chart.Line
+        fillPositionedParent
+        data={tempOutputData}
+        rangeX={[0, tempOutputData.length - 1]}
+        rangeY={[0, Math.max(1800, ...data.tempOutputData)]}
+        strokeColor="rgba(255, 129, 25 , 1)"
+        fillColor="rgba(255, 129, 25 , 0.1)" />
+    </Section>
   );
 };
 
@@ -156,46 +154,44 @@ export const ReactorControl = (props, context) => {
   const fuel_rods = data.rods.length;
   const shutdown_temp = data.shutdownTemp;
   return (
-    <>
-      <Section title="Controls:">
-        <LabeledList>
-          <LabeledList.Item label="Reactor Power">
-            <Button
-              disabled={
-                (data.coreTemp > shutdown_temp && data.active) ||
-                (fuel_rods <= 0 && !data.active) ||
-                k > 0
-              }
-              icon={data.active ? 'power-off' : 'times'}
-              content={data.active ? 'On' : 'Off'}
-              selected={data.active}
-              onClick={() => act('power')}
-            />
-          </LabeledList.Item>
-          <LabeledList.Item label="Control Rod Insertion">
-            <ProgressBar
-              value={(control_rods / 100 * 100) * 0.01}
-              ranges={{
-                good: [0.7, Infinity],
-                average: [0.4, 0.7],
-                bad: [-Infinity, 0.4],
-              }} />
-          </LabeledList.Item>
-          <LabeledList.Item label="Target Criticality">
-            <Slider
-              value={Math.round(desiredK*10)/10}
-              fillValue={Math.round(k*10)/10}
-              minValue={0}
-              maxValue={5}
-              step={0.1}
-              stepPixelSize={5}
-              onDrag={(e, value) => act('input', {
-                target: value,
-              })} />
-          </LabeledList.Item>
-        </LabeledList>
-      </Section>
-    </>
+    <Section title="Controls:">
+      <LabeledList>
+        <LabeledList.Item label="Reactor Power">
+          <Button
+            disabled={
+              (data.coreTemp > shutdown_temp && data.active) ||
+              (fuel_rods <= 0 && !data.active) ||
+              k > 0
+            }
+            icon={data.active ? 'power-off' : 'times'}
+            content={data.active ? 'On' : 'Off'}
+            selected={data.active}
+            onClick={() => act('power')}
+          />
+        </LabeledList.Item>
+        <LabeledList.Item label="Control Rod Insertion">
+          <ProgressBar
+            value={(control_rods / 100 * 100) * 0.01}
+            ranges={{
+              good: [0.7, Infinity],
+              average: [0.4, 0.7],
+              bad: [-Infinity, 0.4],
+            }} />
+        </LabeledList.Item>
+        <LabeledList.Item label="Target Criticality">
+          <Slider
+            value={Math.round(desiredK*10)/10}
+            fillValue={Math.round(k*10)/10}
+            minValue={0}
+            maxValue={5}
+            step={0.1}
+            stepPixelSize={5}
+            onDrag={(e, value) => act('input', {
+              target: value,
+            })} />
+        </LabeledList.Item>
+      </LabeledList>
+    </Section>
   );
 };
 


### PR DESCRIPTION
The reactor controls and monitor now fit into the same window, making it easier to use.

![image](https://github.com/yogstation13/Yogstation/assets/93578146/5fda6207-ee96-4e00-92a4-ef156c91cacd)

![image](https://github.com/yogstation13/Yogstation/assets/93578146/10ee0eff-27f2-481b-a5a5-d049c2e48b8b)

:cl:  
tweak: Changed the reactor monitor UI to be easier to use
/:cl:
