### PR TITLE
Fixes nitrium being incorrectly labeled

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -475,7 +475,7 @@ DEFINE_BITFIELD(vent_movement, list(
 #define GAS_H2O "water_vapor"
 #define GAS_HYPERNOB "hypernob"
 #define GAS_NITROUS "n2o"
-#define GAS_NITRIUM "no2"
+#define GAS_NITRIUM "nitrium"
 #define GAS_TRITIUM "tritium"
 #define GAS_BZ "bz"
 #define GAS_PLUOXIUM "pluox"

--- a/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
+++ b/code/modules/atmospherics/machinery/components/gas_recipe_machines/crystallizer.dm
@@ -296,7 +296,7 @@
 		requirements = list("To create [selected_recipe.name] you will need:")
 		for(var/gas_type in selected_recipe.requirements)
 			var/amount_consumed = selected_recipe.requirements[gas_type]
-			requirements += "-[amount_consumed] moles of [initial(gas_type)]"
+			requirements += "-[amount_consumed] moles of [GLOB.gas_data.names[gas_type]]"
 		requirements += "In a temperature range between [selected_recipe.min_temp] K and [selected_recipe.max_temp] K"
 		requirements += "The crystallization reaction will be [selected_recipe.energy_release ? (selected_recipe.energy_release > 0 ? "exothermic" : "endothermic") : "thermally neutral"]"
 	data["requirements"] = requirements.Join("\n")


### PR DESCRIPTION
![image](https://github.com/yogstation13/Yogstation/assets/93578146/5e37b593-f11d-420f-a783-4792e1d20d2e)

:cl:  
bugfix: fixed crystallizer not using the proper names of gases
spellcheck: fixed nitrium being incorrectly labeled
/:cl:
