### PR TITLE
Fixes exosuit flyswatter not being able to hurt glockroaches

### DIFF
--- a/code/game/mecha/equipment/weapons/melee_weapons.dm
+++ b/code/game/mecha/equipment/weapons/melee_weapons.dm
@@ -671,6 +671,7 @@
 		/mob/living/simple_animal/hostile/poison/bees,
 		/mob/living/simple_animal/butterfly,
 		/mob/living/simple_animal/cockroach,
+		/mob/living/simple_animal/hostile/glockroach,
 		/obj/item/queen_bee
 	))
 

--- a/code/modules/mob/living/simple_animal/hostile/glockroach.dm
+++ b/code/modules/mob/living/simple_animal/hostile/glockroach.dm
@@ -20,6 +20,7 @@
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 270
 	maxbodytemp = INFINITY
+	mob_biotypes = MOB_ORGANIC | MOB_BUG
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
 	mob_size = MOB_SIZE_TINY
 	speak_emote = list("chitters")


### PR DESCRIPTION
Glockroaches are not technically a type of cockroach so they weren't affected by the flyswatter

:cl:  
bugfix: Exosuit flyswatter can now kill glockroaches
/:cl:
