### PR TITLE
Adjusts Changeling Hallucination Sting

### DIFF
--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -241,16 +241,16 @@
 /datum/action/changeling/sting/LSD
 	name = "Hallucination Sting"
 	desc = "We cause mass terror to our victim. Costs 10 chemicals."
-	helptext = "We evolve the ability to sting a target with a powerful hallucinogenic chemical. The target does not notice they have been stung, and the effect occurs after 30 to 60 seconds."
+	helptext = "We evolve the ability to sting a target with a powerful hallucinogenic and liver killing chemical. The target does not notice they have been stung, and the effect occurs after 20 to 30 seconds."
 	button_icon_state = "sting_lsd"
 	sting_icon = "sting_lsd"
-	chemical_cost = 10
-	dna_cost = 1
+	chemical_cost = 25
+	dna_cost = 2
 
 /datum/action/changeling/sting/LSD/sting_action(mob/user, mob/living/carbon/target)
 	log_combat(user, target, "stung", "LSD sting")
 	if(target.reagents)
-		target.reagents.add_reagent(/datum/reagent/toxin/mindbreaker, 30)
+		target.reagents.add_reagent(/datum/reagent/toxin/mindbreaker/changeling, 30)
 	return TRUE
 
 /datum/action/changeling/sting/cryo

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -231,6 +231,15 @@
 		M.adjust_hallucinations(20 SECONDS)
 	return ..()
 
+/datum/reagent/toxin/mindbreaker/changeling
+	name = "Mind Destroyer Toxin"
+	description = "An even more powerful hallucinogen only created by changeling toxin sacs. Not a thing to be messed with."
+
+/datum/reagent/toxin/mindbreaker/changeling/on_mob_life(mob/living/carbon/M)
+	if(!M.has_trauma_type(/datum/brain_trauma/mild/reality_dissociation))
+		M.adjust_hallucinations(40 SECONDS)
+	return ..()
+
 /datum/reagent/toxin/relaxant
 	name = "Muscle Relaxant"
 	description = "A potent paralytic chemical that causes the patient to move and act slower."

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -235,11 +235,6 @@
 	name = "Mind Destroyer Toxin"
 	description = "An even more powerful hallucinogen only created by changeling toxin sacs. Not a thing to be messed with."
 
-/datum/reagent/toxin/mindbreaker/changeling/on_mob_life(mob/living/carbon/M)
-	if(!M.has_trauma_type(/datum/brain_trauma/mild/reality_dissociation))
-		M.adjust_hallucinations(20 SECONDS)
-	return ..()
-
 /datum/reagent/toxin/relaxant
 	name = "Muscle Relaxant"
 	description = "A potent paralytic chemical that causes the patient to move and act slower."

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -237,7 +237,7 @@
 
 /datum/reagent/toxin/mindbreaker/changeling/on_mob_life(mob/living/carbon/M)
 	if(!M.has_trauma_type(/datum/brain_trauma/mild/reality_dissociation))
-		M.adjust_hallucinations(40 SECONDS)
+		M.adjust_hallucinations(20 SECONDS)
 	return ..()
 
 /datum/reagent/toxin/relaxant


### PR DESCRIPTION
# Document the changes in your pull request

Creates a new chemical for players to better understand why they're dying really fast
Adds a new chemical exclusively for changeling LSD sting called "mind destroyer toxin" which is basically just mindbreaker toxin
Adjusts LSD sting to cost 2 DNA points & 25 chems to use (still injects 30u)

# Why is this good for the game?

this is outrageously strong, and instead of directly nerfing the power I think making it have more counter play (sec knows now there's lings if you use this, kinda like cryosting) and also the cost matches it's power

# Testing

numbers adjustments

# Wiki Documentation

Changes the cost of LSD/Hallucination sting to 2 DNA points & 25 chems 

# Changelog

:cl:  
rscadd: Adds new chemical for changelings to inject to people 
tweak: adjusts cost of hallucination sting

/:cl:
