### PR TITLE
[BOX] Fixes library stairs being upside down

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -33108,7 +33108,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/stairs/goon/wood_stairs_middle,
+/turf/open/floor/plasteel/stairs/goon/wood_stairs_middle{
+	dir = 1
+	},
 /area/library)
 "iOa" = (
 /turf/open/floor/engine/airless,
@@ -56996,7 +56998,9 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/turf/open/floor/plasteel/stairs/goon/wood_stairs_wide,
+/turf/open/floor/plasteel/stairs/goon/wood_stairs_wide{
+	dir = 1
+	},
 /area/library)
 "rFS" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
@@ -68478,7 +68482,9 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/open/floor/plasteel/stairs/goon/wood_stairs_wide2,
+/turf/open/floor/plasteel/stairs/goon/wood_stairs_wide2{
+	dir = 1
+	},
 /area/library)
 "vOX" = (
 /obj/structure/sign/warning/securearea,


### PR DESCRIPTION
# Document the changes in your pull request
Trying to tell what's top and what's bottom on these things is confusing yes, but the shading along the rails confirms the front/entrance is below the back of the room, and that the stairs do ascend.
![image](https://github.com/yogstation13/Yogstation/assets/143908044/2a1c45f0-5d8d-4acd-a963-c6075b78e4d1)


# Why is this good for the game?
(Lighter bars on top means it goes down)
![image](https://github.com/yogstation13/Yogstation/assets/143908044/491457bc-8845-42b8-8e35-cae3b8f46b0b)


# Testing
Will do

# Changelog
:cl:
mapping: The stairs in the library on Box are no longer upside down
/:cl:
