### PR TITLE
Heavily adjusts the effects of Red and Sepia stabilized slime cores

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -701,15 +701,12 @@ datum/status_effect/stabilized/blue/on_remove()
 /datum/status_effect/stabilized/sepia/tick()
 	if(prob(50) && mod > -1)
 		mod--
-		owner.add_movespeed_modifier(MOVESPEED_ID_SEPIA, override = TRUE, update=TRUE, priority=100, multiplicative_slowdown=-1, blacklisted_movetypes=(FLYING|FLOATING))
+		owner.add_atom_colour("#ffffff", ADMIN_COLOUR_PRIORITY)
 	else if(mod < 1)
 		mod++
 		// yeah a value of 0 does nothing but replacing the trait in place is cheaper than removing and adding repeatedly
-		owner.add_movespeed_modifier(MOVESPEED_ID_SEPIA, override = TRUE, update=TRUE, priority=100, multiplicative_slowdown=0, blacklisted_movetypes=(FLYING|FLOATING))
+		owner.add_atom_colour("#000000", ADMIN_COLOUR_PRIORITY)
 	return ..()
-
-/datum/status_effect/stabilized/sepia/on_remove()
-	owner.remove_movespeed_modifier(MOVESPEED_ID_SEPIA)
 
 /datum/status_effect/stabilized/cerulean
 	id = "stabilizedcerulean"
@@ -772,12 +769,10 @@ datum/status_effect/stabilized/blue/on_remove()
 	id = "stabilizedred"
 	colour = "red"
 
-/datum/status_effect/stabilized/red/on_apply()
-	owner.add_movespeed_modifier("stabilized_red_speed", update=TRUE, priority=100, multiplicative_slowdown=-0.4, blacklisted_movetypes=(FLYING|FLOATING))
+/datum/status_effect/stabilized/red/tick()
+	if(owner.blood_volume < BLOOD_VOLUME_MAXIMUM(owner)) // we dont want to explode from casting
+		owner.blood_volume += 20
 	return ..()
-
-/datum/status_effect/stabilized/red/on_remove()
-	owner.remove_movespeed_modifier("stabilized_red_speed")
 
 /datum/status_effect/stabilized/green
 	id = "stabilizedgreen"


### PR DESCRIPTION
# Document the changes in your pull request

Removes the speed boost from Red Stabilized cores, replaces it with large blood generation if you're under the same blood amount.

Removes the speed boost/slowdown effect from Sepia Stabilized cores, replaces it with an effect which will make you black/white randomly.

# Why is this good for the game?

Xenobiology speed issues have been an issue for awhile, and it's best to just cut the issue out at it's root rather than make half-hearted measures.

# Testing

the black effect from the sepia slime is actually really funny 

![image](https://github.com/yogstation13/Yogstation/assets/75333826/6c870b02-b89e-4baf-a53a-e2c56551b883)

# Wiki Documentation

Remove mentions of speed change from both cores, replace with the effects noted above.

# Changelog

:cl:  
 
tweak: Tweaks how Red & Sepia slime cores work entirely 

/:cl:
