### PR TITLE
Fixes vending machine maintenance panels being invisible

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -447,7 +447,7 @@ GLOBAL_LIST_EMPTY(vending_products)
 		default_deconstruction_screwdriver(user, icon_state, icon_state, I)
 		cut_overlays()
 		if(panel_open)
-			add_overlay("[initial(icon_state)]-panel")
+			update_appearance(UPDATE_ICON)
 		updateUsrDialog()
 	else
 		to_chat(user, span_warning("You must first secure [src]."))


### PR DESCRIPTION
# Document the changes in your pull request
Closes #21841
they weren't updated to use the panel overlay system

# Testing
Closed -> Opened
![image](https://github.com/yogstation13/Yogstation/assets/143908044/a41d7c5c-5b07-4678-983d-077cc56e4004) ![image](https://github.com/yogstation13/Yogstation/assets/143908044/d1c0aae7-99d2-4cd4-bd03-27630c44b3bc)

![image](https://github.com/yogstation13/Yogstation/assets/143908044/d23536b9-9e3b-4a80-9173-da7c3ee2bd88)
![image](https://github.com/yogstation13/Yogstation/assets/143908044/d3a95dfb-0280-4ba0-b982-4dab78fa0abe)


# Changelog
:cl:  
bugfix: Fixed vending machine maintenance panels not showing up
/:cl:
