### PR TITLE
Adjusts how stabilized sepia slime cores work

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -680,19 +680,6 @@
 	menutab = MENU_CLOTHING
 	additional_desc = "This gaudy hat has surprisingly good weight distribution, you could probably throw it very effectively."
 
-/obj/item/nullrod/tribal_knife/Initialize(mapload)
-	. = ..()
-	START_PROCESSING(SSobj, src)
-	AddComponent(/datum/component/butchering, 50, 100)
-
-/obj/item/nullrod/tribal_knife/Destroy()
-	STOP_PROCESSING(SSobj, src)
-	. = ..()
-
-/obj/item/nullrod/tribal_knife/process()
-	slowdown = rand(-2, 2)
-
-
 /obj/item/nullrod/pitchfork
 	name = "unholy pitchfork"
 	desc = "Holding this makes you look absolutely devilish."

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -710,7 +710,7 @@ datum/status_effect/stabilized/blue/on_remove()
 /datum/status_effect/stabilized/sepia/on_remove()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		owner.next_move_modifier *= 0.7
+		owner.next_move_modifier /= 0.7
 		H.physiology.do_after_speed /= 0.7
 		H.physiology.stamina_mod /= 1.5
 		H.physiology.stun_mod /= 1.5

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -701,8 +701,8 @@ datum/status_effect/stabilized/blue/on_remove()
 /datum/status_effect/stabilized/sepia/on_apply()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		owner.next_move_modifier *= 0.9
-		owner.action_speed_modifier *= 0.9
+		owner.next_move_modifier *= 0.7
+		owner.action_speed_modifier *= 0.7
 		H.physiology.stamina_mod *= 1.5
 		H.physiology.stun_mod *= 1.5
 	return ..()
@@ -710,8 +710,8 @@ datum/status_effect/stabilized/blue/on_remove()
 /datum/status_effect/stabilized/sepia/on_remove()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		owner.next_move_modifier /= 0.9
-		owner.action_speed_modifier /= 0.9
+		owner.next_move_modifier /= 0.7
+		owner.action_speed_modifier /= 0.7
 		H.physiology.stamina_mod /= 1.5
 		H.physiology.stun_mod /= 1.5
 	return ..()

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -702,7 +702,7 @@ datum/status_effect/stabilized/blue/on_remove()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		owner.next_move_modifier *= 0.7
-		owner.action_speed_modifier *= 0.7
+		H.physiology.do_after_speed *= 0.7
 		H.physiology.stamina_mod *= 1.5
 		H.physiology.stun_mod *= 1.5
 	return ..()
@@ -710,8 +710,8 @@ datum/status_effect/stabilized/blue/on_remove()
 /datum/status_effect/stabilized/sepia/on_remove()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		owner.next_move_modifier /= 0.7
-		owner.action_speed_modifier /= 0.7
+		owner.next_move_modifier *= 0.7
+		H.physiology.do_after_speed /= 0.7
 		H.physiology.stamina_mod /= 1.5
 		H.physiology.stun_mod /= 1.5
 	return ..()

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -701,17 +701,17 @@ datum/status_effect/stabilized/blue/on_remove()
 /datum/status_effect/stabilized/sepia/on_apply()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
+		owner.next_move_modifier *= 0.9
+		owner.action_speed_modifier *= 0.9
 		H.physiology.stamina_mod *= 1.5
 		H.physiology.stun_mod *= 1.5
 	return ..()
 
-/datum/status_effect/stabilized/sepia/tick()
-	owner.add_movespeed_modifier(MOVESPEED_ID_SEPIA, override = TRUE, update=TRUE, priority=100, multiplicative_slowdown= rand(-1, 1), blacklisted_movetypes=(FLYING|FLOATING))
-
 /datum/status_effect/stabilized/sepia/on_remove()
-	owner.remove_movespeed_modifier(MOVESPEED_ID_SEPIA)
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
+		owner.next_move_modifier /= 0.9
+		owner.action_speed_modifier /= 0.9
 		H.physiology.stamina_mod /= 1.5
 		H.physiology.stun_mod /= 1.5
 	return ..()

--- a/code/modules/research/xenobiology/crossbreeding/stabilized.dm
+++ b/code/modules/research/xenobiology/crossbreeding/stabilized.dm
@@ -90,7 +90,7 @@ Stabilized extracts:
 
 /obj/item/slimecross/stabilized/sepia
 	colour = "sepia"
-	effect_desc = "Randomly adjusts the owner's speed."
+	effect_desc = "Adjusts the speed at which the owner does actions."
 
 /obj/item/slimecross/stabilized/cerulean
 	colour = "cerulean"


### PR DESCRIPTION
# Document the changes in your pull request

Adjusts sepia slime cores from providing variable speed to providing action speed modifiers

Also removes some double thing i found that tattax added (lol!)

# Why is this good for the game?

The way that /tick was working with the original slime core did not remove the effect, meaning that even if you dropped the slime core you would get the random speed boosts forever. I attempted to alleviate this through several ways, but was not successful. 

This is an alternate option I had in mind, which should hopefully be amicable and equal to what the original did.

# Testing

This one actually works and goes away when dropped, if proof is needed ill post testing pictures

# Wiki Documentation

Change the description to ""Adjusts the speed at which the owner does actions.""

# Changelog

:cl:  

tweak: adjusts how stabilized sepia slime cores works

/:cl:
