### PR TITLE
Reduces the required playercount for a bunch of modes

### DIFF
--- a/code/game/gamemodes/bloodsuckers/bloodsucker.dm
+++ b/code/game/gamemodes/bloodsuckers/bloodsucker.dm
@@ -10,7 +10,7 @@
 		"Research Director", "Chief Engineer", "Chief Medical Officer", "Curator", 
 		"Warden", "Security Officer", "Detective", "Brig Physician",
 	)
-	required_players = 25
+	required_players = 20
 	required_enemies = 1
 	recommended_enemies = 4
 	reroll_friendly = 1

--- a/code/game/gamemodes/bloodsuckers/traitorsuckers.dm
+++ b/code/game/gamemodes/bloodsuckers/traitorsuckers.dm
@@ -11,7 +11,7 @@
 		"Warden", "Security Officer", "Detective", "Brig Physician"
 	)
 	required_players = 20
-	required_enemies = 2 // How many of each type are required
+	required_enemies = 1 // How many of each type are required
 	recommended_enemies = 4
 	reroll_friendly = 1
 	announce_span = "Traitors and Bloodsuckers"

--- a/code/game/gamemodes/bloodsuckers/traitorsuckers.dm
+++ b/code/game/gamemodes/bloodsuckers/traitorsuckers.dm
@@ -10,13 +10,14 @@
 		"Research Director", "Chief Engineer", "Chief Medical Officer", "Curator", 
 		"Warden", "Security Officer", "Detective", "Brig Physician"
 	)
-	required_players = 25
+	required_players = 20
 	required_enemies = 2 // How many of each type are required
 	recommended_enemies = 4
 	reroll_friendly = 1
 	announce_span = "Traitors and Bloodsuckers"
 	announce_text = "There are vampiric monsters on the station along with some syndicate operatives out for their own gain! Do not let the bloodsuckers or the traitors succeed!"
 
+	num_modifier = -2 //less traitors to account for the bloodsuckers
 	var/list/possible_bloodsuckers = list()
 	var/list/bloodsuckers = list()
 	var/const/bloodsucker_amount = 3

--- a/code/game/gamemodes/brother/traitor_bro.dm
+++ b/code/game/gamemodes/brother/traitor_bro.dm
@@ -6,7 +6,7 @@
 	name = "traitor+brothers"
 	config_tag = "traitorbro"
 	restricted_jobs = list("AI", "Cyborg", "Synthetic")
-	required_players = 20 //yogs - just a minor change
+	required_players = 15
 	title_icon = "ss13"
 
 
@@ -16,6 +16,7 @@
 	<span class='danger'>Blood Brothers</span>: Accomplish your objectives.\n\
 	<span class='notice'>Crew</span>: Do not let the traitors or brothers succeed!"
 
+	num_modifier = -2 //less traitors to account for the blood brothers
 	var/list/datum/team/brother_team/pre_brother_teams = list()
 	var/const/team_amount = 2 //hard limit on brother teams if scaling is turned off
 	var/const/min_team_size = 2

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -82,7 +82,7 @@ GLOBAL_VAR(changeling_team_objective_type)
 	restricted_jobs = list("AI", "Cyborg", "Synthetic")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Brig Physician") //YOGS - added hop and brig physician
 	required_players = 15
-	required_enemies = 2
+	required_enemies = 1
 	recommended_enemies = 4
 	reroll_friendly = 1
 

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -81,7 +81,7 @@ GLOBAL_VAR(changeling_team_objective_type)
 	false_report_weight = 10
 	restricted_jobs = list("AI", "Cyborg", "Synthetic")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Brig Physician") //YOGS - added hop and brig physician
-	required_players = 20
+	required_players = 15
 	required_enemies = 2
 	recommended_enemies = 4
 	reroll_friendly = 1

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -5,7 +5,7 @@
 	false_report_weight = 10
 	traitors_possible = 3 //hard limit on traitors if scaling is turned off
 	restricted_jobs = list("AI", "Cyborg", "Synthetic")
-	required_players = 20
+	required_players = 15
 	required_enemies = 1	// how many of each type are required
 	recommended_enemies = 3
 	reroll_friendly = 1
@@ -13,6 +13,7 @@
 	announce_text = "There are alien creatures on the station along with some syndicate operatives out for their own gain! Do not let the changelings or the traitors succeed!"
 	title_icon = "traitorchan"
 
+	num_modifier = -1 //less traitors to account for the changeling
 	var/list/possible_changelings = list()
 	var/list/changelings = list()
 	var/const/changeling_amount = 1 //hard limit on changelings if scaling is turned off

--- a/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
+++ b/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
@@ -6,7 +6,7 @@
 	false_report_weight = 5
 	protected_jobs = list("Chaplain","Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Research Director", "Chief Engineer", "Chief Medical Officer", "Brig Physician", "Synthetic") //Yogs: Added Brig Physician
 	restricted_jobs = list("AI", "Cyborg")
-	required_players = 25
+	required_players = 15
 	required_enemies = 1
 	recommended_enemies = 4
 	reroll_friendly = 1

--- a/yogstation/code/game/gamemodes/darkspawn/darkspawn.dm
+++ b/yogstation/code/game/gamemodes/darkspawn/darkspawn.dm
@@ -15,6 +15,11 @@ GLOBAL_VAR_INIT(sacrament_done, FALSE)
 	var/list/datum/mind/darkspawns = list()
 	var/datum/team/darkspawn/team
 
+	announce_span = "danger"
+	announce_text = "There are <span class='velvet'>Darkspawn</span> on the station!\n\
+	<span class='velvet'>Darkspawn</span>: Consume enough lucidity to complete the Sacrament and ascend once again.\n\
+	<span class='notice'>Crew</span>: Kill the darkspawn before they can complete the Sacrament."
+
 ////////////////////////////////////////////////////////////////////////////////////
 //-------------------------------Gamemode Setup-----------------------------------//
 ////////////////////////////////////////////////////////////////////////////////////
@@ -56,10 +61,6 @@ GLOBAL_VAR_INIT(sacrament_done, FALSE)
 ////////////////////////////////////////////////////////////////////////////////////
 //----------------------------Non-Secret mode stuff-------------------------------//
 ////////////////////////////////////////////////////////////////////////////////////
-/datum/game_mode/darkspawn/announce()
-	to_chat(world, "<b>The current game mode is - Darkspawn!</b>")
-	to_chat(world, "<b>There are [span_velvet("darkspawn")] on the station. Crew: Kill the darkspawn before they can complete the Sacrament. Darkspawn: Consume enough lucidity to complete the Sacrament and ascend once again.</b>")
-
 /datum/game_mode/darkspawn/generate_report()
 	return "Sightings of strange alien creatures have been observed in your area. These aliens appear to be searching for specific patterns of brain activity, with their method for doing so causing victims to lapse into a short coma. \
 	Be wary of dark areas and ensure all lights are kept well-maintained. Investigate all reports of odd or suspicious sightings in maintenance, and be on the lookout for anyone sympathizing with these aliens, as they may be compromised"


### PR DESCRIPTION
gonna need to make traitor/heretic at some point

also did a small code cleanup to darkspawn

# Why is this good for the game?
antag variety is important
with lowpop all the time, we're stuck with traitor close to 100% of the time
until someone ends up porting or creating a new system that fixes the issue better, this is something

# Testing
no need, it's just number changes

:cl:  
tweak: Changed gamemode pop requirements
tweak: traitor/bloodsucker 25 -> 20
tweak: traitor/bloodbrother 20 -> 15
tweak: traitor/changeling 20 -> 15
tweak: bloodsucker 25 -> 20
tweak: changeling 20 -> 15
tweak: heretic 25 -> 15
tweak: all gamemodes that are traitor/something spawn less traitors to account for the other antags
/:cl:
