### PR TITLE
Prevents synthetics from rolling antag

### DIFF
--- a/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
+++ b/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
@@ -4,8 +4,8 @@
 	report_type = "heresy"
 	antag_flag = ROLE_HERETIC
 	false_report_weight = 5
-	protected_jobs = list("Chaplain","Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Research Director", "Chief Engineer", "Chief Medical Officer", "Brig Physician", "Synthetic") //Yogs: Added Brig Physician
-	restricted_jobs = list("AI", "Cyborg")
+	protected_jobs = list("Chaplain","Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Research Director", "Chief Engineer", "Chief Medical Officer", "Brig Physician") //Yogs: Added Brig Physician
+	restricted_jobs = list("AI", "Cyborg", "Synthetic")
 	required_players = 15
 	required_enemies = 1
 	recommended_enemies = 4

--- a/code/game/gamemodes/hivemind/hivemind.dm
+++ b/code/game/gamemodes/hivemind/hivemind.dm
@@ -4,8 +4,8 @@
 	report_type = "hivemind"
 	antag_flag = ROLE_HIVE
 	false_report_weight = 5
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Brig Physician", "Synthetic") //Yogs: Added "Brig Physician
-	restricted_jobs = list("Cyborg","AI")
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Brig Physician") //Yogs: Added "Brig Physician
+	restricted_jobs = list("Cyborg","AI", "Synthetic")
 	required_players = 24
 	required_enemies = 2
 	recommended_enemies = 3

--- a/code/game/gamemodes/monkey/monkey.dm
+++ b/code/game/gamemodes/monkey/monkey.dm
@@ -13,7 +13,7 @@
 	required_enemies = 1
 	recommended_enemies = 1
 
-	restricted_jobs = list("Cyborg", "AI")
+	restricted_jobs = list("Cyborg", "AI", "Synthetic")
 
 	announce_span = "Monkey"
 	announce_text = "One or more crewmembers have been infected with Jungle Fever! Crew: Contain the outbreak. None of the infected monkeys may escape alive to CentCom. Monkeys: Ensure that your kind lives on! Rise up against your captors!"

--- a/code/game/gamemodes/traitor/internal_affairs.dm
+++ b/code/game/gamemodes/traitor/internal_affairs.dm
@@ -18,7 +18,7 @@
 	traitors_possible = 10 //hard limit on traitors if scaling is turned off
 	num_modifier = 4 // Four additional traitors
 	antag_datum = /datum/antagonist/traitor/internal_affairs
-	restricted_jobs = list("AI", "Cyborg")//Yogs -- Silicons can no longer be IAA
+	restricted_jobs = list("AI", "Cyborg", "Synthetic")//Yogs -- Silicons can no longer be IAA
 
 	announce_text = "There are Syndicate Internal Affairs Agents trying to kill each other!\n\
 	<span class='danger'>IAA</span>: Eliminate your targets and protect yourself!\n\

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -11,8 +11,8 @@
 	report_type = "traitor"
 	antag_flag = ROLE_TRAITOR
 	false_report_weight = 20 //Reports of traitors are pretty common.
-	restricted_jobs = list("Cyborg")//They are part of the AI if he is traitor so are they, they use to get double chances
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Brig Physician", "Synthetic") //YOGS -  added the hop and brig physician
+	restricted_jobs = list("Cyborg", "Synthetic")//They are part of the AI if he is traitor so are they, they use to get double chances
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Brig Physician") //YOGS -  added the hop and brig physician
 	required_players = 0
 	required_enemies = 1
 	recommended_enemies = 4

--- a/code/game/gamemodes/zombie/zombie.dm
+++ b/code/game/gamemodes/zombie/zombie.dm
@@ -12,7 +12,7 @@ GLOBAL_LIST_EMPTY(zombies)
 	report_type = "zombie"
 	antag_flag = ROLE_ZOMBIE
 	false_report_weight = 10
-	restricted_jobs = list("AI", "Cyborg")
+	restricted_jobs = list("AI", "Cyborg", "Synthetic")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Medical Officer", "Brig Physician", "Synthetic") //Yogs: Added Brig Physician
 	required_players = 40
 	required_enemies = 3

--- a/yogstation/code/game/gamemodes/vampire/traitor_vamp.dm
+++ b/yogstation/code/game/gamemodes/vampire/traitor_vamp.dm
@@ -3,7 +3,7 @@
 	config_tag = "traitorvamp"
 	false_report_weight = 10
 	traitors_possible = 3 //hard limit on traitors if scaling is turned off
-	restricted_jobs = list("AI", "Cyborg")
+	restricted_jobs = list("AI", "Cyborg", "Synthetic")
 	required_players = 15
 	required_enemies = 1	// how many of each type are required
 	recommended_enemies = 3


### PR DESCRIPTION
# Why is this good for the game?
i assume this was a bug
many antags rely on things that synthetics are incapable of doing
heretic - killing people
iaa and traitor - using their pda(?) to access the uplink


# Testing
it's just list changes, a quick look should be enough, also i can't really prove it with a video or picture

:cl:  
bugfix: Prevents synthetics from rolling antag
/:cl:
