### PR TITLE
Prevents admin only evac shuttles from getting discounts, making them appear on the console

### DIFF
--- a/code/datums/shuttles/emergency.dm
+++ b/code/datums/shuttles/emergency.dm
@@ -19,6 +19,8 @@
 	. = ..()
 	if(!occupancy_limit && who_can_purchase)
 		CRASH("The [name] needs an occupancy limit!")
+	if(credit_cost == INFINITY) //INFINITY cost shuttles aren't even supposed to show up, giving them a sale will technically let people buy them, which we don't want
+		return
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_SHUTTLE_SALE) && credit_cost > 0 && prob(15))
 		var/discount_amount = round(rand(25, 80), 5)
 		name += " ([discount_amount]% Discount!)"


### PR DESCRIPTION
an oversight with how the discount system and console work

# Testing
would need to, but it'd just be me rerolling shuttles again and again, nothing showing up every time

:cl:  
bugfix: Prevents admin only evac shuttles from getting discounts, making them appear on the console
/:cl:
