### PR TITLE
Makes random item rotation look less bad

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -756,10 +756,10 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		. = callback.Invoke()
 	item_flags &= ~IN_INVENTORY
 	var/matrix/M = matrix(transform)
-	M.Turn(rand(-170, 170))
+	M.Turn(pick(-90, 0, 90, 180))
 	transform = M
-	pixel_x = rand(-12, 12)
-	pixel_y = rand(-12, 12)
+	pixel_x = initial(pixel_x) + rand(-12, 12)
+	pixel_y = initial(pixel_y) + rand(-12, 12)
 
 /obj/item/proc/remove_item_from_storage(atom/newLoc) //please use this if you're going to snowflake an item out of a obj/item/storage
 	if(!newLoc)


### PR DESCRIPTION
# Document the changes in your pull request

This makes randomized item rotation round to the nearest multiple of 90 degrees.

# Why is this good for the game?
Rotating sprites to any degree that isn't a multiple of 90 looks bad unless the resolution is high enough, which is not the case in this game. Locking item rotation to multiples of 90 allows random rotation to still exist without making certain sprites unrecognizable or difficult to click on.

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/93578146/d412e24e-5d49-4b5f-bd04-c4a2abdc3f61)

:cl:  

tweak: Randomized item rotation rounds to 90 degrees
/:cl:
