### PR TITLE
Removes the minimum playercount from Icemeta

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -22,7 +22,6 @@ map yogstation
 endmap
 
 map icemeta
-	minplayers 25
 	votable
 endmap
 


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Removes the minimum player requirement for icemeta to show up map rotation or map votes.

# Why is this good for the game?
It's been weeks since I last saw this map. It's rare for it to actually show up in rotation with our much lower playercount and it isn't any bigger than box anyway, which has no minimum.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Icemeta can now be chosen as a map at any playercount
/:cl:
