### PR TITLE
Things with godmode can no longer be gibbed by devastating explosions

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -414,6 +414,8 @@
 
 
 /mob/living/carbon/human/ex_act(severity, target, origin)
+	if(status_flags & GODMODE)
+		return
 	if(HAS_TRAIT(src, TRAIT_BOMBIMMUNE))
 		return
 	if(origin && istype(origin, /datum/spacevine_mutation) && isvineimmune(src))


### PR DESCRIPTION
godmode people are immune to the damage and dismember, but it never protected them from the gib

# Testing
simple check, but i can prove it works if someone other than manatee wants me to

:cl:  
bugfix: Things with godmode can no longer be gibbed by devastating explosions
/:cl:
