### PR TITLE
Closing the gap between station & lavaland

### DIFF
--- a/_maps/shuttles/mining_box.dmm
+++ b/_maps/shuttles/mining_box.dmm
@@ -37,7 +37,9 @@
 	shuttle_id = "mining";
 	name = "mining shuttle";
 	port_direction = 4;
-	width = 7
+	width = 7;
+	ignitionTime = 10;
+	callTime = 10
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4

--- a/_maps/shuttles/mining_delta.dmm
+++ b/_maps/shuttles/mining_delta.dmm
@@ -292,7 +292,9 @@
 	shuttle_id = "mining";
 	name = "mining shuttle";
 	port_direction = 8;
-	width = 7
+	width = 7;
+	callTime = 10;
+	ignitionTime = 10
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4

--- a/_maps/shuttles/mining_kilo.dmm
+++ b/_maps/shuttles/mining_kilo.dmm
@@ -73,7 +73,9 @@
 	shuttle_id = "mining";
 	name = "mining shuttle";
 	port_direction = 4;
-	width = 7
+	width = 7;
+	callTime = 10;
+	ignitionTime = 10
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/mining)


### PR DESCRIPTION
# Document the changes in your pull request
Mining shuttles now take 1 second to depart and 1 second to arrive

# Why is this good for the game?
Optimally, station & planet z-level would be one in the same, but this is a step closer. By making transit incredibly fast, planetside becomes a lot less exclusive. Inspired by IceMeta's ladder

# Testing
It goes fast



# Wiki Documentation
See documentation

# Changelog

:cl:  
tweak: The mining shuttle engines have had their safeties disabled, making interplanetary travel faster than ever before.
/:cl:
