### PR TITLE
Modifies mining tool code to increase consistency of instant tools

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movable.dm
+++ b/code/__DEFINES/dcs/signals/signals_atom/signals_atom_movable.dm
@@ -3,6 +3,8 @@
 // All signals send the source datum of the signal as the first argument
 
 ///from base of atom/movable/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change): (/atom)
+#define COMSIG_MOVABLE_PRE_ENTER "movable_pre_enter"
+///from base of atom/movable/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change): (/atom)
 #define COMSIG_MOVABLE_PRE_MOVE "movable_pre_move"
 	#define COMPONENT_MOVABLE_BLOCK_PRE_MOVE (1<<0)
 ///from base of atom/movable/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change): (atom/old_loc, dir, forced, list/old_locs)

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -588,11 +588,13 @@
 				)
 		) // If this is a multi-tile object then we need to predict the new locs and check if they allow our entrance.
 		for(var/atom/entering_loc as anything in new_locs)
+			SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_ENTER, entering_loc)
 			if(!entering_loc.Enter(src))
 				return
 			if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, entering_loc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE)
 				return
 	else // Else just try to enter the single destination.
+		SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_ENTER, newloc)
 		if(!newloc.Enter(src))
 			return
 		if(SEND_SIGNAL(src, COMSIG_MOVABLE_PRE_MOVE, newloc) & COMPONENT_MOVABLE_BLOCK_PRE_MOVE)

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -234,7 +234,7 @@
 	if(slot == ITEM_SLOT_GLOVES)
 		tool_behaviour = TOOL_MINING
 		RegisterSignal(user, COMSIG_HUMAN_EARLY_UNARMED_ATTACK, PROC_REF(rocksmash))
-		RegisterSignal(user, COMSIG_MOVABLE_BUMP, PROC_REF(rocksmash))
+		RegisterSignal(user, COMSIG_MOVABLE_PRE_ENTER, PROC_REF(walksmash))
 	else
 		stopmining(user)
 
@@ -245,7 +245,16 @@
 /obj/item/clothing/gloves/gauntlets/proc/stopmining(mob/user)
 	tool_behaviour = initial(tool_behaviour)
 	UnregisterSignal(user, COMSIG_HUMAN_EARLY_UNARMED_ATTACK)
-	UnregisterSignal(user, COMSIG_MOVABLE_BUMP)
+	UnregisterSignal(user, COMSIG_MOVABLE_PRE_ENTER)
+
+/obj/item/clothing/gloves/gauntlets/proc/walksmash(mob/user, atom/A)
+	var/turf/target = get_turf(A)
+	if(istype(target, /turf/closed/mineral))
+		target.attackby(src, user)
+		return
+	for(var/atom/thing as anything in target.contents)
+		if(istype(thing, /turf/closed/mineral))
+			thing.attackby(src, user)
 
 /obj/item/clothing/gloves/gauntlets/proc/rocksmash(mob/user, atom/A, proximity)
 	if(!istype(A, /turf/closed/mineral))


### PR DESCRIPTION
it was relying on bumps, so it always stopped movement before it could mine
now it checks before, so if the turf is mined instantly it won't stop movement

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/2d377dc5-832d-45b9-88c3-248c784e30b3)

:cl:  
bugfix: walking orthogonally with instant mining tools is no longer slower than walking diagonally
tweak: if a mining tool is instant, it will now only print one chat message
/:cl:
