### PR TITLE
Fix open air fusion reaction not heating up after sometimes

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -373,7 +373,7 @@
 
 		var/new_heat_capacity = air.heat_capacity()
 		if(new_heat_capacity > MINIMUM_HEAT_CAPACITY)
-			air.set_temperature(clamp(((old_thermal_energy + reaction_energy)/new_heat_capacity),TCMB,INFINITY))
+			air.set_temperature(clamp(((old_thermal_energy + reaction_energy)/(new_heat_capacity*0.8)),TCMB,INFINITY))
 		return REACTING
 
 /datum/gas_reaction/nitriumformation //The formation of nitrium. Endothermic. Requires N2O as a catalyst.


### PR DESCRIPTION
this makes fusion reaction weaker and doesnt generate a lot of heat according to my experience in game

# Document the changes in your pull request
Fix open air fusion reaction not heating up after someti

# Why is this good for the game?
should help fusion reaction generate heat faster

# Testing
still testing, its kinda better but my end is slow kinda slow so i would like a testmerge for a proper test




# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

experimental: Fix open air fusion reaction not heating up after someti
/:cl:
