### PR TITLE
Makes global statpanel data update 6x faster

### DIFF
--- a/code/controllers/subsystem/statpanel.dm
+++ b/code/controllers/subsystem/statpanel.dm
@@ -13,7 +13,7 @@ SUBSYSTEM_DEF(statpanels)
 	///how many subsystem fires between most tab updates
 	var/default_wait = 10
 	///how many subsystem fires between updates of the status tab
-	var/status_wait = 12
+	var/status_wait = 2
 	///how many subsystem fires between updates of the MC tab
 	var/mc_wait = 5
 	///how many full runs this subsystem has completed. used for variable rate refreshes.


### PR DESCRIPTION
# Document the changes in your pull request

Turns out having the statpanel update in 5 second intervals made it way more difficult to see the shuttle times.

matches tg station

# Why is this good for the game?
more accurate shuttle timers = i can get to shuttle better

# Testing

https://github.com/yogstation13/Yogstation/assets/5091394/44b8269b-a9d7-4fa1-b83b-2383cb8143e6



# Changelog

:cl:  
tweak: global statpanel data is updated 6x fasdter
/:cl:
