### PR TITLE
Adds Shipbreaking to Gax, Fixes security reception area

### DIFF
--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -265,7 +265,6 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "afI" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 2;
 	on = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -2575,6 +2574,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"blM" = (
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "bmg" = (
 /obj/structure/chair/pew/left{
 	dir = 1
@@ -3203,7 +3205,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -3669,9 +3670,7 @@
 /area/chapel/office)
 "bPR" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -4169,9 +4168,7 @@
 /area/bridge)
 "caE" = (
 /obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "caI" = (
@@ -5289,7 +5286,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -5448,7 +5444,6 @@
 /area/medical/sleeper)
 "cEl" = (
 /obj/structure/sign/departments/minsky/engineering/atmospherics{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer2,
@@ -5613,11 +5608,6 @@
 /area/escapepodbay)
 "cIO" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/eastleft{
-	dir = 2;
-	name = "Brig Desk";
-	req_access_txt = "1"
-	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "briggate";
 	name = "security shutters"
@@ -5633,6 +5623,11 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/window/eastleft{
+	dir = 1;
+	name = "Brig Desk";
+	req_access_txt = "1"
+	},
 /turf/open/floor/plating,
 /area/security/brig)
 "cIZ" = (
@@ -5951,9 +5946,7 @@
 "cPM" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "cPQ" = (
@@ -6076,6 +6069,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"cUc" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "cUp" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -6226,6 +6225,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"cWU" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "cXc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -6246,8 +6250,7 @@
 /area/science/robotics/lab)
 "cXz" = (
 /obj/structure/sign/departments/minsky/research/genetics{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
@@ -7240,7 +7243,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -7637,6 +7639,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
+"dFH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "dFV" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
@@ -7812,8 +7818,7 @@
 "dJQ" = (
 /obj/machinery/oven,
 /obj/machinery/camera{
-	c_tag = "Kitchen";
-	dir = 2
+	c_tag = "Kitchen"
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -8194,14 +8199,12 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Escape Southeast";
-	dir = 9;
-	network = list("ss13")
+	dir = 9
 	},
 /obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner,
@@ -8335,8 +8338,7 @@
 /area/maintenance/department/eva)
 "dYQ" = (
 /obj/item/radio/intercom{
-	pixel_x = 29;
-	pixel_y = 0
+	pixel_x = 29
 	},
 /obj/machinery/button/massdriver{
 	id = "toxinsdriver";
@@ -8909,8 +8911,7 @@
 /area/hallway/primary/port)
 "emj" = (
 /obj/machinery/camera{
-	c_tag = "Kitchen";
-	dir = 2
+	c_tag = "Kitchen"
 	},
 /obj/machinery/firealarm{
 	pixel_y = 28
@@ -8932,7 +8933,6 @@
 	layer = 4;
 	name = "Test Chamber Telescreen";
 	network = list("toxins");
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel,
@@ -9275,8 +9275,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay North";
 	dir = 5;
-	network = list("ss13","medbay");
-	pixel_x = 0
+	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
@@ -9711,7 +9710,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -10107,6 +10105,13 @@
 "eKF" = (
 /turf/closed/wall/r_wall,
 /area/storage/tech)
+"eKM" = (
+/obj/structure/closet/crate/miningcar{
+	name = "Material cart"
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "eKQ" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -10445,7 +10450,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -11287,8 +11291,7 @@
 /obj/machinery/camera{
 	c_tag = "Surgery Operating";
 	dir = 9;
-	network = list("ss13","medbay");
-	pixel_x = 0
+	network = list("ss13","medbay")
 	},
 /obj/machinery/light_switch{
 	pixel_x = 24
@@ -11390,6 +11393,11 @@
 /obj/item/multitool,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"fqp" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon,
+/turf/open/space/basic,
+/area/space/nearstation)
 "fqH" = (
 /turf/closed/wall,
 /area/medical/genetics/cloning)
@@ -11610,6 +11618,20 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"fwZ" = (
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	layer = 3
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "fxk" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -13211,7 +13233,6 @@
 	pixel_x = 28
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13292,6 +13313,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"giC" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plasteel/dark/corner,
+/area/hydroponics/garden)
 "giF" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
@@ -13437,8 +13462,7 @@
 	},
 /obj/effect/turf_decal/trimline/purple/filled/end,
 /obj/machinery/computer/atmos_sim{
-	dir = 1;
-	mode = 1
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -14002,7 +14026,6 @@
 "gBR" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
-	req_access_txt = "0";
 	req_one_access_txt = "1; 63"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -14832,7 +14855,6 @@
 /obj/item/radio/intercom{
 	dir = 4;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 27
 	},
 /turf/open/floor/plasteel/dark,
@@ -15123,7 +15145,6 @@
 /obj/machinery/door/airlock/command/glass{
 	id_tag = "secondary_aicore_exterior";
 	name = "Physical Core Access";
-	req_access_txt = "0";
 	req_one_access_txt = "30, 70"
 	},
 /turf/open/floor/plating,
@@ -15413,6 +15434,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
+"hni" = (
+/obj/machinery/computer/shipbreaker{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "hnn" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -15624,7 +15653,6 @@
 "hrX" = (
 /obj/structure/table,
 /obj/structure/reagent_dispensers/virusfood{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -15814,9 +15842,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "hwC" = (
@@ -16235,7 +16261,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -16621,7 +16646,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -16875,6 +16899,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"hVK" = (
+/turf/open/floor/plasteel/dark/side,
+/area/hydroponics/garden)
 "hVM" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/captain)
@@ -17019,7 +17046,6 @@
 	},
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -18329,6 +18355,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"iIF" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "Shipbreaking"
+	},
+/obj/structure/rack,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "iIW" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -19081,6 +19115,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"jbF" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "jbW" = (
 /obj/structure/bodycontainer/crematorium{
 	dir = 8;
@@ -19919,8 +19958,7 @@
 	pixel_y = -28
 	},
 /obj/machinery/computer/atmos_sim{
-	dir = 8;
-	mode = 1
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
@@ -20026,7 +20064,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20302,7 +20339,6 @@
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -20348,7 +20384,6 @@
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/structure/sign/departments/minsky/supply/cargo{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -20851,6 +20886,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security)
+"jVg" = (
+/obj/structure/rack,
+/obj/machinery/camera{
+	c_tag = "Brig Equipment Room";
+	dir = 4
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/bag/trash,
+/obj/item/melee/sledgehammer,
+/obj/item/broom,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "jVp" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp{
@@ -21305,6 +21357,14 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
+"kiR" = (
+/obj/machinery/recycler,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "Shipbreaking"
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "kiS" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
@@ -21759,6 +21819,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"kvd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/stairs/old{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "kvW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -22445,6 +22516,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"kNE" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/structure/fans/tiny,
+/turf/open/floor/engine,
+/area/hydroponics/garden)
 "kNF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -22740,7 +22816,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23436,6 +23511,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"llR" = (
+/obj/structure/lattice,
+/turf/closed/wall,
+/area/maintenance/starboard/fore)
 "llZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -23806,6 +23885,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"lwH" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "lwK" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/cleanable/dirt,
@@ -24140,6 +24225,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"lDm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
+	},
+/area/hydroponics/garden)
 "lDF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -24991,6 +25084,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
+"lZD" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "lZL" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -25065,7 +25168,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25396,6 +25498,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"mkp" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/door/window/eastright{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "mky" = (
 /obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 1
@@ -25406,7 +25520,6 @@
 	},
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25970,7 +26083,6 @@
 "mxY" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
-	light_on = 0;
 	pixel_x = -6;
 	pixel_y = 8
 	},
@@ -26080,8 +26192,7 @@
 /obj/machinery/camera{
 	c_tag = "Surgery Observation";
 	dir = 5;
-	network = list("ss13","medbay");
-	pixel_x = 0
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
@@ -26505,8 +26616,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Supermatter Fore";
 	dir = 6;
-	network = list("ss13","engine");
-	pixel_x = 0
+	network = list("ss13","engine")
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -27094,6 +27204,7 @@
 	id = "briggate";
 	name = "security shutters"
 	},
+/obj/item/storage/pencil_holder/crew,
 /turf/open/floor/plating,
 /area/security/brig)
 "new" = (
@@ -27334,6 +27445,9 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ai_monitored/storage/eva)
+"nkH" = (
+/turf/open/space/basic,
+/area/shipbreak)
 "nkM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -27509,7 +27623,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27548,6 +27661,12 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"nqt" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "nqE" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
@@ -27633,9 +27752,7 @@
 	},
 /obj/effect/turf_decal/trimline/white/filled/line/lower,
 /obj/machinery/light,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "nsK" = (
@@ -28204,6 +28321,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"nEY" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "nFB" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 8
@@ -28800,6 +28922,15 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
+"nVo" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "nVr" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/stripes/corner{
@@ -29285,12 +29416,8 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ojV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "oko" = (
@@ -29604,6 +29731,8 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "otk" = (
@@ -30589,7 +30718,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -30981,6 +31109,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"pfT" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/bag/trash,
+/obj/item/melee/sledgehammer,
+/obj/item/broom,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
+	},
+/area/hydroponics/garden)
 "pfU" = (
 /obj/machinery/computer/communications{
 	dir = 8
@@ -31799,7 +31940,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -32167,7 +32307,6 @@
 "pHK" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
-	req_access_txt = "0";
 	req_one_access_txt = "1; 63"
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -32461,7 +32600,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -33124,6 +33262,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"qcY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "qdi" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -34637,9 +34782,7 @@
 /area/medical/genetics/cloning)
 "qTj" = (
 /obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -34650,6 +34793,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"qTG" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "qUn" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -36008,7 +36158,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37039,6 +37188,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"rYm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
+"rYr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "rYG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -37057,7 +37219,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37371,7 +37532,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
@@ -38349,6 +38509,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"sIl" = (
+/turf/open/floor/plasteel/dark/corner,
+/area/hydroponics/garden)
 "sJr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -38387,7 +38550,6 @@
 "sKm" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/structure/sign/departments/minsky/supply/cargo{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
@@ -39023,6 +39185,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite/teleporter)
+"sYo" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/hydroponics/garden)
 "sYN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -39361,7 +39530,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -39506,8 +39674,7 @@
 /area/teleporter)
 "tjM" = (
 /obj/structure/sign/departments/minsky/security/security{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
@@ -39585,7 +39752,6 @@
 	dir = 1
 	},
 /obj/structure/sign/departments/minsky/research/genetics{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
@@ -39634,6 +39800,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"tnq" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "toK" = (
 /obj/machinery/door/airlock{
 	name = "Service Hall";
@@ -41037,7 +41209,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41348,8 +41519,7 @@
 /area/security/checkpoint/customs)
 "uiR" = (
 /obj/structure/sign/departments/minsky/medical/medical2{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
@@ -41546,6 +41716,16 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite/teleporter)
+"umo" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/hydroponics/garden)
 "umy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -41769,7 +41949,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -41907,8 +42086,7 @@
 /area/science/xenobiology)
 "uAj" = (
 /obj/structure/sign/departments/minsky/medical/medical2{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/light{
 	dir = 8
@@ -41949,12 +42127,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "uBR" = (
-/obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 9
 	},
 /obj/machinery/light{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
@@ -42298,7 +42475,6 @@
 	pixel_y = 3
 	},
 /obj/machinery/vending/wallgene{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/white,
@@ -42626,6 +42802,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
+"uQW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "uRb" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -42886,6 +43066,14 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"uXO" = (
+/obj/structure/railing/corner,
+/obj/machinery/conveyor_switch/oneway,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/dark/side{
+	dir = 9
+	},
+/area/hydroponics/garden)
 "uYw" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
@@ -43161,7 +43349,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -43724,6 +43911,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
+"voZ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/stairs/old{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "vpc" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
@@ -44051,7 +44247,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45337,7 +45532,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45353,8 +45547,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Theatre Stage";
-	dir = 2
+	c_tag = "Theatre Stage"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
@@ -46007,11 +46200,6 @@
 /area/engine/atmos/distro)
 "wwI" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/window/eastright{
-	dir = 2;
-	name = "Brig Desk";
-	req_access_txt = "2"
-	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "briggate";
 	name = "security shutters"
@@ -46023,7 +46211,11 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/item/storage/pencil_holder/crew,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Brig Desk";
+	req_access_txt = "1"
+	},
 /turf/open/floor/plating,
 /area/security/brig)
 "wxf" = (
@@ -47071,7 +47263,6 @@
 /obj/machinery/door/airlock/command/glass{
 	id_tag = "secondary_aicore_interior";
 	name = "Physical Core Access";
-	req_access_txt = "0";
 	req_one_access_txt = "30, 70"
 	},
 /turf/open/floor/plating,
@@ -47814,6 +48005,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"xqv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "xqy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -48126,6 +48323,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"xyb" = (
+/obj/structure/rack,
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/bag/trash,
+/obj/item/melee/sledgehammer,
+/obj/item/broom,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/dark/side,
+/area/hydroponics/garden)
 "xyy" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff";
@@ -48325,7 +48536,6 @@
 	dir = 1
 	},
 /obj/structure/sign/departments/minsky/medical/medical2{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
@@ -48347,7 +48557,6 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -48635,7 +48844,6 @@
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -75371,12 +75579,12 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+eRC
+eRC
+gOA
+gOA
+eRC
+eRC
 eRC
 lsS
 eRC
@@ -75619,20 +75827,20 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+tkl
+tkl
+tkl
+tkl
+tkl
+tkl
+tkl
+tkl
+tkl
+kNE
+sYo
+sIl
+cWU
+tnq
 eRC
 eRC
 pXP
@@ -75876,21 +76084,21 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-eRC
+tkl
+tkl
+tkl
+tkl
+tkl
+fqp
+tkl
+tkl
+tkl
+kNE
+sYo
+hVK
+nqt
+nEY
+voZ
 uBR
 gHe
 uNv
@@ -76133,21 +76341,21 @@ vRP
 vRP
 vRP
 vRP
+tkl
 vRP
+tkl
+aCD
+aCD
+aCD
+aCD
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-gOA
+aCD
+eRC
+umo
+lDm
+rYr
+qcY
+kvd
 otc
 ojV
 uCW
@@ -76390,21 +76598,21 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+tkl
+fqp
+tkl
+rtc
+aCD
+eRC
+eRC
 gOA
+eRC
+eRC
+xyb
+xqv
+uXO
+fwZ
+eRC
 oiO
 dGO
 aAh
@@ -76647,20 +76855,20 @@ vRP
 vRP
 vRP
 vRP
+tkl
 vRP
+tkl
+aCD
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+gOA
+giC
+cUc
+lZD
+jVg
+pfT
+xqv
+qTG
+iIF
 gOA
 wHR
 sJF
@@ -76904,20 +77112,20 @@ vRP
 vRP
 vRP
 vRP
+tkl
 vRP
+tkl
+aCD
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+gOA
+hVK
+blM
+uQW
+dFH
+dFH
+rYm
+qTG
+kiR
 gOA
 hmB
 pDd
@@ -77161,20 +77369,20 @@ vRP
 vRP
 vRP
 vRP
+tkl
 vRP
+tkl
+aCD
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+gOA
+lwH
+hni
+jbF
+nVo
+jbF
+jbF
+mkp
+eKM
 eRC
 ehU
 hBV
@@ -77418,19 +77626,19 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+tkl
+fqp
+tkl
+aCD
+aCD
+eRC
+gOA
+gOA
+gOA
+eRC
+gOA
+gOA
+eRC
 eRC
 eRC
 gVy
@@ -77675,16 +77883,16 @@ vRP
 vRP
 vRP
 vRP
+tkl
+vRP
+tkl
+aCD
+vRP
+aCD
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+aCD
 vRP
 vRP
 vRP
@@ -77932,16 +78140,16 @@ vRP
 vRP
 vRP
 vRP
+tkl
+vRP
+tkl
+aCD
+vRP
+aCD
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+aCD
 vRP
 vRP
 vRP
@@ -78189,17 +78397,17 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+tkl
+tkl
+tkl
+aCD
+aCD
+aCD
+aCD
+aCD
+aCD
+aCD
+aCD
 vRP
 vRP
 gOA
@@ -78441,24 +78649,24 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+fqp
+tkl
+tkl
+tkl
+tkl
+tkl
+fqp
+tkl
+tkl
+tkl
+tkl
+tkl
+tkl
+fqp
+aCD
+aCD
+aCD
+aCD
 eRC
 eRC
 kIQ
@@ -78698,22 +78906,22 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+tkl
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+tkl
+aCD
+aCD
 vRP
 vRP
 vRP
@@ -78955,26 +79163,26 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+tkl
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+tkl
+aCD
+aCD
+aCD
+aCD
+aCD
+aCD
 aCD
 aCD
 eRC
@@ -79212,26 +79420,26 @@ vRP
 vRP
 vRP
 vRP
+tkl
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+tkl
+aCD
+vRP
+aCD
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-eLb
+llR
 eLb
 eLb
 eRC
@@ -79469,23 +79677,23 @@ vRP
 vRP
 vRP
 vRP
+tkl
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+tkl
+aCD
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+aCD
 vRP
 vRP
 eLb
@@ -79726,23 +79934,23 @@ vRP
 vRP
 vRP
 vRP
+tkl
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+tkl
+aCD
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+aCD
 vRP
 vRP
 eLb
@@ -79983,23 +80191,23 @@ vRP
 vRP
 vRP
 vRP
+tkl
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+tkl
+aCD
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+aCD
 vRP
 vRP
 eLb
@@ -80240,25 +80448,25 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+tkl
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+tkl
+aCD
+aCD
+aCD
+aCD
+aCD
 eLb
 vRP
 vRP
@@ -80497,20 +80705,20 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+tkl
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+nkH
+tkl
 vRP
 vRP
 vRP
@@ -80754,20 +80962,20 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
-vRP
+fqp
+tkl
+tkl
+tkl
+tkl
+tkl
+fqp
+tkl
+tkl
+tkl
+tkl
+tkl
+tkl
+fqp
 vRP
 vRP
 vRP

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -730,14 +730,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/paramedic)
-"art" = (
-/obj/machinery/recycler,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "Shipbreaking"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "asc" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1
@@ -2367,6 +2359,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"beX" = (
+/obj/structure/railing/corner,
+/obj/machinery/conveyor_switch/oneway{
+	id = "Shipbreaking"
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/dark/side{
+	dir = 9
+	},
+/area/hydroponics/garden)
 "bfb" = (
 /obj/structure/table/optable{
 	dir = 8
@@ -3747,9 +3749,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"bQJ" = (
-/turf/open/floor/plasteel/dark/side,
-/area/hydroponics/garden)
 "bQM" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -4124,6 +4123,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bXQ" = (
+/turf/open/floor/plasteel/dark/side,
+/area/hydroponics/garden)
 "bYF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -4295,6 +4297,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"ceF" = (
+/obj/machinery/recycler,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "Shipbreaking"
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "ceM" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -4959,11 +4969,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"cvE" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/marker_beacon,
-/turf/open/space/basic,
-/area/space/nearstation)
 "cvF" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
@@ -5619,12 +5624,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/escapepodbay)
-"cIL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "cIO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -5655,6 +5654,13 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"cJb" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "cJc" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
@@ -6038,6 +6044,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/engine/atmos/distro)
+"cSI" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "cTk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer2{
 	dir = 8
@@ -7545,10 +7561,6 @@
 /obj/machinery/computer/security/wooden_tv,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
-"dER" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/plasteel/dark/corner,
-/area/hydroponics/garden)
 "dEW" = (
 /obj/structure/fireaxecabinet{
 	pixel_y = 32
@@ -7792,9 +7804,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
-"dHG" = (
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "dHX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -7832,14 +7841,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"dJW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 6
-	},
-/area/hydroponics/garden)
 "dKt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -8382,13 +8383,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"dZp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "dZs" = (
 /obj/machinery/door/poddoor{
 	id = "mixvent";
@@ -8432,6 +8426,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ebt" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "ebz" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -8617,13 +8617,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
-"eel" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "eeq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -8827,6 +8820,13 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"eiS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "ejl" = (
 /turf/open/floor/plasteel,
 /area/engine/foyer)
@@ -9202,6 +9202,14 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
+"eqk" = (
+/obj/machinery/computer/shipbreaker{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "eqw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -9952,15 +9960,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"eFV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side,
-/area/hydroponics/garden)
 "eGu" = (
 /obj/machinery/door/airlock{
 	name = "Private Restroom";
@@ -9974,6 +9973,13 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/heads/captain)
+"eHa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "eHi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -10103,6 +10109,15 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"eJM" = (
+/obj/machinery/advanced_airlock_controller{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "eJX" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
@@ -10601,6 +10616,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"eTa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "eTE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11815,6 +11841,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"fAq" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "fAF" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
@@ -12253,6 +12283,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"fHf" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "fHg" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
@@ -13098,6 +13137,19 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"gdT" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/bag/trash,
+/obj/item/melee/sledgehammer,
+/obj/item/broom,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
+	},
+/area/hydroponics/garden)
 "gdU" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -14807,13 +14859,6 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/secondarydatacore)
-"gYA" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/hydroponics/garden)
 "gZc" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
@@ -17020,15 +17065,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"hXX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/engine,
-/area/hydroponics/garden)
 "hYs" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
@@ -17047,6 +17083,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"hZW" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "iaz" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -19203,6 +19244,12 @@
 "jdr" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/fore)
+"jds" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "jdR" = (
 /obj/structure/rack,
 /obj/item/hand_labeler,
@@ -19271,14 +19318,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"jgB" = (
-/obj/machinery/computer/shipbreaker{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/hydroponics/garden)
 "jgO" = (
 /mob/living/simple_animal/butterfly,
 /turf/open/indestructible/grass/sand,
@@ -19381,6 +19420,10 @@
 "jjX" = (
 /turf/closed/wall/r_wall,
 /area/engine/atmos/distro)
+"jkU" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plasteel/dark/corner,
+/area/hydroponics/garden)
 "jla" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
@@ -19605,6 +19648,23 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/lawoffice)
+"jpu" = (
+/obj/structure/rack,
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/bag/trash,
+/obj/item/melee/sledgehammer,
+/obj/item/broom,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/hydroponics/garden)
 "jpZ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -20316,23 +20376,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
-"jFP" = (
-/obj/structure/rack,
-/obj/machinery/camera{
-	c_tag = "Brig Equipment Room";
-	dir = 4
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/bag/sheetsnatcher,
-/obj/item/storage/bag/trash,
-/obj/item/melee/sledgehammer,
-/obj/item/broom,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "jFZ" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -20677,10 +20720,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jPI" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "jQB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20858,16 +20897,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"jUh" = (
-/obj/structure/railing/corner,
-/obj/machinery/conveyor_switch/oneway{
-	id = "Shipbreaking"
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/dark/side{
-	dir = 9
-	},
-/area/hydroponics/garden)
 "jUy" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -21248,12 +21277,6 @@
 "keq" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"ket" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/hydroponics/garden)
 "keK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
@@ -22117,6 +22140,10 @@
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"kDD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "kEd" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -22452,12 +22479,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"kLk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "kLw" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -24327,15 +24348,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/gravity_generator)
-"lFl" = (
-/obj/machinery/advanced_airlock_controller{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/hydroponics/garden)
 "lFt" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
@@ -24376,6 +24388,13 @@
 	},
 /turf/open/floor/engine/n2,
 /area/engine/atmos/distro)
+"lGi" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "lGx" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/inverse{
 	dir = 4
@@ -24413,18 +24432,6 @@
 "lHe" = (
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"lHE" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/door/window/eastright{
-	dir = 2
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "lHR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -24445,6 +24452,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"lIj" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "lIB" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
@@ -24949,11 +24962,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"lVi" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "lVD" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -27182,17 +27190,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
-"ndU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/stairs/old{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "nel" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -27274,9 +27271,6 @@
 "ngb" = (
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"ngz" = (
-/turf/open/space/basic,
-/area/shipbreak)
 "ngI" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
 	dir = 1
@@ -28189,13 +28183,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"nBG" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "nBN" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
@@ -28681,13 +28668,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
-"nMH" = (
-/obj/structure/closet/crate/miningcar{
-	name = "Material cart"
-	},
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "nMP" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
 	dir = 4
@@ -28826,6 +28806,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"nQU" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/hydroponics/garden)
 "nQW" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
@@ -29166,6 +29156,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"obK" = (
+/obj/structure/closet/crate/miningcar{
+	name = "Material cart"
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "obP" = (
 /obj/structure/chair{
 	dir = 8
@@ -29468,16 +29465,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"onh" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "onu" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -29739,6 +29726,13 @@
 /obj/machinery/computer/med_data,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
+"osN" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "otc" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
@@ -29758,15 +29752,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"otG" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/hydroponics/garden)
 "otH" = (
 /obj/structure/toilet{
 	cistern = 1;
@@ -30778,6 +30763,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"oWA" = (
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	layer = 3
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "oWT" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -31094,10 +31096,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"peu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "peJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/item/kirbyplants/random,
@@ -31194,23 +31192,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"pgL" = (
-/obj/structure/rack,
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/bag/sheetsnatcher,
-/obj/item/storage/bag/trash,
-/obj/item/melee/sledgehammer,
-/obj/item/broom,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/mask/gas,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/corner,
-/area/hydroponics/garden)
 "pgQ" = (
 /obj/structure/table/wood,
 /obj/item/pinpointer/nuke,
@@ -32093,6 +32074,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"pBg" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "pBk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -32226,11 +32213,6 @@
 /obj/effect/turf_decal/siding/wideplating/corner,
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
-/area/hydroponics/garden)
-"pEc" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
 /area/hydroponics/garden)
 "pEt" = (
 /obj/effect/turf_decal/delivery,
@@ -32840,6 +32822,11 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"pTK" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon,
+/turf/open/space/basic,
+/area/space/nearstation)
 "pTW" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -33538,15 +33525,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"qiy" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/stairs/old{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "qiG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -34289,13 +34267,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos/distro)
-"qCM" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side,
-/area/hydroponics/garden)
 "qCO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -34465,6 +34436,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
+"qJn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/stairs/old{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "qJo" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -34549,6 +34531,17 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"qLU" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "qMc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -34606,6 +34599,12 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/aft)
+"qPw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "qPM" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -35490,6 +35489,9 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"riD" = (
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "rjf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -36090,12 +36092,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
-"rww" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "rxd" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -36553,6 +36549,18 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
+"rHr" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark/corner,
+/area/hydroponics/garden)
 "rHt" = (
 /obj/machinery/light{
 	dir = 8
@@ -36887,12 +36895,6 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
-"rQP" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel/dark/corner{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "rQZ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -37079,15 +37081,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
-"rVI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark/corner,
-/area/hydroponics/garden)
 "rVU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -37618,17 +37611,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"sjT" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Airlock"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/hydroponics/garden)
 "skG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -37662,6 +37644,11 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"smc" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "smm" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Customs"
@@ -38070,23 +38057,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"sua" = (
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	layer = 3
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "sup" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -40450,19 +40420,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"tGs" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/bag/sheetsnatcher,
-/obj/item/storage/bag/trash,
-/obj/item/melee/sledgehammer,
-/obj/item/broom,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/dark/side{
-	dir = 6
-	},
-/area/hydroponics/garden)
 "tGv" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
@@ -40533,14 +40490,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"tIa" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "Shipbreaking"
-	},
-/obj/structure/rack,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "tIL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -40830,16 +40779,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"tPy" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/hydroponics/garden)
 "tPI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -41278,6 +41217,11 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/secondarydatacore)
+"tZa" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "tZf" = (
 /obj/machinery/computer/cargo/request,
 /obj/structure/cable{
@@ -42428,6 +42372,10 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"uGV" = (
+/obj/structure/lattice,
+/turf/closed/wall,
+/area/maintenance/starboard/fore)
 "uGX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -43761,6 +43709,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
+"vkp" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/door/window/eastright{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "vkA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -44185,6 +44145,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"vuu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/hydroponics/garden)
 "vuO" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -45306,12 +45277,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/warden)
-"vYR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "vYY" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input,
 /turf/open/floor/engine/vacuum,
@@ -46198,10 +46163,6 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"wvm" = (
-/obj/structure/lattice,
-/turf/closed/wall,
 /area/maintenance/starboard/fore)
 "wvH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -47182,6 +47143,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"wUf" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "Shipbreaking"
+	},
+/obj/structure/rack,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "wUk" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
@@ -47351,6 +47320,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
+"wZK" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/stairs/old{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "wZV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
@@ -47518,11 +47496,9 @@
 "xbK" = (
 /turf/closed/wall/r_wall,
 /area/janitor)
-"xch" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/hydroponics/garden)
+"xbR" = (
+/turf/open/space/basic,
+/area/shipbreak)
 "xcv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -48050,6 +48026,23 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"xoU" = (
+/obj/structure/rack,
+/obj/machinery/camera{
+	c_tag = "Brig Equipment Room";
+	dir = 4
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/bag/trash,
+/obj/item/melee/sledgehammer,
+/obj/item/broom,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "xpi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -48275,18 +48268,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"xuU" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/engine,
-/area/hydroponics/garden)
 "xuW" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/machinery/light_switch{
@@ -49070,12 +49051,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"xOg" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel/dark/corner{
-	dir = 8
-	},
-/area/hydroponics/garden)
 "xOv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -49422,6 +49397,15 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"xVj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "xVn" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
@@ -50020,6 +50004,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"yiQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
+"yjf" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "yjk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -75902,14 +75898,14 @@ tkl
 tkl
 tkl
 tkl
-ket
-lFl
-gYA
-sjT
-xuU
-rVI
-lVi
-rQP
+ebt
+eJM
+lGi
+qLU
+rHr
+eTa
+hZW
+yjf
 eRC
 eRC
 pXP
@@ -76157,17 +76153,17 @@ tkl
 tkl
 tkl
 tkl
-cvE
+pTK
 tkl
 eRC
 eRC
 eRC
 eRC
-tPy
-eFV
-vYR
-xch
-qiy
+nQU
+xVj
+jds
+tZa
+wZK
 uBR
 gHe
 uNv
@@ -76416,15 +76412,15 @@ tkl
 tkl
 tkl
 tkl
-ket
-lFl
-gYA
-sjT
-hXX
-qCM
-dZp
-eel
-ndU
+ebt
+eJM
+lGi
+qLU
+vuu
+osN
+eiS
+eHa
+qJn
 otc
 ojV
 uCW
@@ -76668,7 +76664,7 @@ vRP
 vRP
 vRP
 tkl
-cvE
+pTK
 tkl
 rtc
 aCD
@@ -76677,10 +76673,10 @@ eRC
 gOA
 eRC
 eRC
-pgL
-dJW
-jUh
-sua
+jpu
+qPw
+beX
+oWA
 eRC
 oiO
 dGO
@@ -76930,14 +76926,14 @@ tkl
 aCD
 vRP
 gOA
-dER
-rww
-onh
-jFP
-tGs
-kLk
-nBG
-tIa
+jkU
+pBg
+cSI
+xoU
+gdT
+qPw
+cJb
+wUf
 gOA
 wHR
 sJF
@@ -77187,14 +77183,14 @@ tkl
 aCD
 vRP
 gOA
-bQJ
-dHG
-jPI
-peu
-peu
-cIL
-nBG
-art
+bXQ
+riD
+fAq
+kDD
+kDD
+yiQ
+cJb
+ceF
 gOA
 hmB
 pDd
@@ -77444,14 +77440,14 @@ tkl
 aCD
 vRP
 gOA
-xOg
-jgB
-pEc
-otG
-pEc
-pEc
-lHE
-nMH
+lIj
+eqk
+smc
+fHf
+smc
+smc
+vkp
+obK
 eRC
 ehU
 hBV
@@ -77696,7 +77692,7 @@ vRP
 vRP
 vRP
 tkl
-cvE
+pTK
 tkl
 aCD
 aCD
@@ -78718,20 +78714,20 @@ vRP
 vRP
 vRP
 vRP
-cvE
+pTK
 tkl
 tkl
 tkl
 tkl
 tkl
-cvE
+pTK
 tkl
 tkl
 tkl
 tkl
 tkl
 tkl
-cvE
+pTK
 aCD
 aCD
 aCD
@@ -78976,18 +78972,18 @@ vRP
 vRP
 vRP
 tkl
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
 tkl
 aCD
 aCD
@@ -79233,18 +79229,18 @@ vRP
 vRP
 vRP
 tkl
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
 tkl
 aCD
 aCD
@@ -79490,25 +79486,25 @@ vRP
 vRP
 vRP
 tkl
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
 tkl
 aCD
 vRP
 aCD
 vRP
 vRP
-wvm
+uGV
 eLb
 eLb
 eRC
@@ -79747,18 +79743,18 @@ vRP
 vRP
 vRP
 tkl
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
 tkl
 aCD
 vRP
@@ -80004,18 +80000,18 @@ vRP
 vRP
 vRP
 tkl
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
 tkl
 aCD
 vRP
@@ -80261,18 +80257,18 @@ vRP
 vRP
 vRP
 tkl
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
 tkl
 aCD
 vRP
@@ -80518,18 +80514,18 @@ vRP
 vRP
 vRP
 tkl
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
 tkl
 aCD
 aCD
@@ -80775,18 +80771,18 @@ vRP
 vRP
 vRP
 tkl
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
-ngz
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
+xbR
 tkl
 vRP
 vRP
@@ -81031,20 +81027,20 @@ vRP
 vRP
 vRP
 vRP
-cvE
+pTK
 tkl
 tkl
 tkl
 tkl
 tkl
-cvE
+pTK
 tkl
 tkl
 tkl
 tkl
 tkl
 tkl
-cvE
+pTK
 vRP
 vRP
 vRP

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -526,17 +526,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"amW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/stairs/old{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "anb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -590,9 +579,6 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
-"ank" = (
-/turf/open/space/basic,
-/area/shipbreak)
 "anu" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -1234,6 +1220,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
+"aEL" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "aEO" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -1307,6 +1298,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aIy" = (
+/obj/structure/closet/crate/miningcar{
+	name = "Material cart"
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "aIM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -2472,6 +2470,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"bif" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/hydroponics/garden)
 "bii" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -2695,6 +2700,23 @@
 	dir = 5
 	},
 /area/crew_quarters/bar)
+"bpl" = (
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	layer = 3
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "bpn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2895,6 +2917,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
+"btO" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "buw" = (
 /obj/effect/turf_decal/siding/wideplating/corner{
 	dir = 4
@@ -4485,15 +4512,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
-"cjk" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/stairs/old{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "cjp" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
@@ -5182,20 +5200,6 @@
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"czA" = (
-/obj/structure/rack,
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/bag/sheetsnatcher,
-/obj/item/storage/bag/trash,
-/obj/item/melee/sledgehammer,
-/obj/item/broom,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/dark/side,
-/area/hydroponics/garden)
 "czC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -7124,11 +7128,6 @@
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"drz" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/structure/fans/tiny,
-/turf/open/floor/engine,
-/area/hydroponics/garden)
 "drM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -7664,6 +7663,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
+"dFU" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/hydroponics/garden)
 "dFV" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
@@ -7906,6 +7915,15 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"dNb" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/stairs/old{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "dNv" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
@@ -8430,12 +8448,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ebf" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel/dark/corner{
-	dir = 8
-	},
-/area/hydroponics/garden)
 "ebz" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -8784,6 +8796,11 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"eid" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "eih" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	piping_layer = 2
@@ -9039,11 +9056,6 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
-"enC" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/hydroponics/garden)
 "eoa" = (
 /obj/machinery/power/apc/highcap/fifteen_k{
 	areastring = "/area/engine/engineering";
@@ -12118,13 +12130,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"fER" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "fES" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Hydroponics";
@@ -12680,6 +12685,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"fTi" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/bag/trash,
+/obj/item/melee/sledgehammer,
+/obj/item/broom,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
+	},
+/area/hydroponics/garden)
 "fTl" = (
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
@@ -13885,6 +13903,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"gws" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "gwV" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -14446,9 +14470,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"gMc" = (
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "gMh" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -14524,9 +14545,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge/meeting_room)
-"gOz" = (
-/turf/open/floor/plasteel/dark/side,
-/area/hydroponics/garden)
 "gOA" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -14590,16 +14608,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"gRN" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/corner,
-/area/hydroponics/garden)
 "gRR" = (
 /obj/structure/railing{
 	dir = 8
@@ -14740,17 +14748,13 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
-"gVw" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light{
-	dir = 4
+"gVx" = (
+/obj/machinery/recycler,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "Shipbreaking"
 	},
-/obj/machinery/door/window/eastright{
-	dir = 2
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
+/turf/open/floor/plasteel/dark,
 /area/hydroponics/garden)
 "gVy" = (
 /obj/machinery/light{
@@ -15386,11 +15390,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hlU" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "hmc" = (
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor";
@@ -16560,13 +16559,6 @@
 "hNc" = (
 /turf/open/floor/plasteel,
 /area/security/brig)
-"hNd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "hNf" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -16580,6 +16572,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
+"hNO" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/hydroponics/garden)
 "hNP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -17533,6 +17536,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
+"imf" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/space/basic,
+/area/hydroponics/garden)
 "imt" = (
 /obj/machinery/light{
 	dir = 4
@@ -17786,6 +17795,13 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"iti" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "itk" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -18066,6 +18082,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"ixV" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "iyb" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -18924,6 +18946,15 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
+"iTD" = (
+/obj/machinery/advanced_airlock_controller{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "iTX" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -19039,6 +19070,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"iXE" = (
+/turf/open/space/basic,
+/area/shipbreak)
 "iXH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/firealarm{
@@ -19282,6 +19316,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"jfl" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "jfL" = (
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
@@ -20306,6 +20346,17 @@
 /obj/item/storage/lockbox/medal,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
+"jEk" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/hydroponics/garden)
 "jEp" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/meter,
@@ -20394,12 +20445,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"jHY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "jIH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -20739,6 +20784,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"jRF" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/engine,
+/area/hydroponics/garden)
 "jRL" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -21096,10 +21153,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
-"jZG" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/plasteel/dark/corner,
-/area/hydroponics/garden)
 "kar" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
@@ -21545,6 +21598,15 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"kmz" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "kmD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22630,15 +22692,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"kRj" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/hydroponics/garden)
 "kRl" = (
 /obj/structure/railing{
 	dir = 8
@@ -22929,12 +22982,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
-"kZU" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "kZW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23405,6 +23452,11 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"liC" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon,
+/turf/open/space/basic,
+/area/space/nearstation)
 "liO" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -23644,12 +23696,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/lawoffice)
-"lph" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel/dark/corner{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "lpt" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
@@ -24630,16 +24676,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
-"lOS" = (
-/obj/structure/railing/corner,
-/obj/machinery/conveyor_switch/oneway{
-	id = "Shipbreaking"
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/dark/side{
-	dir = 9
-	},
-/area/hydroponics/garden)
 "lOU" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
@@ -25271,14 +25307,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"mfn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 6
-	},
-/area/hydroponics/garden)
 "mfv" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/royalblue,
@@ -26799,6 +26827,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"mRF" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "mRK" = (
 /obj/structure/closet/secure_closet/engineering_personal{
 	anchored = 1
@@ -27715,14 +27750,6 @@
 "nrB" = (
 /turf/open/floor/engine/o2,
 /area/engine/atmos/distro)
-"nsj" = (
-/obj/machinery/computer/shipbreaker{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/hydroponics/garden)
 "nsu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -27780,6 +27807,13 @@
 	dir = 5
 	},
 /area/crew_quarters/bar)
+"nta" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "nti" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/layer_manifold,
@@ -27949,12 +27983,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"nxS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "nxY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28742,6 +28770,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"nOT" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "nOU" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/item/wheelchair,
@@ -28908,6 +28946,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"nUT" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "Shipbreaking"
+	},
+/obj/structure/rack,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "nUV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -29403,23 +29449,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /turf/open/floor/plasteel,
-/area/hydroponics/garden)
-"ojZ" = (
-/obj/structure/rack,
-/obj/machinery/camera{
-	c_tag = "Brig Equipment Room";
-	dir = 4
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/bag/sheetsnatcher,
-/obj/item/storage/bag/trash,
-/obj/item/melee/sledgehammer,
-/obj/item/broom,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
 /area/hydroponics/garden)
 "oko" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
@@ -30723,6 +30752,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"oVI" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "oVU" = (
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor2";
@@ -33370,10 +33405,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
-"qfJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "qfO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -33594,6 +33625,16 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"qkc" = (
+/obj/structure/railing/corner,
+/obj/machinery/conveyor_switch/oneway{
+	id = "Shipbreaking"
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/dark/side{
+	dir = 9
+	},
+/area/hydroponics/garden)
 "qkg" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable,
@@ -33892,6 +33933,15 @@
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"qra" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/hydroponics/garden)
 "qru" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -33919,13 +33969,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"qtH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "qub" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -34174,6 +34217,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"qAd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/hydroponics/garden)
 "qAe" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -34319,14 +34371,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
-"qGC" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "Shipbreaking"
-	},
-/obj/structure/rack,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "qGM" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/stripes/line{
@@ -34466,16 +34510,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
-"qKH" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "qKI" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
@@ -34620,23 +34654,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/stairs/goon/stairs_middle,
-/area/hydroponics/garden)
-"qQk" = (
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	layer = 3
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
 /area/hydroponics/garden)
 "qQC" = (
 /obj/machinery/navbeacon{
@@ -34820,6 +34837,14 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"qTT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
+	},
+/area/hydroponics/garden)
 "qUn" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -35447,6 +35472,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"rii" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "riA" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Chief Medical Officer";
@@ -36913,11 +36945,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"rSd" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "rSg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -37037,14 +37064,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"rVE" = (
-/obj/machinery/recycler,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "Shipbreaking"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "rVG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -37221,13 +37240,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"rYC" = (
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/hydroponics/garden)
 "rYG" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -38459,6 +38471,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"sFS" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "sGd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -39551,6 +39569,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"tgm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/stairs/old{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "tgC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -41332,6 +41361,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"ucD" = (
+/obj/structure/rack,
+/obj/machinery/camera{
+	c_tag = "Brig Equipment Room";
+	dir = 4
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/bag/trash,
+/obj/item/melee/sledgehammer,
+/obj/item/broom,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "ucL" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
@@ -41471,6 +41517,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"ugr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/engine,
+/area/hydroponics/garden)
 "ugy" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -41828,6 +41883,10 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"uqN" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plasteel/dark/corner,
+/area/hydroponics/garden)
 "uqY" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment,
@@ -41910,6 +41969,12 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
+"uvb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "uvf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -42980,6 +43045,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"uUX" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "uUZ" = (
 /obj/machinery/conveyor{
 	id = "garbage"
@@ -43047,13 +43116,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"uWY" = (
-/obj/structure/closet/crate/miningcar{
-	name = "Material cart"
-	},
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "uXE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -44206,10 +44268,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"vyn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "vyw" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /obj/machinery/door/poddoor/shutters{
@@ -45234,6 +45292,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"vXO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "vYA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -45919,6 +45981,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"wpb" = (
+/obj/structure/lattice,
+/turf/closed/wall,
+/area/maintenance/starboard/fore)
 "wpd" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -46019,10 +46085,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"wrz" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/maintenance/starboard/fore)
 "wrA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -46479,6 +46541,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"wEZ" = (
+/obj/structure/rack,
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/bag/trash,
+/obj/item/melee/sledgehammer,
+/obj/item/broom,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/hydroponics/garden)
 "wFk" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -46786,9 +46865,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"wNj" = (
-/turf/open/floor/plasteel/dark/corner,
-/area/hydroponics/garden)
 "wNm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -47036,6 +47112,12 @@
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"wSG" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "wST" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -47123,6 +47205,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"wUq" = (
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "wUI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -47265,6 +47350,18 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/secondarydatacore)
+"wYN" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/door/window/eastright{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "wYP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
@@ -48038,6 +48135,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"xri" = (
+/turf/open/floor/plasteel/dark/side,
+/area/hydroponics/garden)
 "xrw" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
@@ -48972,11 +49072,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"xNW" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/marker_beacon,
-/turf/open/space/basic,
-/area/space/nearstation)
 "xOb" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 8
@@ -49006,19 +49101,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"xOK" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/bag/sheetsnatcher,
-/obj/item/storage/bag/trash,
-/obj/item/melee/sledgehammer,
-/obj/item/broom,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/dark/side{
-	dir = 6
-	},
-/area/hydroponics/garden)
 "xOY" = (
 /obj/machinery/light_switch{
 	pixel_x = 24
@@ -49278,6 +49360,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"xTJ" = (
+/obj/machinery/computer/shipbreaker{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "xTK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -49349,12 +49439,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"xVm" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "xVn" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
@@ -75578,9 +75662,9 @@ vRP
 vRP
 vRP
 vRP
-vRP
-vRP
-vRP
+eRC
+eRC
+eRC
 eRC
 eRC
 gOA
@@ -75835,14 +75919,14 @@ tkl
 tkl
 tkl
 tkl
-tkl
-tkl
-tkl
-drz
-rYC
-wNj
-hlU
-lph
+imf
+iTD
+nta
+hNO
+jRF
+qAd
+eid
+wSG
 eRC
 eRC
 pXP
@@ -76090,17 +76174,17 @@ tkl
 tkl
 tkl
 tkl
+liC
 tkl
-xNW
-tkl
-tkl
-tkl
-drz
-rYC
-gOz
-kZU
-rSd
-cjk
+eRC
+eRC
+eRC
+eRC
+dFU
+qra
+oVI
+aEL
+dNb
 uBR
 gHe
 uNv
@@ -76346,18 +76430,18 @@ vRP
 tkl
 vRP
 tkl
-aCD
-aCD
-aCD
-aCD
-vRP
-aCD
-eRC
-gRN
-mfn
-qtH
-hNd
-amW
+tkl
+tkl
+tkl
+jfl
+iTD
+nta
+jEk
+ugr
+bif
+iti
+rii
+tgm
 otc
 ojV
 uCW
@@ -76601,7 +76685,7 @@ vRP
 vRP
 vRP
 tkl
-xNW
+liC
 tkl
 rtc
 aCD
@@ -76610,10 +76694,10 @@ eRC
 gOA
 eRC
 eRC
-czA
-nxS
-lOS
-qQk
+wEZ
+qTT
+qkc
+bpl
 eRC
 oiO
 dGO
@@ -76863,14 +76947,14 @@ tkl
 aCD
 vRP
 gOA
-jZG
-xVm
-qKH
-ojZ
-xOK
-nxS
-fER
-qGC
+uqN
+ixV
+nOT
+ucD
+fTi
+uvb
+mRF
+nUT
 gOA
 wHR
 sJF
@@ -77120,14 +77204,14 @@ tkl
 aCD
 vRP
 gOA
-gOz
-gMc
-vyn
-qfJ
-qfJ
-jHY
-fER
-rVE
+xri
+wUq
+uUX
+vXO
+vXO
+gws
+mRF
+gVx
 gOA
 hmB
 pDd
@@ -77377,14 +77461,14 @@ tkl
 aCD
 vRP
 gOA
-ebf
-nsj
-enC
-kRj
-enC
-enC
-gVw
-uWY
+sFS
+xTJ
+btO
+kmz
+btO
+btO
+wYN
+aIy
 eRC
 ehU
 hBV
@@ -77629,7 +77713,7 @@ vRP
 vRP
 vRP
 tkl
-xNW
+liC
 tkl
 aCD
 aCD
@@ -78651,20 +78735,20 @@ vRP
 vRP
 vRP
 vRP
-xNW
+liC
 tkl
 tkl
 tkl
 tkl
 tkl
-xNW
+liC
 tkl
 tkl
 tkl
 tkl
 tkl
 tkl
-xNW
+liC
 aCD
 aCD
 aCD
@@ -78909,18 +78993,18 @@ vRP
 vRP
 vRP
 tkl
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
 tkl
 aCD
 aCD
@@ -79166,18 +79250,18 @@ vRP
 vRP
 vRP
 tkl
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
 tkl
 aCD
 aCD
@@ -79423,25 +79507,25 @@ vRP
 vRP
 vRP
 tkl
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
 tkl
 aCD
 vRP
 aCD
 vRP
 vRP
-wrz
+wpb
 eLb
 eLb
 eRC
@@ -79680,18 +79764,18 @@ vRP
 vRP
 vRP
 tkl
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
 tkl
 aCD
 vRP
@@ -79937,18 +80021,18 @@ vRP
 vRP
 vRP
 tkl
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
 tkl
 aCD
 vRP
@@ -80194,18 +80278,18 @@ vRP
 vRP
 vRP
 tkl
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
 tkl
 aCD
 vRP
@@ -80451,18 +80535,18 @@ vRP
 vRP
 vRP
 tkl
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
 tkl
 aCD
 aCD
@@ -80708,18 +80792,18 @@ vRP
 vRP
 vRP
 tkl
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
-ank
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
+iXE
 tkl
 vRP
 vRP
@@ -80964,20 +81048,20 @@ vRP
 vRP
 vRP
 vRP
-xNW
+liC
 tkl
 tkl
 tkl
 tkl
 tkl
-xNW
+liC
 tkl
 tkl
 tkl
 tkl
 tkl
 tkl
-xNW
+liC
 vRP
 vRP
 vRP

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -526,6 +526,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"amW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/stairs/old{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "anb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -579,6 +590,9 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo)
+"ank" = (
+/turf/open/space/basic,
+/area/shipbreak)
 "anu" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -2574,9 +2588,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"blM" = (
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "bmg" = (
 /obj/structure/chair/pew/left{
 	dir = 1
@@ -4474,6 +4485,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"cjk" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/stairs/old{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "cjp" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
@@ -5162,6 +5182,20 @@
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"czA" = (
+/obj/structure/rack,
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/bag/trash,
+/obj/item/melee/sledgehammer,
+/obj/item/broom,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/dark/side,
+/area/hydroponics/garden)
 "czC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -6069,12 +6103,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"cUc" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "cUp" = (
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -6225,11 +6253,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"cWU" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "cXc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -7101,6 +7124,11 @@
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"drz" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/structure/fans/tiny,
+/turf/open/floor/engine,
+/area/hydroponics/garden)
 "drM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -7501,9 +7529,6 @@
 /obj/machinery/light_switch{
 	pixel_y = -24
 	},
-/obj/machinery/light_switch{
-	pixel_y = -24
-	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "dDm" = (
@@ -7639,10 +7664,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
-"dFH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "dFV" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
@@ -8409,6 +8430,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ebf" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "ebz" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -9012,6 +9039,11 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner,
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
+"enC" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "eoa" = (
 /obj/machinery/power/apc/highcap/fifteen_k{
 	areastring = "/area/engine/engineering";
@@ -10105,13 +10137,6 @@
 "eKF" = (
 /turf/closed/wall/r_wall,
 /area/storage/tech)
-"eKM" = (
-/obj/structure/closet/crate/miningcar{
-	name = "Material cart"
-	},
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "eKQ" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -11393,11 +11418,6 @@
 /obj/item/multitool,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"fqp" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/marker_beacon,
-/turf/open/space/basic,
-/area/space/nearstation)
 "fqH" = (
 /turf/closed/wall,
 /area/medical/genetics/cloning)
@@ -11618,20 +11638,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"fwZ" = (
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	layer = 3
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "fxk" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -12112,6 +12118,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"fER" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "fES" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Hydroponics";
@@ -13313,10 +13326,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"giC" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/plasteel/dark/corner,
-/area/hydroponics/garden)
 "giF" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
@@ -14437,6 +14446,9 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"gMc" = (
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "gMh" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -14512,6 +14524,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge/meeting_room)
+"gOz" = (
+/turf/open/floor/plasteel/dark/side,
+/area/hydroponics/garden)
 "gOA" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -14575,6 +14590,16 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"gRN" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/hydroponics/garden)
 "gRR" = (
 /obj/structure/railing{
 	dir = 8
@@ -14715,6 +14740,18 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
+"gVw" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/door/window/eastright{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "gVy" = (
 /obj/machinery/light{
 	dir = 1
@@ -15349,6 +15386,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hlU" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "hmc" = (
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor";
@@ -15434,14 +15476,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science/xenobiology)
-"hni" = (
-/obj/machinery/computer/shipbreaker{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/hydroponics/garden)
 "hnn" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -16526,6 +16560,13 @@
 "hNc" = (
 /turf/open/floor/plasteel,
 /area/security/brig)
+"hNd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "hNf" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -16899,9 +16940,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"hVK" = (
-/turf/open/floor/plasteel/dark/side,
-/area/hydroponics/garden)
 "hVM" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/captain)
@@ -18355,14 +18393,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"iIF" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "Shipbreaking"
-	},
-/obj/structure/rack,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "iIW" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -19115,11 +19145,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"jbF" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/hydroponics/garden)
 "jbW" = (
 /obj/structure/bodycontainer/crematorium{
 	dir = 8;
@@ -20369,6 +20394,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"jHY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "jIH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -20886,23 +20917,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security)
-"jVg" = (
-/obj/structure/rack,
-/obj/machinery/camera{
-	c_tag = "Brig Equipment Room";
-	dir = 4
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/bag/sheetsnatcher,
-/obj/item/storage/bag/trash,
-/obj/item/melee/sledgehammer,
-/obj/item/broom,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "jVp" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp{
@@ -21082,6 +21096,10 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
+"jZG" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plasteel/dark/corner,
+/area/hydroponics/garden)
 "kar" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
@@ -21357,14 +21375,6 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/meeting_room)
-"kiR" = (
-/obj/machinery/recycler,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "Shipbreaking"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "kiS" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
@@ -21819,17 +21829,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"kvd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/stairs/old{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "kvW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -22516,11 +22515,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"kNE" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/structure/fans/tiny,
-/turf/open/floor/engine,
-/area/hydroponics/garden)
 "kNF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -22636,6 +22630,15 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"kRj" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "kRl" = (
 /obj/structure/railing{
 	dir = 8
@@ -22926,6 +22929,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
+"kZU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "kZW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23511,10 +23520,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"llR" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/maintenance/starboard/fore)
 "llZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -23639,6 +23644,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/lawoffice)
+"lph" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "lpt" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
@@ -23885,12 +23896,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"lwH" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel/dark/corner{
-	dir = 8
-	},
-/area/hydroponics/garden)
 "lwK" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/cleanable/dirt,
@@ -24225,14 +24230,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"lDm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 6
-	},
-/area/hydroponics/garden)
 "lDF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -24633,6 +24630,16 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
+"lOS" = (
+/obj/structure/railing/corner,
+/obj/machinery/conveyor_switch/oneway{
+	id = "Shipbreaking"
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/dark/side{
+	dir = 9
+	},
+/area/hydroponics/garden)
 "lOU" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
@@ -25084,16 +25091,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
-"lZD" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "lZL" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -25274,6 +25271,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"mfn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
+	},
+/area/hydroponics/garden)
 "mfv" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet/royalblue,
@@ -25498,18 +25503,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"mkp" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/door/window/eastright{
-	dir = 2
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "mky" = (
 /obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 1
@@ -27445,9 +27438,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ai_monitored/storage/eva)
-"nkH" = (
-/turf/open/space/basic,
-/area/shipbreak)
 "nkM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -27661,12 +27651,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"nqt" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "nqE" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
@@ -27731,6 +27715,14 @@
 "nrB" = (
 /turf/open/floor/engine/o2,
 /area/engine/atmos/distro)
+"nsj" = (
+/obj/machinery/computer/shipbreaker{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "nsu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -27957,6 +27949,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"nxS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "nxY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -28321,11 +28319,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"nEY" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "nFB" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 8
@@ -28922,15 +28915,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/storage/tech)
-"nVo" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/hydroponics/garden)
 "nVr" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/stripes/corner{
@@ -29419,6 +29403,23 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /turf/open/floor/plasteel,
+/area/hydroponics/garden)
+"ojZ" = (
+/obj/structure/rack,
+/obj/machinery/camera{
+	c_tag = "Brig Equipment Room";
+	dir = 4
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/bag/trash,
+/obj/item/melee/sledgehammer,
+/obj/item/broom,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
 /area/hydroponics/garden)
 "oko" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
@@ -31109,19 +31110,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"pfT" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/bag/sheetsnatcher,
-/obj/item/storage/bag/trash,
-/obj/item/melee/sledgehammer,
-/obj/item/broom,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/dark/side{
-	dir = 6
-	},
-/area/hydroponics/garden)
 "pfU" = (
 /obj/machinery/computer/communications{
 	dir = 8
@@ -33262,13 +33250,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"qcY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "qdi" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
@@ -33389,6 +33370,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
+"qfJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "qfO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -33934,6 +33919,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"qtH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "qub" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
@@ -34327,6 +34319,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
+"qGC" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "Shipbreaking"
+	},
+/obj/structure/rack,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "qGM" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/stripes/line{
@@ -34466,6 +34466,16 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hos)
+"qKH" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "qKI" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
@@ -34610,6 +34620,23 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/stairs/goon/stairs_middle,
+/area/hydroponics/garden)
+"qQk" = (
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	layer = 3
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
 /area/hydroponics/garden)
 "qQC" = (
 /obj/machinery/navbeacon{
@@ -34793,13 +34820,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
-"qTG" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "qUn" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -36893,6 +36913,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"rSd" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "rSg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -37012,6 +37037,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"rVE" = (
+/obj/machinery/recycler,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "Shipbreaking"
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "rVG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -37188,18 +37221,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"rYm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
+"rYC" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
-"rYr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/engine,
 /area/hydroponics/garden)
 "rYG" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -38509,9 +38536,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"sIl" = (
-/turf/open/floor/plasteel/dark/corner,
-/area/hydroponics/garden)
 "sJr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -39185,13 +39209,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite/teleporter)
-"sYo" = (
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/hydroponics/garden)
 "sYN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -39800,12 +39817,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"tnq" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel/dark/corner{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "toK" = (
 /obj/machinery/door/airlock{
 	name = "Service Hall";
@@ -41716,16 +41727,6 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite/teleporter)
-"umo" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/corner,
-/area/hydroponics/garden)
 "umy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -42802,10 +42803,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
-"uQW" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "uRb" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -43050,6 +43047,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"uWY" = (
+/obj/structure/closet/crate/miningcar{
+	name = "Material cart"
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "uXE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -43066,14 +43070,6 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"uXO" = (
-/obj/structure/railing/corner,
-/obj/machinery/conveyor_switch/oneway,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/dark/side{
-	dir = 9
-	},
-/area/hydroponics/garden)
 "uYw" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
@@ -43911,15 +43907,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
-"voZ" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/stairs/old{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "vpc" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
@@ -44219,6 +44206,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"vyn" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "vyw" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /obj/machinery/door/poddoor/shutters{
@@ -46028,6 +46019,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"wrz" = (
+/obj/structure/lattice,
+/turf/closed/wall,
+/area/maintenance/starboard/fore)
 "wrA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -46791,6 +46786,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
+"wNj" = (
+/turf/open/floor/plasteel/dark/corner,
+/area/hydroponics/garden)
 "wNm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -48005,12 +48003,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"xqv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "xqy" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
@@ -48323,20 +48315,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/foyer)
-"xyb" = (
-/obj/structure/rack,
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/bag/sheetsnatcher,
-/obj/item/storage/bag/trash,
-/obj/item/melee/sledgehammer,
-/obj/item/broom,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/dark/side,
-/area/hydroponics/garden)
 "xyy" = (
 /obj/effect/turf_decal/arrows/white{
 	color = "#99ccff";
@@ -48994,6 +48972,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"xNW" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon,
+/turf/open/space/basic,
+/area/space/nearstation)
 "xOb" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 8
@@ -49023,6 +49006,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"xOK" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/bag/trash,
+/obj/item/melee/sledgehammer,
+/obj/item/broom,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
+	},
+/area/hydroponics/garden)
 "xOY" = (
 /obj/machinery/light_switch{
 	pixel_x = 24
@@ -49353,6 +49349,12 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"xVm" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "xVn" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
@@ -75836,11 +75838,11 @@ tkl
 tkl
 tkl
 tkl
-kNE
-sYo
-sIl
-cWU
-tnq
+drz
+rYC
+wNj
+hlU
+lph
 eRC
 eRC
 pXP
@@ -76089,16 +76091,16 @@ tkl
 tkl
 tkl
 tkl
-fqp
+xNW
 tkl
 tkl
 tkl
-kNE
-sYo
-hVK
-nqt
-nEY
-voZ
+drz
+rYC
+gOz
+kZU
+rSd
+cjk
 uBR
 gHe
 uNv
@@ -76351,11 +76353,11 @@ aCD
 vRP
 aCD
 eRC
-umo
-lDm
-rYr
-qcY
-kvd
+gRN
+mfn
+qtH
+hNd
+amW
 otc
 ojV
 uCW
@@ -76599,7 +76601,7 @@ vRP
 vRP
 vRP
 tkl
-fqp
+xNW
 tkl
 rtc
 aCD
@@ -76608,10 +76610,10 @@ eRC
 gOA
 eRC
 eRC
-xyb
-xqv
-uXO
-fwZ
+czA
+nxS
+lOS
+qQk
 eRC
 oiO
 dGO
@@ -76861,14 +76863,14 @@ tkl
 aCD
 vRP
 gOA
-giC
-cUc
-lZD
-jVg
-pfT
-xqv
-qTG
-iIF
+jZG
+xVm
+qKH
+ojZ
+xOK
+nxS
+fER
+qGC
 gOA
 wHR
 sJF
@@ -77118,14 +77120,14 @@ tkl
 aCD
 vRP
 gOA
-hVK
-blM
-uQW
-dFH
-dFH
-rYm
-qTG
-kiR
+gOz
+gMc
+vyn
+qfJ
+qfJ
+jHY
+fER
+rVE
 gOA
 hmB
 pDd
@@ -77375,14 +77377,14 @@ tkl
 aCD
 vRP
 gOA
-lwH
-hni
-jbF
-nVo
-jbF
-jbF
-mkp
-eKM
+ebf
+nsj
+enC
+kRj
+enC
+enC
+gVw
+uWY
 eRC
 ehU
 hBV
@@ -77627,7 +77629,7 @@ vRP
 vRP
 vRP
 tkl
-fqp
+xNW
 tkl
 aCD
 aCD
@@ -78649,20 +78651,20 @@ vRP
 vRP
 vRP
 vRP
-fqp
+xNW
 tkl
 tkl
 tkl
 tkl
 tkl
-fqp
+xNW
 tkl
 tkl
 tkl
 tkl
 tkl
 tkl
-fqp
+xNW
 aCD
 aCD
 aCD
@@ -78907,18 +78909,18 @@ vRP
 vRP
 vRP
 tkl
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
 tkl
 aCD
 aCD
@@ -79164,18 +79166,18 @@ vRP
 vRP
 vRP
 tkl
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
 tkl
 aCD
 aCD
@@ -79421,25 +79423,25 @@ vRP
 vRP
 vRP
 tkl
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
 tkl
 aCD
 vRP
 aCD
 vRP
 vRP
-llR
+wrz
 eLb
 eLb
 eRC
@@ -79678,18 +79680,18 @@ vRP
 vRP
 vRP
 tkl
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
 tkl
 aCD
 vRP
@@ -79935,18 +79937,18 @@ vRP
 vRP
 vRP
 tkl
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
 tkl
 aCD
 vRP
@@ -80192,18 +80194,18 @@ vRP
 vRP
 vRP
 tkl
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
 tkl
 aCD
 vRP
@@ -80449,18 +80451,18 @@ vRP
 vRP
 vRP
 tkl
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
 tkl
 aCD
 aCD
@@ -80706,18 +80708,18 @@ vRP
 vRP
 vRP
 tkl
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
-nkH
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
+ank
 tkl
 vRP
 vRP
@@ -80962,20 +80964,20 @@ vRP
 vRP
 vRP
 vRP
-fqp
+xNW
 tkl
 tkl
 tkl
 tkl
 tkl
-fqp
+xNW
 tkl
 tkl
 tkl
 tkl
 tkl
 tkl
-fqp
+xNW
 vRP
 vRP
 vRP

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -730,6 +730,14 @@
 	},
 /turf/open/floor/plating,
 /area/medical/paramedic)
+"art" = (
+/obj/machinery/recycler,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "Shipbreaking"
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "asc" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1
@@ -1220,11 +1228,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
-"aEL" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "aEO" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -1298,13 +1301,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"aIy" = (
-/obj/structure/closet/crate/miningcar{
-	name = "Material cart"
-	},
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "aIM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -2470,13 +2466,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"bif" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side,
-/area/hydroponics/garden)
 "bii" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -2700,23 +2689,6 @@
 	dir = 5
 	},
 /area/crew_quarters/bar)
-"bpl" = (
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	layer = 3
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "bpn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2917,11 +2889,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
-"btO" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/hydroponics/garden)
 "buw" = (
 /obj/effect/turf_decal/siding/wideplating/corner{
 	dir = 4
@@ -3780,6 +3747,9 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"bQJ" = (
+/turf/open/floor/plasteel/dark/side,
+/area/hydroponics/garden)
 "bQM" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -4989,6 +4959,11 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"cvE" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon,
+/turf/open/space/basic,
+/area/space/nearstation)
 "cvF" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
@@ -5644,6 +5619,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/escapepodbay)
+"cIL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "cIO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -7564,6 +7545,10 @@
 /obj/machinery/computer/security/wooden_tv,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
+"dER" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plasteel/dark/corner,
+/area/hydroponics/garden)
 "dEW" = (
 /obj/structure/fireaxecabinet{
 	pixel_y = 32
@@ -7663,16 +7648,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
-"dFU" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/hydroponics/garden)
 "dFV" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
@@ -7817,6 +7792,9 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/quartermaster/qm)
+"dHG" = (
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "dHX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -7854,6 +7832,14 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"dJW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
+	},
+/area/hydroponics/garden)
 "dKt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment{
@@ -7915,15 +7901,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"dNb" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/stairs/old{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "dNv" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
@@ -8405,6 +8382,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
+"dZp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "dZs" = (
 /obj/machinery/door/poddoor{
 	id = "mixvent";
@@ -8633,6 +8617,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"eel" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "eeq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -8796,11 +8787,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
-"eid" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "eih" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	piping_layer = 2
@@ -9966,6 +9952,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"eFV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/hydroponics/garden)
 "eGu" = (
 /obj/machinery/door/airlock{
 	name = "Private Restroom";
@@ -12685,19 +12680,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"fTi" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/bag/sheetsnatcher,
-/obj/item/storage/bag/trash,
-/obj/item/melee/sledgehammer,
-/obj/item/broom,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/dark/side{
-	dir = 6
-	},
-/area/hydroponics/garden)
 "fTl" = (
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
@@ -13903,12 +13885,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"gws" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "gwV" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -14748,14 +14724,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
-"gVx" = (
-/obj/machinery/recycler,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "Shipbreaking"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "gVy" = (
 /obj/machinery/light{
 	dir = 1
@@ -14839,6 +14807,13 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/secondarydatacore)
+"gYA" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "gZc" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
@@ -16572,17 +16547,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/bridge)
-"hNO" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Airlock"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/space/basic,
-/area/hydroponics/garden)
 "hNP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -17056,6 +17020,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"hXX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/engine,
+/area/hydroponics/garden)
 "hYs" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
@@ -17536,12 +17509,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
-"imf" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/space/basic,
-/area/hydroponics/garden)
 "imt" = (
 /obj/machinery/light{
 	dir = 4
@@ -17795,13 +17762,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"iti" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "itk" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -18082,12 +18042,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"ixV" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "iyb" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -18946,15 +18900,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
-"iTD" = (
-/obj/machinery/advanced_airlock_controller{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/hydroponics/garden)
 "iTX" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -19070,9 +19015,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"iXE" = (
-/turf/open/space/basic,
-/area/shipbreak)
 "iXH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/firealarm{
@@ -19316,12 +19258,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"jfl" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/hydroponics/garden)
 "jfL" = (
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
@@ -19335,6 +19271,14 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"jgB" = (
+/obj/machinery/computer/shipbreaker{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "jgO" = (
 /mob/living/simple_animal/butterfly,
 /turf/open/indestructible/grass/sand,
@@ -20346,17 +20290,6 @@
 /obj/item/storage/lockbox/medal,
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
-"jEk" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Airlock"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/hydroponics/garden)
 "jEp" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/meter,
@@ -20383,6 +20316,23 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"jFP" = (
+/obj/structure/rack,
+/obj/machinery/camera{
+	c_tag = "Brig Equipment Room";
+	dir = 4
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/bag/trash,
+/obj/item/melee/sledgehammer,
+/obj/item/broom,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "jFZ" = (
 /obj/effect/turf_decal/siding/thinplating/dark{
 	dir = 1
@@ -20727,6 +20677,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"jPI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "jQB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20784,18 +20738,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"jRF" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/engine,
-/area/hydroponics/garden)
 "jRL" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -20916,6 +20858,16 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"jUh" = (
+/obj/structure/railing/corner,
+/obj/machinery/conveyor_switch/oneway{
+	id = "Shipbreaking"
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/dark/side{
+	dir = 9
+	},
+/area/hydroponics/garden)
 "jUy" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -21296,6 +21248,12 @@
 "keq" = (
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"ket" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "keK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 8
@@ -21598,15 +21556,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"kmz" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/hydroponics/garden)
 "kmD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22503,6 +22452,12 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"kLk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "kLw" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -23452,11 +23407,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"liC" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/marker_beacon,
-/turf/open/space/basic,
-/area/space/nearstation)
 "liO" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -24377,6 +24327,15 @@
 	},
 /turf/open/floor/engine,
 /area/engine/gravity_generator)
+"lFl" = (
+/obj/machinery/advanced_airlock_controller{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "lFt" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
@@ -24454,6 +24413,18 @@
 "lHe" = (
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
+"lHE" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/door/window/eastright{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "lHR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -24978,6 +24949,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"lVi" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "lVD" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -26827,13 +26803,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"mRF" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "mRK" = (
 /obj/structure/closet/secure_closet/engineering_personal{
 	anchored = 1
@@ -27213,6 +27182,17 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
+"ndU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/stairs/old{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "nel" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -27294,6 +27274,9 @@
 "ngb" = (
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"ngz" = (
+/turf/open/space/basic,
+/area/shipbreak)
 "ngI" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
 	dir = 1
@@ -27807,13 +27790,6 @@
 	dir = 5
 	},
 /area/crew_quarters/bar)
-"nta" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/hydroponics/garden)
 "nti" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/atmospherics/pipe/layer_manifold,
@@ -28213,6 +28189,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nBG" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "nBN" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
@@ -28698,6 +28681,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
+"nMH" = (
+/obj/structure/closet/crate/miningcar{
+	name = "Material cart"
+	},
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "nMP" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
 	dir = 4
@@ -28770,16 +28760,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"nOT" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "nOU" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/item/wheelchair,
@@ -28946,14 +28926,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"nUT" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "Shipbreaking"
-	},
-/obj/structure/rack,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "nUV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -29496,6 +29468,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"onh" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "onu" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -29776,6 +29758,15 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"otG" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "otH" = (
 /obj/structure/toilet{
 	cistern = 1;
@@ -30752,12 +30743,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"oVI" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "oVU" = (
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor2";
@@ -31109,6 +31094,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"peu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "peJ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/item/kirbyplants/random,
@@ -31205,6 +31194,23 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"pgL" = (
+/obj/structure/rack,
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/bag/trash,
+/obj/item/melee/sledgehammer,
+/obj/item/broom,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/hydroponics/garden)
 "pgQ" = (
 /obj/structure/table/wood,
 /obj/item/pinpointer/nuke,
@@ -32220,6 +32226,11 @@
 /obj/effect/turf_decal/siding/wideplating/corner,
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
+/area/hydroponics/garden)
+"pEc" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
 /area/hydroponics/garden)
 "pEt" = (
 /obj/effect/turf_decal/delivery,
@@ -33527,6 +33538,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"qiy" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/stairs/old{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "qiG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -33625,16 +33645,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"qkc" = (
-/obj/structure/railing/corner,
-/obj/machinery/conveyor_switch/oneway{
-	id = "Shipbreaking"
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/dark/side{
-	dir = 9
-	},
-/area/hydroponics/garden)
 "qkg" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable,
@@ -33933,15 +33943,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"qra" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side,
-/area/hydroponics/garden)
 "qru" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34217,15 +34218,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"qAd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark/corner,
-/area/hydroponics/garden)
 "qAe" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -34297,6 +34289,13 @@
 /obj/machinery/light/floor,
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos/distro)
+"qCM" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/hydroponics/garden)
 "qCO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/stripes/line{
@@ -34837,14 +34836,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
-"qTT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 6
-	},
-/area/hydroponics/garden)
 "qUn" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -35472,13 +35463,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"rii" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "riA" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Chief Medical Officer";
@@ -36106,6 +36090,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"rww" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "rxd" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -36897,6 +36887,12 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/crew_quarters/heads/captain)
+"rQP" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "rQZ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -37083,6 +37079,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
+"rVI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark/corner,
+/area/hydroponics/garden)
 "rVU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -37613,6 +37618,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"sjT" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/hydroponics/garden)
 "skG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -38054,6 +38070,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"sua" = (
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	layer = 3
+	},
+/obj/effect/turf_decal/loading_area{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "sup" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -38471,12 +38504,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"sFS" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel/dark/corner{
-	dir = 8
-	},
-/area/hydroponics/garden)
 "sGd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -39569,17 +39596,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"tgm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/stairs/old{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "tgC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -40434,6 +40450,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"tGs" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/bag/trash,
+/obj/item/melee/sledgehammer,
+/obj/item/broom,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
+	},
+/area/hydroponics/garden)
 "tGv" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
@@ -40504,6 +40533,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"tIa" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "Shipbreaking"
+	},
+/obj/structure/rack,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "tIL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -40793,6 +40830,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"tPy" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/hydroponics/garden)
 "tPI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -41361,23 +41408,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/central)
-"ucD" = (
-/obj/structure/rack,
-/obj/machinery/camera{
-	c_tag = "Brig Equipment Room";
-	dir = 4
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/bag/sheetsnatcher,
-/obj/item/storage/bag/trash,
-/obj/item/melee/sledgehammer,
-/obj/item/broom,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "ucL" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
@@ -41517,15 +41547,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"ugr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/engine,
-/area/hydroponics/garden)
 "ugy" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -41883,10 +41904,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"uqN" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/plasteel/dark/corner,
-/area/hydroponics/garden)
 "uqY" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment,
@@ -41969,12 +41986,6 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
-"uvb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "uvf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -43045,10 +43056,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"uUX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "uUZ" = (
 /obj/machinery/conveyor{
 	id = "garbage"
@@ -45292,10 +45299,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"vXO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "vYA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -45303,6 +45306,12 @@
 	},
 /turf/open/floor/plating,
 /area/security/warden)
+"vYR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "vYY" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input,
 /turf/open/floor/engine/vacuum,
@@ -45981,10 +45990,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"wpb" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/maintenance/starboard/fore)
 "wpd" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -46193,6 +46198,10 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"wvm" = (
+/obj/structure/lattice,
+/turf/closed/wall,
 /area/maintenance/starboard/fore)
 "wvH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -46541,23 +46550,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"wEZ" = (
-/obj/structure/rack,
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/bag/sheetsnatcher,
-/obj/item/storage/bag/trash,
-/obj/item/melee/sledgehammer,
-/obj/item/broom,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/mask/gas,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/corner,
-/area/hydroponics/garden)
 "wFk" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -47112,12 +47104,6 @@
 /obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"wSG" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel/dark/corner{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "wST" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -47205,9 +47191,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"wUq" = (
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "wUI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -47350,18 +47333,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/secondarydatacore)
-"wYN" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/door/window/eastright{
-	dir = 2
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "wYP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
@@ -47547,6 +47518,11 @@
 "xbK" = (
 /turf/closed/wall/r_wall,
 /area/janitor)
+"xch" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "xcv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -48135,9 +48111,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"xri" = (
-/turf/open/floor/plasteel/dark/side,
-/area/hydroponics/garden)
 "xrw" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
@@ -48302,6 +48275,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"xuU" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/engine,
+/area/hydroponics/garden)
 "xuW" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/machinery/light_switch{
@@ -49085,6 +49070,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"xOg" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "xOv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -49360,14 +49351,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"xTJ" = (
-/obj/machinery/computer/shipbreaker{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/hydroponics/garden)
 "xTK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -75919,14 +75902,14 @@ tkl
 tkl
 tkl
 tkl
-imf
-iTD
-nta
-hNO
-jRF
-qAd
-eid
-wSG
+ket
+lFl
+gYA
+sjT
+xuU
+rVI
+lVi
+rQP
 eRC
 eRC
 pXP
@@ -76174,17 +76157,17 @@ tkl
 tkl
 tkl
 tkl
-liC
+cvE
 tkl
 eRC
 eRC
 eRC
 eRC
-dFU
-qra
-oVI
-aEL
-dNb
+tPy
+eFV
+vYR
+xch
+qiy
 uBR
 gHe
 uNv
@@ -76433,15 +76416,15 @@ tkl
 tkl
 tkl
 tkl
-jfl
-iTD
-nta
-jEk
-ugr
-bif
-iti
-rii
-tgm
+ket
+lFl
+gYA
+sjT
+hXX
+qCM
+dZp
+eel
+ndU
 otc
 ojV
 uCW
@@ -76685,7 +76668,7 @@ vRP
 vRP
 vRP
 tkl
-liC
+cvE
 tkl
 rtc
 aCD
@@ -76694,10 +76677,10 @@ eRC
 gOA
 eRC
 eRC
-wEZ
-qTT
-qkc
-bpl
+pgL
+dJW
+jUh
+sua
 eRC
 oiO
 dGO
@@ -76947,14 +76930,14 @@ tkl
 aCD
 vRP
 gOA
-uqN
-ixV
-nOT
-ucD
-fTi
-uvb
-mRF
-nUT
+dER
+rww
+onh
+jFP
+tGs
+kLk
+nBG
+tIa
 gOA
 wHR
 sJF
@@ -77204,14 +77187,14 @@ tkl
 aCD
 vRP
 gOA
-xri
-wUq
-uUX
-vXO
-vXO
-gws
-mRF
-gVx
+bQJ
+dHG
+jPI
+peu
+peu
+cIL
+nBG
+art
 gOA
 hmB
 pDd
@@ -77461,14 +77444,14 @@ tkl
 aCD
 vRP
 gOA
-sFS
-xTJ
-btO
-kmz
-btO
-btO
-wYN
-aIy
+xOg
+jgB
+pEc
+otG
+pEc
+pEc
+lHE
+nMH
 eRC
 ehU
 hBV
@@ -77713,7 +77696,7 @@ vRP
 vRP
 vRP
 tkl
-liC
+cvE
 tkl
 aCD
 aCD
@@ -78735,20 +78718,20 @@ vRP
 vRP
 vRP
 vRP
-liC
+cvE
 tkl
 tkl
 tkl
 tkl
 tkl
-liC
+cvE
 tkl
 tkl
 tkl
 tkl
 tkl
 tkl
-liC
+cvE
 aCD
 aCD
 aCD
@@ -78993,18 +78976,18 @@ vRP
 vRP
 vRP
 tkl
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
 tkl
 aCD
 aCD
@@ -79250,18 +79233,18 @@ vRP
 vRP
 vRP
 tkl
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
 tkl
 aCD
 aCD
@@ -79507,25 +79490,25 @@ vRP
 vRP
 vRP
 tkl
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
 tkl
 aCD
 vRP
 aCD
 vRP
 vRP
-wpb
+wvm
 eLb
 eLb
 eRC
@@ -79764,18 +79747,18 @@ vRP
 vRP
 vRP
 tkl
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
 tkl
 aCD
 vRP
@@ -80021,18 +80004,18 @@ vRP
 vRP
 vRP
 tkl
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
 tkl
 aCD
 vRP
@@ -80278,18 +80261,18 @@ vRP
 vRP
 vRP
 tkl
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
 tkl
 aCD
 vRP
@@ -80535,18 +80518,18 @@ vRP
 vRP
 vRP
 tkl
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
 tkl
 aCD
 aCD
@@ -80792,18 +80775,18 @@ vRP
 vRP
 vRP
 tkl
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
-iXE
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
+ngz
 tkl
 vRP
 vRP
@@ -81048,20 +81031,20 @@ vRP
 vRP
 vRP
 vRP
-liC
+cvE
 tkl
 tkl
 tkl
 tkl
 tkl
-liC
+cvE
 tkl
 tkl
 tkl
 tkl
 tkl
 tkl
-liC
+cvE
 vRP
 vRP
 vRP

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -639,6 +639,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"aoS" = (
+/obj/structure/closet/crate/trashcart,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "aoY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
@@ -730,6 +735,10 @@
 	},
 /turf/open/floor/plating,
 /area/medical/paramedic)
+"arC" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plasteel/dark/corner,
+/area/hydroponics/garden)
 "asc" = (
 /obj/structure/chair/comfy/beige{
 	dir = 1
@@ -2215,6 +2224,12 @@
 /obj/machinery/holosign/surgery,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"bcj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "bco" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -2359,16 +2374,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"beX" = (
-/obj/structure/railing/corner,
-/obj/machinery/conveyor_switch/oneway{
-	id = "Shipbreaking"
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel/dark/side{
-	dir = 9
-	},
-/area/hydroponics/garden)
 "bfb" = (
 /obj/structure/table/optable{
 	dir = 8
@@ -4017,6 +4022,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"bVV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/stairs/goon/stairs2_wide,
+/area/hydroponics/garden)
 "bVZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -4123,9 +4137,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bXQ" = (
-/turf/open/floor/plasteel/dark/side,
-/area/hydroponics/garden)
 "bYF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -4257,6 +4268,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"cdH" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "cdO" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -4297,14 +4313,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"ceF" = (
-/obj/machinery/recycler,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "Shipbreaking"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "ceM" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4;
@@ -5557,6 +5565,9 @@
 /obj/effect/turf_decal/bot_white/right,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
+"cFP" = (
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "cGb" = (
 /obj/machinery/atmospherics/miner/n2o,
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
@@ -5654,13 +5665,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"cJb" = (
-/obj/structure/railing,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "cJc" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
@@ -5922,6 +5926,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
+"cPx" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "cPG" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Tanks and Filtration";
@@ -6044,16 +6058,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/engine/atmos/distro)
-"cSI" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "cTk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer2{
 	dir = 8
@@ -6076,6 +6080,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"cTI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "cTL" = (
 /obj/machinery/suit_storage_unit/command,
 /obj/effect/turf_decal/bot,
@@ -6178,6 +6188,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"cVO" = (
+/obj/machinery/advanced_airlock_controller{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "cVQ" = (
 /obj/machinery/light{
 	dir = 1
@@ -6190,6 +6209,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"cVT" = (
+/turf/open/space/basic,
+/area/shipbreak)
 "cWe" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
@@ -6511,6 +6533,12 @@
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"dcI" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "dcK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -6983,6 +7011,13 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"dlb" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "Shipbreaking"
+	},
+/turf/open/floor/plating/airless,
+/area/hydroponics/garden)
 "dll" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
@@ -8426,12 +8461,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ebt" = (
-/obj/machinery/door/airlock/external/glass,
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/hydroponics/garden)
 "ebz" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -8820,13 +8849,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"eiS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "ejl" = (
 /turf/open/floor/plasteel,
 /area/engine/foyer)
@@ -9202,14 +9224,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit)
-"eqk" = (
-/obj/machinery/computer/shipbreaker{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/hydroponics/garden)
 "eqw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -9329,6 +9343,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"etr" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ety" = (
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/ai_upload";
@@ -9501,6 +9520,17 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"evA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/hydroponics/garden)
 "ewg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -9973,13 +10003,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/heads/captain)
-"eHa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "eHi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -10109,15 +10132,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
-"eJM" = (
-/obj/machinery/advanced_airlock_controller{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/hydroponics/garden)
 "eJX" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
@@ -10616,17 +10630,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
-"eTa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "eTE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -11019,6 +11022,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/foyer)
+"ffh" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark/corner,
+/area/hydroponics/garden)
 "ffj" = (
 /obj/machinery/door/airlock/security{
 	name = "Detective's Office";
@@ -11841,10 +11856,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"fAq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "fAF" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
@@ -12283,15 +12294,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"fHf" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/hydroponics/garden)
 "fHg" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
@@ -12855,6 +12857,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"fXc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "fXo" = (
 /turf/closed/wall,
 /area/security/checkpoint/science)
@@ -13137,19 +13146,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"gdT" = (
-/obj/structure/rack,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/bag/sheetsnatcher,
-/obj/item/storage/bag/trash,
-/obj/item/melee/sledgehammer,
-/obj/item/broom,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/dark/side{
-	dir = 6
-	},
-/area/hydroponics/garden)
 "gdU" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -13937,6 +13933,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"gwK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "gwV" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -14080,6 +14082,23 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/storage/satellite/teleporter)
+"gBM" = (
+/obj/structure/rack,
+/obj/machinery/camera{
+	c_tag = "Brig Equipment Room";
+	dir = 4
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/bag/trash,
+/obj/item/melee/sledgehammer,
+/obj/item/broom,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "gBP" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel/dark,
@@ -14137,6 +14156,13 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"gDB" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/stairs/goon/stairs_wide,
+/area/hydroponics/garden)
 "gDI" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 10
@@ -14186,6 +14212,11 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/secondarydatacore)
+"gFp" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 9
+	},
+/area/hydroponics/garden)
 "gFs" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -17083,11 +17114,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"hZW" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "iaz" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -19244,12 +19270,6 @@
 "jdr" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/starboard/fore)
-"jds" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "jdR" = (
 /obj/structure/rack,
 /obj/item/hand_labeler,
@@ -19420,9 +19440,12 @@
 "jjX" = (
 /turf/closed/wall/r_wall,
 /area/engine/atmos/distro)
-"jkU" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/plasteel/dark/corner,
+"jkf" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "Shipbreaking"
+	},
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/plating/airless,
 /area/hydroponics/garden)
 "jla" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -19648,23 +19671,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/lawoffice)
-"jpu" = (
-/obj/structure/rack,
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/bag/sheetsnatcher,
-/obj/item/storage/bag/trash,
-/obj/item/melee/sledgehammer,
-/obj/item/broom,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/mask/gas,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/side,
-/area/hydroponics/garden)
 "jpZ" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin{
@@ -21343,6 +21349,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"kgA" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "kgL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -21677,6 +21689,19 @@
 "kpN" = (
 /turf/closed/wall,
 /area/medical/paramedic)
+"kpR" = (
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/bag/trash,
+/obj/item/melee/sledgehammer,
+/obj/item/broom,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/dark/side{
+	dir = 6
+	},
+/area/hydroponics/garden)
 "kpV" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -22140,10 +22165,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"kDD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "kEd" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -24388,13 +24409,6 @@
 	},
 /turf/open/floor/engine/n2,
 /area/engine/atmos/distro)
-"lGi" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plating,
-/area/hydroponics/garden)
 "lGx" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix/flipped/inverse{
 	dir = 4
@@ -24452,12 +24466,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
-"lIj" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel/dark/corner{
-	dir = 8
-	},
-/area/hydroponics/garden)
 "lIB" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
@@ -24757,6 +24765,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"lRe" = (
+/turf/open/floor/plasteel/dark/side,
+/area/hydroponics/garden)
 "lRg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -25000,6 +25011,11 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"lWl" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "lWm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -28806,16 +28822,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"nQU" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark/side,
-/area/hydroponics/garden)
 "nQW" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
@@ -28833,6 +28839,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"nRq" = (
+/obj/structure/rack,
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/bag/trash,
+/obj/item/melee/sledgehammer,
+/obj/item/broom,
+/obj/item/tank/internals/oxygen,
+/obj/item/clothing/mask/gas,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/hydroponics/garden)
 "nRu" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/department/bridge";
@@ -29156,13 +29179,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"obK" = (
-/obj/structure/closet/crate/miningcar{
-	name = "Material cart"
-	},
-/obj/effect/turf_decal/box,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "obP" = (
 /obj/structure/chair{
 	dir = 8
@@ -29726,13 +29742,6 @@
 /obj/machinery/computer/med_data,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
-"osN" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "otc" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line/lower{
 	dir = 1
@@ -30763,23 +30772,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"oWA" = (
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	layer = 3
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "oWT" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -31116,6 +31108,12 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"pfk" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "pfR" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31689,6 +31687,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"pqi" = (
+/obj/machinery/light_switch{
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "pqj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -32074,12 +32080,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"pBg" = (
-/obj/machinery/suit_storage_unit/standard_unit,
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "pBk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -32822,11 +32822,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"pTK" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/marker_beacon,
-/turf/open/space/basic,
-/area/space/nearstation)
 "pTW" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -34436,17 +34431,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
-"qJn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/stairs/old{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "qJo" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -34531,17 +34515,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"qLU" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Airlock"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/hydroponics/garden)
 "qMc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -34599,12 +34572,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/aft)
-"qPw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "qPM" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -34645,6 +34612,13 @@
 	},
 /turf/open/floor/carpet/red,
 /area/crew_quarters/heads/hos)
+"qPQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel/dark/side{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "qPU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -34935,6 +34909,14 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/science/nanite)
+"qWQ" = (
+/obj/machinery/recycler,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "Shipbreaking"
+	},
+/turf/open/floor/plating/airless,
+/area/hydroponics/garden)
 "qWS" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 4
@@ -35273,6 +35255,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"rel" = (
+/obj/machinery/computer/shipbreaker{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "ren" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -35388,6 +35378,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"rgm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "rgP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -35489,9 +35483,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"riD" = (
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "rjf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -36549,18 +36540,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
-"rHr" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark/corner,
-/area/hydroponics/garden)
 "rHt" = (
 /obj/machinery/light{
 	dir = 8
@@ -37644,11 +37623,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"smc" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 8
-	},
-/area/hydroponics/garden)
 "smm" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Customs"
@@ -39407,6 +39381,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"tcj" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "tcG" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -39991,6 +39972,17 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"tui" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Airlock"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/hydroponics/garden)
 "tuM" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters{
@@ -41217,11 +41209,6 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/secondarydatacore)
-"tZa" = (
-/turf/open/floor/plasteel/dark/side{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "tZf" = (
 /obj/machinery/computer/cargo/request,
 /obj/structure/cable{
@@ -41437,6 +41424,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"uey" = (
+/obj/structure/lattice,
+/turf/closed/wall,
+/area/maintenance/starboard/fore)
 "ueT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -41842,6 +41833,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
+"upT" = (
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "uqi" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -41994,6 +41990,10 @@
 "uwK" = (
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"uwT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "uwU" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced{
@@ -42060,6 +42060,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
+"uya" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "uyk" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -42077,6 +42086,14 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"uyl" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark/corner{
+	dir = 1
+	},
+/area/hydroponics/garden)
 "uyo" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
@@ -42372,10 +42389,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"uGV" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/maintenance/starboard/fore)
 "uGX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -43677,6 +43690,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/janitor)
+"vjK" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark/side,
+/area/hydroponics/garden)
 "vjO" = (
 /obj/machinery/light{
 	dir = 8
@@ -43709,18 +43732,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
-"vkp" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/door/window/eastright{
-	dir = 2
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "vkA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -44145,17 +44156,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"vuu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark/side,
-/area/hydroponics/garden)
 "vuO" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -45620,6 +45620,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet/blue,
 /area/bridge/meeting_room)
+"whp" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics/garden)
 "whZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
@@ -47143,14 +47150,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"wUf" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "Shipbreaking"
-	},
-/obj/structure/rack,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "wUk" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
@@ -47320,15 +47319,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"wZK" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel/stairs/old{
-	dir = 1
-	},
-/area/hydroponics/garden)
 "wZV" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
@@ -47496,9 +47486,6 @@
 "xbK" = (
 /turf/closed/wall/r_wall,
 /area/janitor)
-"xbR" = (
-/turf/open/space/basic,
-/area/shipbreak)
 "xcv" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -48026,23 +48013,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"xoU" = (
-/obj/structure/rack,
-/obj/machinery/camera{
-	c_tag = "Brig Equipment Room";
-	dir = 4
-	},
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/bag/sheetsnatcher,
-/obj/item/storage/bag/trash,
-/obj/item/melee/sledgehammer,
-/obj/item/broom,
-/obj/item/tank/internals/oxygen,
-/obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/dark/side{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "xpi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -48605,6 +48575,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"xDZ" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "xEj" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -48751,6 +48727,15 @@
 "xGP" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hos)
+"xHf" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 8
+	},
+/area/hydroponics/garden)
 "xHm" = (
 /obj/machinery/power/turbine{
 	dir = 8;
@@ -48761,6 +48746,12 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"xHt" = (
+/obj/structure/closet/crate/miningcar{
+	name = "Material cart"
+	},
+/turf/open/floor/plating/airless,
+/area/hydroponics/garden)
 "xHB" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light,
@@ -49397,15 +49388,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"xVj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
 "xVn" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
@@ -49866,6 +49848,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
+"yeQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark/side{
+	dir = 4
+	},
+/area/hydroponics/garden)
 "yfh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -50004,18 +49997,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"yiQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics/garden)
-"yjf" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel/dark/corner{
-	dir = 4
-	},
-/area/hydroponics/garden)
 "yjk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -75898,14 +75879,14 @@ tkl
 tkl
 tkl
 tkl
-ebt
-eJM
-lGi
-qLU
-rHr
-eTa
-hZW
-yjf
+kgA
+cVO
+tcj
+tui
+ffh
+yeQ
+upT
+pfk
 eRC
 eRC
 pXP
@@ -76150,20 +76131,20 @@ vRP
 vRP
 vRP
 tkl
+etr
 tkl
 tkl
-tkl
-pTK
+etr
 tkl
 eRC
 eRC
 eRC
 eRC
-nQU
-xVj
-jds
-tZa
-wZK
+vjK
+uya
+gwK
+cdH
+gDB
 uBR
 gHe
 uNv
@@ -76407,20 +76388,20 @@ vRP
 vRP
 vRP
 tkl
-vRP
 tkl
 tkl
 tkl
 tkl
-ebt
-eJM
-lGi
-qLU
-vuu
-osN
-eiS
-eHa
-qJn
+tkl
+kgA
+cVO
+tcj
+tui
+evA
+whp
+fXc
+qPQ
+bVV
 otc
 ojV
 uCW
@@ -76664,19 +76645,19 @@ vRP
 vRP
 vRP
 tkl
-pTK
 tkl
-rtc
-aCD
+etr
+tkl
+jkf
 eRC
 eRC
 gOA
 eRC
 eRC
-jpu
-qPw
-beX
-oWA
+nRq
+cTI
+gFp
+pqi
 eRC
 oiO
 dGO
@@ -76921,19 +76902,19 @@ vRP
 vRP
 vRP
 tkl
-vRP
 tkl
-aCD
-vRP
+tkl
+tkl
+dlb
 gOA
-jkU
-pBg
-cSI
-xoU
-gdT
-qPw
-cJb
-wUf
+arC
+dcI
+cPx
+gBM
+kpR
+cTI
+cdH
+aoS
 gOA
 wHR
 sJF
@@ -77177,20 +77158,20 @@ vRP
 vRP
 vRP
 vRP
+etr
 tkl
-vRP
 tkl
-aCD
-vRP
+tkl
+qWQ
 gOA
-bXQ
-riD
-fAq
-kDD
-kDD
-yiQ
-cJb
-ceF
+lRe
+cFP
+uwT
+rgm
+rgm
+bcj
+cdH
+aoS
 gOA
 hmB
 pDd
@@ -77435,19 +77416,19 @@ vRP
 vRP
 vRP
 tkl
-vRP
 tkl
-aCD
-vRP
+tkl
+tkl
+xHt
 gOA
-lIj
-eqk
-smc
-fHf
-smc
-smc
-vkp
-obK
+xDZ
+rel
+lWl
+xHf
+lWl
+lWl
+uyl
+aoS
 eRC
 ehU
 hBV
@@ -77692,10 +77673,10 @@ vRP
 vRP
 vRP
 tkl
-pTK
 tkl
-aCD
-aCD
+etr
+tkl
+jkf
 eRC
 gOA
 gOA
@@ -77949,10 +77930,10 @@ vRP
 vRP
 vRP
 tkl
-vRP
+tkl
 tkl
 aCD
-vRP
+aCD
 aCD
 vRP
 vRP
@@ -78206,10 +78187,10 @@ vRP
 vRP
 vRP
 tkl
-vRP
+tkl
 tkl
 aCD
-vRP
+aCD
 aCD
 vRP
 vRP
@@ -78463,7 +78444,7 @@ vRP
 vRP
 vRP
 tkl
-tkl
+etr
 tkl
 aCD
 aCD
@@ -78714,20 +78695,20 @@ vRP
 vRP
 vRP
 vRP
-pTK
-tkl
-tkl
-tkl
-tkl
-tkl
-pTK
+etr
 tkl
 tkl
 tkl
 tkl
 tkl
 tkl
-pTK
+tkl
+tkl
+tkl
+tkl
+tkl
+tkl
+etr
 aCD
 aCD
 aCD
@@ -78972,18 +78953,18 @@ vRP
 vRP
 vRP
 tkl
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
 tkl
 aCD
 aCD
@@ -79229,18 +79210,18 @@ vRP
 vRP
 vRP
 tkl
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
 tkl
 aCD
 aCD
@@ -79486,25 +79467,25 @@ vRP
 vRP
 vRP
 tkl
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
 tkl
 aCD
 vRP
 aCD
 vRP
 vRP
-uGV
+uey
 eLb
 eLb
 eRC
@@ -79743,18 +79724,18 @@ vRP
 vRP
 vRP
 tkl
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
 tkl
 aCD
 vRP
@@ -80000,18 +79981,18 @@ vRP
 vRP
 vRP
 tkl
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
 tkl
 aCD
 vRP
@@ -80257,18 +80238,18 @@ vRP
 vRP
 vRP
 tkl
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
 tkl
 aCD
 vRP
@@ -80514,18 +80495,18 @@ vRP
 vRP
 vRP
 tkl
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
 tkl
 aCD
 aCD
@@ -80771,18 +80752,18 @@ vRP
 vRP
 vRP
 tkl
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
-xbR
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
+cVT
 tkl
 vRP
 vRP
@@ -81027,20 +81008,20 @@ vRP
 vRP
 vRP
 vRP
-pTK
+etr
 tkl
 tkl
 tkl
 tkl
 tkl
-pTK
+etr
 tkl
 tkl
 tkl
 tkl
 tkl
 tkl
-pTK
+etr
 vRP
 vRP
 vRP

--- a/tools/mapmerge2/mapmerge.py
+++ b/tools/mapmerge2/mapmerge.py
@@ -88,7 +88,7 @@ def main(settings):
         shutil.copyfile(fname, fname + ".before")
         old_map = DMM.from_file(fname + ".backup")
         new_map = DMM.from_file(fname)
-        merge_map(new_map, old_map).to_file(fname, settings.tgm)
+        merge_map(new_map, old_map).to_file(fname, tgm=settings.tgm)
 
 if __name__ == '__main__':
     main(frontend.read_settings())


### PR DESCRIPTION
# Document the changes in your pull request

adds ship breaking to gax. up in the garden next to sec
![image](https://github.com/yogstation13/Yogstation/assets/88801435/9f36f843-4bd6-47e0-adb2-7bd801e313ad)
fixes security reception windoors
![image](https://github.com/yogstation13/Yogstation/assets/88801435/0f9dbf97-a287-4c69-a2a1-234617d6dd3e)

updates mapmerge tool becuase it wasnt working for some odd reason


# Why is this good for the game?
since ship breaking was added to box its best to quickly start moving the feature over to the other maps


# Testing
checked when running the map 

# Changelog


:cl:  

mapping: adds shipbreaking to the top of the garden on gax (removes double light switch in garden also)
mapping: fixes security reception windoors covering the bell on Gax
tweak: updates mapmerge.py to fix a weird error
/:cl:
