### PR TITLE
Fix pda mesaages being sent twice

### DIFF
--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -667,12 +667,6 @@
 /obj/item/modular_computer/proc/parent_moved()
 	SEND_SIGNAL(src, COMSIG_MOVABLE_MOVED)
 
-/// Sets visible messages to also send to holder because coders didn't know it didn't do this
-/obj/item/modular_computer/visible_message(message, self_message, blind_message, vision_distance = DEFAULT_MESSAGE_RANGE, list/ignored_mobs, visible_message_flags)
-	. = ..()
-	if(ismob(loc))
-		to_chat(loc, message)
-
 /obj/item/modular_computer/proc/uplink_check(mob/living/M, code)
 	return SEND_SIGNAL(src, COMSIG_NTOS_CHANGE_RINGTONE, M, code) & COMPONENT_STOP_RINGTONE_CHANGE
 


### PR DESCRIPTION

# Document the changes in your pull request

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Prefix the PR title with [admin] if it involves something admin related. 
Prefix the PR title with [s] if you are fixing a game-breaking exploit, so that it is not announced on the Yogstation Discord and the server.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->

send_message already does the job

Fix pda mesaages being sent twice

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/89688125/eaece1c4-c66b-4a7f-a22b-ba381e5ebbd0)





# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

bugfix: Fix pda mesaages being sent twice
/:cl:
