### PR TITLE
Fixes Syndicate Icemoon engineering vendor (in engineering not the warehouse one) needing money

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_syndicate.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_syndicate.dmm
@@ -8135,7 +8135,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/vending/tool,
+/obj/machinery/vending/tool{
+	onstation = 0
+	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/syndicate_icemoon/engine)
 "XE" = (

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_syndicate.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_syndicate.dmm
@@ -4309,6 +4309,7 @@
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/dropper,
 /obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/item/storage/bag/bio,
 /turf/open/floor/plasteel/dark,
 /area/ruin/syndicate_icemoon/xenobio)
 "zW" = (
@@ -6767,6 +6768,7 @@
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/dropper,
 /obj/effect/turf_decal/tile/purple/fourcorners,
+/obj/item/storage/bag/bio,
 /turf/open/floor/plasteel/dark,
 /area/ruin/syndicate_icemoon/xenobio)
 "Oj" = (


### PR DESCRIPTION
changes like one vending machine variable. oops.

i also threw in some biobags because someone ingame mentioned not having them and they were better at xenobio than me

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
bugfix: fixed syndie icemoon needing money for one of their two tool vendors
rscadd: also gives them biobags
/:cl:
