### PR TITLE
Various mecha bugfixes

### DIFF
--- a/code/game/mecha/equipment/tools/work_tools.dm
+++ b/code/game/mecha/equipment/tools/work_tools.dm
@@ -11,11 +11,11 @@
 	energy_drain = 10
 	toolspeed = 0.5
 	usesound = 'sound/mecha/hydraulic.ogg'
-	tool_behaviour = TOOL_CROWBAR
 	equip_actions = list(/datum/action/innate/mecha/equipment/clamp_mode)
 	/// How much damage does it apply when used
 	var/dam_force = 20
 	var/obj/mecha/working/ripley/cargo_holder
+	var/previous_tool_behavior = TOOL_CROWBAR
 	harmful = FALSE
 
 /datum/action/innate/mecha/equipment/clamp_mode
@@ -41,11 +41,14 @@
 /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/attach(obj/mecha/M as obj)
 	..()
 	cargo_holder = M
+	tool_behaviour = previous_tool_behavior
 	return
 
 /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/detach(atom/moveto = null)
 	..()
 	cargo_holder = null
+	previous_tool_behavior = tool_behaviour
+	tool_behaviour = 0
 
 /obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/action(atom/target, mob/living/user, params)
 	if(!action_checks(target))

--- a/code/modules/mining/fulton.dm
+++ b/code/modules/mining/fulton.dm
@@ -257,6 +257,13 @@ GLOBAL_LIST_EMPTY(total_extraction_beacons)
 	chosen_mecha.forceMove(pod)
 	stored_mecha -= chosen_mecha
 	new /obj/effect/DPtarget(get_teleport_turf(get_turf(user), 1), pod)
+	finalize_mech(chosen_mecha)
+
+/obj/item/extraction_pack/mech_drop/proc/finalize_mech(obj/mecha/mecha)
+	// Reverts the anchor & density given by the extraction pack which would of been done through uses_beacon (but didn't because it was set to FALSE).
+	mecha.anchored = FALSE
+	mecha.density = initial(mecha.density)
+	return FALSE
 
 /obj/item/extraction_pack/mech_drop/examine()
 	. = ..()

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -249,7 +249,7 @@
 
 	if(ismecha(mover))
 		var/obj/mecha/mech = mover
-		if(mech.occupant != null && mech.occupant in approved_passengers)
+		if(mech.occupant != null && (mech.occupant in approved_passengers))
 			set_scanline("scanning", 10)
 			return TRUE
 

--- a/code/modules/shuttle/special.dm
+++ b/code/modules/shuttle/special.dm
@@ -247,6 +247,12 @@
 		set_scanline("scanning", 10)
 		return TRUE
 
+	if(ismecha(mover))
+		var/obj/mecha/mech = mover
+		if(mech.occupant != null && mech.occupant in approved_passengers)
+			set_scanline("scanning", 10)
+			return TRUE
+
 	if(!isliving(mover)) //No stowaways
 		return FALSE
 	return FALSE


### PR DESCRIPTION
# Document the changes in your pull request
Extraction beacon properly restores the mecha's density and anchor values.
Closes #21815 
Closes #21592
Closes #20317

Mech hydraulic clamp only gets their tool behavior when attached to a mech.
Closes #21698

Mechs can enter the paid portion of the luxury shuttle if their pilot has paid already.
Closes #7695

# Testing
Extract mech, call down mech, can no longer walk through it.

Spawn in clamp, can no longer crowbar doors with it unless it is on a mech.

Spawn luxury shuttle, give self 5000 holocredits, pay, spawn and enter any mech, can pass through luxury shuttle ticket field.

# Changelog
:cl:  
bugfix: Mech extraction pack correctly gives back density and anchor values to the mecha.
bugfix: Hydraulic clamp no longer acts like a crowbar for non-mecha users.
bugfix: Mechas can pass through luxury shuttle ticket field if the pilot has already paid.
/:cl:
