### PR TITLE
Fixes radio messages redirecting through intercomms and radios instead of headsets

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -23,11 +23,8 @@
 
 #define MODE_ROBOT "robot"
 
-#define MODE_R_HAND "right hand"
-#define MODE_KEY_R_HAND "r"
-
-#define MODE_L_HAND "left hand"
-#define MODE_KEY_L_HAND "l"
+#define MODE_RADIO "radio"
+#define MODE_KEY_RADIO "r"
 
 #define MODE_INTERCOM "intercom"
 #define MODE_KEY_INTERCOM "i"

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -310,14 +310,11 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	if(radio_freq || !broadcasting || get_dist(src, speaker) > canhear_range)
 		return
 
-	if(message_mods[RADIO_EXTENSION] == MODE_L_HAND || message_mods[RADIO_EXTENSION] == MODE_R_HAND || message_mods[RADIO_EXTENSION] == MODE_DEPARTMENT || message_mods[RADIO_EXTENSION] == MODE_HEADSET)
-		// try to avoid being heard double
-		if (loc == speaker && ismob(speaker))
-			var/mob/M = speaker
-			var/idx = M.get_held_index_of_item(src)
-			// left hands are odd slots
-			if (idx && (idx % 2) == (message_mods[RADIO_EXTENSION] == MODE_L_HAND))
-				return
+	// try to avoid being heard double
+	if(loc == speaker && ismob(speaker))
+		var/mob/M = speaker
+		if(M.is_holding(src) && message_mods[RADIO_EXTENSION] == MODE_RADIO)
+			return
 
 	talk_into(speaker, raw_message, , spans, language=message_language)
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -2,8 +2,7 @@ GLOBAL_LIST_INIT(department_radio_prefixes, list(":", "."))
 
 GLOBAL_LIST_INIT(department_radio_keys, list(
 	// Location
-	MODE_KEY_R_HAND = MODE_R_HAND,
-	MODE_KEY_L_HAND = MODE_L_HAND,
+	MODE_KEY_RADIO = MODE_RADIO,
 	MODE_KEY_INTERCOM = MODE_INTERCOM,
 
 	// Department
@@ -32,8 +31,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	//kinda localization -- rastaf0
 	//same keys as above, but on russian keyboard layout. This file uses cp1251 as encoding.
 	// Location
-	"ê" = MODE_R_HAND,
-	"ä" = MODE_L_HAND,
+	"ê" = MODE_RADIO,
 	"ø" = MODE_INTERCOM,
 
 	// Department
@@ -375,44 +373,34 @@ GLOBAL_LIST_INIT(special_radio_keys, list(
 	var/obj/item/implant/radio/imp = locate() in src
 	if(imp && imp.radio.on)
 		if(message_mods[MODE_HEADSET])
-			imp.radio.talk_into(src, message, , spans, language, message_mods)
+			imp.radio.talk_into(src, message, null, spans, language, message_mods)
 			return ITALICS | REDUCE_RANGE
 		if(message_mods[RADIO_EXTENSION] == MODE_DEPARTMENT || (message_mods[RADIO_EXTENSION] in imp.radio.channels))
 			imp.radio.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
 			return ITALICS | REDUCE_RANGE
 
-	var/list/storage_item = list(get_active_held_item(), get_item_by_slot(ITEM_SLOT_BELT), get_item_by_slot(ITEM_SLOT_RPOCKET), get_item_by_slot(ITEM_SLOT_LPOCKET), get_item_by_slot(ITEM_SLOT_SUITSTORE))
-	for(var/obj/item/radio/hand in storage_item)
-		if(message_mods[MODE_HEADSET])
-			hand.talk_into(src, message, , spans, language, message_mods)
-			return ITALICS | REDUCE_RANGE
-		if(message_mods[RADIO_EXTENSION] == MODE_DEPARTMENT || (message_mods[RADIO_EXTENSION] in hand.channels))
-			hand.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
-			return ITALICS | REDUCE_RANGE
-
-	for (var/obj/item/radio/intercom/I in view(1, null))
-		if(message_mods[MODE_HEADSET])
-			I.talk_into(src, message, , spans, language, message_mods)
-			return ITALICS | REDUCE_RANGE
-		if(message_mods[RADIO_EXTENSION] == MODE_DEPARTMENT || (message_mods[RADIO_EXTENSION] in I.channels))
-			I.talk_into(src, message, message_mods[RADIO_EXTENSION], spans, language, message_mods)
-			return ITALICS | REDUCE_RANGE
-			
 	switch(message_mods[RADIO_EXTENSION])
-		if(MODE_R_HAND)
-			for(var/obj/item/r_hand in get_held_items_for_side("r", all = TRUE))
-				if (r_hand)
-					return r_hand.talk_into(src, message, , spans, language, message_mods)
-				return ITALICS | REDUCE_RANGE
-		if(MODE_L_HAND)
-			for(var/obj/item/l_hand in get_held_items_for_side("l", all = TRUE))
-				if (l_hand)
-					return l_hand.talk_into(src, message, , spans, language, message_mods)
+		if(MODE_RADIO)
+			var/list/radio_slots = list(
+				get_active_held_item(),
+				get_inactive_held_item(),
+				get_item_by_slot(ITEM_SLOT_BELT),
+				get_item_by_slot(ITEM_SLOT_RPOCKET),
+				get_item_by_slot(ITEM_SLOT_LPOCKET),
+				get_item_by_slot(ITEM_SLOT_SUITSTORE)
+			)
+			for(var/held_item in radio_slots)
+				if(!held_item)
+					continue
+				if(!istype(held_item, /obj/item/radio))
+					continue
+				var/obj/item/radio/held_radio = held_item
+				held_radio.talk_into(src, message, null, spans, language, message_mods)
 				return ITALICS | REDUCE_RANGE
 
 		if(MODE_INTERCOM)
 			for (var/obj/item/radio/intercom/I in view(1, null))
-				I.talk_into(src, message, , spans, language, message_mods)
+				I.talk_into(src, message, null, spans, language, message_mods)
 			return ITALICS | REDUCE_RANGE
 
 		if(MODE_BINARY)


### PR DESCRIPTION
That's basically it, using a headset makes you use the headset as it should be.
![image](https://github.com/yogstation13/Yogstation/assets/93578146/6cf42528-a4a9-49ba-86ce-b653a0f62334)

 Using .r or .i to talk into a radio or intercom respectively still works as well.
![image](https://github.com/yogstation13/Yogstation/assets/93578146/05b6e33d-32b3-4ed2-b9ae-053678db0975)

:cl:  
bugfix: Fixed radio messages redirecting through intercomms or radios when trying to use a headset.
/:cl:
