### PR TITLE
Updates all current shipbreaking templates to have deconstructable engines

### DIFF
--- a/_maps/templates/shipbreaker/old_nt.dmm
+++ b/_maps/templates/shipbreaker/old_nt.dmm
@@ -66,8 +66,10 @@
 /turf/open/floor/plating,
 /area/template_noop)
 "K" = (
-/obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced/spawner/north,
+/obj/machinery/power/engine_capacitor_bank{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/template_noop)
 "L" = (
@@ -94,7 +96,9 @@
 /turf/open/floor/mineral/titanium/blue/airless,
 /area/template_noop)
 "Q" = (
-/obj/structure/shuttle/engine/propulsion,
+/obj/machinery/shuttle/engine{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/template_noop)
 "S" = (

--- a/_maps/templates/shipbreaker/old_robotics.dmm
+++ b/_maps/templates/shipbreaker/old_robotics.dmm
@@ -14,10 +14,6 @@
 /obj/machinery/door/poddoor/shutters/window,
 /turf/open/floor/plating,
 /area/template_noop)
-"n" = (
-/obj/structure/shuttle/engine/propulsion,
-/turf/open/floor/plating,
-/area/template_noop)
 "o" = (
 /turf/open/floor/engine/airless,
 /area/template_noop)
@@ -27,7 +23,9 @@
 /turf/open/floor/engine/airless,
 /area/template_noop)
 "s" = (
-/obj/structure/shuttle/engine/propulsion/left,
+/obj/machinery/shuttle/engine{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/template_noop)
 "t" = (
@@ -43,10 +41,6 @@
 /area/template_noop)
 "x" = (
 /turf/closed/wall/mineral/titanium,
-/area/template_noop)
-"A" = (
-/obj/structure/shuttle/engine/propulsion/right,
-/turf/open/floor/plating,
 /area/template_noop)
 "D" = (
 /obj/machinery/mecha_part_fabricator,
@@ -108,8 +102,10 @@
 /turf/open/floor/engine/airless,
 /area/template_noop)
 "L" = (
-/obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced/spawner/north,
+/obj/machinery/power/engine_capacitor_bank{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/template_noop)
 "N" = (
@@ -183,7 +179,7 @@ o
 i
 o
 L
-n
+s
 "}
 (5,1,1) = {"
 c
@@ -197,7 +193,7 @@ v
 D
 F
 L
-n
+s
 "}
 (6,1,1) = {"
 x
@@ -211,7 +207,7 @@ t
 w
 X
 L
-A
+s
 "}
 (7,1,1) = {"
 a

--- a/_maps/templates/shipbreaker/old_syndicate.dmm
+++ b/_maps/templates/shipbreaker/old_syndicate.dmm
@@ -3,8 +3,10 @@
 /turf/open/floor/mineral/plastitanium/red/airless,
 /area/template_noop)
 "b" = (
-/obj/structure/shuttle/engine/heater,
 /obj/structure/window/reinforced/spawner/north,
+/obj/machinery/power/engine_capacitor_bank{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/template_noop)
 "c" = (
@@ -39,14 +41,6 @@
 /obj/effect/spawner/structure/window/plastitanium,
 /turf/open/floor/plating,
 /area/template_noop)
-"i" = (
-/obj/structure/shuttle/engine/propulsion/right,
-/turf/open/floor/plating,
-/area/template_noop)
-"l" = (
-/obj/structure/shuttle/engine/propulsion/left,
-/turf/open/floor/plating,
-/area/template_noop)
 "m" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -69,7 +63,9 @@
 /turf/open/floor/mineral/plastitanium/airless/broken,
 /area/template_noop)
 "t" = (
-/obj/structure/shuttle/engine/propulsion,
+/obj/machinery/shuttle/engine{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/template_noop)
 "u" = (
@@ -210,7 +206,7 @@ a
 a
 J
 b
-l
+t
 "}
 (3,1,1) = {"
 h
@@ -280,7 +276,7 @@ Q
 P
 n
 b
-i
+t
 "}
 (8,1,1) = {"
 u


### PR DESCRIPTION
# Document the changes in your pull request

Updates the /structure/ engines to the /machinery/ versions used in custom shuttles

# Why is this good for the game?

Probably better than coding a special tool made for EXCLUSIVELY destroying engines

# Testing

It works on the live server

# Wiki Documentation

wiki call me

# Changelog

:cl:  
 
tweak: adjusts shipbreak template engines
mapping: adjusts shipbreak template engines

/:cl:
