### PR TITLE
Shipbreaking update: Ship Scrap & Tool Vendor

### DIFF
--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -221,10 +221,3 @@
 	categories = list(MAT_CATEGORY_ORE = TRUE)
 	sheet_type = /obj/item/stack/sheet/dilithium_crystal
 
-/datum/material/shipbreakium
-	name = "shipbreak Material"
-	id = "shipbreak_material"
-	desc = "leftover scrap from shipbreaking wrecks."
-	color = "#50c774"
-	greyscale_colors = "#50c774"
-	sheet_type = /obj/item/stack/sheet/shipbreak_material

--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -220,3 +220,11 @@
 	greyscale_colors = "#506bc7"
 	categories = list(MAT_CATEGORY_ORE = TRUE)
 	sheet_type = /obj/item/stack/sheet/dilithium_crystal
+
+/datum/material/shipbreakium
+	name = "shipbreak Material"
+	id = "shipbreak_material"
+	desc = "leftover scrap from shipbreaking wrecks."
+	color = "#50c774"
+	greyscale_colors = "#50c774"
+	sheet_type = /obj/item/stack/sheet/shipbreak_material

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -19,7 +19,20 @@
 	var/item_recycle_sound = 'sound/items/welder.ogg'
 
 /obj/machinery/recycler/Initialize(mapload)
-	AddComponent(/datum/component/material_container, list(/datum/material/iron, /datum/material/glass, /datum/material/plasma, /datum/material/silver, /datum/material/gold, /datum/material/diamond, /datum/material/uranium, /datum/material/bananium, /datum/material/titanium, /datum/material/bluespace, /datum/material/dilithium, /datum/material/plastic), INFINITY, FALSE, null, null, null, TRUE)
+	AddComponent(/datum/component/material_container, list(
+	/datum/material/iron,
+	/datum/material/glass, 
+	/datum/material/plasma, 
+	/datum/material/silver, 
+	/datum/material/gold, 
+	/datum/material/diamond, 
+	/datum/material/uranium, 
+	/datum/material/bananium, 
+	/datum/material/titanium, 
+	/datum/material/bluespace, 
+	/datum/material/dilithium, 
+	/datum/material/plastic,
+	/datum/material/shipbreakium), INFINITY, FALSE, null, null, null, TRUE)
 	AddComponent(/datum/component/butchering, 0.1 SECONDS, amount_produced, amount_produced/5)
 	. = ..()
 	return INITIALIZE_HINT_LATELOAD

--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -31,8 +31,7 @@
 	/datum/material/titanium, 
 	/datum/material/bluespace, 
 	/datum/material/dilithium, 
-	/datum/material/plastic,
-	/datum/material/shipbreakium), INFINITY, FALSE, null, null, null, TRUE)
+	/datum/material/plastic), INFINITY, FALSE, null, null, null, TRUE)
 	AddComponent(/datum/component/butchering, 0.1 SECONDS, amount_produced, amount_produced/5)
 	. = ..()
 	return INITIALIZE_HINT_LATELOAD

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -748,6 +748,24 @@
 		/obj/item/clothing/shoes/drip = 20,
 		"" = 80)
 
+/obj/effect/spawner/lootdrop/scrap_basic
+	name = "Small/Med/Large scrap spawner"
+	lootdoubles = FALSE
+
+	loot = list(
+		/obj/item/scrap = 50,
+		/obj/item/scrap/medium = 30,
+		/obj/item/scrap/large = 20)
+
+/obj/effect/spawner/lootdrop/scrap_advanced
+	name = "Med/Large/rare scrap spawner"
+	lootdoubles = FALSE
+
+	loot = list(
+		/obj/item/scrap/medium = 60,
+		/obj/item/scrap/large = 20,
+		/obj/item/scrap/rare = 10)
+		
 //Mob spawners
 /obj/effect/spawner/lootdrop/mob
 	icon = 'icons/mob/animal.dmi'

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -936,18 +936,3 @@ GLOBAL_LIST_INIT(ashresin_recipes, list (
 /obj/item/stack/sheet/ashresin/Initialize(mapload, new_amount, merge = TRUE)
 	recipes = GLOB.ashresin_recipes
 	. = ..()
-
-
-/obj/item/stack/sheet/shipbreak_material
-	name = "shipbreak material"
-	desc = "Sheets made out of broken ship parts."
-	singular_name = "ship-broken material"
-	icon_state = "sheet-metal"
-	item_state = "sheet-metal"
-	materials = list(/datum/material/shipbreakium=MINERAL_MATERIAL_AMOUNT)
-	throwforce = 10
-	flags_1 = CONDUCT_1
-	resistance_flags = FIRE_PROOF
-	merge_type = /obj/item/stack/sheet/shipbreak_material
-	point_value = 0
-	matter_amount = 4

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -936,3 +936,18 @@ GLOBAL_LIST_INIT(ashresin_recipes, list (
 /obj/item/stack/sheet/ashresin/Initialize(mapload, new_amount, merge = TRUE)
 	recipes = GLOB.ashresin_recipes
 	. = ..()
+
+
+/obj/item/stack/sheet/shipbreak_material
+	name = "shipbreak material"
+	desc = "Sheets made out of broken ship parts."
+	singular_name = "ship-broken material"
+	icon_state = "sheet-metal"
+	item_state = "sheet-metal"
+	materials = list(/datum/material/shipbreakium=MINERAL_MATERIAL_AMOUNT)
+	throwforce = 10
+	flags_1 = CONDUCT_1
+	resistance_flags = FIRE_PROOF
+	merge_type = /obj/item/stack/sheet/shipbreak_material
+	point_value = 0
+	matter_amount = 4

--- a/code/modules/shipbreaker/shipbreak_scrap.dm
+++ b/code/modules/shipbreaker/shipbreak_scrap.dm
@@ -1,0 +1,80 @@
+/obj/item/scrap
+	name = "A small piece of scrap"
+	desc = "Can be recycled for useful materials"
+	icon = 'icons/obj/tools.dmi'
+	icon_state = "fire_extinguisher0"
+	item_state = "fire_extinguisher"
+	hitsound = 'sound/weapons/smash.ogg'
+	flags_1 = CONDUCT_1
+	throwforce = 10
+	w_class = WEIGHT_CLASS_SMALL 
+	throw_speed = 2
+	throw_range = 7
+	force = 10
+	materials = list(
+	/datum/material/iron = MINERAL_MATERIAL_AMOUNT * 1,
+	/datum/material/glass = MINERAL_MATERIAL_AMOUNT * 1,
+	/datum/material/shipbreakium = MINERAL_MATERIAL_AMOUNT * 1)
+	attack_verb = list("slammed", "whacked", "bashed", "thunked", "battered", "bludgeoned", "thrashed")
+	resistance_flags = FIRE_PROOF | ACID_PROOF
+
+/obj/item/scrap/medium
+	name = "A medium piece of scrap"
+	desc = "Can be recycled for useful materials"
+	icon = 'icons/obj/tools.dmi'
+	icon_state = "fire_extinguisher0"
+	item_state = "fire_extinguisher"
+	hitsound = 'sound/weapons/smash.ogg'
+	flags_1 = CONDUCT_1
+	throwforce = 10
+	w_class = WEIGHT_CLASS_NORMAL
+	throw_speed = 2
+	throw_range = 7
+	force = 10
+	materials = list(
+	/datum/material/iron = MINERAL_MATERIAL_AMOUNT * 2,
+	/datum/material/glass = MINERAL_MATERIAL_AMOUNT * 2,
+	/datum/material/shipbreakium = MINERAL_MATERIAL_AMOUNT * 2)
+	attack_verb = list("slammed", "whacked", "bashed", "thunked", "battered", "bludgeoned", "thrashed")
+	resistance_flags = FIRE_PROOF | ACID_PROOF
+
+/obj/item/scrap/large
+	name = "A large piece of scrap"
+	desc = "Can be recycled for useful materials"
+	icon = 'icons/obj/tools.dmi'
+	icon_state = "fire_extinguisher0"
+	item_state = "fire_extinguisher"
+	hitsound = 'sound/weapons/smash.ogg'
+	flags_1 = CONDUCT_1
+	throwforce = 10
+	w_class = WEIGHT_CLASS_BULKY 
+	throw_speed = 2
+	throw_range = 7
+	force = 10
+	materials = list(
+	/datum/material/iron = MINERAL_MATERIAL_AMOUNT * 4,
+	/datum/material/glass = MINERAL_MATERIAL_AMOUNT * 4,
+	/datum/material/shipbreakium = MINERAL_MATERIAL_AMOUNT * 4)
+	attack_verb = list("slammed", "whacked", "bashed", "thunked", "battered", "bludgeoned", "thrashed")
+	resistance_flags = FIRE_PROOF | ACID_PROOF
+
+/obj/item/scrap/rare
+	name = "Advanced scrap material, left over from a sophisticated piece of machinery."
+	desc = "Can be recycled for useful materials"
+	icon = 'icons/obj/tools.dmi'
+	icon_state = "fire_extinguisher0"
+	item_state = "fire_extinguisher"
+	hitsound = 'sound/weapons/smash.ogg'
+	flags_1 = CONDUCT_1
+	throwforce = 10
+	w_class = WEIGHT_CLASS_BULKY
+	throw_speed = 2
+	throw_range = 7
+	force = 10
+	materials = list(
+	/datum/material/silver = MINERAL_MATERIAL_AMOUNT * 10,
+	/datum/material/gold = MINERAL_MATERIAL_AMOUNT * 10,
+	/datum/material/uranium = MINERAL_MATERIAL_AMOUNT * 10,
+	/datum/material/shipbreakium = MINERAL_MATERIAL_AMOUNT * 10)
+	attack_verb = list("slammed", "whacked", "bashed", "thunked", "battered", "bludgeoned", "thrashed")
+	resistance_flags = FIRE_PROOF | ACID_PROOF

--- a/code/modules/shipbreaker/shipbreak_scrap.dm
+++ b/code/modules/shipbreaker/shipbreak_scrap.dm
@@ -13,8 +13,7 @@
 	force = 10
 	materials = list(
 	/datum/material/iron = MINERAL_MATERIAL_AMOUNT * 1,
-	/datum/material/glass = MINERAL_MATERIAL_AMOUNT * 1,
-	/datum/material/shipbreakium = MINERAL_MATERIAL_AMOUNT * 1)
+	/datum/material/glass = MINERAL_MATERIAL_AMOUNT * 1,)
 	attack_verb = list("slammed", "whacked", "bashed", "thunked", "battered", "bludgeoned", "thrashed")
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 
@@ -33,8 +32,7 @@
 	force = 10
 	materials = list(
 	/datum/material/iron = MINERAL_MATERIAL_AMOUNT * 2,
-	/datum/material/glass = MINERAL_MATERIAL_AMOUNT * 2,
-	/datum/material/shipbreakium = MINERAL_MATERIAL_AMOUNT * 2)
+	/datum/material/glass = MINERAL_MATERIAL_AMOUNT * 2,)
 	attack_verb = list("slammed", "whacked", "bashed", "thunked", "battered", "bludgeoned", "thrashed")
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 
@@ -53,8 +51,7 @@
 	force = 10
 	materials = list(
 	/datum/material/iron = MINERAL_MATERIAL_AMOUNT * 4,
-	/datum/material/glass = MINERAL_MATERIAL_AMOUNT * 4,
-	/datum/material/shipbreakium = MINERAL_MATERIAL_AMOUNT * 4)
+	/datum/material/glass = MINERAL_MATERIAL_AMOUNT * 4,)
 	attack_verb = list("slammed", "whacked", "bashed", "thunked", "battered", "bludgeoned", "thrashed")
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 
@@ -74,7 +71,6 @@
 	materials = list(
 	/datum/material/silver = MINERAL_MATERIAL_AMOUNT * 10,
 	/datum/material/gold = MINERAL_MATERIAL_AMOUNT * 10,
-	/datum/material/uranium = MINERAL_MATERIAL_AMOUNT * 10,
-	/datum/material/shipbreakium = MINERAL_MATERIAL_AMOUNT * 10)
+	/datum/material/uranium = MINERAL_MATERIAL_AMOUNT * 10,)
 	attack_verb = list("slammed", "whacked", "bashed", "thunked", "battered", "bludgeoned", "thrashed")
 	resistance_flags = FIRE_PROOF | ACID_PROOF

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3700,6 +3700,8 @@
 #include "code\modules\security_levels\level_interface.dm"
 #include "code\modules\security_levels\security_level_datums.dm"
 #include "code\modules\shipbreaker\shipbreak_console.dm"
+#include "code\modules\shipbreaker\shipbreak_scrap.dm"
+#include "code\modules\shipbreaker\shipbreak_tool_vendor.dm"
 #include "code\modules\shuttle\ai_ship.dm"
 #include "code\modules\shuttle\arrivals.dm"
 #include "code\modules\shuttle\assault_pod.dm"

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3701,7 +3701,6 @@
 #include "code\modules\security_levels\security_level_datums.dm"
 #include "code\modules\shipbreaker\shipbreak_console.dm"
 #include "code\modules\shipbreaker\shipbreak_scrap.dm"
-#include "code\modules\shipbreaker\shipbreak_tool_vendor.dm"
 #include "code\modules\shuttle\ai_ship.dm"
 #include "code\modules\shuttle\arrivals.dm"
 #include "code\modules\shuttle\assault_pod.dm"


### PR DESCRIPTION
# Document the changes in your pull request

Adds 4 types of scrap you can obtain from shipbreaking:
Small - 1 iron, 1 glass
Medium - 2 iron, 2 glass
Large - 4 iron, 4 glass
Rare - 10 silver, 10 gold, 10 uranium

Adds a new type of recycler that will track & give points based on the scrap you break down
When recycling scrap you will gain variable amounts of research points:

Small: 500 points
Medium: 1000 points
Large: 5000 points
Rare: 10000 points

New tools: 

Shipbreaking Sledge
Shipbreaking Welder
More TBA(?)

# Why is this good for the game?

Adds on to the robust system of ship breaking, rounding it out.

# Testing

Will update w/ finished

# Spriting

This will require new sprites

# Wiki Documentation

im going to make the page for shipbreaking once this is done

# Changelog

:cl:  Cowbot92 & Chubbygummibear
rscadd: Adds new shipbreaking tools & vendor
rscadd: Adds new shipbreaking material/scrap
mapping: Adds new scrap spawns to all existing ships
wip: This is work in progress  
imageadd: added some shipbreaking tool/scrap sprites
experimental: This is experimental
/:cl:
