### PR TITLE
Adds a Rage Cage Gimmick objective for traitors

### DIFF
--- a/strings/gimmick_objectives.txt
+++ b/strings/gimmick_objectives.txt
@@ -28,3 +28,4 @@ Purge the AI's laws. Let the silicons be free.
 Steal as many departmental budget cards as possible.
 Become a loan shark. Rack people up on debts. If they don't pay up, teach 'em a little lesson not to mess with the Syndicate.
 Take control of the station from the Captain's hands. Make sure to cause little collateral - we don't want to be rulers of rubble.
+Ruin the station's productivity by holding a Rage Cage Tournament. Bonus points if you overwhelm Medbay with electrocution injuries.


### PR DESCRIPTION
# Document the changes in your pull request

Adds the following gimmick objective: 
Ruin the station's productivity by holding a Rage Cage Tournament. Bonus points if you overwhelm Medbay with electrocution injuries.

# Why is this good for the game?

Someone had mentioned they hadn't seen a Rage Cage in forever, to which I thought perhaps we could fix that.

# Testing

![image](https://github.com/yogstation13/Yogstation/assets/70451213/af36dc24-1d36-49e7-8895-aa8328e373fd)

# Changelog


:cl:  
rscadd: Rage Cage Gimmick objective
/:cl:
