### PR TITLE
supermatter tesla ball nerfs

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -434,7 +434,7 @@
 			adjust_jitter(10 SECONDS)
 			adjustOrganLoss(ORGAN_SLOT_BRAIN, 100, 199)
 
-	if(gib && siemens_coeff > 0 && stat == SOFT_CRIT)
+	if(gib && siemens_coeff > 0 && stat >= SOFT_CRIT)
 		visible_message(
 			span_danger("[src] body is emitting a loud noise!"), \
 			span_userdanger("You feel like you are about to explode!"), \

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -434,7 +434,7 @@
 			adjust_jitter(10 SECONDS)
 			adjustOrganLoss(ORGAN_SLOT_BRAIN, 100, 199)
 
-	if(gib && siemens_coeff > 0)
+	if(gib && siemens_coeff > 0 && stat == SOFT_CRIT)
 		visible_message(
 			span_danger("[src] body is emitting a loud noise!"), \
 			span_userdanger("You feel like you are about to explode!"), \

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -38,7 +38,7 @@
 	icon_state = "smenergy_ball"
 	energy = 10000
 	max_balls = 20
-	zap_range = 20
+	zap_range = 7
 	hypercharged = TRUE
 
 /obj/singularity/energy_ball/supermatter/small_crystals


### PR DESCRIPTION
# Document the changes in your pull request
supermatter tesla ball zap range reduced to 7
supermatter tesla ball zap now only gip you if ur crit or dead

# Why is this good for the game?
you get higher chance to survive in resonance cascade event

# Testing
yes  did


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: supermatter tesla ball zap range reduced to 7
tweak: supermatter tesla ball zap now only gip you if ur crit or dead
/:cl:
