### PR TITLE
Prevents placing items in closed lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -324,12 +324,14 @@ GLOBAL_LIST_EMPTY(lockers)
 /obj/structure/closet/attackby(obj/item/attacking_item, mob/user, params)
 	if(user in src)
 		return
-	if(user.a_intent == INTENT_HARM)
+	if(user.a_intent == INTENT_HARM) //if you're on harm intent, just hit it
 		return ..()
-	if(attacking_item.GetID())
+	if(attacking_item.GetID()) //if you're hitting with an id item, toggle the lock
 		togglelock(user)
 		return TRUE
-	if(user.transferItemToLoc(attacking_item, drop_location()))
+	if(!opened) //if it's closed, just hit it
+		return ..()
+	if(user.transferItemToLoc(attacking_item, drop_location())) //try to transfer the held item to it
 		return TRUE
 
 /obj/structure/closet/welder_act(mob/living/user, obj/item/tool)


### PR DESCRIPTION
i never had the chance to test #21529 before it was merged by manatee
apparently, it let people put items inside closed lockers

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/e212dd98-7d1a-4f41-8339-cec72bca35cc)


:cl:  
bugfix: Prevents placing items in closed lockers
/:cl:
