### PR TITLE
Update rat.dm so rats see brighter in darkness like mice.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/rat.dm
+++ b/code/modules/mob/living/simple_animal/hostile/rat.dm
@@ -21,6 +21,7 @@
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
 	mob_size = MOB_SIZE_TINY
 	mob_biotypes = MOB_ORGANIC|MOB_BEAST
+	lighting_cutoff = LIGHTING_CUTOFF_HIGH
 	faction = list("rat")
 	var/body_color
 


### PR DESCRIPTION

# Document the changes in your pull request
Fixed rats not being able to see in the dark. Added a line giving rats the same "lightning_cutoff" mice get.

Both images below are in the same level of darkness.

**Normal rat vision**
![Space station 13_ Buzz Array Twenty 5_20_2024 12_18_30 AM](https://github.com/yogstation13/Yogstation/assets/126894206/36af2bfd-f7be-42a5-894c-083de049062b)

**Rat vision fixed to be the same as mice**
![Microsoft Game DVR - Space station 13_ Bee Array Fifteen - VLC media player 5_20_2024 12_14_35 AM](https://github.com/yogstation13/Yogstation/assets/126894206/1b1cfe85-7b5c-43a7-8710-aa371634dadb)



# Why is this good for the game?

It's hard to see in the dark as a rat. Not fun trying to find your way out like that.
 
# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

bugfix: fixed a few things  

/:cl:
