### PR TITLE
Removes TEG from roundstart engine rotation once again

### DIFF
--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -110,7 +110,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	return TRUE
 
 /obj/effect/landmark/stationroom/box/engine
-	template_names = list("Engine SM" = 40, "Engine Singulo And Tesla" = 20, "Engine Nuclear Reactor" = 20,"Engine TEG" = 20)
+	template_names = list("Engine SM" = 50, "Engine Singulo And Tesla" = 25, "Engine Nuclear Reactor" = 25)
 
 /obj/effect/landmark/stationroom/box/engine/choose()
 	. = ..()
@@ -151,7 +151,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	return TRUE
 
 /obj/effect/landmark/stationroom/meta/engine
-	template_names = list("Meta SM" = 45, "Meta Nuclear Reactor" = 30, "Meta TEG" = 25) // tesla is loud as fuck and singulo doesn't make sense, so SM/reactor only
+	template_names = list("Meta SM" = 50, "Meta Nuclear Reactor" = 50) // tesla is loud as fuck and singulo doesn't make sense, so SM/reactor only
 
 /obj/effect/landmark/stationroom/meta/engine/choose()
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

tessa asked me to do this and i agreed because this engine is shit can we stop adding it back plz

atmos engines do not belong as the roundstart engine. normal engineers are not atmos techs.

# Why is this good for the game?
TEG is a garbage engine that isn't even designed for engineers, it's designed for atmospheric technicians. If you don't have someone guiding you the engine is almost impossible to set up with the guide and the roundstart setup usually needs modifications just to even run.

This engine is nowhere near beginner friendly, as it requires you to have atmospheric knowledge (pipes clogging, ht pipes etc) that beginners are simply not going to know. More often than not, I see many engineers (myself included) completely ignoring the TEG and going to do solars instead.

# Testing
haven't tested it but it's a two line change and i'm not going to

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscdel: removes teg from roundstart rotation (stop adding it back dear god)
/:cl:
