### PR TITLE
Removes one and adds a few gimmick objectives

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1681,7 +1681,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 
 	var/selected_gimmick = pick(gimmick_list)
 	selected_gimmick = replacetext(selected_gimmick, "%DEPARTMENT", selected_department)
-	if(target?.current)
+	if(target?.current) //it's possible to use both %DEPARTMENT and %TARGET in an objective, just make sure to put it in target_gimmick_objectives.txt
 		selected_gimmick = replacetext(selected_gimmick, "%TARGET", target.name)
 
 	explanation_text = "[selected_gimmick]"
@@ -1690,6 +1690,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	return TRUE
 	
 /datum/objective/gimmick/admin_edit(mob/admin)
+	admin_simple_target_pick(admin)
 	update_explanation_text()
 
 ///////////////////////////////////////////////////////////////////////

--- a/strings/gimmick_objectives.txt
+++ b/strings/gimmick_objectives.txt
@@ -28,3 +28,4 @@ Purge the AI's laws. Let the silicons be free.
 Become a loan shark. Rack people up on debts. If they don't pay up, teach 'em a little lesson not to mess with the Syndicate.
 Take control of the station from the Captain's hands. Make sure to cause little collateral - we don't want to be rulers of rubble.
 Ruin the station's productivity by holding a Rage Cage Tournament. Bonus points if you overwhelm Medbay with electrocution injuries.
+Poison the station's food and blame it on the chef.

--- a/strings/gimmick_objectives.txt
+++ b/strings/gimmick_objectives.txt
@@ -29,3 +29,7 @@ Become a loan shark. Rack people up on debts. If they don't pay up, teach 'em a 
 Take control of the station from the Captain's hands. Make sure to cause little collateral - we don't want to be rulers of rubble.
 Ruin the station's productivity by holding a Rage Cage Tournament. Bonus points if you overwhelm Medbay with electrocution injuries.
 Poison the station's food and blame it on the chef.
+Fill the station with numerous animals to distract the crew from working.
+Attempt to form a loud non-violent cult to distract security from any fellow operatives.
+Any time anyone is arrested, attempt to break them free.
+Fill the maintenance hallways with annoying non-lethal traps.

--- a/strings/gimmick_objectives.txt
+++ b/strings/gimmick_objectives.txt
@@ -25,7 +25,6 @@ Play increasingly dangerous pranks on the crew. If confronted, insist that it wa
 Convince the crew that the AI is malfunctioning through a combination of lies, misdirection, slander, and sabotage.
 Stage a heist on the armory.
 Purge the AI's laws. Let the silicons be free.
-Steal as many departmental budget cards as possible.
 Become a loan shark. Rack people up on debts. If they don't pay up, teach 'em a little lesson not to mess with the Syndicate.
 Take control of the station from the Captain's hands. Make sure to cause little collateral - we don't want to be rulers of rubble.
 Ruin the station's productivity by holding a Rage Cage Tournament. Bonus points if you overwhelm Medbay with electrocution injuries.

--- a/strings/target_gimmick_objectives.txt
+++ b/strings/target_gimmick_objectives.txt
@@ -8,3 +8,6 @@ Pin the blame on %TARGET for any and all crimes you commit, and try to convince 
 Attempt to kidnap %TARGET to take with you alive on an escape pod or shuttle, for questioning at Syndicate HQ.
 Frame %TARGET for murdering you.
 %TARGET knows corporate secrets. Interrogate them. Use force if they pretend to not know.
+Trick %TARGET into thinking someone else is out to get them.
+Make %TARGET think you are going to kill them.
+Make all of %DEPARTMENT hate %TARGET for one reason or another.

--- a/strings/target_gimmick_objectives.txt
+++ b/strings/target_gimmick_objectives.txt
@@ -9,5 +9,5 @@ Attempt to kidnap %TARGET to take with you alive on an escape pod or shuttle, fo
 Frame %TARGET for murdering you.
 %TARGET knows corporate secrets. Interrogate them. Use force if they pretend to not know.
 Trick %TARGET into thinking someone else is out to get them.
-Make %TARGET think you are going to kill them.
+Make %TARGET think you are going to kill them without directly telling them.
 Make all of %DEPARTMENT hate %TARGET for one reason or another.


### PR DESCRIPTION
Removed one 
Steal as many departmental budget cards as possible.

new ones
Poison the station's food and blame it on the chef.
Fill the station with numerous animals to distract the crew from working.
Trick %TARGET into thinking someone else is out to get them.
Make %TARGET think you are going to kill them without directly telling them.
Make all of %DEPARTMENT hate %TARGET for one reason or another.
Attempt to form a loud non-violent cult to distract security from any fellow operatives.
Any time anyone is arrested, attempt to break them free.
Fill the maintenance hallways with annoying non-lethal traps.


# Why is this good for the game?
we don't have budget cards
more gimmick objectives are good

:cl:  Mqiib & Molti
rscadd: Some other gimmick objectives
rscdel: Removed budget card gimmick objective
bugfix: lets admins select the target of targeted gimmick objectives
/:cl:
