### PR TITLE
Allows using ctrl click to open the gps interface

### DIFF
--- a/code/datums/components/gps.dm
+++ b/code/datums/components/gps.dm
@@ -47,6 +47,7 @@ GLOBAL_LIST_EMPTY(GPS_list)
 		A.add_overlay(overlay_state)
 	A.name = "[initial(A.name)] ([gpstag])"
 	RegisterSignal(parent, COMSIG_ITEM_ATTACK_SELF, PROC_REF(interact))
+	RegisterSignal(parent, COMSIG_CLICK_CTRL, PROC_REF(interact))
 	if(!emp_proof)
 		RegisterSignal(parent, COMSIG_ATOM_EMP_ACT, PROC_REF(on_emp_act))
 	RegisterSignal(parent, COMSIG_ATOM_EXAMINE, PROC_REF(on_examine))


### PR DESCRIPTION
# Why is this good for the game?
it works in the pocket, let me access the menu while it's in the pocket

# Testing
gotta make sure it can't be opened from across the world with ctrl click

:cl:  
tweak: Allows using ctrl click to open the gps interface
/:cl:
