### PR TITLE
change cloaker belt name to be stealthy

### DIFF
--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -199,7 +199,7 @@ effective or pretty fucking useless.
 				wavelength = clamp(target, 0, 120)
 
 /obj/item/storage/belt/military/shadowcloak
-	name = "cloaker belt"
+	name = "toolbelt"
 	desc = "A tactical belt that can make you invisible for short periods of time. Recharges in darkness, but must be turned on to recharge."
 	icon = 'icons/obj/clothing/belts.dmi'
 	icon_state = "utilitybelt"


### PR DESCRIPTION
changes cloaker belt name to look like "toolbelt"

# Why is this good for the game?
This fits more in-line with our rules, "_Items from the stealth and implants (once implanted, not the implanter) uplink categories are metashielded. Security are not allowed to “check” these unless they have witnessed the use of the suspicious item before._" How do you expect security to see someone wearing a cloaker belt and go "yeah, that's cool you can keep that". So instead, they will see "toolbelt", much like how the camera flash and hypno flash are named.

# Testing
this is stupid
![image](https://github.com/yogstation13/Yogstation/assets/122807629/a6a6abb5-6235-4eae-bd3f-ad004a8ef3d7)
![image](https://github.com/yogstation13/Yogstation/assets/122807629/d478132f-19f7-49ac-93da-67551d127583)

:cl:  ktlwjec
tweak: Cloaker belt is more stealthy by reading as a normal toolbelt when worn.
/:cl: