### PR TITLE
Case of the disappearing 84mm High Explosive rocket propelled grenade

### DIFF
--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -66,9 +66,8 @@
 /obj/item/gun/ballistic/rocketlauncher/unrestricted
 	pin = /obj/item/firing_pin
 
-/obj/item/gun/ballistic/rocketlauncher/afterattack()
-	. = ..()
-	magazine.get_round(FALSE) //Hack to clear the mag after it's fired
+/obj/item/gun/ballistic/rocketlauncher/process_chamber()
+	magazine.get_round(FALSE)
 
 /obj/item/gun/ballistic/rocketlauncher/equipped()
 	if(prob(1))


### PR DESCRIPTION
# Document the changes in your pull request

While copying code for my musket PR, I noticed that some code meant to delete spent ammo from a gun also deleted unspent ammo if you clicked on an item without firing it. I fixed it in that PR and I am fixing it in this PR with the weapon I got the original code from: the PML-9.

# Why is this good for the game?

I'd be pretty sad if my 84mm HE rocket noped out of existence and this PR should help prevent that.

# Testing

I made a video but thinking about it, clicks don't really show up in-game so it is kinda useless. Too big for here but I can post it in Discord if needed.

# Changelog

:cl:  
bugfix: PML won't delete its rocket if you click on an item.
/:cl:
