### PR TITLE
Allows unique descriptions of double-barrel shotguns

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -176,7 +176,6 @@
 	slot_flags = ITEM_SLOT_BACK
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/dual
 	sawn_desc = "Omar's coming!"
-	obj_flags = UNIQUE_RENAME
 	rack_sound_volume = 0
 	unique_reskin = list("Default" = "dshotgun",
 						"Dark Red Finish" = "dshotgun_d",


### PR DESCRIPTION
I don't know WHY specifically these ones couldn't have a unique description but now they can because customization is cool.


# Why is this good for the game?

Customization good.

# Testing

Just a variable change, should inherit normal gun behavior.


# Changelog


:cl:  

tweak: Double-barrel and improv shotguns can have unique descriptions again

/:cl:
