### PR TITLE
Makes ethereal eye zoom toggleable

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -585,9 +585,6 @@
 			lighting_cutoff = eyes.lighting_cutoff
 		if(!isnull(eyes.color_cutoffs))
 			lighting_color_cutoffs = blend_cutoff_colors(lighting_color_cutoffs, eyes.color_cutoffs)
-		if(istype(eyes, /obj/item/organ/eyes/ethereal) && client) //special view range ethereal eyes
-			client.view_size.resetToDefault(getScreenSize(client.prefs.read_preference(/datum/preference/toggle/widescreen)))
-			client.view_size.addTo("2x2")
 
 	for(var/image/I in infra_images)
 		if(client)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -525,7 +525,7 @@
 
 /obj/item/organ/eyes/ethereal/ui_action_click()
 	var/client/dude = owner.client
-	if(!client)
+	if(!dude)
 		return
 
 	active=!active

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -514,22 +514,22 @@
 	name = "fractal eyes"
 	desc = "Crystalline eyes from an Ethereal. Seeing with them should feel like using a kaleidoscope, but somehow it isn't."
 	icon_state = "ethereal_eyes"
+	actions_types = list(/datum/action/item_action/organ_action/use)
 	///Color of the eyes, is set by the species on gain
 	var/ethereal_color = "#9c3030"
+	var/active = FALSE
 
 /obj/item/organ/eyes/ethereal/Initialize(mapload)
 	. = ..()
 	add_atom_colour(ethereal_color, FIXED_COLOUR_PRIORITY)
 
-/obj/item/organ/eyes/ethereal/Insert(mob/living/carbon/M, special, drop_if_replaced, initialising)
-	. = ..()
-	var/client/dude = M.client
-	if(dude)
-		dude.view_size.resetToDefault(getScreenSize(dude.prefs.read_preference(/datum/preference/toggle/widescreen)))
-		dude.view_size.addTo("2x2")
+/obj/item/organ/eyes/ethereal/ui_action_click()
+	var/client/dude = owner.client
+	if(!client)
+		return
 
-/obj/item/organ/eyes/ethereal/Remove(mob/living/carbon/M, special)
-	var/client/dude = M.client
-	if(dude)
-		dude.view_size.resetToDefault(getScreenSize(dude.prefs.read_preference(/datum/preference/toggle/widescreen)))
-	. = ..()
+	active=!active
+	if(active)
+		dude.view_size.zoomOut(2)
+	else
+		dude.view_size.zoomIn()


### PR DESCRIPTION
# Why is this good for the game?
both makes it optional for those that don't like it
and fixes any possible bugs that come from being zoomed out 100% of the time

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/0cb1630f-4173-495b-9c05-7e38f7be5e86)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/fa7bbbe5-9d5a-4c10-809a-5a2598d309b1)

:cl:  
tweak: Makes ethereal eye zoom toggleable
/:cl:
