### PR TITLE
Makes it so you cannot see the flavour text of husked bodies

### DIFF
--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\generic\CentCom.dmm"
 

--- a/_maps/_basemap.dm
+++ b/_maps/_basemap.dm
@@ -1,4 +1,4 @@
-//#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
+#define LOWMEMORYMODE //uncomment this to load centcom and runtime station and thats it.
 
 #include "map_files\generic\CentCom.dmm"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -489,7 +489,9 @@
 	// What examine_tgui.dm uses to determine if flavor text appears as "Obscured".
 	var/face_obscured = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
 
-	if (!(face_obscured))
+	if(HAS_TRAIT(src, TRAIT_HUSK))
+		flavor_text_link = span_notice("They've been husked, there's no way to tell their flavor text...")
+	else if (!(face_obscured))
 		flavor_text_link = span_notice("[preview_text]... <a href='?src=[REF(src)];lookup_info=open_examine_panel'>\[Look closer?\]</a>")
 	else
 		flavor_text_link = span_notice("<a href='?src=[REF(src)];lookup_info=open_examine_panel'>\[Examine closely...\]</a>")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -491,7 +491,7 @@
 
 	if(HAS_TRAIT(src, TRAIT_HUSK))
 		flavor_text_link = span_notice("This person has been husked, and is unrecognizable!")
-	else if (if(HAS_TRAIT(src, TRAIT_DISFIGURED)))
+	else if ((HAS_TRAIT(src, TRAIT_DISFIGURED)))
 		flavor_text_link = span_notice("This person has been horribly disfigured, and is unrecognizable!")
 	else if (!(face_obscured))
 		flavor_text_link = span_notice("[preview_text]... <a href='?src=[REF(src)];lookup_info=open_examine_panel'>\[Look closer?\]</a>")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -490,7 +490,9 @@
 	var/face_obscured = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
 
 	if(HAS_TRAIT(src, TRAIT_HUSK))
-		flavor_text_link = span_notice("They've been husked, there's no way to tell their flavor text...")
+		flavor_text_link = span_notice("This person has been husked, and is unrecognizable!")
+	else if (if(HAS_TRAIT(src, TRAIT_DISFIGURED)))
+		flavor_text_link = span_notice("This person has been horribly disfigured, and is unrecognizable!")
 	else if (!(face_obscured))
 		flavor_text_link = span_notice("[preview_text]... <a href='?src=[REF(src)];lookup_info=open_examine_panel'>\[Look closer?\]</a>")
 	else


### PR DESCRIPTION
# Document the changes in your pull request

Makes it so husked people temporarily lose their flavour text. & if you're disfigured via acid to the face or cloning you will also lose it until the trait is removed.

# Why is this good for the game?

probably a good idea to reduce meta-gaming or something 

# Testing
Before: 
![image](https://github.com/yogstation13/Yogstation/assets/75333826/d2bb0894-9964-4771-83db-1c897353fe20)
After: 
![image](https://github.com/yogstation13/Yogstation/assets/75333826/43060f5f-7ecd-41ad-bdf5-cac38c3429e2)
Revived: 
![image](https://github.com/yogstation13/Yogstation/assets/75333826/2a1593c9-7c9c-40cd-b005-ef079fd121fb)


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: tweaked how husked flavour text works

/:cl:
