### PR TITLE
Adds shipbreaking to all maps (except gax there's another pr for that already) ((And icemeta sorry))

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -2019,7 +2019,16 @@
 /turf/closed/wall/r_wall,
 /area/security/execution/transfer)
 "arR" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/structure/rack,
+/obj/item/tank/internals/oxygen,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/melee/sledgehammer,
+/obj/item/storage/bag/trash,
+/obj/item/broom,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/escapepodbay)
@@ -4621,7 +4630,12 @@
 /obj/machinery/camera{
 	c_tag = "Escape Podbay"
 	},
-/turf/open/floor/engine,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/escapepodbay)
 "aOR" = (
 /obj/structure/easel,
@@ -5439,10 +5453,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
@@ -8094,6 +8110,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/auxiliary)
+"bPR" = (
+/obj/machinery/computer/shipbreaker,
+/turf/open/floor/plating/airless,
+/area/escapepodbay)
 "bPX" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -12652,6 +12672,14 @@
 	dir = 1
 	},
 /area/engine/engineering)
+"diu" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/escapepodbay)
 "dix" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -14018,9 +14046,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "dKd" = (
-/obj/structure/grille,
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon,
 /turf/open/space/basic,
-/area/escapepodbay)
+/area/space/nearstation)
 "dKi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 8
@@ -17695,6 +17724,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
+"eLy" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "shipbreaking"
+	},
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/escapepodbay)
 "eLO" = (
 /obj/machinery/camera/motion{
 	c_tag = "Armory Motion Sensor"
@@ -17761,11 +17800,17 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "eMp" = (
-/obj/structure/window{
+/obj/structure/rack,
+/obj/item/tank/internals/oxygen,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/melee/sledgehammer,
+/obj/item/storage/bag/trash,
+/obj/item/broom,
+/obj/effect/turf_decal/bot,
+/obj/structure/railing{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/escapepodbay)
 "eMs" = (
@@ -28330,8 +28375,8 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "icE" = (
-/obj/structure/grille,
-/turf/open/space/basic,
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating/airless,
 /area/hallway/secondary/exit)
 "idE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -29186,6 +29231,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"irf" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/escapepodbay)
 "irh" = (
 /obj/effect/turf_decal/stripes{
 	dir = 8
@@ -33093,13 +33151,8 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "jxK" = (
-/obj/machinery/button/door{
-	id = "escapepodbay";
-	name = "Pod Door Control";
-	pixel_x = 6;
-	pixel_y = 24
-	},
-/turf/open/floor/engine,
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel/dark,
 /area/escapepodbay)
 "jyg" = (
 /obj/machinery/door/airlock/security/glass{
@@ -35788,13 +35841,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "kqQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/light{
 	light_color = "#c1caff"
 	},
-/turf/open/floor/engine,
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
 /area/escapepodbay)
 "kqV" = (
 /obj/structure/bed,
@@ -38208,6 +38260,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"lhS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "lid" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -41247,8 +41306,16 @@
 /turf/open/floor/carpet/red,
 /area/bridge)
 "mgZ" = (
-/obj/structure/spacepoddoor,
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 4
+	},
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
 /area/escapepodbay)
 "mha" = (
 /obj/machinery/status_display/evac{
@@ -41465,6 +41532,15 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
+"mkS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "mkT" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/siding/wideplating{
@@ -41503,6 +41579,13 @@
 /obj/item/toy/dummy,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"mlR" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "shipbreaking";
+	name = "shipbreaking recycler conveyer"
+	},
+/turf/open/floor/plating/airless,
+/area/escapepodbay)
 "mlS" = (
 /obj/machinery/camera{
 	c_tag = "Engineering East";
@@ -46453,7 +46536,13 @@
 /turf/open/floor/plasteel,
 /area/maintenance/central)
 "nJH" = (
-/obj/structure/closet/emcloset,
+/obj/structure/rack,
+/obj/item/tank/internals/oxygen,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/melee/sledgehammer,
+/obj/item/storage/bag/trash,
+/obj/item/broom,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/escapepodbay)
@@ -49084,10 +49173,13 @@
 /turf/open/floor/plasteel/freezer,
 /area/ruin/space/has_grav/listeningstation)
 "ozN" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/escapepodbay)
 "ozT" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -50511,8 +50603,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "oWp" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
@@ -57306,9 +57399,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "rce" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/crowbar/red,
+/obj/structure/chair,
 /turf/open/floor/plasteel/dark,
 /area/escapepodbay)
 "rcg" = (
@@ -59931,6 +60022,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"rOh" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "shipbreaking"
+	},
+/obj/structure/railing,
+/turf/open/floor/plating/airless,
+/area/escapepodbay)
 "rOq" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
@@ -60482,10 +60581,8 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/chief)
 "rUZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine/airless,
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating/airless,
 /area/escapepodbay)
 "rVf" = (
 /obj/machinery/nanite_program_hub,
@@ -61934,6 +62031,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
+"sqO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/railing/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "sra" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -61980,6 +62087,10 @@
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "srH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "srI" = (
@@ -62914,7 +63025,8 @@
 /turf/open/floor/plating,
 /area/clerk)
 "sFM" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/escapepodbay)
 "sFQ" = (
@@ -63963,7 +64075,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "sVl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -63974,6 +64085,10 @@
 	name = "Podbay APC";
 	pixel_x = -25
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/railing/corner,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "sVp" = (
@@ -67637,11 +67752,8 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "tZU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/escapepodbay)
+/turf/open/space/basic,
+/area/shipbreak)
 "uac" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = -32
@@ -67658,7 +67770,20 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "uam" = (
-/turf/open/floor/engine,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plasteel,
 /area/escapepodbay)
 "uau" = (
 /obj/effect/turf_decal/stripes/white/line,
@@ -69426,12 +69551,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "uEl" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high/plus,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
+/obj/structure/chair,
 /turf/open/floor/plasteel/dark,
 /area/escapepodbay)
 "uEH" = (
@@ -69830,11 +69953,8 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "uLd" = (
-/obj/machinery/door/poddoor/multi_tile/four_tile_ver{
-	id = "escapepodbay"
-	},
-/obj/structure/spacepoddoor,
-/turf/open/floor/engine,
+/obj/machinery/recycler,
+/turf/open/floor/plating/airless,
 /area/escapepodbay)
 "uLe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -70679,6 +70799,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"vbg" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "vbw" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -71758,14 +71885,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "vuM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#c1caff"
 	},
-/turf/open/floor/engine,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
 /area/escapepodbay)
 "vuQ" = (
 /obj/machinery/door/airlock/hatch{
@@ -76170,6 +76296,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"wLz" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/escapepodbay)
 "wLC" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/red,
@@ -77049,12 +77180,10 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "wWP" = (
-/obj/structure/rack,
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/rods/twentyfive,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/dark,
 /area/escapepodbay)
 "wXg" = (
@@ -124892,8 +125021,8 @@ msb
 msb
 wgX
 rce
-tZU
-srH
+ozN
+sqO
 eMp
 aNY
 dRT
@@ -125149,8 +125278,8 @@ msb
 msb
 wgX
 uEl
-tZU
-srH
+ozN
+vbg
 arR
 aNY
 aNY
@@ -125664,7 +125793,7 @@ msb
 wgX
 vuM
 ozN
-ozN
+srH
 kqQ
 aNY
 ajr
@@ -125920,9 +126049,9 @@ msb
 msb
 wgX
 aOQ
-uam
-uam
-uam
+ozN
+srH
+wLz
 aNY
 ajr
 ajX
@@ -126175,11 +126304,11 @@ msb
 msb
 msb
 msb
-wgX
+rUZ
 jxK
-uam
-uam
-uam
+mkS
+lhS
+diu
 aNY
 ajr
 kIA
@@ -126432,11 +126561,11 @@ msb
 msb
 msb
 msb
+rUZ
 wgX
 uam
-uam
-uam
-uam
+wgX
+wgX
 aNY
 iwc
 jjp
@@ -126683,17 +126812,17 @@ msb
 msb
 msb
 acb
-msb
-msb
-msb
-msb
-msb
-msb
-dKd
+acb
+aNg
+aNg
+aNg
+aNg
+aNg
+rUZ
+wgX
 mgZ
-mgZ
-mgZ
-uLd
+rUZ
+rUZ
 icE
 iSn
 iSn
@@ -126940,18 +127069,18 @@ msb
 msb
 msb
 acb
-msb
-msb
-msb
-msb
-msb
-msb
-dKd
+acb
+acb
+aES
+aES
+aES
+aNg
 rUZ
 rUZ
+irf
 rUZ
 rUZ
-dKd
+acb
 acb
 iSn
 iFH
@@ -127195,19 +127324,19 @@ msb
 msb
 msb
 msb
+aNg
 acb
 acb
 acb
-msb
-msb
-msb
-msb
-acb
-acb
-acb
-acb
-acb
-acb
+aES
+bPR
+aES
+aNg
+aNg
+aNg
+aES
+aNg
+aNg
 acb
 acb
 aNY
@@ -127444,27 +127573,27 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
+dKd
+aES
+aES
+aES
+aES
+aES
+aES
+aES
+aES
+aES
+aES
+aES
+aES
+aES
+aES
+aES
+aES
+aES
+aES
 acb
-acb
-acb
-acb
-acb
-acb
-msb
-acb
-acb
-acb
-acb
-acb
-acb
-acb
+aNg
 acb
 acb
 iSn
@@ -127701,26 +127830,26 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
+aES
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+aES
+mlR
 acb
 acb
 acb
 acb
 acb
-acb
-acb
-acb
-acb
-acb
-acb
-wKR
 acb
 acb
 acb
@@ -127958,21 +128087,21 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-acb
-acb
-acb
-acb
-acb
-acb
-acb
+aES
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+aES
+eLy
 acb
 acb
 acb
@@ -128215,21 +128344,21 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-acb
-acb
-acb
-acb
-acb
-acb
+aES
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+aES
+rOh
 acb
 acb
 acb
@@ -128472,21 +128601,21 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-acb
-acb
-acb
-acb
-acb
-acb
+aES
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+aES
+rOh
 acb
 acb
 acb
@@ -128729,21 +128858,21 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-acb
-acb
-acb
-acb
-acb
+aES
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+aES
+rOh
 acb
 acb
 acb
@@ -128986,21 +129115,21 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-acb
-acb
-acb
-acb
-acb
+aES
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+aES
+rOh
 acb
 acb
 acb
@@ -129243,21 +129372,21 @@ msb
 msb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-acb
-acb
-acb
-acb
-acb
-acb
+aES
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+aES
+uLd
 acb
 acb
 acb
@@ -129500,22 +129629,22 @@ msb
 acb
 msb
 msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-acb
-acb
-acb
-acb
-acb
-acb
-acb
+aES
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+tZU
+aES
+mlR
+aNg
 acb
 acb
 acb
@@ -129757,22 +129886,22 @@ acb
 acb
 msb
 msb
-acb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-msb
-acb
-acb
-acb
-acb
-acb
-acb
-acb
+dKd
+aES
+aES
+aES
+aES
+aES
+aES
+aES
+aES
+aES
+aES
+aES
+aES
+dKd
+aNg
+aNg
 acb
 acb
 acb
@@ -130013,23 +130142,23 @@ acb
 acb
 acb
 msb
-acb
-acb
+aNg
+aNg
+aAA
+aAA
 msb
 msb
 msb
 msb
 msb
-msb
-msb
+aNg
 acb
 acb
 acb
-acb
-acb
-acb
-acb
-acb
+aNg
+aNg
+aNg
+aNg
 acb
 acb
 acb
@@ -130279,8 +130408,8 @@ msb
 msb
 msb
 msb
-acb
-acb
+aNg
+aNg
 acb
 acb
 acb
@@ -130536,8 +130665,8 @@ msb
 msb
 msb
 msb
-acb
-acb
+aNg
+aNg
 acb
 acb
 acb

--- a/_maps/map_files/DonutStation/DonutStation.dmm
+++ b/_maps/map_files/DonutStation/DonutStation.dmm
@@ -2172,8 +2172,12 @@
 /area/crew_quarters/kitchen)
 "aUE" = (
 /obj/structure/rack,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/rods/twentyfive,
+/obj/item/tank/internals/oxygen,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/melee/sledgehammer,
+/obj/item/storage/bag/trash,
+/obj/item/broom,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "aUK" = (
@@ -3509,6 +3513,14 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"buA" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "shipbreaking"
+	},
+/obj/machinery/recycler,
+/turf/open/floor/plating/airless,
+/area/escapepodbay)
 "buL" = (
 /obj/machinery/particle_accelerator/control_box,
 /obj/structure/cable/yellow{
@@ -4419,6 +4431,10 @@
 "bOz" = (
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"bOG" = (
+/obj/structure/sign/poster/official/sey_gax,
+/turf/closed/wall,
+/area/escapepodbay)
 "bOH" = (
 /obj/machinery/rnd/production/circuit_imprinter/department/netmin,
 /obj/structure/sign/plaques/kiddie{
@@ -5695,8 +5711,6 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
 "cmL" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
@@ -7287,6 +7301,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"cSf" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "shipbreaking"
+	},
+/obj/structure/railing,
+/turf/open/floor/plating/airless,
+/area/escapepodbay)
 "cSj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -12250,6 +12272,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"eVL" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "eVV" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -13936,7 +13968,9 @@
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "fCV" = (
-/turf/open/floor/engine/airless,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
 /area/escapepodbay)
 "fDq" = (
 /obj/structure/cable{
@@ -14090,7 +14124,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/engine/airless,
+/turf/open/floor/plasteel,
 /area/escapepodbay)
 "fGO" = (
 /turf/open/floor/wood,
@@ -14406,8 +14440,12 @@
 /turf/open/floor/plating,
 /area/hydroponics/garden)
 "fNm" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/bot,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "fNq" = (
@@ -18240,6 +18278,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"hAd" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/escapepodbay)
 "hAp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -20143,10 +20197,11 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "ite" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
@@ -23417,9 +23472,10 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "jMF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "jMG" = (
@@ -23723,9 +23779,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "jRQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
@@ -24314,6 +24367,10 @@
 /obj/item/dice/d6,
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
+"keQ" = (
+/obj/machinery/computer/shipbreaker,
+/turf/open/floor/plating/airless,
+/area/escapepodbay)
 "keV" = (
 /obj/structure/lattice/catwalk,
 /turf/closed/wall/r_wall,
@@ -25234,13 +25291,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "kBA" = (
-/obj/structure/spacepoddoor{
-	dir = 4
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/machinery/door/poddoor{
-	id = "podbay"
-	},
-/turf/open/floor/engine/airless,
+/turf/open/floor/plasteel,
 /area/escapepodbay)
 "kDd" = (
 /obj/effect/turf_decal/bot,
@@ -25332,13 +25386,9 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "kFU" = (
-/obj/machinery/button/door{
-	id = "podbay";
-	name = "Pod Door Control";
-	pixel_x = -26;
-	pixel_y = 4
-	},
-/turf/open/floor/engine/airless,
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/escapepodbay)
 "kFW" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -32632,8 +32682,7 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "nIe" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/bot,
+/obj/machinery/vending/cola/random,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "nIf" = (
@@ -34779,6 +34828,13 @@
 /obj/structure/closet/crate/medical,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"oBF" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "shipbreaking";
+	name = "shipbreaking recycler conveyer"
+	},
+/turf/open/floor/plating/airless,
+/area/escapepodbay)
 "oBZ" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -36876,9 +36932,10 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "pzW" = (
+/obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space/basic,
-/area/escapepodbay)
+/area/space/nearstation)
 "pzZ" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -37803,6 +37860,15 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
+"pSR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "pSS" = (
 /obj/structure/table/wood,
 /obj/item/nullrod,
@@ -38574,6 +38640,9 @@
 "qjp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
@@ -39733,7 +39802,7 @@
 /area/ai_monitored/turret_protected/ai)
 "qJr" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
@@ -41573,10 +41642,17 @@
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
 "rAN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
 	},
-/turf/open/floor/engine/airless,
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "12"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/escapepodbay)
 "rAR" = (
 /obj/structure/railing{
@@ -42438,6 +42514,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"rTz" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "rTA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -46588,10 +46673,8 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "tGT" = (
-/obj/structure/grille,
-/obj/structure/sign/warning/docking,
 /turf/open/space/basic,
-/area/escapepodbay)
+/area/shipbreak)
 "tHf" = (
 /obj/structure/grille,
 /obj/structure/grille,
@@ -46968,8 +47051,8 @@
 /area/hallway/secondary/entry)
 "tNO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
@@ -51360,6 +51443,18 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"vHR" = (
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 4
+	},
+/obj/machinery/advanced_airlock_controller{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/escapepodbay)
 "vHX" = (
 /obj/structure/rack,
 /obj/item/storage/box/rubbershot{
@@ -53098,6 +53193,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"wvm" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "shipbreaking";
+	name = "shipbreaking recycler conveyer"
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "wvo" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -53981,9 +54083,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "wMR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /obj/machinery/light_switch{
 	pixel_x = -24
 	},
@@ -53991,6 +54090,13 @@
 	c_tag = "Escape Podbay";
 	dir = 4
 	},
+/obj/structure/rack,
+/obj/item/tank/internals/oxygen,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/melee/sledgehammer,
+/obj/item/storage/bag/trash,
+/obj/item/broom,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "wNb" = (
@@ -57472,6 +57578,16 @@
 "ydM" = (
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"ydY" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "shipbreaking"
+	},
+/obj/structure/railing{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/escapepodbay)
 "ydZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -87707,7 +87823,7 @@ ylr
 ylr
 ylr
 ylr
-ylr
+xSu
 ylr
 ylr
 ylr
@@ -87964,8 +88080,8 @@ ylr
 ylr
 ylr
 ylr
-ylr
-ylr
+xSu
+xSu
 ylr
 ylr
 ylr
@@ -88221,6 +88337,22 @@ ylr
 ylr
 ylr
 ylr
+pzW
+pzW
+pzW
+pzW
+pzW
+pzW
+pzW
+pzW
+pzW
+pzW
+pzW
+pzW
+pzW
+pzW
+pzW
+xSu
 ylr
 ylr
 ylr
@@ -88248,24 +88380,8 @@ ylr
 ylr
 ylr
 ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
+xSu
+xSu
 mcq
 mcq
 mcq
@@ -88478,6 +88594,22 @@ ylr
 ylr
 ylr
 ylr
+pzW
+idk
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+xSu
 ylr
 ylr
 ylr
@@ -88504,31 +88636,15 @@ ylr
 ylr
 ylr
 ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-rAN
-kBA
-fCV
+xSu
+xSu
+xSu
+rch
 kFU
-fCV
-fCV
+kFU
+kFU
+eVL
+aUE
 wMR
 aUE
 ite
@@ -88735,6 +88851,22 @@ ylr
 ylr
 ylr
 ylr
+pzW
+bHj
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+bHj
+wvm
 ylr
 ylr
 ylr
@@ -88761,33 +88893,17 @@ ylr
 ylr
 ylr
 ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-rAN
-kBA
-fCV
-fCV
-fCV
-fCV
+xSu
+uHz
+xSu
+rch
 qJr
-kkZ
+qJr
+qJr
+rTz
+qJr
+qJr
+qJr
 qjp
 kUg
 mcq
@@ -88992,6 +89108,22 @@ ylr
 ylr
 ylr
 ylr
+pzW
+bHj
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+bHj
+ydY
 ylr
 ylr
 ylr
@@ -89018,32 +89150,16 @@ ylr
 ylr
 ylr
 ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-rAN
+xSu
+xSu
+xSu
+rch
 kBA
+kkZ
+pSR
 fCV
 fCV
 fCV
-fCV
-qJr
 jMF
 tNO
 psN
@@ -89249,6 +89365,22 @@ ylr
 ylr
 ylr
 ylr
+pzW
+bHj
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+bHj
+cSf
 ylr
 ylr
 ylr
@@ -89275,34 +89407,18 @@ ylr
 ylr
 ylr
 ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-rAN
+xSu
+xSu
+xSu
+rch
 kBA
 fGN
-fCV
-fCV
-fCV
+fNm
+kkZ
+kkZ
 jRQ
 cmL
-fNm
+kkZ
 nIe
 mcq
 uMG
@@ -89506,59 +89622,59 @@ ylr
 ylr
 ylr
 ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-tGT
 pzW
-mcq
+bHj
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+bHj
+cSf
+bHj
+bHj
+ylr
+ylr
+ylr
+ylr
+xSu
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+xSu
+xSu
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+xSu
+xSu
+xSu
 rch
 rch
+mcq
+hAd
+rch
 rch
 mcq
-mcq
+bOG
 mcq
 mcq
 mcq
@@ -89763,6 +89879,29 @@ ylr
 ylr
 ylr
 ylr
+pzW
+bHj
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+bHj
+buA
+keQ
+bHj
+ylr
+ylr
+xSu
+xSu
+xSu
 ylr
 ylr
 ylr
@@ -89772,6 +89911,8 @@ ylr
 ylr
 ylr
 ylr
+xSu
+xSu
 ylr
 ylr
 ylr
@@ -89780,41 +89921,16 @@ ylr
 ylr
 ylr
 ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
+xSu
+xSu
+xSu
+xSu
+xSu
+mcq
+vHR
+mcq
+xSu
+xSu
 ylr
 ylr
 ylr
@@ -90020,6 +90136,28 @@ ylr
 ylr
 ylr
 ylr
+pzW
+bHj
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+bHj
+oBF
+bHj
+bHj
+ylr
+ylr
+xSu
+xSu
 ylr
 ylr
 ylr
@@ -90030,6 +90168,8 @@ ylr
 ylr
 ylr
 ylr
+xSu
+xSu
 ylr
 ylr
 ylr
@@ -90038,39 +90178,15 @@ ylr
 ylr
 ylr
 ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
+xSu
+xSu
+xSu
+xSu
+xSu
+rch
+rAN
+rch
+xSu
 ylr
 ylr
 ylr
@@ -90277,56 +90393,56 @@ ylr
 ylr
 ylr
 ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
+pzW
+bHj
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
 ylr
 ylr
 ylr
@@ -90534,6 +90650,36 @@ ylr
 ylr
 ylr
 ylr
+pzW
+bHj
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+tGT
+bHj
+xSu
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+xSu
+xSu
 ylr
 ylr
 ylr
@@ -90551,38 +90697,8 @@ ylr
 ylr
 ylr
 ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-bIB
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
+bHj
+bHj
 ylr
 ylr
 ylr
@@ -90790,6 +90906,23 @@ ylr
 ylr
 ylr
 ylr
+xSu
+pzW
+idk
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+idk
+xSu
 ylr
 ylr
 ylr
@@ -90803,24 +90936,7 @@ ylr
 ylr
 ylr
 ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
+xSu
 ylr
 ylr
 ylr
@@ -91048,6 +91164,22 @@ ylr
 ylr
 ylr
 ylr
+pzW
+pzW
+pzW
+pzW
+pzW
+pzW
+pzW
+pzW
+pzW
+pzW
+pzW
+pzW
+pzW
+pzW
+pzW
+xSu
 ylr
 ylr
 ylr
@@ -91061,23 +91193,7 @@ ylr
 ylr
 ylr
 ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
+xSu
 ylr
 ylr
 ylr
@@ -91319,7 +91435,7 @@ ylr
 ylr
 ylr
 ylr
-ylr
+xSu
 ylr
 ylr
 ylr


### PR DESCRIPTION
# Document the changes in your pull request

Adds shipbreaking areas to:

Asteroid Station
Donut Station

# Why is this good for the game?

Let all ship break

# Testing

Asteroid: 
![image](https://github.com/yogstation13/Yogstation/assets/75333826/c691b3ff-e9ba-46df-b90c-d5ae154cb550)

Donut:
![image](https://github.com/yogstation13/Yogstation/assets/75333826/2ae4e198-0129-4398-a25f-ae10878a7e55)
![image](https://github.com/yogstation13/Yogstation/assets/75333826/d663fe25-6c5f-4b5a-a38d-487d850c22fa)


# Wiki Documentation

tba

# Changelog

:cl:  

mapping: Adds ship breaking zones to Donut and Asteroid

/:cl:
