### PR TITLE
Adds an end-goal for Space Pirates

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -256,7 +256,7 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	. = ..()
 	if(!.)
 		return FALSE
-	/* 	Half the philosophy of posi-brains. 
+	/* 	Half the philosophy of posi-brains.
 		While they are mass producible like posi-brains, they lack "many of the strengths" that cyborgs have.*/
 	if(GLOB.servant_golem_users[M.ckey])
 		var/time_left = (GLOB.servant_golem_users[M.ckey]) - world.time
@@ -821,8 +821,9 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	var/endings = strings(PIRATE_NAMES_FILE, "endings")
 	return "[rank] [pick(beggings)][pick(endings)]"
 
-/obj/effect/mob_spawn/human/pirate/Destroy()
-	new/obj/structure/showcase/machinery/oldpod/used(drop_location())
+/obj/effect/mob_spawn/human/pirate/Destroy(force)
+	if(!force)
+		new/obj/structure/showcase/machinery/oldpod/used(drop_location())
 	return ..()
 
 /obj/effect/mob_spawn/human/pirate/captain

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -93,14 +93,14 @@
 			return
 		switch(href_list["makeAntag"])
 			if("traitors")
-				if(src.makeTraitors())
+				if(makeTraitors())
 					message_admins("[key_name_admin(usr)] created traitors.")
 					log_admin("[key_name(usr)] created traitors.")
 				else
 					message_admins("[key_name_admin(usr)] tried to create traitors. Unfortunately, there were no candidates available.")
 					log_admin("[key_name(usr)] failed to create traitors.")
 			if("changelings")
-				if(src.makeChangelings())
+				if(makeChangelings())
 					message_admins("[key_name(usr)] created changelings.")
 					log_admin("[key_name(usr)] created changelings.")
 				else
@@ -1183,7 +1183,7 @@
 		var/mob/our_mob = locate(href_list["makeai"])
 		if(!istype(our_mob))
 			return
-		
+
 		message_admins(span_danger("Admin [key_name_admin(usr)] AIized [key_name_admin(our_mob)]!"))
 		log_admin("[key_name(usr)] AIized [key_name(our_mob)].")
 		our_mob.AIize(our_mob.client)

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -33,7 +33,7 @@
 	popup.set_content(dat)
 	popup.open()
 
-/datum/admins/proc/isReadytoRumble(mob/living/carbon/human/applicant, targetrole, onstation = TRUE, conscious = TRUE)
+/proc/isReadytoRumble(mob/living/carbon/human/applicant, targetrole, onstation = TRUE, conscious = TRUE)
 	if(applicant.mind.special_role)
 		return FALSE
 	if(!(targetrole in applicant.client.prefs.be_special))
@@ -49,7 +49,7 @@
 	return !is_banned_from(applicant.ckey, list(targetrole, ROLE_SYNDICATE))
 
 
-/datum/admins/proc/makeTraitors()
+/proc/makeTraitors()
 	var/datum/game_mode/traitor/temp = new
 
 	if(CONFIG_GET(flag/protect_roles_from_antagonist))
@@ -81,7 +81,7 @@
 	return 0
 
 
-/datum/admins/proc/makeChangelings()
+/proc/makeChangelings()
 
 	var/datum/game_mode/changeling/temp = new
 	if(CONFIG_GET(flag/protect_roles_from_antagonist))

--- a/code/modules/antagonists/pirate/pirate.dm
+++ b/code/modules/antagonists/pirate/pirate.dm
@@ -48,6 +48,7 @@
 		var/area/A = get_area(P)
 		if(istype(A,/area/shuttle/pirate))
 			getbooty.cargo_hold = P
+			P.target_points = getbooty.target_value
 			break
 	getbooty.update_explanation_text()
 	objectives += getbooty

--- a/tgui/packages/tgui/interfaces/CargoHoldTerminal.js
+++ b/tgui/packages/tgui/interfaces/CargoHoldTerminal.js
@@ -1,14 +1,16 @@
 import { useBackend } from '../backend';
-import { AnimatedNumber, Box, Button, LabeledList, Section } from '../components';
+import { AnimatedNumber, Box, Button, LabeledList, Section, Dimmer, Icon } from '../components';
 import { Window } from '../layouts';
 
 export const CargoHoldTerminal = (props, context) => {
   const { act, data } = useBackend(context);
   const {
+    target_points,
     points,
     pad,
     sending,
     status_report,
+    erasing,
   } = data;
   return (
     <Window
@@ -16,11 +18,17 @@ export const CargoHoldTerminal = (props, context) => {
       height={230}
       resizable>
       <Window.Content scrollable>
+        {!!erasing && (
+          <Dimmer fontSize="32px">
+            <Icon name="cog" spin={1} />
+            {' Leaving...'}
+          </Dimmer>
+        )}
         <Section>
           <LabeledList>
             <LabeledList.Item label="Current Cargo Value">
               <Box inline bold>
-                <AnimatedNumber value={Math.round(points)} /> credits
+                <AnimatedNumber value={Math.round(points)} />/{Math.round(target_points)} credits
               </Box>
             </LabeledList.Item>
           </LabeledList>


### PR DESCRIPTION
# Document the changes in your pull request
Space pirates and their ship, when fulfilling their goal, are now evacuated (deleted) and are rewarded with a randomly chosen event spawn:
- A handful of crew are made into traitors (prefs respected)
- A handful of crew are made into changelings (prefs respected)
- A space ninja spawns
- A blob spawns
- Threatening meteors spawn
- A lone operative spawns

These are deadly, but manageable if the crew is robust. A proper consequence for allowing pirates to succeed.

# Why is this good for the game?
Space pirates have always been a problem child, especially for low-pop. That problem being that they get the objective done, but continue to rampage, directionless. This is grounds for murderbone, sure, but what the hell are the pirates meant to do, sit in the shuttle? This gives the pirates true closure and a small reward (utter chaos) for completing their objective.

# Testing
Tested thoroughly by spawning large stacks of gold onto the cargo pad

# Wiki Documentation
Pirates now spawn one of the above when reaching their credit goal

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: Added an end-game for Space Pirates- Upon reaching the credit goal, pirates are sent away and a deadly event is spawned.
/:cl:
