### PR TITLE
Reactor blowout tweaks

### DIFF
--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -40,7 +40,7 @@
 	var/next_flicker = 0 //Light flicker timer
 	var/base_power_modifier = REACTOR_POWER_FLAVOURISER
 	var/slagged = FALSE //Is this reactor even usable any more?
-	var/explosion_power = 7
+	var/explosion_power = 7 //The explosion strength 
 	//Console statistics.
 	var/last_coolant_temperature = 0
 	var/last_output_temperature = 0

--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -40,6 +40,7 @@
 	var/next_flicker = 0 //Light flicker timer
 	var/base_power_modifier = REACTOR_POWER_FLAVOURISER
 	var/slagged = FALSE //Is this reactor even usable any more?
+	var/explosion_power = 7
 	//Console statistics.
 	var/last_coolant_temperature = 0
 	var/last_output_temperature = 0
@@ -601,11 +602,14 @@
 		var/turf/lowest_turf = GET_TURF_BELOW(lower_turf)
 		if(lowest_turf) // WE NEED TO GO DEEPER
 			new /obj/structure/reactor_corium(lower_turf)
-	explosion(get_turf(src), 0, 5, 10, 20, TRUE, TRUE)
+	explosion(get_turf(src), GLOB.MAX_EX_DEVESTATION_RANGE, GLOB.MAX_EX_HEAVY_RANGE, GLOB.MAX_EX_LIGHT_RANGE, GLOB.MAX_EX_FLASH_RANGE)
+	radiation_pulse(src, (K+1)*temperature*get_fuel_power()*has_fuel()/(REACTOR_MAX_CRITICALITY*REACTOR_MAX_FUEL_RODS))
+	shockwave()
 
 //Failure condition 2: Blowout. Achieved by reactor going over-pressured. This is a round-ender because it requires more fuckery to achieve.
 /obj/machinery/atmospherics/components/trinary/nuclear_reactor/proc/blowout()
-	explosion(get_turf(src), GLOB.MAX_EX_DEVESTATION_RANGE, GLOB.MAX_EX_HEAVY_RANGE, GLOB.MAX_EX_LIGHT_RANGE, GLOB.MAX_EX_FLASH_RANGE)
+	var/explosion_mod = clamp(log(10, pressure), 1, 10)
+	explosion(get_turf(src), explosion_power * explosion_mod  * 0.5, explosion_power * explosion_mod + 2, explosion_power * explosion_mod + 4, explosion_power * explosion_mod + 6, 1, 1)
 	meltdown() //Double kill.
 	relay('sound/effects/reactor/explode.ogg')
 	SSweather.run_weather("nuclear fallout", src.z)
@@ -613,8 +617,16 @@
 		if(istype(X, /obj/effect/landmark/nuclear_waste_spawner))
 			var/obj/effect/landmark/nuclear_waste_spawner/WS = X
 			if(is_station_level(WS.z)) //Begin the SLUDGING
-				WS.range *= 3
+				WS.range *= log(temperature)+K
 				WS.fire()
+
+/obj/machinery/atmospherics/components/trinary/nuclear_reactor/proc/shockwave()
+	var/atom/movable/gravity_lens/shockwave = new(src)
+	shockwave.transform = matrix().Scale(0.5)
+	shockwave.pixel_x = -240
+	shockwave.pixel_y = -240
+	animate(shockwave, alpha = 0, transform = matrix().Scale(20), time = 10 SECONDS, easing = QUAD_EASING)
+	QDEL_IN(shockwave, 10.5 SECONDS)
 
 /obj/machinery/atmospherics/components/trinary/nuclear_reactor/update_icon(updates=ALL)
 	. = ..()
@@ -962,7 +974,7 @@
 	weather_color = "green"
 	telegraph_sound = null
 	weather_sound = 'sound/effects/reactor/falloutwind.ogg'
-	end_duration = 100
+	end_duration = 200
 	area_type = /area
 	protected_areas = list(/area/maintenance, /area/ai_monitored/turret_protected/ai_upload, /area/ai_monitored/turret_protected/ai_upload_foyer,
 	/area/ai_monitored/turret_protected/ai, /area/shuttle)
@@ -970,7 +982,7 @@
 	immunity_type = "rad"
 
 /datum/weather/nuclear_fallout/weather_act(mob/living/L)
-	L.rad_act(100)
+	L.rad_act(2000)
 
 /datum/weather/nuclear_fallout/telegraph()
 	..()


### PR DESCRIPTION
# Document the changes in your pull request
Reactor blowout explosion now scales with pressure
Plutonium sludges range now scales with temperature and K
Reactor fallout now lasts longer and deals more rads, better GET IN MAINT
Reactor explosion now gives pulsewave effect


# Why is this good for the game?
Make reactor blowout explosion not having an explosion cap just like supermatter cuz having an explosion cap is kinda weird when you have a loads of pressure but it explodes very gentle, the fallout should be more intimidating.. Make it JUST LIKE chernobyl

# Testing
uhhhh i died
![image](https://github.com/yogstation13/Yogstation/assets/89688125/c6356e74-7ba3-4309-9ef0-ca30ff1e715c)



# Wiki Documentation
in document of chenge

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Reactor blowout explosion and plutonium sludge range now scales with pressure
tweak: Reactor fallout now lasts longer and deals more rads, better GET IN MAINT
tweak: Reactor explosion now gives pulsewave effect
/:cl:
