### PR TITLE
Fixes worn overlays

### DIFF
--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -54,7 +54,8 @@ GLOBAL_LIST_INIT(plasmaman_helmet_list, list(
 	"Halo" = "halo",
 	"Wizard" = "wizard",
 	"Plate" = "plate",
-	"Low" = "low")) //for icon making -> use "enviro" before this
+	"Low" = "low",
+)) //for icon making -> use "enviro" before this
 
 GLOBAL_LIST_EMPTY(ethereal_mark_list) //ethereal face marks
 

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -862,7 +862,7 @@
 			var/mob/living/carbon/human/C = loc
 			C.regenerate_icons()
 
-/obj/item/nullrod/staff/worn_overlays(isinhands)
+/obj/item/nullrod/staff/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
 	if(isinhands)
 		. += mutable_appearance('icons/effects/effects.dmi', shield_icon, MOB_LAYER + 0.01)

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -389,7 +389,7 @@
 		filling.color = mix_color_from_reagents(reagents.reagent_list)
 		add_overlay(filling)
 
-/obj/item/reagent_containers/chemtank/worn_overlays(isinhands = FALSE) //apply chemcolor and level
+/obj/item/reagent_containers/chemtank/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file) //apply chemcolor and level
 	. = ..()
 	//inhands + reagent_filling
 	if(!isinhands && reagents.total_volume)

--- a/code/modules/antagonists/clockcult/clock_items/clockwork_slab.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clockwork_slab.dm
@@ -106,7 +106,7 @@
 	. = ..()
 	update_quickbind(user)
 
-/obj/item/clockwork/slab/worn_overlays(isinhands = FALSE, icon_file)
+/obj/item/clockwork/slab/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
 	if(isinhands && item_state && inhand_overlay)
 		var/mutable_appearance/M = mutable_appearance(icon_file, "slab_[inhand_overlay]")

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -445,7 +445,7 @@
 		holder.visible_message(span_danger("A runed shield surges from the robe, surrounding [holder]!"))
 		holder.update_inv_wear_suit()
 
-/obj/item/clothing/suit/hooded/cultrobes/cult_shield/worn_overlays(isinhands)
+/obj/item/clothing/suit/hooded/cultrobes/cult_shield/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
 	if(!isinhands && shielded)
 		. += mutable_appearance('icons/effects/cult_effects.dmi', "shield-cult", MOB_LAYER + 0.01)

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -357,7 +357,7 @@
 		colored_before = TRUE
 	return ..()
 
-/obj/item/clothing/glasses/blindfold/white/worn_overlays(isinhands = FALSE, file2use)
+/obj/item/clothing/glasses/blindfold/white/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
 	if(!isinhands && ishuman(loc) && !colored_before)
 		var/mob/living/carbon/human/H = loc

--- a/code/modules/clothing/gloves/_gloves.dm
+++ b/code/modules/clothing/gloves/_gloves.dm
@@ -26,7 +26,7 @@
 	user.visible_message(span_suicide("\the [src] are forcing [user]'s hands around [user.p_their()] neck! It looks like the gloves are possessed!"))
 	return OXYLOSS
 
-/obj/item/clothing/gloves/worn_overlays(isinhands = FALSE)
+/obj/item/clothing/gloves/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
 	if(!isinhands)
 		if(damaged_clothes)

--- a/code/modules/clothing/head/_head.dm
+++ b/code/modules/clothing/head/_head.dm
@@ -17,7 +17,7 @@
 		var/mob/living/carbon/human/H = loc
 		H.update_hair()
 
-/obj/item/clothing/head/worn_overlays(isinhands = FALSE)
+/obj/item/clothing/head/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
 	if(isinhands)
 		return

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -149,7 +149,7 @@
 		playsound(src, 'sound/mecha/mechmove03.ogg', 50, 1) //Visors don't just come from nothing
 	update_appearance(UPDATE_ICON)
 
-/obj/item/clothing/head/hardhat/weldhat/worn_overlays(isinhands)
+/obj/item/clothing/head/hardhat/weldhat/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
 	if(!isinhands)
 		. += mutable_appearance(mob_overlay_icon, "weldhelmet")

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -229,16 +229,17 @@
 	M.color = hair_color
 	. += M
 
-/obj/item/clothing/head/wig/worn_overlays(isinhands = FALSE, file2use)
+/obj/item/clothing/head/wig/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
-	if(!isinhands)
-		var/datum/sprite_accessory/S = GLOB.hair_styles_list[hair_style]
-		if(!S)
-			return
-		var/mutable_appearance/M = mutable_appearance(S.icon, S.icon_state,layer = -HAIR_LAYER)
-		M.appearance_flags |= RESET_COLOR
-		M.color = hair_color
-		. += M
+	if(isinhands)
+		return
+	var/datum/sprite_accessory/S = GLOB.hair_styles_list[hair_style]
+	if(!S)
+		return
+	var/mutable_appearance/M = mutable_appearance(S.icon, S.icon_state,layer = -HAIR_LAYER)
+	M.appearance_flags |= RESET_COLOR
+	M.color = hair_color
+	. += M
 
 /obj/item/clothing/head/wig/attack_self(mob/user)
 	var/new_style = input(user, "Select a hair style", "Wig Styling")  as null|anything in (GLOB.hair_styles_list - "Bald")

--- a/code/modules/clothing/masks/_masks.dm
+++ b/code/modules/clothing/masks/_masks.dm
@@ -30,7 +30,7 @@
 
 /obj/item/clothing/mask/proc/handle_speech()
 
-/obj/item/clothing/mask/worn_overlays(isinhands = FALSE)
+/obj/item/clothing/mask/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
 	if(!isinhands)
 		if(body_parts_covered & HEAD)

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -6,16 +6,18 @@
 	strip_delay = 40
 	equip_delay_other = 40
 
-/obj/item/clothing/neck/worn_overlays(isinhands = FALSE)
+/obj/item/clothing/neck/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
-	if(!isinhands)
-		if(body_parts_covered & HEAD)
-			if(damaged_clothes)
-				. += mutable_appearance('icons/effects/item_damage.dmi', "damagedmask")
-			if(HAS_BLOOD_DNA(src))
-				var/mutable_appearance/bloody_mask = mutable_appearance('icons/effects/blood.dmi', "maskblood")
-				bloody_mask.color = get_blood_dna_color(return_blood_DNA())
-				. += bloody_mask
+	if(isinhands)
+		return
+	if(!(body_parts_covered & HEAD))
+		return
+	if(damaged_clothes)
+		. += mutable_appearance('icons/effects/item_damage.dmi', "damagedmask")
+	if(HAS_BLOOD_DNA(src))
+		var/mutable_appearance/bloody_mask = mutable_appearance('icons/effects/blood.dmi', "maskblood")
+		bloody_mask.color = get_blood_dna_color(return_blood_DNA())
+		. += bloody_mask
 
 /obj/item/clothing/neck/tie
 	name = "tie"
@@ -248,12 +250,13 @@
 	w_class = WEIGHT_CLASS_TINY
 	var/sourceBandanaType
 
-/obj/item/clothing/neck/neckerchief/worn_overlays(isinhands)
+/obj/item/clothing/neck/neckerchief/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
-	if(!isinhands)
-		var/mutable_appearance/realOverlay = mutable_appearance('icons/mob/clothing/mask/mask.dmi', icon_state)
-		realOverlay.pixel_y = -3
-		. += realOverlay
+	if(isinhands)
+		return
+	var/mutable_appearance/realOverlay = mutable_appearance('icons/mob/clothing/mask/mask.dmi', icon_state)
+	realOverlay.pixel_y = -3
+	. += realOverlay
 
 /obj/item/clothing/neck/neckerchief/AltClick(mob/user)
 	. = ..()

--- a/code/modules/clothing/shoes/_shoes.dm
+++ b/code/modules/clothing/shoes/_shoes.dm
@@ -38,7 +38,7 @@
 			playsound(user, 'sound/weapons/genhit2.ogg', 50, 1)
 		return(BRUTELOSS)
 
-/obj/item/clothing/shoes/worn_overlays(isinhands = FALSE)
+/obj/item/clothing/shoes/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
 	if(isinhands)
 		return

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -44,7 +44,7 @@
 		var/datum/action/A = X
 		A.build_all_button_icons()
 
-/obj/item/clothing/head/helmet/space/hardsuit/worn_overlays(isinhands = FALSE)
+/obj/item/clothing/head/helmet/space/hardsuit/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
 	if(!isinhands && hat_overlay)
 		. += hat_overlay
@@ -1008,7 +1008,7 @@
 			var/mob/living/carbon/human/C = loc
 			C.update_inv_wear_suit()
 
-/obj/item/clothing/suit/space/hardsuit/shielded/worn_overlays(isinhands)
+/obj/item/clothing/suit/space/hardsuit/shielded/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
 	if(!isinhands)
 		. += mutable_appearance('icons/effects/effects.dmi', shield_state, MOB_LAYER + 0.01)

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -87,7 +87,7 @@
 	for(var/datum/action/A as anything in actions)
 		A.build_all_button_icons()
 
-/obj/item/clothing/head/helmet/space/plasmaman/worn_overlays(isinhands = FALSE)
+/obj/item/clothing/head/helmet/space/plasmaman/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
 	if(isinhands)
 		return

--- a/code/modules/clothing/suits/_suits.dm
+++ b/code/modules/clothing/suits/_suits.dm
@@ -23,7 +23,7 @@
 		QDEL_NULL(attached_badge)
 	return ..()
 
-/obj/item/clothing/suit/worn_overlays(isinhands = FALSE)
+/obj/item/clothing/suit/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
 	if(!isinhands)
 		if(damaged_clothes)

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -283,7 +283,7 @@
 			var/mob/living/carbon/human/C = loc
 			C.update_inv_wear_suit()
 
-/obj/item/clothing/suit/wizrobe/armor/worn_overlays(isinhands)
+/obj/item/clothing/suit/wizrobe/armor/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
 	if(!isinhands)
 		. += mutable_appearance('icons/effects/effects.dmi', shield_state, MOB_LAYER + 0.01)

--- a/code/modules/clothing/under/_under.dm
+++ b/code/modules/clothing/under/_under.dm
@@ -23,7 +23,7 @@
 	var/freshly_laundered = FALSE
 	tearable = TRUE //all jumpsuits can be torn down and used for cloth in an emergency | yogs
 
-/obj/item/clothing/under/worn_overlays(isinhands = FALSE)
+/obj/item/clothing/under/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
 	if(!isinhands)
 		if(damaged_clothes)

--- a/code/modules/food_and_drinks/pizzabox.dm
+++ b/code/modules/food_and_drinks/pizzabox.dm
@@ -93,7 +93,7 @@
 			tag_overlay.pixel_y = boxes.len * 3
 			. += tag_overlay
 
-/obj/item/pizzabox/worn_overlays(isinhands, icon_file)
+/obj/item/pizzabox/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
 	var/current_offset = 2
 	if(isinhands)

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -132,9 +132,10 @@
 	glass_overlay.appearance_flags = RESET_COLOR
 	. += glass_overlay
 
-/obj/item/clothing/head/helmet/space/hostile_environment/worn_overlays(isinhands)
+/obj/item/clothing/head/helmet/space/hostile_environment/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
-	if(!isinhands)
-		var/mutable_appearance/M = mutable_appearance(mob_overlay_icon, "hostile_env_glass")
-		M.appearance_flags = RESET_COLOR
-		. += M
+	if(isinhands)
+		return
+	var/mutable_appearance/M = mutable_appearance(mob_overlay_icon, "hostile_env_glass")
+	M.appearance_flags = RESET_COLOR
+	. += M

--- a/yogstation/code/modules/ninja/suit/ninja.dm
+++ b/yogstation/code/modules/ninja/suit/ninja.dm
@@ -27,14 +27,14 @@
 	var/lights_on = FALSE
 	var/lights_colour = "16be00"
 
-/obj/item/clothing/suit/space/space_ninja/worn_overlays(isinhands = FALSE)
+/obj/item/clothing/suit/space/space_ninja/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
 	if(!isinhands && lights_on)
 		var/mutable_appearance/M = mutable_appearance(mob_overlay_icon, "s-ninja-overlay")
 		M.color = lights_colour
 		. += M
 
-/obj/item/clothing/mask/gas/space_ninja/worn_overlays(isinhands = FALSE)
+/obj/item/clothing/mask/gas/space_ninja/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
 	if(!isinhands && lights_on)
 		var/mutable_appearance/M = mutable_appearance(mob_overlay_icon, "s-ninja-overlay")
@@ -42,14 +42,14 @@
 		. += M
 
 
-/obj/item/clothing/shoes/space_ninja/worn_overlays(isinhands = FALSE)
+/obj/item/clothing/shoes/space_ninja/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
 	if(!isinhands && lights_on)
 		var/mutable_appearance/M = mutable_appearance(mob_overlay_icon, "s-ninja-overlay")
 		M.color = lights_colour
 		. += M
 
-/obj/item/clothing/gloves/space_ninja/worn_overlays(isinhands = FALSE)
+/obj/item/clothing/gloves/space_ninja/worn_overlays(mutable_appearance/standing, isinhands = FALSE, icon_file)
 	. = ..()
 	if(!isinhands && lights_on)
 		var/mutable_appearance/M = mutable_appearance(mob_overlay_icon, "s-ninja-overlay")


### PR DESCRIPTION
# Document the changes in your pull request

Part of the fallout of GAGS, I found the problem because of plasmamen helmets which is apparently the ONLY thing from the many things broken that seems to have been reported.
Either yogstation is dead as mods or no one thought to report these.

Fixes plasmamen helmets, blood overlays, wigs, hardsuit helmets, and some other things.
![image](https://github.com/yogstation13/Yogstation/assets/53777086/bbc9db22-aa62-4aa9-93f1-061c211c4b5c)
![image](https://github.com/yogstation13/Yogstation/assets/53777086/3e135e43-b9c9-4d88-8328-09f12d5fd966)

# Why is this good for the game?

idk?
Closes https://github.com/yogstation13/Yogstation/issues/21753
Closes https://github.com/yogstation13/Yogstation/issues/21710
Closes https://github.com/yogstation13/Yogstation/issues/21862

# Testing

see above

# Changelog

:cl:  
bugfix: Worn overlays (like plasmamen helmets and blood) now work again.
/:cl: