### PR TITLE
Adds 5 new ship templates for shipbreaking

### DIFF
--- a/_maps/templates/shipbreaker/old_alien.dmm
+++ b/_maps/templates/shipbreaker/old_alien.dmm
@@ -1,0 +1,208 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"c" = (
+/obj/structure/sign/poster/abductor/ayy_over_tizira,
+/turf/closed/wall/mineral/abductor,
+/area/template_noop)
+"f" = (
+/obj/structure/table/abductor,
+/obj/item/surgicaldrill/alien,
+/turf/open/floor/plating/abductor,
+/area/template_noop)
+"g" = (
+/obj/effect/decal/cleanable/xenoblood/xgibs/down,
+/turf/open/floor/plating/abductor,
+/area/template_noop)
+"m" = (
+/obj/structure/table/optable/abductor,
+/obj/effect/decal/cleanable/xenoblood/xgibs/core,
+/turf/open/floor/plating/abductor,
+/area/template_noop)
+"r" = (
+/obj/structure/table/optable/abductor,
+/obj/effect/decal/cleanable/xenoblood/xgibs/larva/body,
+/turf/open/floor/plating/abductor,
+/area/template_noop)
+"s" = (
+/obj/structure/table/abductor,
+/obj/item/organ/heart/gland,
+/turf/open/floor/plating/abductor,
+/area/template_noop)
+"u" = (
+/obj/structure/sign/poster/abductor/ayy_no,
+/turf/closed/wall/mineral/abductor,
+/area/template_noop)
+"w" = (
+/obj/structure/sign/poster/abductor/ayylian,
+/turf/closed/wall/mineral/abductor,
+/area/template_noop)
+"y" = (
+/obj/item/toy/plush/abductor,
+/turf/open/floor/plating/abductor,
+/area/template_noop)
+"z" = (
+/obj/machinery/door/airlock/abductor,
+/turf/open/space/basic,
+/area/template_noop)
+"A" = (
+/obj/structure/table/optable/abductor,
+/obj/effect/decal/cleanable/xenoblood/xgibs/down,
+/turf/open/floor/plating/abductor,
+/area/template_noop)
+"C" = (
+/obj/structure/sign/poster/abductor/ayy,
+/turf/closed/wall/mineral/abductor,
+/area/template_noop)
+"G" = (
+/obj/structure/sign/poster/abductor/ayy_cops,
+/turf/closed/wall/mineral/abductor,
+/area/template_noop)
+"I" = (
+/obj/item/toy/plush/abductor/agent,
+/turf/open/floor/plating/abductor,
+/area/template_noop)
+"K" = (
+/turf/closed/wall/mineral/abductor,
+/area/template_noop)
+"O" = (
+/obj/structure/table/abductor,
+/obj/item/storage/box/alienhandcuffs,
+/turf/open/floor/plating/abductor,
+/area/template_noop)
+"R" = (
+/turf/open/floor/plating/abductor,
+/area/template_noop)
+"S" = (
+/obj/structure/sign/poster/abductor/ayy_recruitment,
+/turf/closed/wall/mineral/abductor,
+/area/template_noop)
+"T" = (
+/obj/structure/closet/abductor,
+/obj/item/organ/heart/gland,
+/obj/item/organ/heart/gland,
+/obj/item/organ/heart/gland,
+/turf/open/floor/plating/abductor,
+/area/template_noop)
+"Z" = (
+/obj/structure/closet/abductor,
+/obj/item/organ/heart/gland,
+/obj/item/organ/heart/gland,
+/obj/item/organ/heart/gland,
+/obj/effect/decal/cleanable/xenoblood/xgibs/down,
+/turf/open/floor/plating/abductor,
+/area/template_noop)
+
+(1,1,1) = {"
+a
+a
+a
+a
+K
+K
+c
+K
+a
+a
+a
+a
+"}
+(2,1,1) = {"
+a
+a
+a
+K
+O
+f
+s
+s
+K
+a
+a
+a
+"}
+(3,1,1) = {"
+a
+a
+K
+Z
+R
+R
+R
+g
+R
+K
+a
+a
+"}
+(4,1,1) = {"
+a
+a
+C
+R
+R
+r
+m
+R
+y
+S
+a
+a
+"}
+(5,1,1) = {"
+a
+a
+G
+R
+R
+A
+A
+R
+I
+w
+a
+a
+"}
+(6,1,1) = {"
+a
+a
+K
+g
+R
+R
+R
+g
+R
+K
+a
+a
+"}
+(7,1,1) = {"
+a
+a
+a
+K
+T
+R
+R
+R
+K
+a
+a
+a
+"}
+(8,1,1) = {"
+a
+a
+a
+a
+K
+u
+z
+K
+a
+a
+a
+a
+"}

--- a/_maps/templates/shipbreaker/old_alien.dmm
+++ b/_maps/templates/shipbreaker/old_alien.dmm
@@ -8,7 +8,6 @@
 /area/template_noop)
 "f" = (
 /obj/structure/table/abductor,
-/obj/item/surgicaldrill/alien,
 /turf/open/floor/plating/abductor,
 /area/template_noop)
 "g" = (

--- a/_maps/templates/shipbreaker/old_bathroom.dmm
+++ b/_maps/templates/shipbreaker/old_bathroom.dmm
@@ -27,10 +27,6 @@
 	},
 /turf/open/floor/plating,
 /area/template_noop)
-"q" = (
-/obj/structure/curtain,
-/turf/open/floor/plasteel/freezer/airless,
-/area/template_noop)
 "s" = (
 /obj/structure/toilet{
 	dir = 8
@@ -39,6 +35,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/curtain,
 /turf/open/floor/plasteel/freezer/airless,
 /area/template_noop)
 "x" = (
@@ -173,10 +170,10 @@ a
 (5,1,1) = {"
 a
 c
-q
-q
-q
-q
+h
+h
+h
+h
 A
 A
 A

--- a/_maps/templates/shipbreaker/old_bathroom.dmm
+++ b/_maps/templates/shipbreaker/old_bathroom.dmm
@@ -1,0 +1,225 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer/airless,
+/area/template_noop)
+"d" = (
+/obj/machinery/shower,
+/obj/item/soap,
+/turf/open/floor/plasteel/freezer/airless,
+/area/template_noop)
+"g" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/template_noop)
+"m" = (
+/obj/machinery/shuttle/engine{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"q" = (
+/obj/structure/curtain,
+/turf/open/floor/plasteel/freezer/airless,
+/area/template_noop)
+"r" = (
+/turf/open/floor/plasteel/freezer/airless,
+/area/template_noop)
+"t" = (
+/obj/structure/urinal{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/item/reagent_containers/food/snacks/urinalcake,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer/airless,
+/area/template_noop)
+"v" = (
+/obj/structure/bedsheetbin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer/airless,
+/area/template_noop)
+"x" = (
+/obj/machinery/shower,
+/turf/open/floor/plasteel/freezer/airless,
+/area/template_noop)
+"B" = (
+/turf/template_noop,
+/area/template_noop)
+"G" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/machinery/power/engine_capacitor_bank{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"H" = (
+/obj/machinery/shower,
+/obj/item/soap/nanotrasen,
+/turf/open/floor/plasteel/freezer/airless,
+/area/template_noop)
+"I" = (
+/obj/structure/urinal{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer/airless,
+/area/template_noop)
+"L" = (
+/obj/structure/mirror,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/template_noop)
+"Q" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer/airless,
+/area/template_noop)
+"T" = (
+/obj/machinery/door/airlock/highsecurity,
+/turf/open/floor/plasteel/freezer/airless,
+/area/template_noop)
+"U" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/structure/urinal{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer/airless,
+/area/template_noop)
+"V" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/open/floor/plasteel/freezer/airless,
+/area/template_noop)
+"Y" = (
+/obj/item/bikehorn/rubberducky,
+/obj/item/soap/deluxe,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer/airless,
+/area/template_noop)
+
+(1,1,1) = {"
+B
+B
+B
+B
+B
+B
+B
+B
+B
+B
+B
+B
+"}
+(2,1,1) = {"
+B
+B
+g
+g
+g
+g
+L
+g
+T
+g
+B
+B
+"}
+(3,1,1) = {"
+B
+g
+d
+x
+H
+x
+V
+v
+Y
+G
+m
+B
+"}
+(4,1,1) = {"
+B
+g
+r
+r
+r
+r
+Q
+Q
+Q
+G
+m
+B
+"}
+(5,1,1) = {"
+B
+g
+q
+q
+q
+q
+Q
+Q
+Q
+G
+m
+B
+"}
+(6,1,1) = {"
+B
+g
+a
+a
+a
+a
+U
+t
+I
+G
+m
+B
+"}
+(7,1,1) = {"
+B
+B
+g
+g
+g
+g
+g
+g
+g
+g
+B
+B
+"}
+(8,1,1) = {"
+B
+B
+B
+B
+B
+B
+B
+B
+B
+B
+B
+B
+"}

--- a/_maps/templates/shipbreaker/old_bathroom.dmm
+++ b/_maps/templates/shipbreaker/old_bathroom.dmm
@@ -1,23 +1,27 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/freezer/airless,
+/turf/template_noop,
+/area/template_noop)
+"c" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/template_noop)
 "d" = (
-/obj/machinery/shower,
-/obj/item/soap,
+/obj/machinery/door/airlock/highsecurity,
 /turf/open/floor/plasteel/freezer/airless,
 /area/template_noop)
 "g" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/machinery/power/engine_capacitor_bank{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/template_noop)
-"m" = (
+"h" = (
+/turf/open/floor/plasteel/freezer/airless,
+/area/template_noop)
+"j" = (
 /obj/machinery/shuttle/engine{
 	dir = 1
 	},
@@ -27,10 +31,34 @@
 /obj/structure/curtain,
 /turf/open/floor/plasteel/freezer/airless,
 /area/template_noop)
-"r" = (
+"s" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/freezer/airless,
 /area/template_noop)
-"t" = (
+"x" = (
+/obj/structure/bedsheetbin,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer/airless,
+/area/template_noop)
+"y" = (
+/obj/structure/urinal{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer/airless,
+/area/template_noop)
+"A" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/freezer/airless,
+/area/template_noop)
+"E" = (
 /obj/structure/urinal{
 	dir = 8;
 	pixel_x = 32
@@ -39,53 +67,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/freezer/airless,
 /area/template_noop)
-"v" = (
-/obj/structure/bedsheetbin,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/freezer/airless,
-/area/template_noop)
-"x" = (
-/obj/machinery/shower,
-/turf/open/floor/plasteel/freezer/airless,
-/area/template_noop)
-"B" = (
-/turf/template_noop,
-/area/template_noop)
 "G" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 1
-	},
-/obj/machinery/power/engine_capacitor_bank{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/template_noop)
-"H" = (
-/obj/machinery/shower,
-/obj/item/soap/nanotrasen,
-/turf/open/floor/plasteel/freezer/airless,
-/area/template_noop)
-"I" = (
-/obj/structure/urinal{
-	dir = 8;
-	pixel_x = 32
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/freezer/airless,
-/area/template_noop)
-"L" = (
 /obj/structure/mirror,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/template_noop)
-"Q" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/freezer/airless,
-/area/template_noop)
-"T" = (
-/obj/machinery/door/airlock/highsecurity,
-/turf/open/floor/plasteel/freezer/airless,
-/area/template_noop)
-"U" = (
+"J" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 1
 	},
@@ -96,7 +82,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/freezer/airless,
 /area/template_noop)
-"V" = (
+"K" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink{
 	dir = 8;
@@ -104,122 +90,139 @@
 	},
 /turf/open/floor/plasteel/freezer/airless,
 /area/template_noop)
-"Y" = (
+"O" = (
 /obj/item/bikehorn/rubberducky,
 /obj/item/soap/deluxe,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/freezer/airless,
 /area/template_noop)
+"P" = (
+/obj/machinery/shower,
+/turf/open/floor/plasteel/freezer/airless,
+/area/template_noop)
+"W" = (
+/turf/closed/wall/mineral/titanium,
+/area/template_noop)
+"X" = (
+/obj/machinery/shower,
+/obj/item/soap,
+/turf/open/floor/plasteel/freezer/airless,
+/area/template_noop)
+"Z" = (
+/obj/machinery/shower,
+/obj/item/soap/nanotrasen,
+/turf/open/floor/plasteel/freezer/airless,
+/area/template_noop)
 
 (1,1,1) = {"
-B
-B
-B
-B
-B
-B
-B
-B
-B
-B
-B
-B
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
 "}
 (2,1,1) = {"
-B
-B
-g
-g
-g
-g
-L
-g
-T
-g
-B
-B
+a
+a
+W
+c
+c
+c
+G
+c
+d
+W
+a
+a
 "}
 (3,1,1) = {"
-B
+a
+W
+X
+P
+Z
+P
+K
+x
+O
 g
-d
-x
-H
-x
-V
-v
-Y
-G
-m
-B
+j
+a
 "}
 (4,1,1) = {"
-B
+a
+c
+h
+h
+h
+h
+A
+A
+A
 g
-r
-r
-r
-r
-Q
-Q
-Q
-G
-m
-B
+j
+a
 "}
 (5,1,1) = {"
-B
+a
+c
+q
+q
+q
+q
+A
+A
+A
 g
-q
-q
-q
-q
-Q
-Q
-Q
-G
-m
-B
+j
+a
 "}
 (6,1,1) = {"
-B
+a
+W
+s
+s
+s
+s
+J
+E
+y
 g
+j
 a
-a
-a
-a
-U
-t
-I
-G
-m
-B
 "}
 (7,1,1) = {"
-B
-B
-g
-g
-g
-g
-g
-g
-g
-g
-B
-B
+a
+a
+W
+c
+c
+c
+c
+c
+c
+W
+a
+a
 "}
 (8,1,1) = {"
-B
-B
-B
-B
-B
-B
-B
-B
-B
-B
-B
-B
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
 "}

--- a/_maps/templates/shipbreaker/old_chapel.dmm
+++ b/_maps/templates/shipbreaker/old_chapel.dmm
@@ -1,0 +1,241 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/statue/cheese/cheesus,
+/turf/open/floor/plasteel/chapel,
+/area/template_noop)
+"c" = (
+/obj/machinery/shuttle/engine{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"h" = (
+/turf/open/floor/carpet/purple,
+/area/template_noop)
+"m" = (
+/obj/item/storage/fancy/candle_box,
+/turf/open/floor/carpet/purple,
+/area/template_noop)
+"n" = (
+/turf/open/floor/plasteel/chapel{
+	dir = 4
+	},
+/area/template_noop)
+"q" = (
+/obj/item/storage/fancy/candle_box,
+/turf/open/floor/plasteel/chapel,
+/area/template_noop)
+"r" = (
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
+/turf/open/floor/carpet/purple,
+/area/template_noop)
+"s" = (
+/turf/open/floor/plasteel/chapel{
+	dir = 8
+	},
+/area/template_noop)
+"A" = (
+/obj/structure/statue/cheese/cheesus,
+/turf/open/floor/plasteel/chapel{
+	dir = 1
+	},
+/area/template_noop)
+"B" = (
+/turf/template_noop,
+/area/template_noop)
+"C" = (
+/obj/item/storage/book/bible,
+/turf/open/floor/plasteel/chapel{
+	dir = 1
+	},
+/area/template_noop)
+"E" = (
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
+/turf/open/floor/carpet/purple,
+/area/template_noop)
+"G" = (
+/obj/structure/statue/cheese/cheesus,
+/turf/open/floor/plasteel/chapel{
+	dir = 8
+	},
+/area/template_noop)
+"I" = (
+/obj/item/reagent_containers/food/snacks/store/cheesewheel/goat,
+/turf/open/floor/plasteel/chapel{
+	dir = 1
+	},
+/area/template_noop)
+"L" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/power/engine_capacitor_bank{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"N" = (
+/obj/structure/statue/cheese/cheesus,
+/turf/open/floor/plasteel/chapel{
+	dir = 4
+	},
+/area/template_noop)
+"P" = (
+/turf/open/floor/plasteel/chapel,
+/area/template_noop)
+"R" = (
+/obj/item/stack/sheet/cheese,
+/obj/item/stack/sheet/cheese,
+/obj/item/stack/sheet/cheese,
+/obj/item/stack/sheet/cheese,
+/obj/item/stack/sheet/cheese,
+/obj/item/stack/sheet/cheese,
+/obj/item/stack/sheet/cheese,
+/obj/item/stack/sheet/cheese,
+/obj/item/stack/sheet/cheese,
+/obj/item/stack/sheet/cheese,
+/obj/item/stack/sheet/cheese,
+/obj/item/stack/sheet/cheese,
+/obj/item/stack/sheet/cheese,
+/obj/item/stack/sheet/cheese,
+/obj/item/stack/sheet/cheese,
+/obj/item/stack/sheet/cheese,
+/obj/item/stack/sheet/cheese,
+/obj/item/stack/sheet/cheese,
+/obj/item/stack/sheet/cheese,
+/obj/item/stack/sheet/cheese,
+/obj/item/stack/sheet/cheese,
+/turf/open/floor/plasteel/chapel{
+	dir = 1
+	},
+/area/template_noop)
+"S" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/template_noop)
+"U" = (
+/obj/item/reagent_containers/food/snacks/store/cheesewheel/cheddar,
+/turf/open/floor/carpet/purple,
+/area/template_noop)
+"W" = (
+/obj/structure/table/altar_of_gods,
+/obj/item/reagent_containers/food/snacks/hotcrossbun,
+/turf/open/floor/plasteel/chapel{
+	dir = 4
+	},
+/area/template_noop)
+
+(1,1,1) = {"
+B
+B
+B
+B
+B
+B
+B
+B
+B
+B
+B
+B
+"}
+(2,1,1) = {"
+B
+S
+S
+S
+S
+S
+S
+S
+S
+S
+S
+B
+"}
+(3,1,1) = {"
+B
+S
+A
+s
+E
+U
+h
+E
+R
+G
+L
+c
+"}
+(4,1,1) = {"
+B
+S
+W
+q
+r
+h
+h
+r
+n
+P
+L
+c
+"}
+(5,1,1) = {"
+B
+S
+C
+s
+E
+h
+m
+E
+I
+s
+L
+c
+"}
+(6,1,1) = {"
+B
+S
+N
+P
+r
+h
+h
+r
+n
+a
+L
+c
+"}
+(7,1,1) = {"
+B
+S
+S
+S
+S
+S
+S
+S
+S
+S
+S
+B
+"}
+(8,1,1) = {"
+B
+B
+B
+B
+B
+B
+B
+B
+B
+B
+B
+B
+"}

--- a/_maps/templates/shipbreaker/old_escape_pod.dmm
+++ b/_maps/templates/shipbreaker/old_escape_pod.dmm
@@ -1,0 +1,241 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/template_noop,
+/area/template_noop)
+"g" = (
+/obj/machinery/shuttle/engine{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"h" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod Airlock"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"i" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/item/ammo_casing/reusable/kineticspear,
+/turf/open/floor/mineral/titanium/blue/airless,
+/area/template_noop)
+"k" = (
+/obj/machinery/shuttle/engine,
+/turf/open/floor/plating,
+/area/template_noop)
+"l" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/item/radio/intercom{
+	pixel_x = 25
+	},
+/obj/item/storage/toolbox/emergency,
+/obj/item/clothing/suit/space/fragile,
+/obj/effect/decal/cleanable/blood/innards,
+/turf/open/floor/mineral/titanium/blue/airless,
+/area/template_noop)
+"m" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/template_noop)
+"q" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/item/pickaxe/emergency,
+/turf/open/floor/mineral/titanium/blue/airless,
+/area/template_noop)
+"s" = (
+/turf/closed/wall/mineral/titanium,
+/area/template_noop)
+"A" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = 27
+	},
+/obj/item/pneumatic_cannon/speargun,
+/obj/item/clothing/head/helmet/space/fragile,
+/turf/open/floor/mineral/titanium/blue/airless,
+/area/template_noop)
+"D" = (
+/obj/machinery/shuttle/engine{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"F" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod Airlock"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/template_noop)
+"L" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod Airlock"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"M" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/template_noop)
+"P" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/item/ammo_casing/reusable/kineticspear,
+/turf/open/floor/mineral/titanium/blue/airless,
+/area/template_noop)
+"Y" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_x = 25
+	},
+/obj/item/flashlight/flare/emergency,
+/obj/item/tank/internals/emergency_oxygen/double/empty,
+/obj/effect/decal/cleanable/blood/innards,
+/turf/open/floor/mineral/titanium/blue/airless,
+/area/template_noop)
+
+(1,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+"}
+(2,1,1) = {"
+a
+s
+M
+M
+D
+a
+a
+g
+h
+g
+a
+a
+"}
+(3,1,1) = {"
+a
+m
+Y
+P
+F
+a
+a
+M
+q
+M
+a
+a
+"}
+(4,1,1) = {"
+a
+s
+M
+M
+D
+a
+a
+M
+A
+M
+a
+a
+"}
+(5,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+s
+m
+s
+a
+a
+"}
+(6,1,1) = {"
+a
+a
+k
+M
+M
+s
+a
+a
+a
+a
+a
+a
+"}
+(7,1,1) = {"
+a
+a
+L
+i
+l
+m
+a
+a
+a
+a
+a
+a
+"}
+(8,1,1) = {"
+a
+a
+k
+M
+M
+s
+a
+a
+a
+a
+a
+a
+"}
+(9,1,1) = {"
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+a
+"}

--- a/_maps/templates/shipbreaker/old_stealth_cutter.dmm
+++ b/_maps/templates/shipbreaker/old_stealth_cutter.dmm
@@ -1,0 +1,190 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/open/floor/mineral/plastitanium/airless/broken,
+/area/space)
+"b" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/space)
+"f" = (
+/turf/template_noop,
+/area/space)
+"h" = (
+/obj/machinery/modular_computer,
+/turf/open/floor/mineral/plastitanium/airless/broken,
+/area/space)
+"m" = (
+/obj/effect/spawner/structure/window/plastitanium,
+/turf/open/floor/plating,
+/area/space)
+"n" = (
+/obj/item/cardboard_cutout/adaptive,
+/turf/open/floor/mineral/plastitanium/airless/broken,
+/area/space)
+"o" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/airless/broken,
+/area/space)
+"r" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/space)
+"w" = (
+/obj/machinery/door/poddoor/shutters,
+/turf/open/floor/mineral/plastitanium/airless/broken,
+/area/space)
+"x" = (
+/obj/item/clothing/glasses/eyepatch,
+/turf/open/floor/mineral/plastitanium/airless/broken,
+/area/space)
+"z" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/machinery/power/engine_capacitor_bank{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space)
+"F" = (
+/obj/effect/mine/stun,
+/turf/open/floor/mineral/plastitanium/airless/broken,
+/area/space)
+"H" = (
+/obj/item/clothing/under/syndicate/tacticool,
+/turf/open/floor/mineral/plastitanium/airless/broken,
+/area/space)
+"L" = (
+/obj/machinery/door/airlock/hatch,
+/turf/open/floor/mineral/plastitanium/airless/broken,
+/area/space)
+"P" = (
+/obj/machinery/shuttle/engine{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space)
+"S" = (
+/obj/structure/closet/cardboard/metal,
+/turf/open/floor/mineral/plastitanium/airless/broken,
+/area/space)
+"Z" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/item/clothing/glasses/night,
+/turf/open/floor/mineral/plastitanium/airless/broken,
+/area/space)
+
+(1,1,1) = {"
+f
+f
+f
+f
+f
+f
+b
+r
+w
+r
+b
+f
+"}
+(2,1,1) = {"
+f
+f
+f
+f
+f
+f
+r
+n
+a
+n
+z
+P
+"}
+(3,1,1) = {"
+b
+r
+r
+r
+r
+r
+b
+n
+a
+n
+z
+P
+"}
+(4,1,1) = {"
+m
+h
+Z
+a
+x
+a
+L
+a
+a
+b
+f
+f
+"}
+(5,1,1) = {"
+m
+h
+o
+a
+F
+a
+L
+a
+a
+b
+f
+f
+"}
+(6,1,1) = {"
+b
+r
+r
+r
+r
+r
+b
+a
+a
+a
+z
+P
+"}
+(7,1,1) = {"
+f
+f
+f
+f
+f
+f
+r
+S
+H
+a
+z
+P
+"}
+(8,1,1) = {"
+f
+f
+f
+f
+f
+f
+b
+r
+r
+r
+b
+f
+"}

--- a/yogstation/code/modules/shipbreaker/shipbreaker.dm
+++ b/yogstation/code/modules/shipbreaker/shipbreaker.dm
@@ -26,3 +26,33 @@
 	template_id = "old_Robo"
 	description = "mapshaker_old_robo"
 	mappath = "_maps/templates/shipbreaker/old_robotics.dmm"
+
+/datum/map_template/shipbreaker/chapel_old
+	name = "Old Chapel Ship"
+	template_id = "old_Chapel"
+	description = "mapshaker_old_chapel"
+	mappath = "_maps/templates/shipbreaker/old_chapel.dmm"
+
+/datum/map_template/shipbreaker/alien_old
+	name = "Old Alien Ship"
+	template_id = "old_Alien"
+	description = "mapshaker_old_alien"
+	mappath = "_maps/templates/shipbreaker/old_alien.dmm"
+
+/datum/map_template/shipbreaker/escape_pod_old
+	name = "Old Escape Pods"
+	template_id = "old_Escape_Pods"
+	description = "mapshaker_old_escape_pods"
+	mappath = "_maps/templates/shipbreaker/old_escape_pod.dmm"
+
+/datum/map_template/shipbreaker/bathroom_old
+	name = "Old Bathroom Ship"
+	template_id = "old_Bathroom"
+	description = "mapshaker_old_bathroom"
+	mappath = "_maps/templates/shipbreaker/old_bathroom.dmm"
+
+/datum/map_template/shipbreaker/stealthcutter_old
+	name = "Old Stealth Cutter Ship"
+	template_id = "old_Stealth_Cutter"
+	description = "mapshaker_old_stealth_cutter"
+	mappath = "_maps/templates/shipbreaker/old_stealth_cutter.dmm"


### PR DESCRIPTION
# Document the changes in your pull request

Adds 5 new ship templates:

The Chapel Ship
The Alien Ship
The Bathroom Ship
Several Old Escape Pods
The Stealth Cutter Ship

# Why is this good for the game?

More variety keeps people from getting bored

<details closed>
<summary>Ship Layouts</summary>
<br>
Chapel

![image](https://github.com/yogstation13/Yogstation/assets/75333826/8510de87-a170-4b7f-8e7f-1304e49e07f0)

Alien
![image](https://github.com/yogstation13/Yogstation/assets/75333826/7a74aaa5-0f18-4cdb-95de-79a97a2649c4)

Escape Pods
![image](https://github.com/yogstation13/Yogstation/assets/75333826/8ff64fc8-9e42-47bd-b9a5-ead3c6014248)

The Bathroom (read as if said by murdoc from the gorillaz)
![image](https://github.com/yogstation13/Yogstation/assets/75333826/2620ef34-f54c-4704-bf21-44731daf881c)

Stealth Cutter
![image](https://github.com/yogstation13/Yogstation/assets/75333826/acffb572-26e0-431d-977a-f0ef5e1b90f0)


</details>

# Testing

Follows the same format as the other ship spawns

# Wiki Documentation

Wiki PLEASE return my calls

# Changelog

:cl:  
rscadd: Adds 5 new ships to break!
mapping: Adds 5 new ships to break!

/:cl:
