### PR TITLE
New traitor item: Armored Mech Pilot's Suit

### DIFF
--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -791,7 +791,7 @@
 	greyscale_config_inhand_right = /datum/greyscale_config/jumpsuit_inhand_right
 	greyscale_config_worn = /datum/greyscale_config/jumpsuit_worn
 	can_adjust = FALSE
-	armor = list(MELEE = 10, LASER = 10, FIRE = 40, ACID = 10, BOMB = 5)
+	armor = list(MELEE = 10, BULLET = 0, LASER = 10, ENERGY = 0, BOMB = 5, BIO = 0, RAD = 0, FIRE = 40, ACID = 10, WOUND= 5)
 	mutantrace_variation = MUTANTRACE_VARIATION
 
 /obj/item/clothing/under/mech_suit
@@ -821,6 +821,14 @@
 	desc = "A blue mech pilot's suit. For the more reluctant mech pilots."
 	icon_state = "blue_mech_suit"
 	item_state = "blue_mech_suit"
+	mutantrace_variation = MUTANTRACE_VARIATION
+
+/obj/item/clothing/under/mech_suit/cybersun
+	name = "Cybersun mech pilot's suit"
+	desc = "An armored mech pilot suit, used exclusively by Cybersun mech agents."
+	icon_state = "black_mech_suit"
+	item_state = "black_mech_suit"
+	armor = list(MELEE = 15, BULLET = 15, LASER = 10, ENERGY = 10, BOMB = 50, BIO = 50, RAD = 20, FIRE = 50, ACID = 50, WOUND = 5)
 	mutantrace_variation = MUTANTRACE_VARIATION
 
 /obj/item/clothing/under/lampskirt

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2462,6 +2462,14 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	manufacturer = /datum/corporation/traitor/waffleco
 	restricted_roles = list("Research Director", "Scientist")
 
+/datum/uplink_item/role_restricted/armoredmechsuit
+	name = "Cybersun Mech Pilot's Suit"
+	desc = "A black and red stylishly armored mech pilot's suit used by Cybersun's elite mecha pilots. Provides potent protection both inside and outside a mech."
+	item = /obj/item/clothing/under/mech_suit/cybersun
+	cost = 4
+	manufacturer = /datum/corporation/traitor/cybersun
+	restricted_roles = list("Research Director", "Scientist", "Roboticist")
+
 /datum/uplink_item/role_restricted/gorillacubes
 	name = "Box of Gorilla Cubes"
 	desc = "A box with three Waffle Co. brand gorilla cubes. Eat big to get big. \


### PR DESCRIPTION
Special thanks to @RG4ORDR for the idea

# Document the changes in your pull request

Adds a new role restricted traitor item: "Cybersun mech pilot's suit" it provides the normal mecha bonuses as a normal suit, but provides armor = list(MELEE = 15, BULLET = 15, LASER = 10, ENERGY = 10, BOMB = 50, BIO = 50, RAD = 20, FIRE = 50, ACID = 50, WOUND = 5) armor as a jumpsuit, costs 4 TC

# Why is this good for the game?

This gives mecha focused traitors more to buy.

# Testing

works

![image](https://github.com/yogstation13/Yogstation/assets/75333826/bef5e53d-59f3-45d4-8913-a6240f889934)


# Spriting

![image](https://github.com/yogstation13/Yogstation/assets/75333826/20be9810-6cff-4594-aca2-2179f01f8190)
![image](https://github.com/yogstation13/Yogstation/assets/75333826/c56f60f3-1cf7-4042-969b-27b94d5fb529)

# Wiki Documentation

Add this to the wiki: "Cybersun mech pilot's suit" - 4TC

# Changelog

:cl:  
rscadd: Adds a new traitor item: Cybersun mech pilot's suit
bugfix: fixes durathread jumpsuits not getting full wound protection.

/:cl:
