### PR TITLE
Adjusts the effects of Stabilized red and Stabilized sepia slime cores

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -701,9 +701,8 @@ datum/status_effect/stabilized/blue/on_remove()
 /datum/status_effect/stabilized/sepia/on_apply()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		H.physiology.brute_mod *= 1.5
-		H.physiology.burn_mod *= 1.5
 		H.physiology.stamina_mod *= 1.5
+		H.physiology.stun_mod *= 1.5
 	return ..()
 
 /datum/status_effect/stabilized/sepia/tick()
@@ -720,9 +719,8 @@ datum/status_effect/stabilized/blue/on_remove()
 	owner.remove_movespeed_modifier(MOVESPEED_ID_SEPIA)
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		H.physiology.brute_mod /= 1.5
-		H.physiology.burn_mod /= 1.5
 		H.physiology.stamina_mod /= 1.5
+		H.physiology.stun_mod /= 1.5
 	return ..()
 
 /datum/status_effect/stabilized/cerulean
@@ -790,18 +788,16 @@ datum/status_effect/stabilized/blue/on_remove()
 	owner.add_movespeed_modifier("stabilized_red_speed", update=TRUE, priority=100, multiplicative_slowdown=-0.4, blacklisted_movetypes=(FLYING|FLOATING))
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		H.physiology.brute_mod *= 1.5
-		H.physiology.burn_mod *= 1.5
 		H.physiology.stamina_mod *= 1.5
+		H.physiology.stun_mod *= 1.5
 	return ..()
 
 /datum/status_effect/stabilized/red/on_remove()
 	owner.remove_movespeed_modifier("stabilized_red_speed")
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		H.physiology.brute_mod /= 1.5
-		H.physiology.burn_mod /= 1.5
 		H.physiology.stamina_mod /= 1.5
+		H.physiology.stun_mod /= 1.5
 	return ..()
 
 /datum/status_effect/stabilized/green

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -698,6 +698,13 @@ datum/status_effect/stabilized/blue/on_remove()
 	colour = "sepia"
 	var/mod = 0
 
+/datum/status_effect/stabilized/sepia/on_apply()
+	if(ishuman(owner))
+		var/mob/living/carbon/human/H = owner
+		H.physiology.brute_mod *= 1.5
+		H.physiology.burn_mod *= 1.5
+	return ..()
+
 /datum/status_effect/stabilized/sepia/tick()
 	if(prob(50) && mod > -1)
 		mod--
@@ -710,6 +717,11 @@ datum/status_effect/stabilized/blue/on_remove()
 
 /datum/status_effect/stabilized/sepia/on_remove()
 	owner.remove_movespeed_modifier(MOVESPEED_ID_SEPIA)
+	if(ishuman(owner))
+		var/mob/living/carbon/human/H = owner
+		H.physiology.brute_mod /= 1.5
+		H.physiology.burn_mod /= 1.5
+	return ..()
 
 /datum/status_effect/stabilized/cerulean
 	id = "stabilizedcerulean"
@@ -774,10 +786,19 @@ datum/status_effect/stabilized/blue/on_remove()
 
 /datum/status_effect/stabilized/red/on_apply()
 	owner.add_movespeed_modifier("stabilized_red_speed", update=TRUE, priority=100, multiplicative_slowdown=-0.4, blacklisted_movetypes=(FLYING|FLOATING))
+	if(ishuman(owner))
+		var/mob/living/carbon/human/H = owner
+		H.physiology.brute_mod *= 1.5
+		H.physiology.burn_mod *= 1.5
 	return ..()
 
 /datum/status_effect/stabilized/red/on_remove()
 	owner.remove_movespeed_modifier("stabilized_red_speed")
+	if(ishuman(owner))
+		var/mob/living/carbon/human/H = owner
+		H.physiology.brute_mod /= 1.5
+		H.physiology.burn_mod /= 1.5
+	return ..()
 
 /datum/status_effect/stabilized/green
 	id = "stabilizedgreen"

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -706,14 +706,7 @@ datum/status_effect/stabilized/blue/on_remove()
 	return ..()
 
 /datum/status_effect/stabilized/sepia/tick()
-	if(prob(50) && mod > -1)
-		mod--
-		owner.add_movespeed_modifier(MOVESPEED_ID_SEPIA, override = TRUE, update=TRUE, priority=100, multiplicative_slowdown=-1, blacklisted_movetypes=(FLYING|FLOATING))
-	else if(mod < 1)
-		mod++
-		// yeah a value of 0 does nothing but replacing the trait in place is cheaper than removing and adding repeatedly -- just make it 1 dumbass
-		owner.add_movespeed_modifier(MOVESPEED_ID_SEPIA, override = TRUE, update=TRUE, priority=100, multiplicative_slowdown=1, blacklisted_movetypes=(FLYING|FLOATING))
-	return ..()
+	owner.add_movespeed_modifier(MOVESPEED_ID_SEPIA, override = TRUE, update=TRUE, priority=100, multiplicative_slowdown= rand(-1, 1), blacklisted_movetypes=(FLYING|FLOATING))
 
 /datum/status_effect/stabilized/sepia/on_remove()
 	owner.remove_movespeed_modifier(MOVESPEED_ID_SEPIA)

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -703,6 +703,7 @@ datum/status_effect/stabilized/blue/on_remove()
 		var/mob/living/carbon/human/H = owner
 		H.physiology.brute_mod *= 1.5
 		H.physiology.burn_mod *= 1.5
+		H.physiology.stamina_mod *= 1.5
 	return ..()
 
 /datum/status_effect/stabilized/sepia/tick()
@@ -721,6 +722,7 @@ datum/status_effect/stabilized/blue/on_remove()
 		var/mob/living/carbon/human/H = owner
 		H.physiology.brute_mod /= 1.5
 		H.physiology.burn_mod /= 1.5
+		H.physiology.stamina_mod /= 1.5
 	return ..()
 
 /datum/status_effect/stabilized/cerulean
@@ -790,6 +792,7 @@ datum/status_effect/stabilized/blue/on_remove()
 		var/mob/living/carbon/human/H = owner
 		H.physiology.brute_mod *= 1.5
 		H.physiology.burn_mod *= 1.5
+		H.physiology.stamina_mod *= 1.5
 	return ..()
 
 /datum/status_effect/stabilized/red/on_remove()
@@ -798,6 +801,7 @@ datum/status_effect/stabilized/blue/on_remove()
 		var/mob/living/carbon/human/H = owner
 		H.physiology.brute_mod /= 1.5
 		H.physiology.burn_mod /= 1.5
+		H.physiology.stamina_mod /= 1.5
 	return ..()
 
 /datum/status_effect/stabilized/green

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -712,8 +712,8 @@ datum/status_effect/stabilized/blue/on_remove()
 		owner.add_movespeed_modifier(MOVESPEED_ID_SEPIA, override = TRUE, update=TRUE, priority=100, multiplicative_slowdown=-1, blacklisted_movetypes=(FLYING|FLOATING))
 	else if(mod < 1)
 		mod++
-		// yeah a value of 0 does nothing but replacing the trait in place is cheaper than removing and adding repeatedly
-		owner.add_movespeed_modifier(MOVESPEED_ID_SEPIA, override = TRUE, update=TRUE, priority=100, multiplicative_slowdown=0, blacklisted_movetypes=(FLYING|FLOATING))
+		// yeah a value of 0 does nothing but replacing the trait in place is cheaper than removing and adding repeatedly -- just make it 1 dumbass
+		owner.add_movespeed_modifier(MOVESPEED_ID_SEPIA, override = TRUE, update=TRUE, priority=100, multiplicative_slowdown=1, blacklisted_movetypes=(FLYING|FLOATING))
 	return ..()
 
 /datum/status_effect/stabilized/sepia/on_remove()


### PR DESCRIPTION
# Document the changes in your pull request

Additionally adds a 1.5x stam damage modifier, and 1.5x stun mod to each stabilized extract.

Additionally adjusts sepia to now actually slow you instead of just resetting you back to base speed, as it was supposed to do.

# Why is this good for the game?

Move speed is a potent tool in this game, and the effects you gain from these cores warrant some drawbacks. I did not want to nerf the actual speed they grant, as I feel like this is a suitable trade-off, making you more like a glass-cannon in certain cases.

# Testing

Stunmod testing - 2 telescopic baton hits to take a target down w/ 1.5x stunmod, even quicker with regular batons.
Sepia testing - works like the knife now, could honestly be -2/1 but not needed at this point
stun testing - going down keeps you down 1.5x longer.

# Wiki Documentation

Add the "you take extra stun/stam" damage part to the wiki

# Changelog

:cl:  

tweak: Adds stamina damage & stun duration modifiers to Red & Sepia Stabilized slime cores.

/:cl:
