### PR TITLE
Adjust player count requirement for nuclear operatives

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -5,8 +5,8 @@
 	config_tag = "nuclear"
 	report_type = "nuclear"
 	false_report_weight = 10
-	required_players = 10 // scales with player count, 1 operative for every 10 players, rounded down
-	required_enemies = 1 // lone operative at minimum
+	required_players = 20 // scales with player count, 1 operative for every 10 players, rounded down
+	required_enemies = 2 // needs more than one person to make a team
 	recommended_enemies = 5
 	antag_flag = ROLE_OPERATIVE
 	enemy_minimum_age = 14

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -5,8 +5,8 @@
 	config_tag = "nuclear"
 	report_type = "nuclear"
 	false_report_weight = 10
-	required_players = 35 // 35 players - 3 players to be the nuke ops = 32 players remaining
-	required_enemies = 3
+	required_players = 10 // scales with player count, 1 operative for every 10 players, rounded down
+	required_enemies = 1 // lone operative at minimum
 	recommended_enemies = 5
 	antag_flag = ROLE_OPERATIVE
 	enemy_minimum_age = 14

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -1,7 +1,9 @@
-#define CHALLENGE_TELECRYSTALS 280
-#define CHALLENGE_TIME_LIMIT 3000
-#define CHALLENGE_MIN_PLAYERS 40
-#define CHALLENGE_SHUTTLE_DELAY 15000 // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
+/// The number of telecrystals per player
+#define CHALLENGE_TELECRYSTALS_PER_PLAYER 8
+/// How long the operatives have to declare war
+#define CHALLENGE_TIME_LIMIT (5 MINUTES)
+/// How long after declaring war before the operatives can show up
+#define CHALLENGE_SHUTTLE_DELAY (25 MINUTES) // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
 
 GLOBAL_LIST_EMPTY(jam_on_wardec)
 
@@ -75,7 +77,7 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 		uplinks += uplink
 
 
-	var/tc_to_distribute = CHALLENGE_TELECRYSTALS
+	var/tc_to_distribute = CHALLENGE_TELECRYSTALS_PER_PLAYER * GLOB.player_list.len
 	var/tc_per_nukie = round(tc_to_distribute / (length(orphans)+length(uplinks)))
 
 	for (var/datum/component/uplink/uplink in uplinks)
@@ -104,9 +106,6 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 	if(declaring_war)
 		to_chat(user, "You are already in the process of declaring war! Make your mind up.")
 		return FALSE
-	if(GLOB.player_list.len < CHALLENGE_MIN_PLAYERS)
-		to_chat(user, "The enemy crew is too small to be worth declaring war on.")
-		return FALSE
 	if(!user.onSyndieBase())
 		to_chat(user, "You have to be at your base to use this.")
 		return FALSE
@@ -123,7 +122,6 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 /obj/item/nuclear_challenge/clownops
 	uplink_type = /obj/item/uplink/clownop
 
-#undef CHALLENGE_TELECRYSTALS
+#undef CHALLENGE_TELECRYSTALS_PER_PLAYER
 #undef CHALLENGE_TIME_LIMIT
-#undef CHALLENGE_MIN_PLAYERS
 #undef CHALLENGE_SHUTTLE_DELAY

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -1,5 +1,5 @@
 /// The number of telecrystals per player
-#define CHALLENGE_TELECRYSTALS_PER_PLAYER 8
+#define CHALLENGE_TELECRYSTALS_PER_PLAYER 7
 /// How long the operatives have to declare war
 #define CHALLENGE_TIME_LIMIT (5 MINUTES)
 /// How long after declaring war before the operatives can show up


### PR DESCRIPTION
# Document the changes in your pull request

Nuclear operatives player count requirement has been reduced to 20, with the number of operatives and telecrystals received from declaring war scaling with player count. Current scaling is 1 operative per 10 players rounded down, and 7 TC per player when declaring war.

# Why is this good for the game?

Currently with our significantly lower player count there's a lack of any interesting gamemodes that can happen, which further harms player count. Allowing more gamemodes to happen and making them scale better when player count is low would help fix this to some extent.

# Testing
Good luck.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Nuclear operatives minimum player count reduced to 20
tweak: Telecrystals gained when declaring war now scales with player count
/:cl:
