### PR TITLE
apply post-job equip in VR

### DIFF
--- a/code/modules/VR/vr_sleeper.dm
+++ b/code/modules/VR/vr_sleeper.dm
@@ -180,6 +180,8 @@
 		if(outfit)
 			var/datum/outfit/O = new outfit()
 			O.equip(vr_human)
+		var/datum/job/vr_job = vr_human.mind.assigned_role
+		vr_human.dna.species.after_equip_job(vr_job, vr_human)
 		if(transfer && H.mind)
 			SStgui.close_user_uis(H, src)
 			vr_human.ckey = H.ckey


### PR DESCRIPTION
This should fix Vox and Plasmamen spawning w/o survival equipment like masks, tanks

Fixes https://github.com/yogstation13/Yogstation/issues/21843

# Testing
<!-- Describe what testing you did with this PR. Try to be thorough, especially if this is a larger project. -->
Tested in the Vox PR, works fine when spawning in VR and disconnecting/reconnecting to it

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: Species should properly receive essential survival gear in VR
/:cl:
