### PR TITLE
Fixes Aspect of Tar not blocking anything

### DIFF
--- a/yogstation/code/modules/jungleland/jungle_status_effects.dm
+++ b/yogstation/code/modules/jungleland/jungle_status_effects.dm
@@ -98,6 +98,7 @@
 	new /obj/effect/better_animated_temp_visual/tar_shield_pop(get_turf(owner))
 	owner.visible_message(span_danger("[owner]'s shields absorbs [attack_text]!"))
 	qdel(src)
+	return SHIELD_BLOCK
 
 /datum/status_effect/bounty_of_the_forest
 	id = "bounty_of_the_forest"


### PR DESCRIPTION
Aspect of tar was supposed to block a single hit but it didn't return `SHIELD_BLOCK` like it was supposed to so it didn't actually block the hit.

![image](https://github.com/yogstation13/Yogstation/assets/93578146/4d6ef3ac-423f-49d3-b0df-4a6fcc60ec7f)

:cl:  
bugfix: Fixed Aspect of Tar crusher trophy not blocking hits as intended.
/:cl:
