### PR TITLE
Adds teleport return implants to syndicate derelict agents

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -894,7 +894,9 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	id = /obj/item/card/id/syndicate
 	l_pocket = /obj/item/flashlight
 	r_pocket = /obj/item/kitchen/knife/combat/survival
-	implants = list(/obj/item/implant/weapons_auth)
+	implants = list(
+		/obj/item/implant/weapons_auth,
+		/obj/item/implant/teleporter/syndicate_engineer)
 	box = /obj/item/storage/box/survival/syndie
 
 /datum/outfit/syndicate_derelict_engi/post_equip(mob/living/carbon/human/H)

--- a/yogstation/code/game/objects/items/implants/implant_teleporter.dm
+++ b/yogstation/code/game/objects/items/implants/implant_teleporter.dm
@@ -127,6 +127,11 @@
 	usewhitelist = TRUE
 	retrievalmessage = "Agent retrieval complete."
 
+/obj/item/implant/teleporter/syndicate_engineer
+	pointofreturn = /area/ruin/space/has_grav/syndiederelict
+	usewhitelist = TRUE
+	retrievalmessage = "Agent retrieval complete."
+
 /obj/item/implant/teleporter/demon
 	pointofreturn = /area/ruin/powered/sinden
 	usewhitelist = TRUE


### PR DESCRIPTION
I think someone told me to add this with the first pr but I forgot, oops!

# Document the changes in your pull request

Gives the derelict syndicate engineers a beacon to return them to their ruin

# Why is this good for the game?

All the other ones have them for the same reason, shouldnt leave their base

# Testing

you can tell I didnt test because I didnt forget to remove lowmemmode



# Changelog

:cl:  
rscadd: Adds new return implant to syndicate derelict engineers

/:cl:
