### PR TITLE
Slight nerf/revert on the solaris incendiary effect

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -114,7 +114,7 @@
 	desc = "A weapon for combat exosuits. Shoots heavy lasers."
 	icon_state = "mecha_laser"
 	energy_drain = 60
-	projectile = /obj/projectile/beam/laser/heavylaser
+	projectile = /obj/projectile/beam/laser/heavylaser/no_fire
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/xray

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -60,6 +60,9 @@
 			target_turf.ignite_turf(rand(8, 16))
 	return ..()
 
+/obj/projectile/beam/laser/heavylaser/no_fire	//For the heavy mech laser weapon
+	fire_hazard = FALSE
+
 /obj/projectile/beam/weak
 	damage = 15
 	armour_penetration = 50


### PR DESCRIPTION
I don't know who decided to give the heavy lasers a fire turf but it was a pretty significant buff to the solaris since it basically made an already very strong weapon also incendiary. In hindsight, this probably should have been done earlier.

# Why is this good for the game?

Solaris was and still is one of the strongest mech weapons you can get, it never needed the fire component as well.

# Testing

Effectively just flipped a true to a false.

# Wiki Documentation

It doesn't ignite any more, if that was ever even mentioned.

# Changelog

:cl:  

tweak: Solaris laser cannon shots no longer create fire turfs

/:cl:
