### PR TITLE
No Gods, no Masters, only Shotgun

### DIFF
--- a/code/datums/components/crafting/weapons.dm
+++ b/code/datums/components/crafting/weapons.dm
@@ -457,6 +457,7 @@
 	time = 0.5 SECONDS
 	category = CAT_WEAPON_AMMO
 
+/datum/crafting_recipe/bolts
 	name = "Bolts"
 	result = /obj/item/ammo_casing/caseless/bolts
 	reqs = list(/obj/item/stack/rods = 1)


### PR DESCRIPTION
# Document the changes in your pull request

Crafting recipe for coilgun bolts were overriding anarchy shell's recipe. This PR fixes that, making anarchy shells craftable.

# Why is this good for the game?

I cast swarm of pellets!
![image](https://github.com/yogstation13/Yogstation/assets/113869252/cb27a8d3-d4c3-48c1-81a1-108daa8fe3bc)

# Testing

![image](https://github.com/yogstation13/Yogstation/assets/113869252/e5281cc2-b49a-4827-8273-0fa91f54c5b7)

# Changelog

:cl:  
bugfix: Anarchy shells are craftable again. 
/:cl:
