### PR TITLE
Mimes can use the darkspawn mindlink without needing to break their oath

### DIFF
--- a/code/datums/saymode.dm
+++ b/code/datums/saymode.dm
@@ -1,6 +1,7 @@
 /datum/saymode
 	var/key
 	var/mode
+	var/bypass_mute = FALSE
 
 //Return FALSE if you have handled the message. Otherwise, return TRUE and saycode will continue doing saycode things.
 //user = whoever said the message
@@ -143,6 +144,7 @@
 /datum/saymode/darkspawn //yogs: darkspawn
 	key = MODE_KEY_DARKSPAWN
 	mode = MODE_DARKSPAWN
+	bypass_mute = TRUE //it's mentally talking, not physically
 
 /datum/saymode/darkspawn/handle_message(mob/living/user, message, datum/language/language)
 	var/datum/mind = user.mind

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -147,7 +147,7 @@ GLOBAL_LIST_INIT(special_radio_keys, list(
 	if(!language)
 		language = get_selected_language()
 
-	if(!(can_speak_vocal(message) || (saymode && istype(saymode, /datum/saymode/darkspawn)))) //yogs change - mindlink is mental, not vocal
+	if(!(can_speak_vocal(message) || (saymode && saymode.bypass_mute))) //yogs change - mindlink is mental, not vocal
 		to_chat(src, span_warning("You find yourself unable to speak!"))
 		return
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -147,7 +147,7 @@ GLOBAL_LIST_INIT(special_radio_keys, list(
 	if(!language)
 		language = get_selected_language()
 
-	if(!can_speak_vocal(message))
+	if(!(can_speak_vocal(message) || (saymode && istype(saymode, /datum/saymode/darkspawn)))) //yogs change - mindlink is mental, not vocal
 		to_chat(src, span_warning("You find yourself unable to speak!"))
 		return
 


### PR DESCRIPTION
# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/a909aac3-0190-40a5-9f56-51a8a86c3180)

:cl:  
bugfix: Mimes can use the darkspawn mindlink without needing to break their oath
/:cl:
