### PR TITLE
Adds Camera Laser Gun Upgrade to Malf Modules

### DIFF
--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -789,7 +789,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/AI_Module))
 
 /// AI Laser Gun: Upgrades the ability to shoot lasers from cameras. If they do not have it, gives the non-upgraded ability.
 /datum/AI_Module/upgrade/camera_laser_gun
-	name = "Camera Laser Gun"
+	name = "Upgrade Camera Laser Gun"
 	description = "Upgrades your ability to shoot lasers from any camera at targets. \
 	Should you already not have the ability, grants the non-upgraded ability. Upgrade is done immediately upon purchase."
 	cost = 30

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -802,7 +802,6 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/AI_Module))
 	for(var/datum/action/innate/ai/ranged/cameragun/listed_action in AI.actions)
 		ai_action = listed_action
 		ai_action.proj_type = /obj/projectile/beam/laser/heavylaser
-		break
 
 	if(ai_action)
 		unlock_text = span_notice("Optimization detected in camera light program... Changes applied.")

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -787,5 +787,30 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/AI_Module))
 /datum/AI_Module/upgrade/mecha_domination/upgrade(mob/living/silicon/ai/AI)
 	AI.can_dominate_mechs = TRUE //Yep. This is all it does. Honk!
 
+/// AI Laser Gun: Upgrades the ability to shoot lasers from cameras. If they do not have it, gives the non-upgraded ability.
+/datum/AI_Module/upgrade/camera_laser_gun
+	name = "Camera Laser Gun"
+	description = "Upgrades your ability to shoot lasers from any camera at targets. \
+	Should you already not have the ability, grants the non-upgraded ability. Upgrade is done immediately upon purchase."
+	cost = 30
+	upgrade = TRUE
+	unlock_text = span_notice("You remove the safety controls on your camera light program.")
+	unlock_sound = 'sound/items/rped.ogg'
+
+/datum/AI_Module/upgrade/camera_laser_gun/upgrade(mob/living/silicon/ai/AI)
+	var/datum/action/innate/ai/ranged/cameragun/ai_action
+	for(var/datum/action/innate/ai/ranged/cameragun/listed_action in AI.actions)
+		ai_action = listed_action
+		ai_action.proj_type = /obj/projectile/beam/laser/heavylaser
+		break
+
+	if(ai_action)
+		unlock_text = span_notice("Optimization detected in camera light program... Changes applied.")
+		return
+	
+	// For non-traitor AIs. Non-upgraded ability.
+	ai_action = new
+	ai_action.Grant(AI)
+
 #undef DEFAULT_DOOMSDAY_TIMER
 #undef DOOMSDAY_ANNOUNCE_INTERVAL

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -791,7 +791,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/AI_Module))
 /datum/AI_Module/upgrade/camera_laser_gun
 	name = "Upgrade Camera Laser Gun"
 	description = "Upgrades your ability to shoot lasers from any camera at targets. \
-	Should you already not have the ability, grants the non-upgraded ability. Upgrade is done immediately upon purchase."
+	Should you not already have the ability, grants the non-upgraded ability. Upgrade is done immediately upon purchase."
 	cost = 30
 	upgrade = TRUE
 	unlock_text = span_notice("You remove the safety controls on your camera light program.")

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -801,6 +801,7 @@ GLOBAL_LIST_INIT(malf_modules, subtypesof(/datum/AI_Module))
 	var/datum/action/innate/ai/ranged/cameragun/ai_action
 	for(var/datum/action/innate/ai/ranged/cameragun/listed_action in AI.actions)
 		ai_action = listed_action
+		// Benefits: 2x damage, more wound, and setting people on fire.
 		ai_action.proj_type = /obj/projectile/beam/laser/heavylaser
 
 	if(ai_action)


### PR DESCRIPTION
# Document the changes in your pull request
Adds a purchasable upgrade called "Upgrade Camera Laser Gun" to malfunction modules. 
It costs 30 CPU.
It changes the projectile shot out of the camera laser gun to be heavy lasers.
This means 2x damage, increased chance for wounds, and setting stuff on fire.

If upgrading is not possible, grants the non-upgraded camera laser gun ability instead.

# Why is this good for the game?
Lets AIs who get the rare combat upgrade from lavalands/junglelands to try out the camera laser gun instead of hoping to roll traitor. Rewards traitor AIs (only them since malf is disabled) with a cooler camera gun if they also somehow get the rare combat upgrade.

# Testing
Gives non-upgraded action when buying upgrade after giving malf upgrade to non-traitor AI.
Action upgraded when buying upgrade when malf AI.

# Wiki Documentation
Add to https://wiki.yogstation.net/wiki/Guide_to_malfunction

Upgrade Camera Laser Gun (Costs 30 CPU): Changes the projectile that is shot out of your camera laser gun to be heavy lasers.

# Changelog
:cl:  
rscadd: "Upgrade Camera Laser Gun" added to malfunction modules costing 30 CPU. Changes projectile to heavy lasers.
/:cl:
