### PR TITLE
makes tar king more bearable

### DIFF
--- a/yogstation/code/modules/jungleland/jungle_items.dm
+++ b/yogstation/code/modules/jungleland/jungle_items.dm
@@ -365,7 +365,7 @@
 
 /obj/item/clothing/head/yogs/tar_king_crown
 	name = "crown of the tar king"
-	desc = "And old and withered crown from bones of unknown origin with a vibrant pinkish crystal embedded in the central spike. It is warm to the touch."
+	desc = "An old and withered crown from bones of unknown origin with a vibrant pinkish crystal embedded in the central spike. It is warm to the touch."
 	icon = 'yogstation/icons/obj/jungle.dmi'
 	icon_state = "tar_king_crown"
 	armor = list(MELEE = 80, BULLET = 40, LASER = 60, ENERGY = 50, BOMB = 80, BIO = 70, RAD = 60, FIRE = 100, ACID = 100)

--- a/yogstation/code/modules/jungleland/jungle_items.dm
+++ b/yogstation/code/modules/jungleland/jungle_items.dm
@@ -364,8 +364,8 @@
 	icon_state = "slime_sling_0"
 
 /obj/item/clothing/head/yogs/tar_king_crown
-	name = "Crown of the Tar King"
-	desc = "And old and withered crown made out of bone of unknown origin, there is a vibrant pinkish crystal embedded in it, it is warm to the touch..."
+	name = "crown of the tar king"
+	desc = "And old and withered crown from bones of unknown origin with a vibrant pinkish crystal embedded in the central spike. It is warm to the touch."
 	icon = 'yogstation/icons/obj/jungle.dmi'
 	icon_state = "tar_king_crown"
 	armor = list(MELEE = 80, BULLET = 40, LASER = 60, ENERGY = 50, BOMB = 80, BIO = 70, RAD = 60, FIRE = 100, ACID = 100)
@@ -662,7 +662,7 @@
 
 /obj/item/gem/tarstone
 	name = "primal tarstone"
-	desc = "An incredibly dense and tough chunk of ancient tar. Millions of microscopic runes subtly line the surface, and probably make this artifact worth thousands."
+	desc = "A dense, tough chunk of ancient tar. Millions of microscopic runes subtly line the surface."
 	icon = 'yogstation/icons/obj/jungle.dmi'
 	icon_state = "targem"
 	point_value = 3000

--- a/yogstation/code/modules/jungleland/jungle_megafauna.dm
+++ b/yogstation/code/modules/jungleland/jungle_megafauna.dm
@@ -9,7 +9,7 @@
 #define ATTACK_MATRIX list(SLASH_ATTACK = DIRECTION_MATRIX, RUNE_ATTACK = DIRECTION_MATRIX, IMPALE_ATTACK = DIRECTION_MATRIX)
 
 /mob/living/simple_animal/hostile/megafauna/tar_king 
-	name = "king of tar"
+	name = "King of Tar"
 	desc = "A hunking mass of tar resembling a human, a shining gem glows from within. It yearns for the end of its agony..."
 	health = 2000
 	maxHealth = 2000

--- a/yogstation/code/modules/jungleland/jungle_megafauna.dm
+++ b/yogstation/code/modules/jungleland/jungle_megafauna.dm
@@ -23,6 +23,7 @@
 	melee_damage_lower = 40
 	melee_damage_upper = 40
 	movement_type = GROUND
+	gps_name = "Murky Signal"
 	ranged = TRUE 
 	faction = list("tar", "boss")
 	speak_emote = list("roars")
@@ -50,7 +51,6 @@
 
 /mob/living/simple_animal/hostile/megafauna/tar_king/Initialize()
 	. = ..()
-	src.AddComponent(/datum/component/shielded,'yogstation/icons/effects/effects.dmi',"tar_shield", 1, 30 SECONDS)
 	START_PROCESSING(SSfastprocess,src)
 
 /mob/living/simple_animal/hostile/megafauna/tar_king/Life(seconds_per_tick, times_fired)
@@ -443,3 +443,8 @@
 	var/obj/effect/better_animated_temp_visual/tar_king_chaser_impale/T = new(loc, caster)
 	T.damage = damage
 
+/obj/item/gps/internal/tar_king
+	icon_state = null
+	gpstag = "Murky Signal"
+	desc = "There's something flickering in the dark."
+	invisibility = 100

--- a/yogstation/code/modules/jungleland/jungle_megafauna.dm
+++ b/yogstation/code/modules/jungleland/jungle_megafauna.dm
@@ -3,7 +3,6 @@
 #define RUNE_ATTACK "rune"
 #define TAR_ATTACK "tar"
 #define TELEPORT_ATTACK "teleport"
-#define SPAWN_ATTACK "spawn"
 
 #define DIRECTION_MATRIX list("NORTH" = 0 , "EAST" = 0, "SOUTH" = 0, "WEST" = 0, "NORTHEAST" = 0 , "SOUTHEAST" = 0 , "SOUTHWEST" = 0, "NORTHWEST" = 0)
 #define ATTACK_MATRIX list(SLASH_ATTACK = DIRECTION_MATRIX, RUNE_ATTACK = DIRECTION_MATRIX, IMPALE_ATTACK = DIRECTION_MATRIX)
@@ -188,7 +187,7 @@
 
 /mob/living/simple_animal/hostile/megafauna/tar_king/proc/forge_combo()
 	var/list/combo = list()
-	var/list/possible_moves = list(SLASH_ATTACK,IMPALE_ATTACK,RUNE_ATTACK,TELEPORT_ATTACK,SPAWN_ATTACK)
+	var/list/possible_moves = list(SLASH_ATTACK,IMPALE_ATTACK,RUNE_ATTACK,TELEPORT_ATTACK)
 	for(var/i = 0 ; i < 3; i++)
 		combo += pick_n_take(possible_moves)
 	return combo
@@ -412,6 +411,7 @@
 		. = pick(cardinal_copy)
 
 /obj/effect/temp_visual/tar_king_chaser/proc/seek_target()
+
 	if(!currently_seeking)
 		currently_seeking = TRUE
 		targetturf = get_turf(target)

--- a/yogstation/code/modules/jungleland/jungle_megafauna.dm
+++ b/yogstation/code/modules/jungleland/jungle_megafauna.dm
@@ -20,8 +20,8 @@
 	mob_biotypes = list(MOB_ORGANIC, MOB_HUMANOID)
 	light_color = "#dd35d5"
 	a_intent = INTENT_HARM
-	melee_damage_lower = 25
-	melee_damage_upper = 50
+	melee_damage_lower = 40
+	melee_damage_upper = 40
 	movement_type = GROUND
 	ranged = TRUE 
 	faction = list("tar", "boss")
@@ -35,7 +35,7 @@
 	deathsound = "bodyfall"
 	do_footstep = TRUE
 	ranged_cooldown_time = 10 SECONDS
-	armour_penetration = 50
+	armour_penetration = 40
 	dodge_prob = 0
 	loot = list(/obj/item/clothing/head/yogs/tar_king_crown = 1, /obj/item/gem/tarstone = 1, /obj/item/demon_core = 1)
 	crusher_loot = list(/obj/item/crusher_trophy/jungleland/aspect_of_tar = 1,/obj/item/clothing/head/yogs/tar_king_crown = 1, /obj/item/gem/tarstone = 1, /obj/item/demon_core = 1)
@@ -50,6 +50,7 @@
 
 /mob/living/simple_animal/hostile/megafauna/tar_king/Initialize()
 	. = ..()
+	src.AddComponent(/datum/component/shielded,'yogstation/icons/effects/effects.dmi',"tar_shield", 1, 30 SECONDS)
 	START_PROCESSING(SSfastprocess,src)
 
 /mob/living/simple_animal/hostile/megafauna/tar_king/Life(seconds_per_tick, times_fired)
@@ -133,8 +134,6 @@
 				rune_attack_chain()
 			if(TELEPORT_ATTACK)
 				teleport_attack_chain()
-			if(SPAWN_ATTACK)
-				spawn_attack_chain()
 		attack_stack -= move
 		Goto(target,move_to_delay,minimum_distance)
 		SLEEP_CHECK_DEATH(1 SECONDS)
@@ -261,7 +260,7 @@
 	SLEEP_CHECK_DEATH(8)
 	for(var/mob/living/carbon/C in (range(2,src) - range(1,src)))
 		var/limb_to_hit = C.get_bodypart(pick(BODY_ZONE_HEAD, BODY_ZONE_CHEST, BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG))
-		C.apply_damage(45, BURN, limb_to_hit, C.run_armor_check(limb_to_hit, MAGIC, null, null, armour_penetration), wound_bonus = CANT_WOUND)
+		C.apply_damage(25, BURN, limb_to_hit, C.run_armor_check(limb_to_hit, MAGIC, null, null, armour_penetration), wound_bonus = CANT_WOUND)
 
 /mob/living/simple_animal/hostile/megafauna/tar_king/proc/teleport_attack_chain()
 	new /obj/effect/tar_king/orb_in(get_turf(src),src,dir)
@@ -288,21 +287,6 @@
 	visible_message(span_colossus("Atyr!"))	
 	throw_at(target,get_dist(target,src),4, spin = FALSE)		
 
-/mob/living/simple_animal/hostile/megafauna/tar_king/proc/spawn_attack_chain()
-	if(!GLOB.tar_pits.len)
-		return
-	visible_message(span_colossus("At-Karan!"))
-	var/list/spawnable = list(/mob/living/simple_animal/hostile/asteroid/hivelordbrood/tar)
-	for(var/TP in GLOB.tar_pits)
-		if(prob(50))
-			continue
-		var/obj/structure/tar_pit/pit = TP 
-		var/picked = pick(spawnable)
-		var/mob/living/simple_animal/hostile/H = new picked(pit.loc)
-		H.GiveTarget(target)
-		H.friends = friends
-		H.faction = faction.Copy()
-
 /mob/living/simple_animal/hostile/megafauna/tar_king/proc/process_orbitals()
 	var/orbitals_shown = 3
 	switch(maxHealth - health)
@@ -321,13 +305,14 @@
 		var/ycoord = loc.y + orbital_range * sin(orbitals[i])
 		var/turf/located = locate(xcoord,ycoord,loc.z)
 		var/obj/effect/better_animated_temp_visual/tar_king_chaser_impale/T = new(located, src)
-		T.damage = 25
+		T.damage = 10
 
 /mob/living/simple_animal/hostile/megafauna/tar_king/proc/sword_hit(list/turfs)
 	for(var/turf/T as anything in turfs)
 		for(var/mob/living/carbon/C in T.contents)
 			var/limb_to_hit = C.get_bodypart(pick(BODY_ZONE_HEAD, BODY_ZONE_CHEST, BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG))
-			C.apply_damage(35, BRUTE, limb_to_hit, C.run_armor_check(limb_to_hit, MELEE, null, null, armour_penetration), wound_bonus = CANT_WOUND)
+			C.apply_damage(15, BRUTE, limb_to_hit, C.run_armor_check(limb_to_hit, MELEE, null, null, armour_penetration), wound_bonus = CANT_WOUND)
+			
 
 /mob/living/simple_animal/hostile/megafauna/tar_king/proc/stage_transition()
 	walk(src,0)
@@ -383,7 +368,7 @@
 		to_chat(L, span_userdanger("You're struck by a [name]!"))
 		var/limb_to_hit = L.get_bodypart(pick(BODY_ZONE_HEAD, BODY_ZONE_CHEST, BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_R_LEG, BODY_ZONE_L_LEG))
 		var/armor = L.run_armor_check(limb_to_hit, MELEE, "Your armor absorbs [src]!", "Your armor blocks part of [src]!", 50, "Your armor was penetrated by [src]!")
-		L.apply_damage(damage, BRUTE, limb_to_hit, armor)
+		L.apply_damage(damage, BRUTE, limb_to_hit, armor, wound_bonus = CANT_WOUND)
 		if(caster)
 			log_combat(caster, L, "struck with a [name]")
 

--- a/yogstation/code/modules/jungleland/jungle_status_effects.dm
+++ b/yogstation/code/modules/jungleland/jungle_status_effects.dm
@@ -85,9 +85,10 @@
 
 /datum/status_effect/tar_shield/on_apply()
 	. = ..()
-	cached_image = mutable_appearance('yogstation/icons/effects/effects.dmi',"tar_shield")
-	owner.add_overlay(cached_image)
-	RegisterSignal(owner,COMSIG_MOB_CHECK_SHIELDS,PROC_REF(react_to_attack))
+	if(.)
+		cached_image = mutable_appearance('yogstation/icons/effects/effects.dmi',"tar_shield")
+		owner.add_overlay(cached_image)
+		RegisterSignal(owner,COMSIG_MOB_CHECK_SHIELDS,PROC_REF(react_to_attack))
 
 /datum/status_effect/tar_shield/on_remove()
 	owner.cut_overlay(cached_image)

--- a/yogstation/code/modules/jungleland/jungle_status_effects.dm
+++ b/yogstation/code/modules/jungleland/jungle_status_effects.dm
@@ -85,10 +85,9 @@
 
 /datum/status_effect/tar_shield/on_apply()
 	. = ..()
-	if(.)
-		cached_image = mutable_appearance('yogstation/icons/effects/effects.dmi',"tar_shield")
-		owner.add_overlay(cached_image)
-		RegisterSignal(owner,COMSIG_MOB_CHECK_SHIELDS,PROC_REF(react_to_attack))
+	cached_image = mutable_appearance('yogstation/icons/effects/effects.dmi',"tar_shield")
+	owner.add_overlay(cached_image)
+	RegisterSignal(owner,COMSIG_MOB_CHECK_SHIELDS,PROC_REF(react_to_attack))
 
 /datum/status_effect/tar_shield/on_remove()
 	owner.cut_overlay(cached_image)


### PR DESCRIPTION
# Document the changes in your pull request

the tar king fight is the worst not good so i tried lessening that

- melee damage was changed to a consistent 40
- AP changed from 50 to 40
- Rune damage changed from 45 to 25
- removed the move that spawns a billion tar legion heads
- chaser damage changed from 25 to 10
- sword hit damage changed from 35 to 15
- no more inflicting wounds
-changed gem and crown description to be less wordy
-added "murky signal" to it

# Why is this good for the game?

reducing the damage and removing wounds helps let players win and identify all moves as "oh this is the one that kills me"


# Testing

https://streamable.com/pz36r6


# Wiki Documentation

there's no documentation on the megafauna page so i'm just writing it now https://wiki.yogstation.net/wiki/Megafauna#Types_of_Megafauna

Tar King:

![tkchase](https://github.com/yogstation13/Yogstation/assets/58535870/62611652-6939-498a-8601-23b3112d9b72)
 A monarch whose reign must end. The sword isn't for decoration's sake, as he will relentlessly chase you down to prove it. Challenging him requires the combination of three broken crystals scattered throughout his places of worship.
 
 GPS Signal
"Murky Signal"
 and 
 "Reckoning Signal" for the crystal pieces

Statistics
Difficulty: Hard

Health: 2000

Melee Damage: 40

Speed: Fast



Attacks:

The tar king's fight takes place within a large room with tar at the borders, especially by the exit. This still leaves a lot of room to run, which is very much needed to keep you from being filleted while being chased. The tar king constantly has blades orbiting him, making it difficult to stay in typical kinetic accelerator range, while unleashing stronger attacks up close. Additionally, he will often produce tar pits to teleport to later and close the distance with.

The tar king's attacks are as follows:

-Flashing a rune momentarily before hurting everything near him
-A sweeping slash that covers 3 spaces in front of him within melee range
-A long stab that reaches 3 spaces straight ahead of him
-As he takes damage, the tar king will begin planting his sword in the ground and stand there, sending out rapid blades after you for several seconds before moving again


Loot:

When the tar king is put down, he'll drop:

-The crown of the tar king ![tkc](https://github.com/yogstation13/Yogstation/assets/58535870/41bb6c8a-0513-45b7-8728-185b75bed120), which would allow the wearer to deploy 3 tar pits to teleport to later
- A demon core ![dc](https://github.com/yogstation13/Yogstation/assets/58535870/2a531ee7-8bb4-42b6-9a79-c9bf9a291a59), which produces a protective barrier when attached to outerwear, or can be used to improve the efficiency of a supermatter crystal if applied there instead.

-A primal tarstone (no fucking sprite)

https://wiki.yogstation.net/wiki/Shaft_Miner#Gems
 New gem: Primal tarstone
 icon: n/a
 points: 3000
 export price: n/a
 material: none
 dropped by: tar king
 notes: glows dark
 
 
# Changelog


:cl:  
rscdel: Removed instaloss move from tar king  
bugfix: fixed tar king wounding when it shouldnt
tweak: tweaked tar king damage and AP down
spellcheck: cut down descriptions on some tar king loot
/:cl:
