### PR TITLE
Venus human traps ignore gravity checks if close enough to vines

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
+++ b/code/modules/mob/living/simple_animal/hostile/venus_human_trap.dm
@@ -137,6 +137,11 @@
 	AddElement(/datum/element/life_draining, damage_overtime = 5, check_damage_callback = CALLBACK(src, PROC_REF(kudzu_need)))
 	remove_verb(src, /mob/living/verb/pulled) //no dragging the poor sap into the depths of the vines never to be seen again
 
+/mob/living/simple_animal/hostile/venus_human_trap/mob_negates_gravity()
+	if(kudzu_need(FALSE))
+		return TRUE
+	return ..()
+
 /mob/living/simple_animal/hostile/venus_human_trap/Life(seconds_per_tick = SSMOBS_DT, times_fired)
 	. = ..()
 	pull_vines()


### PR DESCRIPTION
it means they don't get trapped in one spot because they can't move

# Why is this good for the game?
it's frustrating to be just utterly trapped without anything to do

# Testing
gotta

:cl:  
tweak: Venus human traps ignore gravity checks if close enough to vines
/:cl:
