### PR TITLE
Buffs sentient disease

### DIFF
--- a/code/modules/antagonists/disease/disease_abilities.dm
+++ b/code/modules/antagonists/disease/disease_abilities.dm
@@ -437,7 +437,7 @@ new /datum/disease_ability/symptom/powerful/heal/youth
 /datum/disease_ability/symptom/powerful/flesh_eating
 	symptoms = list(/datum/symptom/flesh_eating)
 
-/datum/disease_ability/symptom/powerful/inorganic_adaptation
+/datum/disease_ability/symptom/mild/inorganic_adaptation
 	symptoms = list(/datum/symptom/inorganic_adaptation)
 
 //yogs start

--- a/code/modules/antagonists/disease/disease_abilities.dm
+++ b/code/modules/antagonists/disease/disease_abilities.dm
@@ -37,7 +37,7 @@ new /datum/disease_ability/symptom/medium/heal/sensory_restoration,
 new /datum/disease_ability/symptom/medium/heal/mind_restoration,
 new /datum/disease_ability/symptom/powerful/fire,
 new /datum/disease_ability/symptom/powerful/flesh_eating,
-new /datum/disease_ability/symptom/powerful/inorganic_adaptation,
+new /datum/disease_ability/symptom/mild/inorganic_adaptation,
 new /datum/disease_ability/symptom/powerful/undead_adaptation, //yogs change
 new /datum/disease_ability/symptom/powerful/heal/starlight,
 new /datum/disease_ability/symptom/powerful/heal/oxygen,


### PR DESCRIPTION
# Document the changes in your pull request

Allows sentient viruses to purchase inorganic adaptation sooner

# Why is this good for the game?

too many people playing IPCs/Preternis

# Testing

yes

# Wiki Documentation

is this something that should be updated?

# Changelog

:cl:  

tweak: changes the cost of inorganic biology to be less for sent virus  

/:cl:
