### PR TITLE
Make healium be as useful as cryoxadone

### DIFF
--- a/code/datums/wounds/_wounds.dm
+++ b/code/datums/wounds/_wounds.dm
@@ -330,6 +330,12 @@
 	if(cryo_progress > 66 * severity)
 		qdel(src)
 
+/// Same as above but called from healium, only work when the person is unconscious and cold
+/datum/wound/proc/on_healium(power)
+	cryo_progress += power
+	if(cryo_progress > 44 * severity)
+		qdel(src)
+
 /// When synthflesh is applied to the victim, we call this. No sense in setting up an entire chem reaction system for wounds when we only care for a few chems. Probably will change in the future
 /datum/wound/proc/on_synthflesh(power)
 	return

--- a/code/datums/wounds/pierce.dm
+++ b/code/datums/wounds/pierce.dm
@@ -98,6 +98,10 @@
 	. = ..()
 	blood_flow -= 0.03 * power // i think it's like a minimum of 3 power, so .09 blood_flow reduction per tick is pretty good for 0 effort
 
+/datum/wound/pierce/on_healium(power)
+	. = ..()
+	blood_flow -= 0.08 * power 
+
 /datum/wound/pierce/on_synthflesh(power)
 	. = ..()
 	blood_flow -= 0.05 * power // 20u * 0.05 = -1 blood flow, less than with slashes but still good considering smaller bleed rates

--- a/code/datums/wounds/slash.dm
+++ b/code/datums/wounds/slash.dm
@@ -155,6 +155,10 @@
 	. = ..()
 	blood_flow -= 0.03 * power // i think it's like a minimum of 3 power, so .09 blood_flow reduction per tick is pretty good for 0 effort
 
+/datum/wound/slash/on_healium(power)
+	. = ..()
+	blood_flow -= 0.08 * power 
+
 /datum/wound/slash/on_synthflesh(power)
 	. = ..()
 	blood_flow -= 0.075 * power // 20u * 0.075 = -1.5 blood flow, pretty good for how little effort it is

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -253,19 +253,30 @@
 		for(var/obj/item/bodypart/limb in C.get_damaged_bodyparts(TRUE, TRUE, FALSE, BODYPART_ROBOTIC))
 			robotic_limb_damage += limb.get_damage(stamina=FALSE)
 
+	var/datum/gas_mixture/air1 = airs[1]
+
 	if(mob_occupant.health >= mob_occupant.getMaxHealth() - robotic_limb_damage) // Don't bother with fully healed people. Now takes robotic limbs into account.
-		var/has_cryo_wound = FALSE
+		var/has_wound = FALSE
 		if(C && C.all_wounds)
-			for(var/datum/wound/wound as anything in C.all_wounds)
-				if(wound.wound_flags & ACCEPTS_CRYO)
+			if(air1.total_moles() && air1.get_moles(GAS_HEALIUM) > MINIMUM_MOLE_COUNT)
+				for(var/datum/wound/wound as anything in C.all_wounds)
 					if(!treating_wounds) // if we have wounds and haven't already alerted the doctors we're only dealing with the wounds, let them know
 						playsound(src, 'sound/machines/cryo_warning.ogg', volume) // Bug the doctors.
-						var/msg = "Patient vitals fully recovered, continuing automated burn treatment."
+						var/msg = "Patient vitals fully recovered, continuing automated wound treatment."
 						radio.talk_into(src, msg, radio_channel)
-					has_cryo_wound = TRUE
+					has_wound = TRUE
 					break
+			else
+				for(var/datum/wound/wound as anything in C.all_wounds)
+					if(wound.wound_flags & ACCEPTS_CRYO)
+						if(!treating_wounds) // if we have wounds and haven't already alerted the doctors we're only dealing with the wounds, let them know
+							playsound(src, 'sound/machines/cryo_warning.ogg', volume) // Bug the doctors.
+							var/msg = "Patient vitals fully recovered, continuing automated burn treatment."
+							radio.talk_into(src, msg, radio_channel)
+						has_wound = TRUE
+						break
 
-		treating_wounds = has_cryo_wound
+		treating_wounds = has_wound
 		if(!treating_wounds)
 			set_on(FALSE)
 			playsound(src, 'sound/machines/cryo_warning.ogg', volume) // Bug the doctors.
@@ -275,8 +286,6 @@
 				open_machine()
 			radio.talk_into(src, msg, radio_channel)
 			return
-
-	var/datum/gas_mixture/air1 = airs[1]
 
 	if(air1.total_moles())
 		if(mob_occupant.bodytemperature < T0C) // Sleepytime. Why? More cryo magic.

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -259,13 +259,12 @@
 		var/has_wound = FALSE
 		if(C && C.all_wounds)
 			if(air1.total_moles() && air1.get_moles(GAS_HEALIUM) > MINIMUM_MOLE_COUNT)
-				for(var/datum/wound/wound as anything in C.all_wounds)
+				if(C.all_wounds)
 					if(!treating_wounds) // if we have wounds and haven't already alerted the doctors we're only dealing with the wounds, let them know
 						playsound(src, 'sound/machines/cryo_warning.ogg', volume) // Bug the doctors.
 						var/msg = "Patient vitals fully recovered, continuing automated wound treatment."
 						radio.talk_into(src, msg, radio_channel)
 					has_wound = TRUE
-					break
 			else
 				for(var/datum/wound/wound as anything in C.all_wounds)
 					if(wound.wound_flags & ACCEPTS_CRYO)

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -259,12 +259,11 @@
 		var/has_wound = FALSE
 		if(C && C.all_wounds)
 			if(air1.total_moles() && air1.get_moles(GAS_HEALIUM) > MINIMUM_MOLE_COUNT)
-				if(C.all_wounds)
-					if(!treating_wounds) // if we have wounds and haven't already alerted the doctors we're only dealing with the wounds, let them know
-						playsound(src, 'sound/machines/cryo_warning.ogg', volume) // Bug the doctors.
-						var/msg = "Patient vitals fully recovered, continuing automated wound treatment."
-						radio.talk_into(src, msg, radio_channel)
-					has_wound = TRUE
+				if(!treating_wounds) // if we have wounds and haven't already alerted the doctors we're only dealing with the wounds, let them know
+					playsound(src, 'sound/machines/cryo_warning.ogg', volume) // Bug the doctors.
+					var/msg = "Patient vitals fully recovered, continuing automated wound treatment."
+					radio.talk_into(src, msg, radio_channel)
+				has_wound = TRUE
 			else
 				for(var/datum/wound/wound as anything in C.all_wounds)
 					if(wound.wound_flags & ACCEPTS_CRYO)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1530,6 +1530,7 @@
 	L.SetUnconscious(1000)
 	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=0.5, blacklisted_movetypes=(FLYING|FLOATING)) // slowdown for if you're awake
 	ADD_TRAIT(L, TRAIT_SURGERY_PREPARED, "healium")
+	ADD_TRAIT(L, TRAIT_PRESERVED_ORGANS, "healium")
 
 /datum/reagent/healium/on_mob_life(mob/living/carbon/M)
 	M.SetSleeping(100)
@@ -1540,11 +1541,18 @@
 		M.adjust_disgust((40 - M.disgust) / 10) // makes you sick
 		M.adjust_jitter_up_to(2, 10)
 	else if(M.bodytemperature < T0C)
+		var/power = -0.00009 * (M.bodytemperature ** 2) + 9
 		heal_factor *= (100 + max(T0C - M.bodytemperature, 200)) / 100 // if you're asleep, you get healed faster when you're cold (up to 3x at 73 kelvin)
+		for(var/i in M.all_wounds)
+			var/datum/wound/iter_wound = i
+			iter_wound.on_healium(power)
+
 	M.adjustOxyLoss(-10*heal_factor*REM)
 	M.adjustFireLoss(-7*heal_factor*REM)
 	M.adjustToxLoss(-5*heal_factor*REM)
 	M.adjustBruteLoss(-5*heal_factor*REM)
+	M.adjustCloneLoss(-5*heal_factor*REM)
+	REMOVE_TRAIT(M, TRAIT_DISFIGURED, TRAIT_GENERIC)
 	..()
 
 /datum/reagent/healium/on_mob_end_metabolize(mob/living/L)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1530,7 +1530,14 @@
 	L.SetUnconscious(1000)
 	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=0.5, blacklisted_movetypes=(FLYING|FLOATING)) // slowdown for if you're awake
 	ADD_TRAIT(L, TRAIT_SURGERY_PREPARED, "healium")
+
+/datum/reagent/healium/on_mob_add(mob/living/L)
+	. = ..()
 	ADD_TRAIT(L, TRAIT_PRESERVED_ORGANS, "healium")
+
+/datum/reagent/healium/on_mob_delete(mob/living/L)
+	REMOVE_TRAIT(L, TRAIT_PRESERVED_ORGANS, "healium")
+	return ..()
 
 /datum/reagent/healium/on_mob_life(mob/living/carbon/M)
 	M.SetSleeping(100)
@@ -1546,6 +1553,9 @@
 		for(var/i in M.all_wounds)
 			var/datum/wound/iter_wound = i
 			iter_wound.on_healium(power)
+
+		if(M.blood_volume < BLOOD_VOLUME_SAFE(M))
+			M.blood_volume = BLOOD_VOLUME_SAFE(M)
 
 	M.adjustOxyLoss(-10*heal_factor*REM)
 	M.adjustFireLoss(-7*heal_factor*REM)


### PR DESCRIPTION
# Document the changes in your pull request
Healium can now heal cloneloss
Healium can now treat all type of wounds (Only work during unconscious and below 0C)
Healium now remove trait_disfigured
Healium can now preserve organ if metabolizing
Healium can now restore blood (Only work during unconscious and below 0C)

# Why is this good for the game?
So called healium supposed to heal other type of wounds as well right? More useful in cryotube and this stuffs is quite not that easy to make so would be fair to make it worth for all the efforts 

# Testing

https://github.com/yogstation13/Yogstation/assets/89688125/85ed543c-cf7b-4e52-9384-780c5108cc79



# Wiki Documentation
in document of change

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Healium can now heal cloneloss
tweak: Healium can now treat all type of wounds (Only work during unconscious and below 0C)
tweak: Healium now remove trait_disfigured
tweak: Healium can now preserve organ if metabolizing
tweak: Healium can now restore blood (Only work during unconscious and below 0C)
/:cl:
