### PR TITLE
Fixes the particool system from leaving permanent smoke visual effects

### DIFF
--- a/code/modules/particles/byond_particles/particle_holder.dm
+++ b/code/modules/particles/byond_particles/particle_holder.dm
@@ -25,7 +25,7 @@
 
 	var/atom/parent
 
-/obj/effect/abstract/particle_holder/Initialize(mapload, particle_path = /particles/smoke, particle_flags = NONE)
+/obj/effect/abstract/particle_holder/Initialize(mapload, particle_path, particle_flags = NONE)
 	. = ..()
 	if(!loc)
 		stack_trace("particle holder was created with no loc!")
@@ -37,7 +37,8 @@
 	// Mouse opacity can get set to opaque by some objects when placed into the object's contents (storage containers).
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	src.particle_flags = particle_flags
-	particles = new particle_path()
+	if(particle_path)
+		particles = new particle_path()
 	// /atom doesn't have vis_contents, /turf and /atom/movable do
 	var/atom/movable/lie_about_areas = parent
 	lie_about_areas.vis_contents += src
@@ -79,4 +80,5 @@
 /// Sets the particles position to the passed coordinate list (X, Y, Z)
 /// See [https://www.byond.com/docs/ref/#/{notes}/particles] for position documentation
 /obj/effect/abstract/particle_holder/proc/set_particle_position(list/pos)
-	particles.position = pos
+	if(particles)
+		particles.position = pos


### PR DESCRIPTION
it was creating a smoke visual effect for the master holder that's used by the particle emitter system

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/9c005a69-8baa-46f6-9f68-625a4fbd1fe8)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/1ad756ff-9477-4ffe-9118-d3e530f05d5f)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/84c7ef17-c5e1-4ad1-9b80-d305201c53cf)

just to show that regular particles (water) still work
![image](https://github.com/yogstation13/Yogstation/assets/108117184/f42715e1-4ea9-4b4b-8101-6d1cc980f647)

:cl:  
bugfix: Fixes the particool system from leaving permanent smoke visual effects
/:cl:
