### PR TITLE
Non-edible grown items properly inherit seed stats/traits

### DIFF
--- a/code/modules/hydroponics/growninedible.dm
+++ b/code/modules/hydroponics/growninedible.dm
@@ -8,7 +8,7 @@
 	resistance_flags = FLAMMABLE
 	var/obj/item/seeds/seed = null // type path, gets converted to item on New(). It's safe to assume it's always a seed item.
 
-/obj/item/grown/Initialize(mapload, newloc, obj/item/seeds/new_seed)
+/obj/item/grown/Initialize(mapload, obj/item/seeds/new_seed)
 	. = ..()
 	create_reagents(50)
 
@@ -24,7 +24,7 @@
 
 	if(seed)
 		for(var/datum/plant_gene/trait/T in seed.genes)
-			T.on_new(src, newloc)
+			T.on_new(src, loc)
 
 		if(istype(src, seed.product)) // no adding reagents if it is just a trash item
 			seed.prepare_result(src)


### PR DESCRIPTION
# Document the changes in your pull request
Non-edible grown items (e.g. cotton/durathread) properly inherit seed stats/traits.

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/30399783/24679c8b-f31e-4ca8-a84b-076d5cc75df9)

# Changelog
:cl:   
bugfix: Non-edible grown items (e.g. cotton/durathread) properly inherit seed stats/traits.
/:cl:
