### PR TITLE
Gives the revenant antag an innate medhud

### DIFF
--- a/code/modules/antagonists/revenant/revenant.dm
+++ b/code/modules/antagonists/revenant/revenant.dm
@@ -91,6 +91,8 @@
 
 	random_revenant_name()
 	LoadComponent(/datum/component/walk/jaunt) //yogs
+	var/datum/atom_hud/H = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED] //yogs medhud
+	H.show_to(src)
 
 /mob/living/simple_animal/revenant/canUseTopic(atom/movable/M, be_close=FALSE, no_dextery=FALSE, no_tk=FALSE)
 	return FALSE


### PR DESCRIPTION
# Why is this good for the game?
the revenant is all about capitalizing on people that are injured
not being able to tell who is injured doesn't make it interesting, it makes it frustrating

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/eff44b1e-6f76-4ffd-89f5-1d0cc78fd838)


:cl:  
tweak: Gives the revenant antag an innate medhud
/:cl:
