### PR TITLE
Fixes radiation collectors not generating power when hit by nuclear particles

### DIFF
--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -260,7 +260,7 @@
 	. = ..()
 	if(active)
 		if(mode == POWER)
-			. += "<span class='notice'>[src]'s display states that it has stored <b>[DisplayPower(stored_power)]</b>, and processing <b>[DisplayPower(RAD_COLLECTOR_OUTPUT)]</b>.</span>"
+			. += "<span class='notice'>[src]'s display states that it has stored <b>[DisplayJoules(stored_power)]</b>, and processing <b>[DisplayPower(RAD_COLLECTOR_OUTPUT)]</b>.</span>"
 		else if(mode == SCIENCE)
 			. += "<span class='notice'>[src]'s display states that it has stored a total of <b>[stored_power*RAD_COLLECTOR_MINING_CONVERSION_RATE]</b>, and producing [last_output*60] research points per minute.</span>"
 		else if(mode == MONEY)
@@ -327,9 +327,9 @@
 
 /obj/machinery/power/rad_collector/bullet_act(obj/projectile/P)
 	if(istype(P, /obj/projectile/energy/nuclear_particle))
-		rad_act(P.irradiate * P.damage) // equivalent of a 2000 strength rad pulse for each particle
-		P.damage = 0
-	..()
+		rad_act(P.irradiate * P.damage, collectable_radiation = TRUE) // equivalent of a 2000 strength rad pulse for each particle
+		P.nodamage = TRUE
+	return ..()
 
 #undef RAD_COLLECTOR_EFFICIENCY
 #undef RAD_COLLECTOR_COEFFICIENT


### PR DESCRIPTION
THEOS!!!!!!!!!!

:cl:  
bugfix: Fixed radiation collectors not generating power when hit by nuclear particles
spellcheck: Radiation collectors now display stored power in joules instead of watts
/:cl:
