### PR TITLE
Fixes ghosts getting pushed around by mops

### DIFF
--- a/code/game/mecha/equipment/weapons/melee_weapons.dm
+++ b/code/game/mecha/equipment/weapons/melee_weapons.dm
@@ -631,6 +631,8 @@
 			playsound(moved_atom, 'sound/effects/gib_step.ogg', 50, 1)
 			qdel(moved_atom)
 			continue
+		if(isobserver(moved_atom))
+			continue // what the fuck?
 		if(moved_atom.wash(CLEAN_SCRUB))
 			cleaned = TRUE
 		if(moved_atom.anchored)


### PR DESCRIPTION
Ghosts can no longer be pushed around by a mech-mounted mop

:cl:  
bugfix: fixed ghosts getting pushed around by the exosuit-mounted mop
/:cl:
