### PR TITLE
Adds spawnpoints for space ninja on IceMeta for when it rolls

### DIFF
--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -12915,6 +12915,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
+"dPh" = (
+/obj/effect/landmark/carpspawn,
+/turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
+/area/icemoon/top_layer/outdoors)
 "dPj" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/satellite)
@@ -221379,7 +221383,7 @@ hcl
 hcl
 hcl
 ozK
-ozK
+dPh
 ozK
 tRh
 tRh
@@ -222465,7 +222469,7 @@ ozK
 ozK
 ozK
 ozK
-ozK
+dPh
 tRh
 tRh
 tRh
@@ -224224,7 +224228,7 @@ ozK
 ozK
 ozK
 ozK
-ozK
+dPh
 ozK
 ozK
 ozK
@@ -226604,7 +226608,7 @@ ozK
 ozK
 ozK
 ozK
-ozK
+dPh
 ozK
 ozK
 tRh
@@ -228818,7 +228822,7 @@ tRh
 tRh
 ozK
 ozK
-ozK
+dPh
 ozK
 ozK
 ozK
@@ -231105,7 +231109,7 @@ tRh
 tRh
 tRh
 tRh
-ozK
+dPh
 ozK
 ozK
 ozK
@@ -234077,7 +234081,7 @@ ozK
 ozK
 ozK
 ozK
-ozK
+dPh
 ozK
 ozK
 tRh
@@ -236247,7 +236251,7 @@ tRh
 tRh
 tRh
 tRh
-ozK
+dPh
 ozK
 ozK
 ozK
@@ -245404,7 +245408,7 @@ ozK
 ozK
 ozK
 ozK
-ozK
+dPh
 ozK
 tRh
 tRh
@@ -257844,7 +257848,7 @@ tRh
 tRh
 tRh
 tRh
-ozK
+dPh
 ozK
 ozK
 ozK
@@ -262855,7 +262859,7 @@ ozK
 ozK
 ozK
 ozK
-ozK
+dPh
 ozK
 tRh
 tRh
@@ -274632,7 +274636,7 @@ ozK
 ozK
 ozK
 ozK
-ozK
+dPh
 tRh
 tRh
 tRh

--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -12915,10 +12915,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
-"dPh" = (
-/obj/effect/landmark/carpspawn,
-/turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/icemoon/top_layer/outdoors)
 "dPj" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/satellite)
@@ -221383,7 +221379,7 @@ hcl
 hcl
 hcl
 ozK
-dPh
+ozK
 ozK
 tRh
 tRh
@@ -222469,7 +222465,7 @@ ozK
 ozK
 ozK
 ozK
-dPh
+ozK
 tRh
 tRh
 tRh
@@ -224228,7 +224224,7 @@ ozK
 ozK
 ozK
 ozK
-dPh
+ozK
 ozK
 ozK
 ozK
@@ -226608,7 +226604,7 @@ ozK
 ozK
 ozK
 ozK
-dPh
+ozK
 ozK
 ozK
 tRh
@@ -228822,7 +228818,7 @@ tRh
 tRh
 ozK
 ozK
-dPh
+ozK
 ozK
 ozK
 ozK
@@ -231109,7 +231105,7 @@ tRh
 tRh
 tRh
 tRh
-dPh
+ozK
 ozK
 ozK
 ozK
@@ -234081,7 +234077,7 @@ ozK
 ozK
 ozK
 ozK
-dPh
+ozK
 ozK
 ozK
 tRh
@@ -236251,7 +236247,7 @@ tRh
 tRh
 tRh
 tRh
-dPh
+ozK
 ozK
 ozK
 ozK
@@ -245408,7 +245404,7 @@ ozK
 ozK
 ozK
 ozK
-dPh
+ozK
 ozK
 tRh
 tRh
@@ -257848,7 +257844,7 @@ tRh
 tRh
 tRh
 tRh
-dPh
+ozK
 ozK
 ozK
 ozK
@@ -262859,7 +262855,7 @@ ozK
 ozK
 ozK
 ozK
-dPh
+ozK
 ozK
 tRh
 tRh
@@ -274636,7 +274632,7 @@ ozK
 ozK
 ozK
 ozK
-dPh
+ozK
 tRh
 tRh
 tRh

--- a/code/modules/ninja/ninja_event.dm
+++ b/code/modules/ninja/ninja_event.dm
@@ -42,6 +42,13 @@ Contents:
 		for(var/obj/effect/landmark/carpspawn/L in GLOB.landmarks_list)
 			if(isturf(L.loc))
 				spawn_locs += L.loc
+
+		for(var/X in GLOB.xeno_spawn)
+			var/turf/T = X
+			var/light_amount = T.get_lumcount()
+			if(light_amount < SHADOW_SPECIES_DIM_LIGHT)
+				spawn_locs += T
+
 		if(!spawn_locs.len)
 			return kill()
 		spawn_loc = pick(spawn_locs)


### PR DESCRIPTION
# Document the changes in your pull request

I don't see why this event shouldn't be allowed to roll on this station.

# Why is this good for the game?

Not technically a bugfix but I like space ninjas

# Testing

![image](https://github.com/yogstation13/Yogstation/assets/75333826/c7d25eff-6486-4ba6-b56a-b269f36fdc54)


# Changelog



:cl:  

mapping: Adjusts it so that space ninjas can spawn on icemeta properly

/:cl:
