### PR TITLE
Fixes Duke Nukem announcer having 10 weight

### DIFF
--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -65,7 +65,7 @@
 /datum/station_trait/announcement_duke
 	name = "Announcement Duke"
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 0.05
+	weight = 0.2
 	show_in_report = TRUE
 	report_message = "All our announcement systems are down and our interns are on strike, so we hired some guy off the street."
 	blacklist = list(/datum/station_trait/announcement_medbot,

--- a/code/datums/station_traits/neutral_traits.dm
+++ b/code/datums/station_traits/neutral_traits.dm
@@ -65,14 +65,14 @@
 /datum/station_trait/announcement_duke
 	name = "Announcement Duke"
 	trait_type = STATION_TRAIT_NEUTRAL
-	weight = 0.2
+	weight = 0.05
 	show_in_report = TRUE
 	report_message = "All our announcement systems are down and our interns are on strike, so we hired some guy off the street."
 	blacklist = list(/datum/station_trait/announcement_medbot,
 	/datum/station_trait/announcement_intern
 	)
 
-/datum/station_trait/announcement_duket/New()
+/datum/station_trait/announcement_duke/New()
 	. = ..()
 	SSstation.announcer = /datum/centcom_announcer/duke
 


### PR DESCRIPTION
# Document the changes in your pull request

Fixes the duke nukem announcer having a base of 10 weight

# Why is this good for the game?

Something was wrong

# Testing

I wouldnt make this if i didnt open a private server 10 times to hear duke (editor's note my fix still worked somehow, not sure why)

# Changelog

:cl:  

tweak:  tweaks how often duke nukem talks to us

/:cl:
