### PR TITLE
Adds a priority warning for nuclear fallout and increase the delay for the nuclear fallout to hit

### DIFF
--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -612,6 +612,7 @@
 	explosion(get_turf(src), explosion_power * explosion_mod  * 0.5, explosion_power * explosion_mod + 2, explosion_power * explosion_mod + 4, explosion_power * explosion_mod + 6, 1, 1)
 	meltdown() //Double kill.
 	relay('sound/effects/reactor/explode.ogg')
+	priority_announce("Level 10 radiation hazard alert! Clouds of nuclear ash are forming near the reactor and expanding rapidly. Maintenance is the best shield against the ash storm.", "Radiation Alert", 'sound/misc/notice1.ogg', color_override="yellow")
 	SSweather.run_weather("nuclear fallout", src.z)
 	for(var/X in GLOB.landmarks_list)
 		if(istype(X, /obj/effect/landmark/nuclear_waste_spawner))
@@ -964,7 +965,7 @@
 /datum/weather/nuclear_fallout
 	name = "nuclear fallout"
 	desc = "Irradiated dust falls down everywhere."
-	telegraph_duration = 50
+	telegraph_duration = 20 SECONDS
 	telegraph_message = "<span class='boldwarning'>The air suddenly becomes dusty..</span>"
 	weather_message = "<span class='userdanger'><i>You feel a wave of hot ash fall down on you.</i></span>"
 	weather_overlay = "light_ash"

--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -612,7 +612,7 @@
 	explosion(get_turf(src), explosion_power * explosion_mod  * 0.5, explosion_power * explosion_mod + 2, explosion_power * explosion_mod + 4, explosion_power * explosion_mod + 6, 1, 1)
 	meltdown() //Double kill.
 	relay('sound/effects/reactor/explode.ogg')
-	priority_announce("Level 10 radiation hazard alert! Clouds of nuclear ash are forming near the reactor and expanding rapidly. Maintenance is the best shield against the ash storm.", "Radiation Alert", 'sound/misc/notice1.ogg', color_override="yellow")
+	priority_announce("Level 10 radiation hazard alert! Clouds of nuclear ash are forming near the reactor and expanding rapidly. Maintenance is the best shield against the ash storm.", "Radiation Alert", 'sound/misc/airraid.ogg', color_override="yellow")
 	SSweather.run_weather("nuclear fallout", src.z)
 	for(var/X in GLOB.landmarks_list)
 		if(istype(X, /obj/effect/landmark/nuclear_waste_spawner))


### PR DESCRIPTION


# Document the changes in your pull request
Adds a priority warning for nuclear fallout to alert people before the it hits (+AIRRAID SOUND)
Increase the nuclear fallout weather start delay to 20 Seconds
# Why is this good for the game?
People get to know what about to hit them and seek shelters quick enough before it happen

# Testing
yes



# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: Adds a priority warning for nuclear fallout to alert people before the it hits (+AIRRAID SOUND)
tweak: Increase the nuclear fallout weather start delay to 20 Seconds
/:cl:
