### PR TITLE
Fixes resin floors appearing under turf decals

### DIFF
--- a/code/game/objects/structures/aliens.dm
+++ b/code/game/objects/structures/aliens.dm
@@ -115,7 +115,7 @@
 	desc = "A thick resin surface covers the floor."
 	anchored = TRUE
 	density = FALSE
-	layer = TURF_LAYER
+	layer = CULT_OVERLAY_LAYER
 	plane = FLOOR_PLANE
 	icon_state = "weeds"
 	max_integrity = 15


### PR DESCRIPTION
# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/168697c4-75ed-4533-aba3-69bd7b1f0abf)


:cl:  
bugfix: Fixes resin floors appearing under turf decals
/:cl:
