### PR TITLE
Gives Syndicate space comms agents spacesuits

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -202,10 +202,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/suit_storage_unit/open,
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
+	},
+/obj/machinery/suit_storage_unit/syndicate{
+	helmet_type = /obj/item/clothing/head/helmet/space/syndicate/black/red;
+	suit_type = /obj/item/clothing/suit/space/syndicate/black/red
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation/engineering)
@@ -388,7 +391,7 @@
 "bq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper{
-	info = "Due to Syndicate security protocols and several desertion incidents, we have not shipped you any spacesuits."
+	info = "We have seen fit to provide you with spacesuits. HOWEVER, you are also issued a recall implant. It will bring you back to the post if you go too far. In addition, it WILL kill you - PERMANENTLY - if removed."
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation/engineering)
@@ -490,10 +493,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/suit_storage_unit/open,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -28
+	},
+/obj/machinery/suit_storage_unit/syndicate{
+	helmet_type = /obj/item/clothing/head/helmet/space/syndicate/black/red;
+	suit_type = /obj/item/clothing/suit/space/syndicate/black/red
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/listeningstation/engineering)
@@ -2469,9 +2475,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/warehouse)
-"LU" = (
-/turf/open/floor/plating/asteroid/airless,
-/area)
 "Mc" = (
 /obj/effect/turf_decal/stripes/asteroid/corner,
 /obj/effect/turf_decal/sand/plating,
@@ -4323,7 +4326,7 @@ aL
 bn
 bn
 sR
-LU
+Mw
 NO
 NO
 NO


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Gives them Syndicate softsuits.

# Why is this good for the game?
It permits space comms agents to repel curators with added force
this also ties in with the fact they now have recall implants, protecting them from getting captured, and protecting the station from a very bored comms agent stabbing them

# Testing
will do soon trust

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: The Syndicate has seen fit to start providing their listening outpost recon agents with standard-issue armoured softsuits.
/:cl:
