### PR TITLE
Gives one more expansion bay to all modular computers

### DIFF
--- a/code/modules/modular_computers/computers/item/laptop/laptop.dm
+++ b/code/modules/modular_computers/computers/item/laptop/laptop.dm
@@ -14,7 +14,7 @@
 	hardware_flag = PROGRAM_LAPTOP
 	max_hardware_size = WEIGHT_CLASS_NORMAL
 	w_class = WEIGHT_CLASS_NORMAL
-	max_bays = 4
+	max_bays = 5
 
 	// No running around with open laptops in hands.
 	item_flags = SLOWS_WHILE_IN_HAND

--- a/code/modules/modular_computers/computers/item/pda/pda.dm
+++ b/code/modules/modular_computers/computers/item/pda/pda.dm
@@ -14,7 +14,7 @@
 	hardware_flag = PROGRAM_PDA
 	max_hardware_size = WEIGHT_CLASS_SMALL
 	w_class = WEIGHT_CLASS_SMALL
-	max_bays = 1
+	max_bays = 2
 	steel_sheet_cost = 1
 	slot_flags = ITEM_SLOT_ID | ITEM_SLOT_BELT
 

--- a/code/modules/modular_computers/computers/item/phone/phone.dm
+++ b/code/modules/modular_computers/computers/item/phone/phone.dm
@@ -8,6 +8,6 @@
 	hardware_flag = PROGRAM_PHONE
 	max_hardware_size = WEIGHT_CLASS_SMALL
 	w_class = WEIGHT_CLASS_SMALL
-	max_bays = 2
+	max_bays = 3
 	steel_sheet_cost = 1
 	slot_flags = ITEM_SLOT_ID | ITEM_SLOT_BELT

--- a/code/modules/modular_computers/computers/item/processor.dm
+++ b/code/modules/modular_computers/computers/item/processor.dm
@@ -8,7 +8,7 @@
 	icon_state_unpowered = null
 	icon_state_menu = null
 	hardware_flag = 0
-	max_bays = 5
+	max_bays = 6
 
 	var/obj/machinery/modular_computer/machinery_computer = null
 

--- a/code/modules/modular_computers/computers/item/tablet/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet/tablet.dm
@@ -11,7 +11,7 @@
 	hardware_flag = PROGRAM_TABLET
 	max_hardware_size = WEIGHT_CLASS_SMALL
 	w_class = WEIGHT_CLASS_NORMAL
-	max_bays = 3
+	max_bays = 4
 	steel_sheet_cost = 1
 	slot_flags = ITEM_SLOT_BELT
 	has_light = TRUE //LED flashlight!


### PR DESCRIPTION
laptop 4->5
tablet 3->4
phone 2->3
pda 1->2

# Why is this good for the game?
command positions are given both the 2nd card reader and miniprinter by default
this makes it impossible to upgrade their phone without requiring them to remove a component first

removing the bay slot cost from either the card reader or miniprinter doesn't make sense
tablets are too large, so it's not worth giving them one of those instead of a phone
giving only phones more expansion slots creates inconsistencies that will keep me awake at night

# Testing
no need, just number changes

:cl:  
tweak: Gives one more expansion bay to all modular computers
/:cl:
