### PR TITLE
Tweaks the chance to not get a traitor escape objective to be 50/50

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -165,7 +165,7 @@
 			if(minorObjective)
 				add_objective(minorObjective)
 		if(!(locate(/datum/objective/escape) in objectives))
-			if(prob(70)) //doesn't always need to escape
+			if(prob(50)) //doesn't always need to escape
 				var/datum/objective/escape/escape_objective = new
 				escape_objective.owner = owner
 				add_objective(escape_objective)


### PR DESCRIPTION
# Why is this good for the game?
When i initially added this, i made it a bit lower than i wanted to just to see how people would take it.
after some time, it seems like people actually quite like it, so i'm changing it to be 50/50 like i planned

# Testing
number tweak

:cl:  
tweak: Tweaks the chance to not get a traitor escape objective to be 50/50
/:cl:
