### PR TITLE
Update singularity.dm

### DIFF
--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -452,7 +452,7 @@
 			if(STAGE_ONE)
 				steps = 1
 			if(STAGE_TWO)
-				steps = 3//Yes this is right
+				steps = 2
 			if(STAGE_THREE)
 				steps = 3
 			if(STAGE_FOUR)


### PR DESCRIPTION
> ## About The Pull Request
> 
> Stage 2 singularities have the wrong step size, allowing them to eat the containment field if they happen to be right next to it. (For instance, if they are contained in a 3x3 or 4x4 field) 2 lines of code, and that's fixed.
> ## Why It's Good For The Game
> 
> BEFORE
> 2024-05-01.15-11-12-1.mp4
> 
> AFTER
> 2024-05-01.15-54-45-1.mp4
> ## The Source
> 
> This was introduced in a googlecode commit in 2011:
> 
> https://github.com/tgstation/tgstation/blob/337be2c3bcc7a739ffc927ccce9d6aa2b43c114c/code/modules/power/singularity/singularity.dm#L269
> 
> No, mport2004, I _don't_ think this is right.
> 
> ## Changelog
> 
> 🆑 fix: Stage 2 singularities should no longer escape containment /:cl:


https://github.com/tgstation/tgstation/pull/83005
🆑 Ikalpo
fix: Stage 2 singularities should no longer escape containment
/:cl: 
