### PR TITLE
AI Project: Cyborg Management

### DIFF
--- a/code/__DEFINES/ai.dm
+++ b/code/__DEFINES/ai.dm
@@ -28,7 +28,9 @@
 #define AI_PROJECT_SURVEILLANCE "Surveillance"
 #define AI_PROJECT_EFFICIENCY "Efficiency"
 #define AI_PROJECT_CROWD_CONTROL "Crowd Control"
+#define AI_PROJECT_CYBORG "Cyborg Management"
 #define AI_PROJECT_MISC "Misc."
+
 //Update this list if you add any new ones, else the category won't show up in the UIs
 GLOBAL_LIST_INIT(ai_project_categories, list(
 	AI_PROJECT_HUDS,
@@ -37,6 +39,7 @@ GLOBAL_LIST_INIT(ai_project_categories, list(
 	AI_PROJECT_INDUCTION,
 	AI_PROJECT_EFFICIENCY,
 	AI_PROJECT_CROWD_CONTROL,
+	AI_PROJECT_CYBORG,
 	AI_PROJECT_MISC
 ))
 

--- a/code/modules/mob/living/silicon/ai/decentralized/projects/cyborg_management.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/projects/cyborg_management.dm
@@ -1,0 +1,116 @@
+
+
+/datum/ai_project/cyborg_management_basic
+	name = "Cyborg Management Basics"
+	description = "This research functions as a prerequisite for other cyborg research such as remote unlock and remote module reset."
+	research_cost = 2500
+	can_be_run = FALSE
+	category = AI_PROJECT_CYBORG
+
+/datum/ai_project/cyborg_management_unlock
+	name = "Cyborg Management - Unlock"
+	description = "Mimicking a robotics console, generates and sends an one-time use signal that can unlock an active connected cyborg."
+	research_cost = 2500
+	research_requirements_text = "Cyborg Management Basics"
+	research_requirements = list(/datum/ai_project/cyborg_management_basic)
+	category = AI_PROJECT_CYBORG
+	can_be_run = FALSE
+	ability_path = /datum/action/innate/ai/ranged/remote_unlock
+	ability_recharge_cost = 2500
+
+/datum/ai_project/cyborg_management_unlock/finish()
+	add_ability(ability_path)
+
+/datum/action/innate/ai/ranged/remote_unlock
+	name = "Unlock Cyborg"
+	desc = "Unlock an active connected cyborg."
+	button_icon = 'icons/mob/actions/actions_flightsuit.dmi' // Better sprites welcome.
+	button_icon_state = "flightsuit_lock"
+	uses = 1
+	delete_on_empty = FALSE
+	enable_text = span_notice("You mimick and prepare to send one-time code used by robotics consoles. Click an active connected cyborg to unlock them.")
+	disable_text = span_notice("You decide not to send the one-time code.")
+
+/datum/action/innate/ai/ranged/remote_unlock/do_ability(mob/living/caller, params, atom/clicked_on)
+	if(!iscyborg(clicked_on))
+		to_chat(owner, span_warning("You can only unlock cyborgs!"))
+		return FALSE
+	if(!isAI(caller))
+		CRASH("Non-AI has /remote_unlock ability!")
+		return FALSE
+
+	var/mob/living/silicon/robot/cyborg = clicked_on
+	var/mob/living/silicon/ai/ai = caller
+	if(cyborg.stat == DEAD)
+		to_chat(ai, span_warning("You cannot unlock dead cyborgs!"))
+		return FALSE
+	if(!(cyborg in ai.connected_robots))
+		to_chat(ai, span_warning("You cannot unlock unconnected cyborgs!"))
+		return FALSE
+	if(!cyborg.lockcharge)
+		to_chat(ai, span_warning("This cyborg is not locked down!"))
+		return FALSE
+
+	unset_ranged_ability(ai)
+	adjust_uses(-1)
+
+	to_chat(ai, span_notice("You send the one-time code toward [cyborg]."))
+	cyborg.SetLockdown(FALSE)
+
+	playsound(cyborg, 'sound/machines/twobeep.ogg', 50, 0)
+	cyborg.audible_message(span_danger("You hear beeps coming from [cyborg]!"))
+	return TRUE
+
+/datum/ai_project/cyborg_management_reset
+	name = "Cyborg Management - Reset"
+	description = "With a specially tailored program, tricks a connected cyborg's module connect into believing it was disconnected briefly which trigger a module reset." // Weak flavor.
+	research_cost = 2500
+	research_requirements_text = "Cyborg Management Basics"
+	research_requirements = list(/datum/ai_project/cyborg_management_basic)
+	category = AI_PROJECT_CYBORG
+	can_be_run = FALSE
+	ability_path = /datum/action/innate/ai/ranged/remote_reset
+	ability_recharge_cost = 2500
+
+/datum/ai_project/cyborg_management_reset/finish()
+	add_ability(ability_path)
+
+/datum/action/innate/ai/ranged/remote_reset
+	name = "Reset Cyborg Module"
+	desc = "Triggers a module reset on an active connected cyborg."
+	button_icon = 'icons/mob/actions/actions_revenant.dmi' // Better sprites welcome.
+	button_icon_state = "malfunction"
+	uses = 1
+	delete_on_empty = FALSE
+	enable_text = span_notice("You prepare to upload and run to a special program to a cyborg. Click an active connected cyborg to reset them.")
+	disable_text = span_notice("You decide not to upload the program.")
+
+/datum/action/innate/ai/ranged/remote_reset/do_ability(mob/living/caller, params, atom/clicked_on)
+	if(!iscyborg(clicked_on))
+		to_chat(owner, span_warning("You can only reset cyborgs!"))
+		return FALSE
+	if(!isAI(caller))
+		CRASH("Non-AI has /remote_reset ability!")
+		return FALSE
+
+	var/mob/living/silicon/robot/cyborg = clicked_on
+	var/mob/living/silicon/ai/ai = caller
+	if(cyborg.stat == DEAD)
+		to_chat(ai, span_warning("You cannot reset dead cyborgs!"))
+		return FALSE
+	if(!(cyborg in ai.connected_robots))
+		to_chat(ai, span_warning("You cannot reset unconnected cyborgs!"))
+		return FALSE
+	if(!cyborg.has_module())
+		to_chat(ai, span_warning("This cyborg hasn't selected a module yet!"))
+		return FALSE
+
+	unset_ranged_ability(ai)
+	adjust_uses(-1)
+
+	to_chat(ai, span_notice("You upload and run a special program to [cyborg]."))
+	cyborg.ResetModule(FALSE)
+
+	playsound(cyborg, 'sound/machines/twobeep.ogg', 50, 0)
+	cyborg.audible_message(span_danger("You hear beeps coming from [cyborg]!"))
+	return TRUE

--- a/code/modules/mob/living/silicon/ai/decentralized/projects/cyborg_management.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/projects/cyborg_management.dm
@@ -63,7 +63,7 @@
 
 /datum/ai_project/cyborg_management_reset
 	name = "Cyborg Management - Reset"
-	description = "With a specially tailored program, tricks a connected cyborg's module connection into believing it was disconnected briefly which trigger a module reset." // Weak flavor.
+	description = "With a specially tailored program, tricks a connected cyborg's module connection into believing it was briefly disconnected which trigger a module reset." // Weak flavor.
 	research_cost = 2500
 	research_requirements_text = "Cyborg Management Basics"
 	research_requirements = list(/datum/ai_project/cyborg_management_basic)

--- a/code/modules/mob/living/silicon/ai/decentralized/projects/cyborg_management.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/projects/cyborg_management.dm
@@ -9,7 +9,7 @@
 
 /datum/ai_project/cyborg_management_unlock
 	name = "Cyborg Management - Unlock"
-	description = "Mimicking a robotics console, generates and sends an one-time use signal that can unlock an active connected cyborg."
+	description = "Mimicking a robotics console, generates and sends a one-time use signal that can unlock an active connected cyborg."
 	research_cost = 2500
 	research_requirements_text = "Cyborg Management Basics"
 	research_requirements = list(/datum/ai_project/cyborg_management_basic)

--- a/code/modules/mob/living/silicon/ai/decentralized/projects/cyborg_management.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/projects/cyborg_management.dm
@@ -63,7 +63,7 @@
 
 /datum/ai_project/cyborg_management_reset
 	name = "Cyborg Management - Reset"
-	description = "With a specially tailored program, tricks a connected cyborg's module connect into believing it was disconnected briefly which trigger a module reset." // Weak flavor.
+	description = "With a specially tailored program, tricks a connected cyborg's module connection into believing it was disconnected briefly which trigger a module reset." // Weak flavor.
 	research_cost = 2500
 	research_requirements_text = "Cyborg Management Basics"
 	research_requirements = list(/datum/ai_project/cyborg_management_basic)

--- a/code/modules/mob/living/silicon/ai/decentralized/projects/cyborg_management.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/projects/cyborg_management.dm
@@ -62,7 +62,7 @@
 
 /datum/ai_project/cyborg_management_reset
 	name = "Cyborg Management - Reset"
-	description = "With a specially tailored program, tricks a connected cyborg's module connection into believing it was briefly disconnected which trigger a module reset." // Weak flavor.
+	description = "With a specially tailored program, tricks a connected cyborg's module connection into believing it was briefly disconnected which triggers a module reset." // Weak flavor.
 	research_cost = 2500
 	research_requirements_text = "Cyborg Management Basics"
 	research_requirements = list(/datum/ai_project/cyborg_management_basic)

--- a/code/modules/mob/living/silicon/ai/decentralized/projects/cyborg_management.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/projects/cyborg_management.dm
@@ -37,7 +37,6 @@
 		return FALSE
 	if(!isAI(caller))
 		CRASH("Non-AI has /remote_unlock ability!")
-		return FALSE
 
 	var/mob/living/silicon/robot/cyborg = clicked_on
 	var/mob/living/silicon/ai/ai = caller
@@ -91,7 +90,6 @@
 		return FALSE
 	if(!isAI(caller))
 		CRASH("Non-AI has /remote_reset ability!")
-		return FALSE
 
 	var/mob/living/silicon/robot/cyborg = clicked_on
 	var/mob/living/silicon/ai/ai = caller

--- a/code/modules/mob/living/silicon/ai/decentralized/projects/induction.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/projects/induction.dm
@@ -83,6 +83,7 @@
 	owner.playsound_local(owner, "sparks", 50, 0)
 
 	if(charge_borg_or_apc(clicked_on))
+		unset_ranged_ability(owner)
 		adjust_uses(-1)
 		do_sparks(3, FALSE,clicked_on)
 		to_chat(owner, span_notice("You charge [clicked_on]."))

--- a/tgui/packages/tgui/interfaces/AiDashboard.js
+++ b/tgui/packages/tgui/interfaces/AiDashboard.js
@@ -12,7 +12,7 @@ export const AiDashboard = (props, context) => {
 
   return (
     <Window
-      width={650}
+      width={800}
       height={600}
       resizable
       title="Dashboard">

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2988,6 +2988,7 @@
 #include "code\modules\mob\living\silicon\ai\decentralized\projects\ai_translation.dm"
 #include "code\modules\mob\living\silicon\ai\decentralized\projects\camera_mobility.dm"
 #include "code\modules\mob\living\silicon\ai\decentralized\projects\coolant_manager.dm"
+#include "code\modules\mob\living\silicon\ai\decentralized\projects\cyborg_management.dm"
 #include "code\modules\mob\living\silicon\ai\decentralized\projects\examine.dm"
 #include "code\modules\mob\living\silicon\ai\decentralized\projects\firewall.dm"
 #include "code\modules\mob\living\silicon\ai\decentralized\projects\induction.dm"


### PR DESCRIPTION
# Document the changes in your pull request
Adds a new AI project category called "Cyborg Management"
Adds three AI projects:
- Cyborg Management Basics: Prerequisite, 2500 CPU.
- Cyborg Management - Unlock: Ability, 2500 CPU, 2500 CPU Recharge.
- Cyborg Management - Reset: Ability, 2500 CPU, 2500 CPU Recharge.

Unlock ability unlocks a cyborg as if it was done through a robotics console.
Reset triggers a module reset.
These abilities can only be used if the cyborg is alive, connected, and locked down (for unlock) or has a module (for reset).
These abilities can only hold one charge at a time.

Widens the Processing Dashboards from 650 to 800 to make all the categories appear in one line/row.
Charge Cyborg/APC ability from the Induction AI project automatically detoggles after use. This prevents AIs from infinitely using it (since it doesn't detoggle after use) which also causes it go negative in use count.

# Why is this good for the game?
More reasons to get CPU and more stuff to do with it after unlocking everything besides using it on induction or room lockdown.

# Testing
Abilities appear on research completion.
![image](https://github.com/yogstation13/Yogstation/assets/30399783/e8959496-e64f-4cc5-8380-8f61422b5aae)

Research appears and new window default sizing.
![image](https://github.com/yogstation13/Yogstation/assets/30399783/f1be5375-3e1d-4301-a353-75fc945eac25)

Module reset ability works.
![image](https://github.com/yogstation13/Yogstation/assets/30399783/64a29008-7eda-4799-ad14-617fe3fbb306)

# Changelog
:cl:  
rscadd: New AI project category called "Cyborg Management".
rscadd: Two/three AI projects that can be researched to unlock and/or reset an connected cyborg.
bugfix: Charge Cyborg/APC ability automatically detoggles after use; no longer allows negative/infinite usages.
tweak: AI's Processing Dashboard tgui starts out more wider.
/:cl:
