### PR TITLE
Fixes ghost toggle darkness to not be useless, or a flashbang

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -567,8 +567,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	switch(lighting_cutoff)
 		if (LIGHTING_CUTOFF_VISIBLE)
-			lighting_cutoff = 50
-		if (50)
+			lighting_cutoff = 40
+		if (40)
 			lighting_cutoff = LIGHTING_CUTOFF_FULLBRIGHT
 		else
 			lighting_cutoff = LIGHTING_CUTOFF_VISIBLE

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -12,7 +12,6 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	stat = DEAD
 	density = FALSE
 	see_invisible = SEE_INVISIBLE_OBSERVER
-	lighting_cutoff = LIGHTING_CUTOFF_MEDIUM
 	invisibility = INVISIBILITY_OBSERVER
 	hud_type = /datum/hud/ghost
 	movement_type = GROUND | FLYING
@@ -565,15 +564,16 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 /mob/dead/observer/verb/toggle_darkness()
 	set name = "Toggle Darkness"
 	set category = "Ghost"
+
 	switch(lighting_cutoff)
-		if (LIGHTING_CUTOFF_VISIBLE)
-			lighting_cutoff = LIGHTING_CUTOFF_MEDIUM
-		if (LIGHTING_CUTOFF_MEDIUM)
-			lighting_cutoff = LIGHTING_CUTOFF_HIGH
-		if (LIGHTING_CUTOFF_HIGH)
-			lighting_cutoff = LIGHTING_CUTOFF_FULLBRIGHT
+		if (0)
+			lighting_cutoff = 50
+		if (50)
+			lighting_cutoff = 100
+		if (100)
+			lighting_cutoff = 0
 		else
-			lighting_cutoff = LIGHTING_CUTOFF_VISIBLE
+			lighting_cutoff = 0
 
 	update_sight()
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -566,14 +566,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set category = "Ghost"
 
 	switch(lighting_cutoff)
-		if (0)
+		if (LIGHTING_CUTOFF_VISIBLE)
 			lighting_cutoff = 50
 		if (50)
-			lighting_cutoff = 100
-		if (100)
-			lighting_cutoff = 0
+			lighting_cutoff = LIGHTING_CUTOFF_FULLBRIGHT
 		else
-			lighting_cutoff = 0
+			lighting_cutoff = LIGHTING_CUTOFF_VISIBLE
 
 	update_sight()
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -19,6 +19,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	light_range = 1
 	light_power = 2
 	light_on = FALSE
+	lighting_cutoff = LIGHTING_CUTOFF_MEDIUM
 	var/can_reenter_corpse
 	var/bootime = 0
 	var/started_as_observer //This variable is set to 1 when you enter the game as an observer.
@@ -567,8 +568,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	switch(lighting_cutoff)
 		if (LIGHTING_CUTOFF_VISIBLE)
-			lighting_cutoff = 40
-		if (40)
+			lighting_cutoff = LIGHTING_CUTOFF_MEDIUM
+		if (LIGHTING_CUTOFF_MEDIUM)
+			lighting_cutoff = 50
+		if (50)
 			lighting_cutoff = LIGHTING_CUTOFF_FULLBRIGHT
 		else
 			lighting_cutoff = LIGHTING_CUTOFF_VISIBLE


### PR DESCRIPTION
It wasn't updated after how nightvision works was changed
so it ended up being very small changes, then all of a sudden it would remove darkness entirely

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/bed710bf-80ba-4c7c-93cf-5d1784b9ba5e)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/050f7d35-43da-4406-b5bb-782a45fdd1c7)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/ddf96dff-2800-4840-9576-5f8c42b6efa1)


:cl:  
bugfix: Fixes ghost toggle darkness to not be useless, or a flashbang
/:cl:
