### PR TITLE
Renames Grand Admiral to Executive Admiral

### DIFF
--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -115,11 +115,11 @@
 	rename_team = "CentCom Admirals"
 	polldesc = "a CentCom Admiral"
 
-/datum/ert/official/grand_admiral
-	leader_role = /datum/antagonist/centcom/grand_admiral
-	roles = list(/datum/antagonist/centcom/grand_admiral)
-	rename_team = "CentCom Grand Admirals"
-	polldesc = "a CentCom Grand Admiral"
+/datum/ert/official/executive_admiral
+	leader_role = /datum/antagonist/centcom/executive_admiral
+	roles = list(/datum/antagonist/centcom/executive_admiral)
+	rename_team = "CentCom Executive Admirals"
+	polldesc = "a CentCom Executive Admiral"
 
 /datum/ert/uplinked
 	leader_role = /datum/antagonist/ert/common/leader

--- a/code/modules/antagonists/official/official.dm
+++ b/code/modules/antagonists/official/official.dm
@@ -81,7 +81,7 @@
 	role = "Admiral"
 	outfit = /datum/outfit/centcom/admiral
 
-/datum/antagonist/centcom/grand_admiral
-	name = "CentCom Grand Admiral"
-	role = "Grand Admiral"
-	outfit = /datum/outfit/centcom/grand_admiral
+/datum/antagonist/centcom/executive_admiral
+	name = "CentCom Executive Admiral"
+	role = "Executive Admiral"
+	outfit = /datum/outfit/centcom/executive_admiral

--- a/code/modules/clothing/gloves/color.dm
+++ b/code/modules/clothing/gloves/color.dm
@@ -167,7 +167,7 @@
 
 /obj/item/clothing/gloves/color/captain/centcom/admiral
 	desc = "Regal black gloves, with a nice gold trim, a diamond anti-shock coating, and an integrated thermal barrier. Swanky."
-	name = "\improper CentCom grand admiral gloves"
+	name = "\improper CentCom executive admiral gloves"
 	icon_state = "grand_admiral"
 	item_state = "grand_admiral"
 

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -13,10 +13,10 @@
 	desc = "It's good to be a god."
 	item_state = "admiral"
 
-/obj/item/clothing/head/centhat/admiral/grand
-	name = "\improper CentCom grand admiral hat"
+/obj/item/clothing/head/centhat/admiral/executive
+	name = "\improper CentCom executive admiral hat"
 	icon_state = "grand_admiral"
-	desc = "It's good to be a Q."
+	desc = "It's good to be free."
 	item_state = "grand_admiral"
 
 /obj/item/clothing/head/powdered_wig

--- a/code/modules/clothing/neck/_neck.dm
+++ b/code/modules/clothing/neck/_neck.dm
@@ -220,7 +220,7 @@
 		RegisterSignal(user, COMSIG_MOB_RESTRICT_MAGIC, PROC_REF(restrict_casting_magic))
 		inmate_name = user.name
 		return
-	
+
 /obj/item/clothing/neck/anti_magic_collar/dropped(mob/user)
 	. = ..()
 	UnregisterSignal(user, COMSIG_MOB_RESTRICT_MAGIC)
@@ -295,7 +295,7 @@
 
 /obj/item/clothing/neck/pauldron/colonel
 	name = "colonel's pauldrons"
-	desc = "Gold alloy reinforced pauldrons signifying the rank of Colonel; offers slightly more protection than the Commander's pauldron to the wearer."
+	desc = "Gold alloy reinforced pauldrons signifying the rank of Colonel; offers slightly more protection than the Commodore's pauldron to the wearer."
 	icon_state = "colonel"
 	item_state = "colonel"
 	armor = list(MELEE = 35, BULLET = 30, LASER = 35, ENERGY = 35, BOMB = 5, BIO = 20, RAD = 0, FIRE = 0, ACID = 90)
@@ -309,9 +309,9 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDESUITSTORAGE
 
-/obj/item/clothing/neck/cape/grand
-	name = "grand admiral's cape"
-	desc = "A sizable white cape with gold connects."
+/obj/item/clothing/neck/cape/executive
+	name = "executive admiral's cape"
+	desc = "My conquest is the sea of stars."
 	icon_state = "grandadmiral"
 	item_state = "grand_admiral"
 

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -156,9 +156,9 @@
 	item_state = "admiral"
 	can_adjust = FALSE //too important to look unimportant.
 
-/obj/item/clothing/under/rank/centcom_admiral/grand
+/obj/item/clothing/under/rank/centcom_admiral/executive
 	desc = "It's a jumpsuit with gold markings worn by CentCom's highest-ranking officer."
-	name = "\improper CentCom grand admiral's jumpsuit"
+	name = "\improper CentCom executive admiral's jumpsuit"
 	icon_state = "grandadmiral"
 	item_state = "grandadmiral"
 

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -419,7 +419,7 @@
 
 /// Gets all centcom jobs
 /proc/get_all_centcom_jobs()
-	return list("VIP Guest","Custodian","Thunderdome Overseer","CentCom Official","Medical Officer","Research Officer","Special Ops Officer","Admiral","CentCom Commander","Emergency Response Team Commander","Security Response Officer","Engineer Response Officer", "Medical Response Officer","CentCom Bartender", "Janitorial Response Officer", "Religious Response Officer", "CentCom Captain", "CentCom Major", "CentCom Commodore", "CentCom Colonel", "CentCom Rear-Admiral", "CentCom Admiral", "CentCom Grand Admiral", "Comedy Response Officer", "HONK Squad Trooper")
+	return list("VIP Guest","Custodian","Thunderdome Overseer","CentCom Official","Medical Officer","Research Officer","Special Ops Officer","Admiral","CentCom Commander","Emergency Response Team Commander","Security Response Officer","Engineer Response Officer", "Medical Response Officer","CentCom Bartender", "Janitorial Response Officer", "Religious Response Officer", "CentCom Captain", "CentCom Major", "CentCom Commodore", "CentCom Colonel", "CentCom Rear-Admiral", "CentCom Admiral", "CentCom Executive Admiral", "Comedy Response Officer", "HONK Squad Trooper")
 
 /// Gets all task for jobs
 /proc/get_all_task_force_jobs()

--- a/code/modules/jobs/job_types/centcom.dm
+++ b/code/modules/jobs/job_types/centcom.dm
@@ -3,7 +3,7 @@
 	box = /obj/item/storage/box/survival
 
 /datum/outfit/centcom/official //Generic centcom person. Whatever rank you want that is Lieutenant or lower.
-	name = "(CO-1)CentCom Official"
+	name = "CentCom Official"
 	var/pdaequip = TRUE
 
 	uniform = /obj/item/clothing/under/rank/centcom_officer
@@ -48,7 +48,7 @@
 /datum/outfit/centcom/official/nopda
 	pdaequip = FALSE
 /datum/outfit/centcom/captain //CentCom Captain. Essentially a station captain.
-	name = "(CO-2)CentCom Captain"
+	name = "CentCom Captain"
 
 	uniform = /obj/item/clothing/under/rank/centcom_commander
 	suit = /obj/item/clothing/suit/armor/vest/capcarapace/centcom
@@ -81,7 +81,7 @@
 	H.ignores_capitalism = TRUE // Yogs -- Lets Centcom guys buy a damned smoke for christ's sake
 
 /datum/outfit/centcom/major //CentCom Major.
-	name = "(CO-3)CentCom Major"
+	name = "CentCom Major"
 
 	uniform = /obj/item/clothing/under/rank/centcom_commander
 	suit = /obj/item/clothing/suit/armor/vest/capcarapace/centcom
@@ -115,7 +115,7 @@
 	H.ignores_capitalism = TRUE // Yogs -- Lets Centcom guys buy a damned smoke for christ's sake
 
 /datum/outfit/centcom/commander //CentCom Commander.
-	name = "(CO-4)CentCom Commodore"
+	name = "CentCom Commodore"
 
 	uniform = /obj/item/clothing/under/rank/centcom_commander
 	suit = /obj/item/clothing/suit/armor/vest/capcarapace/centcom
@@ -150,7 +150,7 @@
 	H.ignores_capitalism = TRUE // Yogs -- Lets Centcom guys buy a damned smoke for christ's sake
 
 /datum/outfit/centcom/colonel //CentCom Commander.
-	name = "(CO-5)CentCom Colonel"
+	name = "CentCom Colonel"
 
 	uniform = /obj/item/clothing/under/rank/centcom_commander
 	suit = /obj/item/clothing/suit/armor/vest/capcarapace/centcom
@@ -185,7 +185,7 @@
 	H.ignores_capitalism = TRUE // Yogs -- Lets Centcom guys buy a damned smoke for christ's sake
 
 /datum/outfit/centcom/rear_admiral //CentCom Rear-Admiral. Low-tier admiral.
-	name = "(CO-6)CentCom Rear-Admiral"
+	name = "CentCom Rear-Admiral"
 
 	uniform = /obj/item/clothing/under/rank/centcom_admiral
 	suit = null
@@ -220,7 +220,7 @@
 	H.ignores_capitalism = TRUE // Yogs -- Lets Centcom guys buy a damned smoke for christ's sake
 
 /datum/outfit/centcom/admiral //CentCom Admiral.
-	name = "(CO-7)CentCom Admiral"
+	name = "CentCom Admiral"
 
 	uniform = /obj/item/clothing/under/rank/centcom_admiral
 	suit = null
@@ -254,18 +254,18 @@
 
 	H.ignores_capitalism = TRUE // Yogs -- Lets Centcom guys buy a damned smoke for christ's sake
 
-/datum/outfit/centcom/grand_admiral //CentCom Grand Admiral. The final boss.
-	name = "(NO-8)CentCom Grand Admiral"
+/datum/outfit/centcom/executive_admiral //CentCom Executive Admiral. The final boss.
+	name = "CentCom Executive Admiral"
 
-	uniform = /obj/item/clothing/under/rank/centcom_admiral/grand
+	uniform = /obj/item/clothing/under/rank/centcom_admiral/executive
 	suit = null
 	shoes = /obj/item/clothing/shoes/combat/swat
 	gloves = /obj/item/clothing/gloves/color/captain/centcom/admiral
 	ears = /obj/item/radio/headset/headset_cent/commander
 	glasses = /obj/item/clothing/glasses/sunglasses
 	mask = /obj/item/clothing/mask/cigarette/cigar/havana
-	head = /obj/item/clothing/head/centhat/admiral/grand
-	neck = /obj/item/clothing/neck/cape/grand
+	head = /obj/item/clothing/head/centhat/admiral/executive
+	neck = /obj/item/clothing/neck/cape/executive
 	belt = /obj/item/gun/energy/pulse/pistol
 	r_pocket = /obj/item/lighter
 	l_pocket = /obj/item/melee/transforming/energy/sword/saber/green
@@ -273,7 +273,7 @@
 	id = /obj/item/card/id/centcom/gold
 	backpack_contents = list(/obj/item/restraints/handcuffs/cable/zipties=1)
 
-/datum/outfit/centcom/grand_admiral/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/centcom/executive_admiral/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)
 		return
 
@@ -282,8 +282,8 @@
 	W.icon_state = "centcom_gold"
 	W.access = get_all_accesses()
 	W.access += get_centcom_access("CentCom Commander")
-	W.assignment = "CentCom Grand Admiral"
-	W.originalassignment = "CentCom Grand Admiral"
+	W.assignment = "CentCom Executive Admiral"
+	W.originalassignment = "CentCom Executive Admiral"
 	W.registered_name = H.real_name
 	W.update_label()
 


### PR DESCRIPTION
# Document the changes in your pull request
This would have been paired with a cape resprite but I don't know when I will finish that.

Also changes a few descriptions.

# Why is this good for the game?
More corporate and less identical to Star Wars. Allows them to be referred as "His/Her Executiveship"

# Changelog

:cl:  Identification
tweak: Renames Grand Admiral to Executive Admiral.
/:cl:
