### PR TITLE
Fixes a bug with ghost roles being able to get picked as antags 2: this time more dynamic

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -29,6 +29,9 @@
 		if(P.mind.quiet_round) //Does the candidate have quiet mode enabled?
 			candidates.Remove(P)
 			continue
+		if(P.mind && !(P.mind.assigned_role in GLOB.crew_positions)) //don't antag non crewmembers
+			candidates.Remove(P)
+			continue
 
 /datum/dynamic_ruleset/latejoin/ready(forced = 0)
 	if (!forced)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -201,8 +201,8 @@
 		if(is_centcom_level(player.z))
 			living_players -= player // We don't autotator people in CentCom
 			continue
-		if(player.mind && (player.mind.special_role || player.mind.antag_datums?.len > 0))
-			living_players -= player // We don't autotator people with roles already
+		if(player.mind && (player.mind.special_role || player.mind.antag_datums?.len > 0 || !(player.mind.assigned_role in GLOB.crew_positions)))
+			living_players -= player // We don't autotator people with roles already or non crewmembers
 			continue
 		if(!(ROLE_TRAITOR in player.client.prefs.be_special))
 			living_players -= player
@@ -252,7 +252,7 @@
 		if(is_centcom_level(player.z))
 			candidates -= player
 			continue
-		if(player.mind && (player.mind.special_role || player.mind.antag_datums?.len > 0))
+		if(player.mind && (player.mind.special_role || player.mind.antag_datums?.len > 0 || !(player.mind.assigned_role in GLOB.crew_positions)))
 			candidates -= player
 			continue
 		if(!(ROLE_MALF in player.client.prefs.be_special))
@@ -588,7 +588,7 @@
 		if(is_centcom_level(player.z))
 			living_players -= player // We don't autotator people in CentCom
 			continue
-		if(player.mind && (player.mind.special_role || player.mind.antag_datums?.len > 0))
+		if(player.mind && (player.mind.special_role || player.mind.antag_datums?.len > 0 || !(player.mind.assigned_role in GLOB.crew_positions)))
 			living_players -= player // We don't autovamp people with roles already
 			continue
 		if(!(ROLE_VAMPIRE in player.client.prefs.be_special))
@@ -733,7 +733,7 @@
 			living_players -= player
 		else if(is_centcom_level(player.z))
 			living_players -= player // We don't allow people in CentCom
-		else if(player.mind && (player.mind.special_role || player.mind.antag_datums?.len > 0))
+		else if(player.mind && (player.mind.special_role || player.mind.antag_datums?.len > 0 || !(player.mind.assigned_role in GLOB.crew_positions)))
 			living_players -= player // We don't allow people with roles already
 
 /datum/dynamic_ruleset/midround/bloodsucker/execute()
@@ -845,6 +845,7 @@
 			|| !(ROLE_OBSESSED in candidate.client?.prefs?.be_special) \
 			|| !SSjob.GetJob(candidate.mind.assigned_role) \
 			|| (candidate.mind.assigned_role in GLOB.nonhuman_positions) \
+			|| !(candidate.mind.assigned_role in GLOB.crew_positions) \
 		)
 			candidates -= candidate
 


### PR DESCRIPTION
https://github.com/yogstation13/Yogstation/pull/21770
only handled regular gamemode mulliganing
it didn't touch dynamic

# Testing
gotta, but again, i imagine it will prove difficult

:cl:  
bugfix: Fixes a bug with ghost roles being able to get picked as antags 2: this time more dynamic
/:cl:
