### PR TITLE
[BUGFIX] Allows traitor AI to pick their backstory

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -189,6 +189,7 @@
 	var/datum/objective/survive/exist/exist_objective = new
 	exist_objective.owner = owner
 	add_objective(exist_objective)
+	setup_backstories()
 
 /datum/antagonist/traitor/proc/forge_single_human_optional() //adds this for if/when soft-tracked objectives are added, so they can be a 50/50
 	var/datum/objective/gimmick/gimmick_objective = new


### PR DESCRIPTION
# Document the changes in your pull request

Allows traitor AIs to pick their backstories, Ill probably do more with this later (or maybe bibby will lol!!!!!) but for now they can have a regular button that doesn't crash their NTOS


# Testing

Wouldnt make it if It didnt work

# Changelog

:cl:  

bugfix: Fixes traitor AIs not being able to access backstories

/:cl:
