### PR TITLE
Fixes holotool lighting

### DIFF
--- a/yogstation/code/game/objects/items/holotool/holotool.dm
+++ b/yogstation/code/game/objects/items/holotool/holotool.dm
@@ -11,6 +11,8 @@
 	actions_types = list(/datum/action/item_action/change_tool, /datum/action/item_action/change_ht_color)
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	light_system = MOVABLE_LIGHT
+	light_range = 3
+	light_on = FALSE
 
 	/// Buffer used by the multitool mode
 	var/buffer
@@ -63,6 +65,7 @@
 		if(!C || QDELETED(src))
 			return
 		current_color = C
+		set_light_color(current_color)
 	update_appearance(UPDATE_ICON)
 	action.build_all_button_icons()
 	user.regenerate_icons()
@@ -105,13 +108,14 @@
 		item_state = current_tool.name
 		add_overlay(holo_item)
 		if(current_tool.name == "off")
-			set_light(0)
+			set_light_on(FALSE)
 		else
-			set_light(3, null, current_color)
+			set_light_on(TRUE)
+			set_light()
 	else
 		item_state = "holotool"
 		icon_state = "holotool"
-		set_light(0)
+		set_light_on(FALSE)
 
 	for(var/datum/action/A as anything in actions)
 		A.build_all_button_icons()

--- a/yogstation/code/game/objects/items/holotool/holotool.dm
+++ b/yogstation/code/game/objects/items/holotool/holotool.dm
@@ -111,7 +111,6 @@
 			set_light_on(FALSE)
 		else
 			set_light_on(TRUE)
-			set_light()
 	else
 		item_state = "holotool"
 		icon_state = "holotool"


### PR DESCRIPTION
# Document the changes in your pull request

``set_light`` is a proc used for static lights, and it throws a runtime when you try to use it on movable lights (like the Holotool).
This fixes that, basically.

# Why is this good for the game?

Fix

# Testing

https://github.com/yogstation13/Yogstation/assets/53777086/ee7bb9d1-1ae0-4a11-b1d0-dd2e7acbcf9f
https://github.com/yogstation13/Yogstation/assets/53777086/89e90c39-e203-4288-a8c0-61b11305e3c3

# Changelog

:cl:  
fix: Holotool now doesn't cause errors and lights should more consistently follow the player.
/:cl:
