### PR TITLE
Lesser Pride Mirror now offers Felinid species

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -166,6 +166,8 @@
 
 /obj/structure/mirror/magic/lesser/New()
 	choosable_races = GLOB.roundstart_races.Copy()
+	if(!("felinid" in choosable_races))
+		choosable_races += "felinid"
 	..()
 
 /obj/structure/mirror/magic/badmin/New()


### PR DESCRIPTION
# Document the changes in your pull request
Lesser Pride Mirror now lets Felinid to be selectable as a species.

# Why is this good for the game?
Provides players who mainly play human species an alright reason to interact with the pride demon instead of just ignoring them.

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/30399783/a41e74b4-494b-4e9a-899c-51c42824a676)


# Changelog
:cl:  
tweak: Lesser Pride Mirror now offers Felinid as a selectable species.
/:cl:
