### PR TITLE
Gives CMO Locker Gene Scanner and Simplifies Genetics Locker Mapping (Bonus: Gene scanner in medical belts)

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -8164,27 +8164,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central/secondary)
-"bRn" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/structure/closet/wardrobe/genetics_white,
-/obj/item/storage/box/rxglasses,
-/obj/item/storage/box/disks{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/radio/headset/headset_medsci,
-/obj/item/reagent_containers/syringe,
-/obj/item/reagent_containers/glass/bottle/morphine,
-/obj/item/sequence_scanner,
-/obj/item/sequence_scanner,
-/obj/item/stack/cable_coil/white,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics/cloning)
 "bRo" = (
 /obj/effect/landmark/stationroom/maint/tenxten,
 /turf/template_noop,
@@ -56020,6 +55999,16 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"qFs" = (
+/obj/machinery/newscaster{
+	pixel_x = 32
+	},
+/obj/structure/closet/wardrobe/genetics_white,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics/cloning)
 "qFY" = (
 /obj/machinery/light{
 	dir = 1
@@ -117790,7 +117779,7 @@ tkM
 sHK
 nra
 jme
-bRn
+qFs
 aPy
 mul
 bUZ

--- a/_maps/map_files/DonutStation/DonutStation.dmm
+++ b/_maps/map_files/DonutStation/DonutStation.dmm
@@ -29704,6 +29704,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"mBz" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 10
+	},
+/obj/machinery/light_switch{
+	pixel_x = -24
+	},
+/obj/structure/closet/wardrobe/genetics_white,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "mBA" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -56222,15 +56232,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/lab)
-"xHt" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 10
-	},
-/obj/machinery/light_switch{
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "xHI" = (
 /obj/structure/table/wood,
 /obj/machinery/light,
@@ -83883,7 +83884,7 @@ tEL
 ehj
 ody
 uIp
-xHt
+mBz
 mVq
 fUX
 gJH

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -11087,14 +11087,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"fhS" = (
-/obj/structure/window/reinforced,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 6
-	},
-/obj/structure/closet/wardrobe/genetics_white,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "fih" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27787,6 +27779,15 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nvS" = (
+/obj/structure/window/reinforced,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 6
+	},
+/obj/structure/closet/wardrobe/genetics_white,
+/obj/item/storage/box/disks,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "nvT" = (
 /obj/machinery/computer/shuttle/mining,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
@@ -83394,7 +83395,7 @@ ftr
 wpP
 kWr
 jZd
-fhS
+nvS
 wHj
 xBM
 ftr

--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -3768,6 +3768,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"bex" = (
+/obj/machinery/requests_console{
+	department = "Genetics";
+	name = "Genetics Requests Console";
+	pixel_y = 30
+	},
+/obj/item/storage/box/monkeycubes,
+/obj/item/flashlight/pen{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/item/flashlight/pen{
+	pixel_x = 4;
+	pixel_y = 3
+	},
+/obj/structure/table/glass,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "beG" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -34314,25 +34335,6 @@
 /obj/item/paicard,
 /turf/open/floor/wood,
 /area/library)
-"jYY" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/closet/wardrobe/genetics_white,
-/obj/item/stack/cable_coil/white,
-/obj/item/sequence_scanner,
-/obj/item/sequence_scanner,
-/obj/item/reagent_containers/glass/bottle/morphine,
-/obj/item/reagent_containers/syringe,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Genetics Lab";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "jZd" = (
 /turf/open/floor/plasteel/grimy,
 /area/security/interrogation)
@@ -54302,6 +54304,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"pGU" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/wardrobe/genetics_white,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Genetics Lab";
+	network = list("ss13","medbay")
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "pHy" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/airalarm{
@@ -76284,28 +76300,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"vSe" = (
-/obj/machinery/requests_console{
-	department = "Genetics";
-	name = "Genetics Requests Console";
-	pixel_y = 30
-	},
-/obj/item/storage/box/monkeycubes,
-/obj/item/radio/headset/headset_medsci,
-/obj/item/flashlight/pen{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/flashlight/pen{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/structure/table/glass,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "vSj" = (
 /turf/open/floor/wood,
 /area/vacant_room/office)
@@ -241476,7 +241470,7 @@ opQ
 ptR
 fLo
 prw
-vSe
+bex
 jlE
 oSm
 grK
@@ -242250,7 +242244,7 @@ sfy
 sfy
 pVK
 sfy
-jYY
+pGU
 jlE
 aKb
 rXs

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -18969,6 +18969,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"dXb" = (
+/obj/structure/closet/wardrobe/genetics_white,
+/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "dXi" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
@@ -40829,19 +40837,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/aft)
-"lOk" = (
-/obj/structure/closet/wardrobe/genetics_white,
-/obj/item/stack/cable_coil/white,
-/obj/item/sequence_scanner,
-/obj/item/sequence_scanner,
-/obj/item/reagent_containers/glass/bottle/morphine,
-/obj/item/reagent_containers/syringe,
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "lOq" = (
 /obj/machinery/door/airlock/research{
 	name = "Experimentation Lab";
@@ -56539,6 +56534,21 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"rxO" = (
+/obj/structure/table/glass,
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 1
+	},
+/obj/item/storage/box/rxglasses,
+/obj/item/storage/box/disks{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "rxR" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower,
@@ -66189,22 +66199,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"vbV" = (
-/obj/structure/table/glass,
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 1
-	},
-/obj/item/storage/box/rxglasses,
-/obj/item/storage/box/disks{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/radio/headset/headset_medsci,
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "vca" = (
 /obj/machinery/computer/aifixer,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
@@ -116580,7 +116574,7 @@ wBd
 hof
 rYQ
 wBd
-lOk
+dXb
 vGx
 uEc
 ufj
@@ -116832,7 +116826,7 @@ cpr
 uvN
 htQ
 kYK
-vbV
+rxO
 wBd
 oJT
 iqX

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -286,7 +286,8 @@
 		/obj/item/pinpointer/crew,
 		/obj/item/stack/medical/bone_gel,
 		/obj/item/holosign_creator/medical,
-		/obj/item/holosign_creator/firstaid
+		/obj/item/holosign_creator/firstaid,
+		/obj/item/sequence_scanner
 		))
 
 /obj/item/storage/belt/medical/chief

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -246,7 +246,7 @@
 		/obj/item/storage/backpack/genetics = 2,
 		/obj/item/storage/backpack/satchel/gen = 2,
 		/obj/item/sequence_scanner = 2,
-		/obj/item/stack/cable_coul/white,
+		/obj/item/stack/cable_coil/white,
 		/obj/item/reagent_containers/glass/bottle/morphine,
 		/obj/item/reagent_containers/syringe,
 		/obj/item/radio/headset/headset_medsci)

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -244,7 +244,12 @@
 		/obj/item/clothing/shoes/sneakers/white = 2,
 		/obj/item/clothing/suit/toggle/labcoat/genetics = 2,
 		/obj/item/storage/backpack/genetics = 2,
-		/obj/item/storage/backpack/satchel/gen = 2)
+		/obj/item/storage/backpack/satchel/gen = 2,
+		/obj/item/sequence_scanner = 2,
+		/obj/item/stack/cable_coul/white,
+		/obj/item/reagent_containers/glass/bottle/morphine,
+		/obj/item/reagent_containers/syringe,
+		/obj/item/radio/headset/headset_medsci)
 	generate_items_inside(items_inside,src)
 	return
 

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -246,10 +246,10 @@
 		/obj/item/storage/backpack/genetics = 2,
 		/obj/item/storage/backpack/satchel/gen = 2,
 		/obj/item/sequence_scanner = 2,
-		/obj/item/stack/cable_coil/white,
-		/obj/item/reagent_containers/glass/bottle/morphine,
-		/obj/item/reagent_containers/syringe,
-		/obj/item/radio/headset/headset_medsci)
+		/obj/item/stack/cable_coil/white = 1,
+		/obj/item/reagent_containers/glass/bottle/morphine = 1,
+		/obj/item/reagent_containers/syringe = 1,
+		/obj/item/radio/headset/headset_medsci = 1)
 	generate_items_inside(items_inside,src)
 	return
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -69,7 +69,7 @@
 	new /obj/item/clipboard/yog/paperwork/cmo(src)
 	new /obj/item/storage/backpack/duffelbag/clothing/med/chief(src)
 	new /obj/item/storage/lockbox/medal/med(src)
-
+	new /obj/item/sequence_scanner(src)
 
 /obj/structure/closet/secure_closet/paramedic
 	name = "paramedical closet"


### PR DESCRIPTION
# Document the changes in your pull request

Adds a genetics scanner for the CMO.
Also adds things to the Genetics locker so it's easier to map as you don't need to add a whole bunch of stuff that every station should have.
Also gene scanners in medical belts!

# Why is this good for the game?

Easier mapping, CMO better equipped.

# Testing

![image](https://github.com/yogstation13/Yogstation/assets/70451213/067dd785-78c2-4a0d-8b67-65d089517e5b)

![image](https://github.com/yogstation13/Yogstation/assets/70451213/74b90e91-5f47-4fde-a4ab-44398230b05d)

![image](https://github.com/yogstation13/Yogstation/assets/70451213/3f689748-3af7-42fa-bce9-d11e2f8d6713)

# Changelog

:cl:  
tweak: Gene Scanner into CMO locker
tweak: Took things mapped directly and instead put them in the job_closets.dm code for easier mapping
tweak: Gene Scanners fit in Medical Belts
/:cl:
