### PR TITLE
Makes clown bugs slippery

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cockroach.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cockroach.dm
@@ -58,6 +58,9 @@
 	verb_yell = "honks loudly"
 	speak_emote = list("honks")
 
+/mob/living/simple_animal/cockroach/clownbug/Initialize(mapload)
+	. = ..()
+	AddComponent(/datum/component/slippery, 40)
 
 /mob/living/simple_animal/cockroach/clownbug/death(gibbed)
 	var/turf/T = get_turf(src)


### PR DESCRIPTION
look at the title

# Why is this good for the game?
Clown(clown) + cockroach(thing that gets stepped on) = banana(clown thing that gets stepped on)
banana = slippery

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/806df446-4fdf-45e3-8786-6659600e5ba2)


:cl:  
tweak: Makes clown bugs slippery
/:cl:
