### PR TITLE
Adds shipbreaking to Icemeta

### DIFF
--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -2004,6 +2004,16 @@
 /obj/structure/sink/puddle,
 /turf/open/floor/grass,
 /area/medical/genetics)
+"aDH" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/fans/tiny{
+	resistance_flags = 115
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/snowed/smoothed,
+/area/icemoon/top_layer/outdoors)
 "aDI" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -3502,6 +3512,12 @@
 "aYT" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating/snowed/smoothed,
 /area/icemoon/top_layer/outdoors)
 "aYY" = (
@@ -5801,6 +5817,16 @@
 /obj/structure/ladder,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/underground/explored/laborcamp)
+"bJC" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/fans/tiny{
+	resistance_flags = 115
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/snowed/smoothed,
+/area/icemoon/top_layer/outdoors)
 "bJD" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel,
@@ -8926,7 +8952,9 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
-/obj/structure/fans/tiny,
+/obj/structure/fans/tiny{
+	resistance_flags = 115
+	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -11993,6 +12021,12 @@
 /obj/structure/lattice,
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating/snowed/smoothed,
 /area/icemoon/top_layer/outdoors)
 "dAp" = (
@@ -17335,7 +17369,9 @@
 /turf/open/floor/engine/n2,
 /area/engine/atmos/distro)
 "fiM" = (
-/obj/structure/fans/tiny,
+/obj/structure/fans/tiny{
+	resistance_flags = 115
+	},
 /turf/open/floor/plating,
 /area/mine/abandoned)
 "fiU" = (
@@ -18975,7 +19011,9 @@
 	id = "Podbaydoor";
 	name = "Wilderness Access"
 	},
-/obj/structure/fans/tiny,
+/obj/structure/fans/tiny{
+	resistance_flags = 115
+	},
 /turf/open/floor/engine,
 /area/escapepodbay)
 "fIm" = (
@@ -19326,6 +19364,19 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/solar/port/fore)
+"fMQ" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/fans/tiny{
+	resistance_flags = 115
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/snowed/smoothed,
+/area/icemoon/top_layer/outdoors)
 "fMT" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Starboard Primary Hallway"
@@ -20640,6 +20691,19 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall,
 /area/science/xenobiology)
+"ged" = (
+/obj/structure/lattice/catwalk,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/smoothed,
+/area/icemoon/top_layer/outdoors)
 "gep" = (
 /turf/closed/wall,
 /area/storage/art)
@@ -27658,7 +27722,9 @@
 /obj/item/flashlight/lantern{
 	light_on = 1
 	},
-/obj/structure/fans/tiny,
+/obj/structure/fans/tiny{
+	resistance_flags = 115
+	},
 /turf/open/floor/plating/snowed/colder,
 /area/mine/abandoned)
 "ihb" = (
@@ -28279,7 +28345,9 @@
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "iqX" = (
-/obj/structure/fans/tiny,
+/obj/structure/fans/tiny{
+	resistance_flags = 115
+	},
 /obj/machinery/door/poddoor{
 	id = "Podbaydoor";
 	name = "Wilderness Access"
@@ -39647,6 +39715,17 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
+"lAM" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon,
+/obj/structure/fans/tiny{
+	resistance_flags = 115
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating/snowed/smoothed,
+/area/icemoon/top_layer/outdoors)
 "lAO" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/atmospherics,
@@ -40170,7 +40249,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "lIB" = (
-/obj/structure/fans/tiny,
+/obj/structure/fans/tiny{
+	resistance_flags = 115
+	},
 /turf/open/floor/plating,
 /area/mine/laborcamp)
 "lIC" = (
@@ -40708,9 +40789,14 @@
 	},
 /area/chapel/main)
 "lPT" = (
-/obj/structure/lattice,
 /obj/structure/lattice/catwalk,
-/turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
+/obj/structure/fans/tiny{
+	resistance_flags = 115
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/snowed/smoothed,
 /area/icemoon/top_layer/outdoors)
 "lPV" = (
 /obj/machinery/door/airlock/public/glass{
@@ -46198,7 +46284,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/structure/fans/tiny,
+/obj/structure/fans/tiny{
+	resistance_flags = 115
+	},
 /obj/machinery/door/airlock/external{
 	name = "Engineering Escape Pod";
 	req_one_access_txt = "10;61"
@@ -57215,7 +57303,9 @@
 	id = "chapelgun";
 	name = "Chapel Launcher Door"
 	},
-/obj/structure/fans/tiny,
+/obj/structure/fans/tiny{
+	resistance_flags = 115
+	},
 /turf/open/floor/plating,
 /area/chapel/main)
 "qyk" = (
@@ -65795,7 +65885,9 @@
 /area/ai_monitored/security/armory)
 "sVd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/fans/tiny,
+/obj/structure/fans/tiny{
+	resistance_flags = 115
+	},
 /turf/open/floor/plating,
 /area/mine/abandoned)
 "sVf" = (
@@ -69043,9 +69135,14 @@
 /turf/open/floor/plasteel/dark,
 /area/mine/infirmary)
 "tQu" = (
-/obj/structure/fans/tiny,
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon,
+/obj/structure/fans/tiny{
+	resistance_flags = 115
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/plating/snowed/smoothed,
 /area/icemoon/top_layer/outdoors)
 "tQF" = (
@@ -69760,6 +69857,17 @@
 /obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"tZD" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon,
+/obj/structure/fans/tiny{
+	resistance_flags = 115
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/snowed/smoothed,
+/area/icemoon/top_layer/outdoors)
 "tZL" = (
 /obj/machinery/light/small,
 /turf/open/floor/engine,
@@ -75554,8 +75662,11 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "vEE" = (
-/obj/structure/fans/tiny,
 /obj/structure/lattice/catwalk,
+/obj/structure/fans/tiny{
+	resistance_flags = 115
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/snowed/smoothed,
 /area/icemoon/top_layer/outdoors)
 "vEJ" = (
@@ -77139,6 +77250,17 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
+"wbG" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon,
+/obj/structure/fans/tiny{
+	resistance_flags = 115
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating/snowed/smoothed,
+/area/icemoon/top_layer/outdoors)
 "wbK" = (
 /obj/structure/table,
 /obj/item/storage/belt/medical{
@@ -81317,6 +81439,12 @@
 /area/maintenance/starboard/secondary)
 "xkE" = (
 /obj/structure/lattice/catwalk,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plating/snowed/smoothed,
 /area/icemoon/top_layer/outdoors)
 "xkF" = (
@@ -82649,7 +82777,9 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
-/obj/structure/fans/tiny,
+/obj/structure/fans/tiny{
+	resistance_flags = 115
+	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -84101,7 +84231,9 @@
 	id = "toxinsdriver";
 	name = "Toxins Launcher Bay Door"
 	},
-/obj/structure/fans/tiny,
+/obj/structure/fans/tiny{
+	resistance_flags = 115
+	},
 /turf/open/floor/plating,
 /area/science/mixing)
 "xTp" = (
@@ -243990,20 +244122,20 @@ ozK
 ozK
 ozK
 aKW
-tQu
-vEE
-vEE
-vEE
-vEE
-vEE
-vEE
-vEE
-vEE
-vEE
-vEE
-vEE
-vEE
-tQu
+wbG
+lPT
+lPT
+lPT
+lPT
+lPT
+lPT
+lPT
+lPT
+lPT
+lPT
+lPT
+lPT
+tZD
 tRh
 tRh
 tRh
@@ -244247,7 +244379,7 @@ ozK
 ozK
 ozK
 kBB
-vEE
+aDH
 fWS
 fWS
 fWS
@@ -244504,7 +244636,7 @@ ozK
 ozK
 ozK
 nNq
-vEE
+aDH
 fWS
 fWS
 fWS
@@ -244761,7 +244893,7 @@ ozK
 ozK
 ozK
 vqV
-vEE
+aDH
 fWS
 fWS
 fWS
@@ -245018,7 +245150,7 @@ ozK
 ozK
 ueX
 tJz
-vEE
+aDH
 fWS
 fWS
 fWS
@@ -245257,8 +245389,8 @@ bwy
 hIF
 pDH
 iqX
-lPT
-pnX
+ueX
+ozK
 ozK
 ozK
 ozK
@@ -245275,7 +245407,7 @@ ozK
 ozK
 ueX
 aKW
-vEE
+aDH
 fWS
 fWS
 fWS
@@ -245516,11 +245648,7 @@ pDH
 iqX
 dAi
 xkE
-xkE
-xkE
-aYT
-xkE
-xkE
+ged
 xkE
 aYT
 xkE
@@ -245532,7 +245660,11 @@ xkE
 xkE
 aYT
 xkE
-vEE
+xkE
+xkE
+aYT
+xkE
+aDH
 fWS
 fWS
 fWS
@@ -245771,8 +245903,8 @@ bwy
 hIF
 pDH
 fIf
-lPT
-pnX
+ueX
+ozK
 ozK
 ozK
 ozK
@@ -245789,7 +245921,7 @@ ueX
 ueX
 ueX
 kSM
-vEE
+fMQ
 fWS
 fWS
 fWS
@@ -246046,7 +246178,7 @@ ozK
 ozK
 ozK
 ozK
-vEE
+fMQ
 fWS
 fWS
 fWS
@@ -246304,19 +246436,19 @@ ozK
 ozK
 ozK
 tQu
-vEE
-vEE
-vEE
-vEE
-vEE
-vEE
-vEE
-vEE
-vEE
-vEE
-vEE
-vEE
-tQu
+bJC
+bJC
+bJC
+bJC
+bJC
+bJC
+bJC
+bJC
+bJC
+bJC
+bJC
+bJC
+lAM
 tRh
 tRh
 tRh

--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -2006,9 +2006,6 @@
 /area/medical/genetics)
 "aDH" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/fans/tiny{
-	resistance_flags = 115
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -5819,9 +5816,6 @@
 /area/icemoon/underground/explored/laborcamp)
 "bJC" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/fans/tiny{
-	resistance_flags = 115
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -19366,9 +19360,6 @@
 /area/solar/port/fore)
 "fMQ" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/fans/tiny{
-	resistance_flags = 115
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -20151,7 +20142,7 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/mine/maintenance)
 "fWS" = (
-/turf/open/space/basic,
+/turf/open/floor/plating/snowed/smoothed,
 /area/shipbreak)
 "fXe" = (
 /obj/machinery/airalarm{
@@ -39718,9 +39709,6 @@
 "lAM" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon,
-/obj/structure/fans/tiny{
-	resistance_flags = 115
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -40790,9 +40778,6 @@
 /area/chapel/main)
 "lPT" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/fans/tiny{
-	resistance_flags = 115
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -69137,9 +69122,6 @@
 "tQu" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon,
-/obj/structure/fans/tiny{
-	resistance_flags = 115
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -69860,9 +69842,6 @@
 "tZD" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon,
-/obj/structure/fans/tiny{
-	resistance_flags = 115
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -75663,9 +75642,6 @@
 /area/science/mixing)
 "vEE" = (
 /obj/structure/lattice/catwalk,
-/obj/structure/fans/tiny{
-	resistance_flags = 115
-	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/snowed/smoothed,
 /area/icemoon/top_layer/outdoors)
@@ -77253,9 +77229,6 @@
 "wbG" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon,
-/obj/structure/fans/tiny{
-	resistance_flags = 115
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},

--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -12012,17 +12012,20 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dAi" = (
-/obj/structure/lattice,
-/obj/structure/lattice/catwalk,
-/obj/structure/marker_beacon,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/plating/snowed/smoothed,
-/area/icemoon/top_layer/outdoors)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/secondary)
 "dAp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -13451,6 +13454,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
@@ -24207,9 +24213,11 @@
 /area/maintenance/starboard)
 "haS" = (
 /obj/structure/cable/yellow,
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/power/apc/auto_name{
 	pixel_y = -23
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
@@ -37054,9 +37062,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
 "kJK" = (
-/obj/effect/turf_decal/stripes{
-	dir = 9
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -37065,6 +37070,9 @@
 /obj/machinery/camera{
 	c_tag = "Podbay Camera 2";
 	dir = 5
+	},
+/obj/effect/turf_decal/stripes{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
@@ -70888,6 +70896,12 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
@@ -245608,7 +245622,7 @@ ijj
 jgu
 qwx
 wAR
-uZv
+dAi
 qHW
 pOm
 wjA
@@ -245619,7 +245633,7 @@ bwy
 hIF
 pDH
 iqX
-dAi
+aYT
 xkE
 ged
 xkE

--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -2407,6 +2407,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"aKW" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "shipbreaking";
+	name = "shipbreaking recycler conveyer"
+	},
+/turf/open/floor/plating/snowed/smoothed,
+/area/escapepodbay)
 "aLa" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating{
@@ -3492,6 +3499,11 @@
 /obj/effect/turf_decal/trimline/green/warning,
 /turf/closed/wall,
 /area/hydroponics/garden)
+"aYT" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon,
+/turf/open/floor/plating/snowed/smoothed,
+/area/icemoon/top_layer/outdoors)
 "aYY" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -5548,14 +5560,16 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "bFW" = (
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
 /area/escapepodbay)
 "bGs" = (
 /obj/structure/rack,
@@ -11975,6 +11989,12 @@
 /obj/machinery/vending/wardrobe/robo_wardrobe,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"dAi" = (
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon,
+/turf/open/floor/plating/snowed/smoothed,
+/area/icemoon/top_layer/outdoors)
 "dAp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -20080,9 +20100,8 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/mine/maintenance)
 "fWS" = (
-/obj/item/reagent_containers/food/snacks/egg/yellow,
-/turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/icemoon/top_layer/outdoors)
+/turf/open/space/basic,
+/area/shipbreak)
 "fXe" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -25644,13 +25663,21 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "hAg" = (
-/obj/effect/turf_decal/stripes{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/structure/rack,
+/obj/item/tank/internals/oxygen,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/bag/trash,
+/obj/item/melee/sledgehammer,
+/obj/item/broom,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
 /area/escapepodbay)
 "hAq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -36251,6 +36278,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"kBB" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "shipbreaking"
+	},
+/obj/structure/railing{
+	dir = 9
+	},
+/turf/open/floor/plating/snowed/smoothed,
+/area/escapepodbay)
 "kBG" = (
 /obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel,
@@ -37481,6 +37518,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"kSM" = (
+/obj/machinery/computer/shipbreaker{
+	dir = 1
+	},
+/turf/open/floor/plating/snowed/smoothed,
+/area/escapepodbay)
 "kSO" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Vacant Office";
@@ -40664,6 +40707,11 @@
 	dir = 1
 	},
 /area/chapel/main)
+"lPT" = (
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
+/area/icemoon/top_layer/outdoors)
 "lPV" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Library"
@@ -44454,15 +44502,24 @@
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
 /area/icemoon/top_layer/outdoors)
 "mQy" = (
-/obj/effect/turf_decal/stripes/end,
-/obj/structure/closet/emcloset,
 /obj/machinery/button/door{
 	id = "Podbaydoor";
 	pixel_x = 24;
 	pixel_y = -1
 	},
 /obj/machinery/light,
-/turf/open/floor/plasteel,
+/obj/structure/rack,
+/obj/item/tank/internals/oxygen,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/bag/trash,
+/obj/item/melee/sledgehammer,
+/obj/item/broom,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
 /area/escapepodbay)
 "mQz" = (
 /turf/closed/wall,
@@ -47159,6 +47216,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
+"nCR" = (
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
+/area/escapepodbay)
 "nDh" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -47850,6 +47915,16 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
 /area/medical/genetics)
+"nNq" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "shipbreaking"
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating/snowed/smoothed,
+/area/escapepodbay)
 "nNr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -50415,16 +50490,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "oxF" = (
-/obj/effect/turf_decal/stripes{
-	dir = 5
-	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/suit_storage_unit/standard_unit,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
 /area/escapepodbay)
 "oxJ" = (
 /obj/structure/cable/yellow{
@@ -57319,6 +57396,10 @@
 /obj/effect/landmark/stationroom/maint/tenxfive,
 /turf/baseturf_bottom,
 /area/maintenance/port/aft)
+"qBg" = (
+/obj/structure/lattice,
+/turf/closed/mineral/random/snow/top_layer,
+/area/icemoon/top_layer/outdoors)
 "qBm" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/command,
@@ -61685,10 +61766,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "rQf" = (
-/obj/effect/turf_decal/stripes{
-	dir = 4
+/obj/structure/rack,
+/obj/item/tank/internals/oxygen,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/bag/sheetsnatcher,
+/obj/item/storage/bag/trash,
+/obj/item/melee/sledgehammer,
+/obj/item/broom,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/dark,
 /area/escapepodbay)
 "rQi" = (
 /obj/machinery/camera{
@@ -64352,6 +64441,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
+"sBE" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel/dark,
+/area/escapepodbay)
 "sBH" = (
 /obj/structure/chair{
 	dir = 1
@@ -68544,6 +68638,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/auxiliary)
+"tJz" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "shipbreaking"
+	},
+/obj/structure/railing{
+	dir = 5
+	},
+/turf/open/floor/plating/snowed/smoothed,
+/area/escapepodbay)
 "tJN" = (
 /obj/structure/sign/warning/nosmoking,
 /turf/closed/wall,
@@ -68938,6 +69042,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/mine/infirmary)
+"tQu" = (
+/obj/structure/fans/tiny,
+/obj/structure/lattice/catwalk,
+/obj/structure/marker_beacon,
+/turf/open/floor/plating/snowed/smoothed,
+/area/icemoon/top_layer/outdoors)
 "tQF" = (
 /turf/closed/wall,
 /area/security/warden)
@@ -74442,6 +74552,17 @@
 /obj/structure/bodycontainer/morgue,
 /turf/open/floor/plasteel/dark,
 /area/security/detectives_office)
+"vqV" = (
+/obj/machinery/recycler,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "shipbreaking"
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/open/floor/plating/snowed/smoothed,
+/area/escapepodbay)
 "vqZ" = (
 /obj/machinery/conveyor{
 	id = "gulag"
@@ -75432,6 +75553,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"vEE" = (
+/obj/structure/fans/tiny,
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating/snowed/smoothed,
+/area/icemoon/top_layer/outdoors)
 "vEJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -77727,6 +77853,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"wlq" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/dark,
+/area/escapepodbay)
 "wlr" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -81184,6 +81315,10 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
+"xkE" = (
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating/snowed/smoothed,
+/area/icemoon/top_layer/outdoors)
 "xkF" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -243342,7 +243477,7 @@ ozK
 ozK
 ozK
 ozK
-ozK
+ueX
 ozK
 ozK
 ozK
@@ -243355,7 +243490,7 @@ tRh
 tRh
 tRh
 tRh
-tRh
+qBg
 tRh
 tRh
 tRh
@@ -243599,7 +243734,7 @@ ozK
 ozK
 ozK
 ozK
-ozK
+ueX
 ozK
 ozK
 ozK
@@ -243610,8 +243745,8 @@ ozK
 tRh
 tRh
 tRh
-tRh
-tRh
+qBg
+qBg
 tRh
 tRh
 tRh
@@ -243854,21 +243989,21 @@ ozK
 ozK
 ozK
 ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-tRh
-tRh
-tRh
-tRh
-tRh
+aKW
+tQu
+vEE
+vEE
+vEE
+vEE
+vEE
+vEE
+vEE
+vEE
+vEE
+vEE
+vEE
+vEE
+tQu
 tRh
 tRh
 tRh
@@ -244111,21 +244246,21 @@ ozK
 ozK
 ozK
 ozK
-ozK
-ozK
-ozK
-ozK
+kBB
+vEE
 fWS
-ozK
-ozK
-ozK
-ozK
-ozK
-tRh
-tRh
-tRh
-tRh
-tRh
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+vEE
 tRh
 tRh
 tRh
@@ -244368,21 +244503,21 @@ ozK
 ozK
 ozK
 ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-tRh
-tRh
-tRh
-tRh
-tRh
+nNq
+vEE
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+vEE
 tRh
 tRh
 tRh
@@ -244625,21 +244760,21 @@ ozK
 ozK
 ozK
 ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-tRh
-tRh
-tRh
-tRh
-tRh
+vqV
+vEE
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+vEE
 tRh
 tRh
 tRh
@@ -244881,22 +245016,22 @@ ozK
 ozK
 ozK
 ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-tRh
-tRh
-tRh
-tRh
-tRh
+ueX
+tJz
+vEE
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+vEE
 tRh
 tRh
 tRh
@@ -245122,38 +245257,38 @@ bwy
 hIF
 pDH
 iqX
+lPT
+pnX
+ozK
+ozK
+ozK
+ozK
+ozK
+ozK
+ozK
+ozK
+ozK
+ozK
+ozK
+ozK
+ozK
+ozK
 ueX
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-tRh
-tRh
-tRh
-tRh
-tRh
+aKW
+vEE
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+vEE
 tRh
 tRh
 tRh
@@ -245374,43 +245509,43 @@ pOm
 wjA
 eNB
 qHW
-olt
+sBE
 bwy
 hIF
 pDH
 iqX
-ueX
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-tRh
-tRh
-tRh
-tRh
-tRh
+dAi
+xkE
+xkE
+xkE
+aYT
+xkE
+xkE
+xkE
+aYT
+xkE
+xkE
+xkE
+aYT
+xkE
+xkE
+xkE
+aYT
+xkE
+vEE
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+vEE
 tRh
 tRh
 tRh
@@ -245631,43 +245766,43 @@ qHW
 qHW
 qHW
 qHW
-olt
+wlq
 bwy
 hIF
 pDH
 fIf
+lPT
+pnX
+ozK
+ozK
+ozK
+ozK
+ozK
+ozK
+ozK
+ozK
+ozK
+ozK
+ozK
+ozK
 ueX
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-tRh
-tRh
-tRh
-tRh
-tRh
+ueX
+ueX
+kSM
+vEE
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+vEE
 tRh
 tRh
 tRh
@@ -245911,20 +246046,20 @@ ozK
 ozK
 ozK
 ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-tRh
-tRh
-tRh
-tRh
-tRh
+vEE
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+fWS
+vEE
 tRh
 tRh
 tRh
@@ -246145,7 +246280,7 @@ haS
 dbQ
 oxF
 bFW
-rQf
+nCR
 rQf
 hAg
 mQy
@@ -246168,20 +246303,20 @@ ozK
 ozK
 ozK
 ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-ozK
-tRh
-tRh
-tRh
-tRh
-tRh
+tQu
+vEE
+vEE
+vEE
+vEE
+vEE
+vEE
+vEE
+vEE
+vEE
+vEE
+vEE
+vEE
+tQu
 tRh
 tRh
 tRh
@@ -246429,8 +246564,8 @@ ozK
 ozK
 ozK
 ozK
-ozK
-ozK
+ueX
+ueX
 ozK
 ozK
 ozK
@@ -246687,7 +246822,7 @@ ozK
 ozK
 ozK
 ozK
-ozK
+ueX
 ozK
 ozK
 ozK

--- a/_maps/templates/shipbreaker/old_alien.dmm
+++ b/_maps/templates/shipbreaker/old_alien.dmm
@@ -43,7 +43,7 @@
 /area/template_noop)
 "z" = (
 /obj/machinery/door/airlock/abductor,
-/turf/open/space/basic,
+/turf/open/floor/plating/abductor,
 /area/template_noop)
 "A" = (
 /obj/structure/table/optable/abductor,

--- a/code/modules/shipbreaker/shipbreak_console.dm
+++ b/code/modules/shipbreaker/shipbreak_console.dm
@@ -45,6 +45,9 @@
 
 /obj/machinery/computer/shipbreaker/proc/area_clear_check()
 	for(var/turf/t in linked)
+		if(isopenturf(t) (istype(t, /turf/open/floor/plating/snowed/smoothed)))
+			spawn_area_clear = TRUE
+
 		if(!isspaceturf(t))
 			spawn_area_clear = FALSE
 			return

--- a/code/modules/shipbreaker/shipbreak_console.dm
+++ b/code/modules/shipbreaker/shipbreak_console.dm
@@ -45,10 +45,10 @@
 
 /obj/machinery/computer/shipbreaker/proc/area_clear_check()
 	for(var/turf/t in linked)
-		if(isopenturf(t) (istype(t, /turf/open/floor/plating/snowed/smoothed)))
+		if(((istype(t, /turf/open/floor/plating/snowed/smoothed))))
 			spawn_area_clear = TRUE
 
-		if(!isspaceturf(t))
+		else if(!isspaceturf(t))
 			spawn_area_clear = FALSE
 			return
 	for(var/obj/s in linked)
@@ -60,9 +60,9 @@
 
 /obj/machinery/computer/shipbreaker/proc/clear_floor_plating()
 	for(var/turf/t in linked)
-		if(isfloorturf(t))
+		if(((!istype(t, /turf/open/floor/plating/snowed/smoothed))))
 			t.ScrapeAway()
-
+			
 
 /obj/machinery/computer/shipbreaker/ui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)


### PR DESCRIPTION
# Document the changes in your pull request

Adds all current shipbreaking structures to Icemeta

# Why is this good for the game?

I was too busy figuring out if I can to figure out if I should.

# Testing

it actually works wonderfully

Inside area
![image](https://github.com/yogstation13/Yogstation/assets/75333826/8560bd0f-89cb-4f7f-8b57-8af0ad870cbf)

Shipbreaking area
![image](https://github.com/yogstation13/Yogstation/assets/75333826/0e76da02-8817-4c64-a0df-d387caf21a77)

# Wiki Documentation

Will be added

# Changelog

:cl:  

mapping: Adds shipbreaking to Icemeta

/:cl:
