### PR TITLE
Vital emergency skeleton buff hotfix

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -5,7 +5,7 @@
 	say_mod = "rattles"
 	possible_genders = list(NEUTER)
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/skeleton
-	species_traits = list(NOBLOOD,HAS_BONE, NO_DNA_COPY, NOTRANSSTING, NOHUSK)
+	species_traits = list(NOBLOOD,HAS_BONE, NO_DNA_COPY, NOTRANSSTING, NOHUSK, NO_UNDERWEAR)
 	inherent_traits = list(TRAIT_RESISTHEAT,TRAIT_NOBREATH,TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_RADIMMUNE,TRAIT_GENELESS,TRAIT_PIERCEIMMUNE,TRAIT_NOHUNGER,TRAIT_EASYDISMEMBER,TRAIT_LIMBATTACHMENT,TRAIT_FAKEDEATH, TRAIT_CALCIUM_HEALER)
 	inherent_biotypes = MOB_UNDEAD|MOB_HUMANOID
 	mutanttongue = /obj/item/organ/tongue/bone


### PR DESCRIPTION
# Why is this good for the game?
Every time I spawn in to debug I need to remove the nasty random undergarments the game FORCES on me.
I then need to spend precious time removing the BIKINI, THONG, MANKINI or whatever the hell is on me every damn time, as it looks completely ridiculous.

Yes that is my entire argument. Yes underwear on creatures of pure BONE is weird, and you're weirder if you think it isn't :sus:

# Testing
30 skeletons spawned in rapid succession! Simply beautiful.
![image](https://github.com/yogstation13/Yogstation/assets/143908044/943d4dca-c192-44e1-9d66-ab7090c836ed)


# Changelog
:cl: 
tweak: Skeletons will no longer have bikinis or underwear. Yes this was sorely needed.
/:cl:
