### PR TITLE
Reworks haloperidol to not be haloperidol

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -60,7 +60,7 @@
 										/datum/reagent/toxin/lipolicide, /datum/reagent/medicine/sal_acid
 									),
 									list(	// level 10
-										/datum/reagent/medicine/haloperidol, /datum/reagent/drug/aranesp, /datum/reagent/medicine/diphenhydramine
+										/datum/reagent/medicine/naloxone, /datum/reagent/drug/aranesp, /datum/reagent/medicine/diphenhydramine
 									),
 									list(	//level 11
 										/datum/reagent/medicine/modafinil, /datum/reagent/toxin/anacea

--- a/code/modules/hydroponics/grown/cannabis.dm
+++ b/code/modules/hydroponics/grown/cannabis.dm
@@ -68,7 +68,7 @@
 						/datum/reagent/mercury = 0.15,
 						/datum/reagent/lithium = 0.15,
 						/datum/reagent/medicine/atropine = 0.15,
-						/datum/reagent/medicine/haloperidol = 0.15,
+						/datum/reagent/medicine/naloxone = 0.15,
 						/datum/reagent/drug/methamphetamine = 0.15,
 						/datum/reagent/consumable/capsaicin = 0.15,
 						/datum/reagent/barbers_aid = 0.15,

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1288,23 +1288,27 @@
 	..()
 	. = 1
 
-/datum/reagent/medicine/haloperidol
-	name = "Haloperidol"
-	description = "Increases depletion rates for most stimulating/hallucinogenic drugs. Reduces druggy effects and jitteriness. Severe stamina regeneration penalty, causes drowsiness. Small chance of brain damage."
+/datum/reagent/medicine/naloxone
+	name = "Naloxone"
+	description = "Rapidly purges most hazardous chemicals. Causes muscle weakness, and in higher dosages, brain and liver damage"
 	reagent_state = LIQUID
 	color = "#27870a"
+	overdose_threshold = 20
 	metabolization_rate = 0.4 * REAGENTS_METABOLISM
+	var/list/purge_types = list(typecacheof(list(/datum/reagent/drug, /datum/reagent/toxin))) //add more to this list as needed
 
-/datum/reagent/medicine/haloperidol/on_mob_life(mob/living/carbon/M)
-	for(var/datum/reagent/drug/R in M.reagents.reagent_list)
-		M.reagents.remove_reagent(R.type,5)
-	M.adjust_drowsiness(2 SECONDS)
-	M.adjust_jitter(-3 SECONDS)
-	M.adjust_hallucinations(-5 SECONDS)
-	if(prob(20))
-		M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 1*REM, 50)
+/datum/reagent/medicine/naloxone/on_mob_life(mob/living/carbon/M)
+	for(var/datum/reagent/R in M.reagents.reagent_list)
+		if(is_type_in_typecache(R, purge_types))
+			M.reagents.remove_reagent(R.type,5)
 	M.adjustStaminaLoss(2.5*REM, 0)
 	M.clear_stamina_regen()
+	..()
+	return TRUE
+
+/datum/reagent/medicine/naloxone/overdose_process(mob/living/M)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 0.5 * REM, 50)
+	M.adjustOrganLoss(ORGAN_SLOT_LIVER, 0.5 * REM)
 	..()
 	return TRUE
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1295,7 +1295,7 @@
 	color = "#27870a"
 	overdose_threshold = 20
 	metabolization_rate = 0.4 * REAGENTS_METABOLISM
-	var/list/purge_types = list(typecacheof(list(/datum/reagent/drug, /datum/reagent/toxin))) //add more to this list as needed
+	var/static/list/purge_types = list(typecacheof(list(/datum/reagent/drug, /datum/reagent/toxin))) //add more to this list as needed
 
 /datum/reagent/medicine/naloxone/on_mob_life(mob/living/carbon/M)
 	for(var/datum/reagent/R in M.reagents.reagent_list)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -214,10 +214,10 @@
 	required_reagents = list(/datum/reagent/medicine/cryoxadone = 1, /datum/reagent/sodium = 1)
 	required_catalysts = list(/datum/reagent/toxin/plasma = 5)
 
-/datum/chemical_reaction/haloperidol
-	name = "Haloperidol"
-	id = /datum/reagent/medicine/haloperidol
-	results = list(/datum/reagent/medicine/haloperidol = 5)
+/datum/chemical_reaction/naloxone
+	name = "Naloxone"
+	id = /datum/reagent/medicine/naloxone
+	results = list(/datum/reagent/medicine/naloxone = 5)
 	required_reagents = list(/datum/reagent/chlorine = 1, /datum/reagent/fluorine = 1, /datum/reagent/aluminium = 1, /datum/reagent/medicine/potass_iodide = 1, /datum/reagent/oil = 1)
 
 /datum/chemical_reaction/bicaridine

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -100,7 +100,7 @@
 	name = "Anacea"
 	id = /datum/reagent/toxin/anacea
 	results = list(/datum/reagent/toxin/anacea = 3)
-	required_reagents = list(/datum/reagent/medicine/haloperidol = 1, /datum/reagent/impedrezene = 1, /datum/reagent/uranium/radium = 1)
+	required_reagents = list(/datum/reagent/medicine/naloxone = 1, /datum/reagent/impedrezene = 1, /datum/reagent/uranium/radium = 1)
 
 /datum/chemical_reaction/mimesbane
 	name = "Mime's Bane"

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -10,7 +10,7 @@
 	)
 
 #define EXPANDED_MEDICAL_REAGENTS list(\
-		/datum/reagent/medicine/haloperidol,\
+		/datum/reagent/medicine/naloxone,\
 		/datum/reagent/medicine/inacusiate,\
 		/datum/reagent/medicine/mannitol,\
 		/datum/reagent/medicine/mutadone,\


### PR DESCRIPTION
i was gonna just tweak haloperidol to be like selective blood purification nanites, but then i found out it's already selective for drugs
When i went to add toxins, i noticed that haloperidol is more of an anti-psychotic in real life, and as such makes less sense to be used for purging, so i renamed it to be a somewhat more suitable chemical

# Why is this good for the game?
currently the chem purge design space is entirely consumed by charcoal and pentetic acid
This leaves things like haloperidol and calomel to be utterly useless
hobo is tweaking calomel to be stronger at purging with a lessened weakness, to make it the definitive super purge chem, as it's very easy to make.
I'm reworking haloperidol to be a selective purge chem as we don't have one that can function in a mix with other chems without purging all those other chemicals.


# Testing
i dunno how to chemistry and don't know how to test reagents

:cl:  
rscadd: Adds naloxone, a new chem that purges specifically drugs and toxins
rscdel: Removes haloperidol
/:cl:
