### PR TITLE
Teleshield bounty should now work

### DIFF
--- a/code/modules/cargo/bounties/security.dm
+++ b/code/modules/cargo/bounties/security.dm
@@ -24,7 +24,7 @@
 	description = "Our riot officers are complaining about lugging their heavy shields around all the time. Ship some lightweight foldable ones to help them out."
 	reward = 5000
 	required_count = 3
-	wanted_types = list(/datum/design/tele_shield)
+	wanted_types = list(/obj/item/shield/riot/tele)
 
 /datum/bounty/item/security/revolverspeedloaders
 	name = ".38 Speedloaders"


### PR DESCRIPTION
# Document the changes in your pull request

Makes it so, instead of wanting three abstract ideas of a teleshield, it now wants three teleshields.

# Why is this good for the game?

Fixes a bug

# Testing

Don't know how to force bounties, but it now looks for an object like the other bounties so :I

# Changelog

:cl:  
bugfix: fixed teleshield bounty  
/:cl:
