### PR TITLE
Modifies the rod of asclepius healing to be more consistent

### DIFF
--- a/code/datums/status_effects/buffs/buffs.dm
+++ b/code/datums/status_effects/buffs/buffs.dm
@@ -456,36 +456,16 @@
 			//Because a servant of medicines stops at nothing to help others, lets keep them on their toes and give them an additional boost.
 			if(itemUser.health < itemUser.maxHealth)
 				new /obj/effect/temp_visual/heal(get_turf(itemUser), "#375637")
-			itemUser.adjustBruteLoss(-1.5 * efficiency)
-			itemUser.adjustFireLoss(-1.5 * efficiency)
-			itemUser.adjustToxLoss(-1.5 * efficiency, forced = TRUE) //Because Slime People are people too
-			itemUser.adjustOxyLoss(-1.5 * efficiency)
-			itemUser.adjustStaminaLoss(-1.5 * efficiency)
-			itemUser.adjustOrganLoss(ORGAN_SLOT_BRAIN, -1.5 * efficiency)
-			itemUser.adjustCloneLoss(-0.5 * efficiency) //Becasue apparently clone damage is the bastion of all health
+			itemUser.heal_ordered_damage(3 * efficiency, list(BRUTE, BURN, TOX, OXY, STAMINA, BRAIN, CLONE), forced = TRUE)
 		//Heal all those around you, unbiased
 		for(var/mob/living/L in view(7, owner))
-			if(ispath(rod_type, /obj/item/rod_of_asclepius/white)) //Used for adjusting the Holy Light Sect Favor from white rod healing.
-				if(L.stat == DEAD)
-					continue
-				var/total_healing = (min(L.getBruteLoss(), 3.5*efficiency) + min(L.getFireLoss(), 3.5*efficiency) + min(L.getOxyLoss(), 3.5*efficiency) + min(L.getToxLoss(), 3.5 * efficiency))
-				GLOB.religious_sect.adjust_favor(total_healing * 0.2)
+			var/total_healing = 7 * efficiency
 			if(L.health < L.maxHealth)
 				new /obj/effect/temp_visual/heal(get_turf(L), "#375637")
-			if(iscarbon(L))
-				L.adjustBruteLoss(-3.5 * efficiency)
-				L.adjustFireLoss(-3.5 * efficiency)
-				L.adjustToxLoss(-3.5 * efficiency, forced = TRUE) //Because Slime People are people too
-				L.adjustOxyLoss(-3.5 * efficiency)
-				L.adjustStaminaLoss(-3.5 * efficiency)
-				L.adjustOrganLoss(ORGAN_SLOT_BRAIN, -3.5 * efficiency)
-				L.adjustCloneLoss(-1 * efficiency) //Becasue apparently clone damage is the bastion of all health
-			else if(issilicon(L))
-				L.adjustBruteLoss(-3.5 * efficiency)
-				L.adjustFireLoss(-3.5 * efficiency)
-			else if(isanimal(L))
-				var/mob/living/simple_animal/SM = L
-				SM.adjustHealth(-3.5 * efficiency, forced = TRUE)
+			var/residual_healing = max(L.heal_ordered_damage(total_healing, list(BRUTE, BURN, TOX, OXY, STAMINA, BRAIN, CLONE), forced = TRUE), 0)
+			if(ispath(rod_type, /obj/item/rod_of_asclepius/white) && L.stat != DEAD) //Used for adjusting the Holy Light Sect Favor from white rod healing.
+				var/actual_healing = total_healing - residual_healing
+				GLOB.religious_sect.adjust_favor(actual_healing * 0.2)
 
 /datum/status_effect/good_music
 	id = "Good Music"

--- a/code/datums/status_effects/buffs/buffs.dm
+++ b/code/datums/status_effects/buffs/buffs.dm
@@ -459,6 +459,8 @@
 			itemUser.heal_ordered_damage(2 * efficiency, list(BRUTE, BURN, TOX, OXY, STAMINA, BRAIN, CLONE), forced = TRUE)
 		//Heal all those around you, unbiased
 		for(var/mob/living/L in view(7, owner))
+			if(issilicon(L)) //this is the organics heal rod, not the robotics heal rod
+				continue
 			var/total_healing = 5 * efficiency
 			if(L.health < L.maxHealth)
 				new /obj/effect/temp_visual/heal(get_turf(L), "#375637")

--- a/code/datums/status_effects/buffs/buffs.dm
+++ b/code/datums/status_effects/buffs/buffs.dm
@@ -456,10 +456,10 @@
 			//Because a servant of medicines stops at nothing to help others, lets keep them on their toes and give them an additional boost.
 			if(itemUser.health < itemUser.maxHealth)
 				new /obj/effect/temp_visual/heal(get_turf(itemUser), "#375637")
-			itemUser.heal_ordered_damage(3 * efficiency, list(BRUTE, BURN, TOX, OXY, STAMINA, BRAIN, CLONE), forced = TRUE)
+			itemUser.heal_ordered_damage(2 * efficiency, list(BRUTE, BURN, TOX, OXY, STAMINA, BRAIN, CLONE), forced = TRUE)
 		//Heal all those around you, unbiased
 		for(var/mob/living/L in view(7, owner))
-			var/total_healing = 7 * efficiency
+			var/total_healing = 5 * efficiency
 			if(L.health < L.maxHealth)
 				new /obj/effect/temp_visual/heal(get_turf(L), "#375637")
 			var/residual_healing = max(L.heal_ordered_damage(total_healing, list(BRUTE, BURN, TOX, OXY, STAMINA, BRAIN, CLONE), forced = TRUE), 0)

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -26,22 +26,26 @@
 			adjustCloneLoss(damage * hit_percent)
 		if(STAMINA)
 			adjustStaminaLoss(damage * hit_percent)
+		if(BRAIN)
+			adjustOrganLoss(ORGAN_SLOT_BRAIN, damage * hit_percent)
 	return 1
 
-/mob/living/proc/apply_damage_type(damage = 0, damagetype = BRUTE, required_status) //like apply damage except it always uses the damage procs
+/mob/living/proc/apply_damage_type(damage = 0, damagetype = BRUTE, required_status, forced) //like apply damage except it always uses the damage procs
 	switch(damagetype)
 		if(BRUTE)
-			return adjustBruteLoss(damage, TRUE, FALSE, required_status)
+			return adjustBruteLoss(damage, TRUE, forced, required_status)
 		if(BURN)
-			return adjustFireLoss(damage, TRUE, FALSE, required_status)
+			return adjustFireLoss(damage, TRUE, forced, required_status)
 		if(TOX)
-			return adjustToxLoss(damage)
+			return adjustToxLoss(damage, TRUE, forced)
 		if(OXY)
-			return adjustOxyLoss(damage)
+			return adjustOxyLoss(damage, TRUE, forced)
 		if(CLONE)
-			return adjustCloneLoss(damage)
+			return adjustCloneLoss(damage, TRUE, forced)
 		if(STAMINA)
-			return adjustStaminaLoss(damage)
+			return adjustStaminaLoss(damage, TRUE, forced)
+		if(BRAIN)
+			return adjustOrganLoss(ORGAN_SLOT_BRAIN, damage)
 
 /mob/living/proc/get_damage_amount(damagetype = BRUTE)
 	switch(damagetype)
@@ -57,6 +61,8 @@
 			return getCloneLoss()
 		if(STAMINA)
 			return getStaminaLoss()
+		if(BRAIN)
+			return getOrganLoss(ORGAN_SLOT_BRAIN)
 
 
 /mob/living/proc/apply_damages(brute = 0, burn = 0, tox = 0, oxy = 0, clone = 0, def_zone = null, blocked = FALSE, stamina = 0, brain = 0)
@@ -298,12 +304,12 @@
 		update_stamina()
 
 //heal up to amount damage, in a given order
-/mob/living/proc/heal_ordered_damage(amount, list/damage_types, required_status)
+/mob/living/proc/heal_ordered_damage(amount, list/damage_types, required_status, forced)
 	. = amount //we'll return the amount of damage healed
 	for(var/i in damage_types)
 		var/amount_to_heal = min(amount, get_damage_amount(i)) //heal only up to the amount of damage we have
 		if(amount_to_heal)
-			apply_damage_type(-amount_to_heal, i, required_status)
+			apply_damage_type(-amount_to_heal, i, required_status, forced)
 			amount -= amount_to_heal //remove what we healed from our current amount
 		if(!amount)
 			break


### PR DESCRIPTION
Changed the numerous adjust[DAMAGE]loss procs to instead use healOrderedDamage
That way it just uses one "amount of healing" rather than several

i adjusted the base number to be slightly stronger to account for the reduction of overall healing
self heal
1.5 -> 2
aoe heal
3.5 -> 5

also removed it's ability to heal cyborgs
it can't and shouldn't be able to heal robotic limbs, so it makes little sense for it to also heal cyborgs

# Why is this good for the game?
I dislike heals that are stronger when used against people with multiple damage types at once
it's not easy to convey to players, and it can create a weird situation where the heal is both too strong and too weak at the same time

# Testing
gotta

:cl:  
tweak: Modifies the rod of asclepius healing to be more consistent
tweak: rod of asclepius no longer heals silicons
/:cl:
