### PR TITLE
Fixes AIs piloting a shell not receiving law change notifications.

### DIFF
--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -18,6 +18,11 @@
 		addtimer(CALLBACK(src, PROC_REF(show_laws)), 0)
 		last_lawchange_announce = world.time
 
+/mob/living/silicon/ai/post_lawchange(announce = TRUE)
+	if(deployed_shell) // AI might be in a shell, send the announcement there instead
+		return deployed_shell.post_lawchange(announce)
+	return ..()
+
 //
 // Devil Laws
 // 


### PR DESCRIPTION
AIs now get the notification for law change as intended when deployed to a shell.

![image](https://github.com/yogstation13/Yogstation/assets/93578146/b1e1a1ff-c5d3-4a7a-8295-5c6104e1e771)

:cl:  
bugfix: Fixed AIs piloting their shell not receiving law change notifications.
/:cl:
