### PR TITLE
Gas harpoon readability adjustments

### DIFF
--- a/code/game/objects/items/devices/busterarm/gasharpoon.dm
+++ b/code/game/objects/items/devices/busterarm/gasharpoon.dm
@@ -1,5 +1,5 @@
 /obj/item/clothing/gloves/gasharpoon
-	name = "gasharpoon"
+	name = "gas-harpoon"
 	desc = "A metal gauntlet with a harpoon attatched, powered by gasoline and traditionally used by space-whalers."
 	///reminder to channge all this -- I changed it :)
 	icon = 'icons/obj/traitor.dmi'
@@ -7,7 +7,7 @@
 	item_state = "gasharpoon"
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
-	attack_verb = list("harpooned", "gouged", "pierced")
+	attack_verb = list("harpooned", "hooked", "gouged", "pierced")
 	force = 10
 	throwforce = 10
 	throw_range = 7

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -340,8 +340,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 0
 
 /datum/uplink_item/dangerous/gasharpoon
-	name = "Gasharpoon"
-	desc = "A repurposed space-whaling tool attatched to a glove, can be used as a sturdy weapon in both hands, or worn as a glove to allow access to it's harpoon."
+	name = "Gas-Harpoon"
+	desc = "A repurposed space-whaling tool attached to a glove. \
+		It can be used as a sturdy weapon in both hands, or worn as a glove to activate its deadly harpoon, capable of reeling in even the biggest catches."
 	item = /obj/item/clothing/gloves/gasharpoon
 	cost = 10
 	surplus = 0


### PR DESCRIPTION
# Document the changes in your pull request
I'm a bit tired of reading "gasharpoon" all in one word, so I made some text adjustments for readability
Fixed some typos too, and redid some descriptions and attack verbs, minor stuff

# Why is this good for the game?
readability good
grammar also good

# Testing
just text changes, but I can if ye want me to of course

# Wiki Documentation
ye I can do it

# Changelog
:cl:
spellcheck: Gasharpoon -> Gas-Harpoon
spellcheck: Redid a bit of the gas-harpoon desc in the traitor uplink
/:cl:
