### PR TITLE
Fixes variant hearts changing icons when consumed

### DIFF
--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -31,7 +31,7 @@
 	if(beating)
 		icon_state = "[icon_base]-on"
 	else
-		icon_state = "[icon_base]"
+		icon_state = icon_base
 
 /obj/item/organ/heart/Remove(mob/living/carbon/M, special = 0)
 	..()
@@ -62,7 +62,7 @@
 
 /obj/item/organ/heart/prepare_eat()
 	var/obj/S = ..()
-	S.icon_state = "heart-off"
+	S.icon_state = icon_base
 	return S
 
 /obj/item/organ/heart/on_life()


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

fixes #21046

# Why is this good for the game?
<!-- Describe why you think this change is good for the game. This section is not required for bugfixes. -->
You probably shouldnt be able to eat cybernetic hearts but who am i to judge

:cl:  
bugfix: heart variants no longer gain the appewrance of a normal heart if eaten
/:cl:
