### PR TITLE
adds oxygen to towercaps and buffs steelcaps melee damage

### DIFF
--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -16,7 +16,7 @@
 	icon_dead = "towercap-dead"
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism)
 	mutatelist = list(/obj/item/seeds/tower/steel)
-	reagents_add = list(/datum/reagent/carbon = 0.5, reagents_add = list(/datum/reagent/oxygen = 0.1))
+	reagents_add = list(/datum/reagent/carbon = 0.5, /datum/reagent/oxygen = 0.1)
 
 /obj/item/seeds/tower/steel
 	name = "pack of steel-cap mycelium"

--- a/code/modules/hydroponics/grown/towercap.dm
+++ b/code/modules/hydroponics/grown/towercap.dm
@@ -16,7 +16,7 @@
 	icon_dead = "towercap-dead"
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism)
 	mutatelist = list(/obj/item/seeds/tower/steel)
-	reagents_add = list(/datum/reagent/carbon = 0.5)
+	reagents_add = list(/datum/reagent/carbon = 0.5, reagents_add = list(/datum/reagent/oxygen = 0.1))
 
 /obj/item/seeds/tower/steel
 	name = "pack of steel-cap mycelium"
@@ -93,6 +93,8 @@
 	seed = /obj/item/seeds/tower/steel
 	name = "steel-cap log"
 	desc = "It's made of metal."
+	force = 9
+	throwforce = 7
 	icon_state = "steellogs"
 	plank_type = /obj/item/stack/rods
 	plank_name = "rods"


### PR DESCRIPTION
i tried making this pr in the past and it wasnt merged so whyt not
# Changelog

buffed steelcaps melee and throwforce to  9 for force 7 for thrown
and adds oxygen to towercaps as there trees that recycle carbon for oxygen why wouldnt they
:cl:  
rscadd: Added oxygen to towercaps
tweak: tweaked steel caps damage
/:cl:
