### PR TITLE
Fixes roundstart job gps not updating the tag to the user's name

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -380,6 +380,9 @@
 		for(var/obj/item/gps/G in H.get_all_contents())
 			G.gpstag = H.real_name
 			G.name = "global positioning system ([G.gpstag])"
+			var/datum/component/gps/tracker = G.GetComponent(/datum/component/gps)
+			if(tracker)
+				tracker.gpstag = G.gpstag
 			continue
 
 /datum/outfit/job/get_chameleon_disguise_info()


### PR DESCRIPTION
Fixes job gps not updating the tag to the user's name

# Testing
gotta

:cl:  
bugfix: Fixes job gps not updating the tag to the user's name
/:cl:
