### PR TITLE
Adds 5 more ships to the shipbreaking templet

### DIFF
--- a/_maps/templates/shipbreaker/old_altar.dmm
+++ b/_maps/templates/shipbreaker/old_altar.dmm
@@ -1,0 +1,279 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/effect/turf_decal/ramp_middle,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
+/area/template_noop)
+"c" = (
+/obj/item/storage/fancy/candle_box,
+/turf/open/floor/plasteel/cult/airless,
+/area/template_noop)
+"d" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/template_noop)
+"g" = (
+/turf/closed/wall/mineral/titanium,
+/area/template_noop)
+"j" = (
+/obj/machinery/door/airlock/shuttle{
+	welded = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/template_noop)
+"n" = (
+/obj/structure/chair/pew{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult/airless,
+/area/template_noop)
+"u" = (
+/obj/structure/rack/skeletal/left,
+/obj/item/kitchen/knife/ritual,
+/obj/effect/decal/cleanable/blood/old,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 8
+	},
+/obj/effect/turf_decal/siding/wood/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cult/airless,
+/area/template_noop)
+"w" = (
+/obj/machinery/shuttle/engine{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"x" = (
+/obj/structure/fluff/drake_statue{
+	pixel_x = 0
+	},
+/turf/open/floor/plasteel/cult/airless,
+/area/template_noop)
+"y" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult/airless,
+/area/template_noop)
+"B" = (
+/obj/structure/statue/resin/ashwalker,
+/obj/item/candle/resin{
+	pixel_y = -10;
+	pixel_x = -12
+	},
+/obj/item/trash/candle/resin{
+	pixel_y = -10;
+	pixel_x = 10
+	},
+/turf/open/floor/plasteel/cult/airless,
+/area/template_noop)
+"C" = (
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs/goon/wood_stairs_alone,
+/area/template_noop)
+"D" = (
+/obj/structure/grille,
+/obj/structure/window/shuttle/tinted,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"F" = (
+/obj/machinery/power/engine_capacitor_bank{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"I" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult/airless,
+/area/template_noop)
+"M" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/carpet/red,
+/area/template_noop)
+"N" = (
+/obj/structure/rack/skeletal/right,
+/obj/item/organ/heart,
+/obj/effect/decal/cleanable/blood/old,
+/obj/item/candle/resin,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/turf_decal/siding/wood{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/wood/corner,
+/turf/open/floor/plasteel/cult/airless,
+/area/template_noop)
+"Q" = (
+/turf/open/floor/plasteel/cult/airless,
+/area/template_noop)
+"R" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/machinery/power/engine_capacitor_bank{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"V" = (
+/obj/structure/chair/pew/left{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult/airless,
+/area/template_noop)
+"W" = (
+/obj/structure/statue/resin/ashwalker,
+/obj/item/candle/resin{
+	pixel_y = -10;
+	pixel_x = 12
+	},
+/obj/item/trash/candle/resin{
+	pixel_y = -10;
+	pixel_x = -10
+	},
+/turf/open/floor/plasteel/cult/airless,
+/area/template_noop)
+"X" = (
+/turf/template_noop,
+/area/template_noop)
+"Y" = (
+/obj/structure/chair/pew/right{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/cult/airless,
+/area/template_noop)
+"Z" = (
+/obj/item/storage/box/holy/follower,
+/turf/open/floor/plasteel/cult/airless,
+/area/template_noop)
+
+(1,1,1) = {"
+X
+X
+X
+X
+X
+X
+X
+X
+X
+X
+X
+X
+"}
+(2,1,1) = {"
+X
+X
+g
+d
+d
+d
+j
+d
+d
+d
+g
+X
+"}
+(3,1,1) = {"
+X
+g
+d
+W
+Z
+C
+a
+M
+M
+M
+F
+w
+"}
+(4,1,1) = {"
+X
+D
+y
+x
+Q
+u
+a
+V
+V
+V
+R
+w
+"}
+(5,1,1) = {"
+X
+D
+I
+Q
+Q
+N
+a
+n
+n
+n
+R
+w
+"}
+(6,1,1) = {"
+X
+g
+d
+B
+c
+C
+a
+Y
+Y
+Y
+R
+w
+"}
+(7,1,1) = {"
+X
+X
+g
+d
+d
+d
+d
+d
+d
+d
+g
+X
+"}
+(8,1,1) = {"
+X
+X
+X
+X
+X
+X
+X
+X
+X
+X
+X
+X
+"}

--- a/_maps/templates/shipbreaker/old_banana.dmm
+++ b/_maps/templates/shipbreaker/old_banana.dmm
@@ -1,0 +1,192 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/closed/wall/mineral/bananium,
+/area/template_noop)
+"c" = (
+/obj/structure/chair/bananium{
+	dir = 4
+	},
+/turf/open/floor/mineral/bananium/airless,
+/area/template_noop)
+"k" = (
+/obj/machinery/shuttle/engine{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"q" = (
+/turf/open/floor/mineral/bananium/airless,
+/area/template_noop)
+"r" = (
+/obj/structure/chair/bananium{
+	dir = 8
+	},
+/turf/open/floor/mineral/bananium/airless,
+/area/template_noop)
+"u" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/bananium,
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"x" = (
+/obj/structure/closet/secure_closet/freezer/cream_pie,
+/turf/open/floor/mineral/bananium/airless,
+/area/template_noop)
+"B" = (
+/obj/machinery/vending/autodrobe/all_access,
+/turf/open/floor/mineral/bananium/airless,
+/area/template_noop)
+"M" = (
+/obj/machinery/door/airlock/bananium/glass,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/mine/sound/bwoink,
+/turf/open/floor/mineral/bananium/airless,
+/area/template_noop)
+"P" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/machinery/power/engine_capacitor_bank{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"R" = (
+/obj/machinery/modular_computer{
+	dir = 8
+	},
+/turf/open/floor/mineral/bananium/airless,
+/area/template_noop)
+"T" = (
+/obj/structure/table/bananium,
+/obj/item/reagent_containers/food/snacks/burger/clown,
+/obj/item/bikehorn,
+/turf/open/floor/mineral/bananium/airless,
+/area/template_noop)
+"Y" = (
+/turf/template_noop,
+/area/template_noop)
+
+(1,1,1) = {"
+Y
+Y
+Y
+Y
+Y
+a
+a
+P
+k
+Y
+Y
+Y
+"}
+(2,1,1) = {"
+Y
+Y
+Y
+Y
+a
+q
+x
+a
+Y
+Y
+Y
+Y
+"}
+(3,1,1) = {"
+Y
+Y
+Y
+a
+T
+q
+a
+Y
+Y
+Y
+Y
+Y
+"}
+(4,1,1) = {"
+Y
+Y
+Y
+u
+r
+q
+M
+Y
+Y
+Y
+Y
+Y
+"}
+(5,1,1) = {"
+Y
+Y
+Y
+u
+c
+q
+M
+Y
+Y
+Y
+Y
+Y
+"}
+(6,1,1) = {"
+Y
+Y
+Y
+a
+R
+q
+a
+Y
+Y
+Y
+Y
+Y
+"}
+(7,1,1) = {"
+Y
+Y
+Y
+Y
+a
+q
+B
+a
+Y
+Y
+Y
+Y
+"}
+(8,1,1) = {"
+Y
+Y
+Y
+Y
+Y
+a
+a
+P
+k
+Y
+Y
+Y
+"}

--- a/_maps/templates/shipbreaker/old_banana.dmm
+++ b/_maps/templates/shipbreaker/old_banana.dmm
@@ -63,7 +63,7 @@
 /turf/open/floor/plating,
 /area/template_noop)
 "R" = (
-/obj/machinery/modular_computer{
+/obj/machinery/computer{
 	dir = 8
 	},
 /turf/open/floor/mineral/bananium/airless,

--- a/_maps/templates/shipbreaker/old_clockwork.dmm
+++ b/_maps/templates/shipbreaker/old_clockwork.dmm
@@ -1,0 +1,185 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/structure/window/reinforced/fulltile/bronze,
+/turf/open/floor/plating,
+/area/template_noop)
+"f" = (
+/obj/structure/girder/bronze,
+/turf/open/floor/bronze,
+/area/template_noop)
+"j" = (
+/obj/structure/destructible/clockwork/trap/steam_vent,
+/turf/open/floor/plating,
+/area/template_noop)
+"k" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/clockwork{
+	req_access = null
+	},
+/turf/open/floor/bronze/reebe,
+/area/template_noop)
+"l" = (
+/obj/structure/chair/bronze{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/bronze/reebe,
+/area/template_noop)
+"q" = (
+/obj/structure/table/bronze,
+/obj/item/screwdriver/brass,
+/obj/item/weldingtool/experimental/brass,
+/obj/item/crowbar/brass,
+/obj/item/wrench/brass,
+/obj/item/wirecutters/brass,
+/turf/open/floor/bronze/reebe,
+/area/template_noop)
+"w" = (
+/turf/closed/wall/mineral/bronze,
+/area/template_noop)
+"C" = (
+/obj/structure/table/bronze,
+/obj/item/clothing/shoes/bronze,
+/obj/item/clothing/suit/bronze,
+/obj/item/clothing/head/bronze,
+/turf/open/floor/bronze/reebe,
+/area/template_noop)
+"I" = (
+/turf/template_noop,
+/area/template_noop)
+"L" = (
+/obj/machinery/shuttle/engine{
+	dir = 1;
+	color = "orange"
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"U" = (
+/obj/structure/window/reinforced/fulltile/bronze,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"W" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/bronze/reebe,
+/area/template_noop)
+
+(1,1,1) = {"
+I
+I
+I
+I
+I
+I
+I
+I
+I
+I
+I
+I
+"}
+(2,1,1) = {"
+I
+I
+w
+w
+w
+k
+w
+w
+w
+w
+I
+I
+"}
+(3,1,1) = {"
+I
+w
+w
+f
+W
+W
+W
+f
+a
+j
+L
+I
+"}
+(4,1,1) = {"
+I
+U
+q
+l
+W
+W
+W
+f
+a
+j
+L
+I
+"}
+(5,1,1) = {"
+I
+U
+C
+l
+W
+W
+W
+f
+a
+j
+L
+I
+"}
+(6,1,1) = {"
+I
+w
+w
+f
+W
+W
+W
+f
+a
+j
+L
+I
+"}
+(7,1,1) = {"
+I
+I
+w
+w
+w
+k
+w
+w
+w
+w
+I
+I
+"}
+(8,1,1) = {"
+I
+I
+I
+I
+I
+I
+I
+I
+I
+I
+I
+I
+"}

--- a/_maps/templates/shipbreaker/old_diner.dmm
+++ b/_maps/templates/shipbreaker/old_diner.dmm
@@ -59,7 +59,6 @@
 /area/template_noop)
 "j" = (
 /obj/effect/turf_decal/ameritard,
-/obj/effect/turf_decal/ameritard,
 /obj/machinery/jukebox,
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plasteel/airless,
@@ -177,7 +176,6 @@
 /obj/structure/table,
 /obj/machinery/microwave,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/wood/airless,
 /area/template_noop)
 "I" = (
@@ -231,7 +229,6 @@
 "X" = (
 /obj/machinery/deepfryer,
 /obj/effect/decal/cleanable/dirt/dust,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/item/reagent_containers/food/snacks/deadmouse/fat,
 /turf/open/floor/wood/airless/broken/three,
 /area/template_noop)

--- a/_maps/templates/shipbreaker/old_diner.dmm
+++ b/_maps/templates/shipbreaker/old_diner.dmm
@@ -1,0 +1,350 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/template_noop)
+"b" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/kitchen/knife,
+/obj/item/clothing/suit/apron/chef,
+/obj/item/clothing/head/chefhat,
+/obj/item/kitchen/rollingpin,
+/turf/open/floor/wood/airless/broken/three,
+/area/template_noop)
+"c" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/airless,
+/area/template_noop)
+"d" = (
+/obj/effect/turf_decal/ameritard,
+/turf/open/floor/plasteel/airless,
+/area/template_noop)
+"e" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/airless/broken/three,
+/area/template_noop)
+"f" = (
+/obj/effect/turf_decal/ameritard,
+/obj/structure/table/glass,
+/turf/open/floor/plasteel/airless,
+/area/template_noop)
+"g" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/machinery/power/engine_capacitor_bank{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"i" = (
+/obj/effect/turf_decal/ameritard,
+/obj/structure/table/glass,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/template_noop)
+"j" = (
+/obj/effect/turf_decal/ameritard,
+/obj/effect/turf_decal/ameritard,
+/obj/machinery/jukebox,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/template_noop)
+"l" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/sink/kitchen{
+	pixel_y = 28
+	},
+/turf/open/floor/wood/airless/broken/three,
+/area/template_noop)
+"m" = (
+/obj/machinery/door/airlock/glass_large{
+	doorOpen = 'sound/machines/defib_success.ogg'
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/airless,
+/area/template_noop)
+"n" = (
+/obj/effect/turf_decal/ameritard,
+/obj/structure/chair/americandiner/booth/end_left,
+/turf/open/floor/plasteel/airless,
+/area/template_noop)
+"o" = (
+/obj/effect/turf_decal/ameritard,
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plasteel/airless,
+/area/template_noop)
+"p" = (
+/obj/effect/turf_decal/ameritard,
+/obj/item/kirbyplants,
+/turf/open/floor/plasteel/airless,
+/area/template_noop)
+"q" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood,
+/obj/machinery/coffeemaker,
+/obj/item/reagent_containers/food/drinks/bottle/coffeepot,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/airless,
+/area/template_noop)
+"t" = (
+/obj/effect/turf_decal/ameritard,
+/obj/structure/chair/americandiner/booth/end_right{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/template_noop)
+"u" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/airless,
+/area/template_noop)
+"w" = (
+/obj/effect/turf_decal/ameritard,
+/obj/structure/chair/americandiner/booth/end_right,
+/turf/open/floor/plasteel/airless,
+/area/template_noop)
+"y" = (
+/obj/machinery/oven,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/airless,
+/area/template_noop)
+"z" = (
+/obj/machinery/griddle,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/melee/fryingpan,
+/turf/open/floor/wood/airless,
+/area/template_noop)
+"A" = (
+/obj/structure/closet/secure_closet/freezer/fridge/open,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/item/reagent_containers/food/snacks/raw_patty,
+/obj/item/reagent_containers/food/snacks/raw_patty,
+/obj/item/reagent_containers/food/snacks/raw_patty,
+/turf/open/floor/wood/airless,
+/area/template_noop)
+"B" = (
+/obj/machinery/shuttle/engine{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"C" = (
+/turf/template_noop,
+/area/template_noop)
+"D" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/siding/wood,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/airless/broken/four,
+/area/template_noop)
+"E" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 1
+	},
+/obj/machinery/power/engine_capacitor_bank{
+	dir = 1
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"F" = (
+/turf/open/floor/wood/airless/broken/two,
+/area/template_noop)
+"H" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/wood/airless,
+/area/template_noop)
+"I" = (
+/turf/open/floor/wood/airless/broken/six,
+/area/template_noop)
+"J" = (
+/obj/effect/turf_decal/ameritard,
+/obj/structure/chair/americandiner/booth/end_left{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plasteel/airless,
+/area/template_noop)
+"K" = (
+/obj/machinery/door/window,
+/obj/effect/turf_decal/siding/wood,
+/turf/open/floor/wood/airless,
+/area/template_noop)
+"L" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/airless,
+/area/template_noop)
+"O" = (
+/obj/machinery/door/airlock/glass_large{
+	doorOpen = 'sound/machines/defib_success.ogg'
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/airless/broken/six,
+/area/template_noop)
+"P" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/wood/airless/broken/two,
+/area/template_noop)
+"Q" = (
+/turf/open/floor/wood/airless/broken/four,
+/area/template_noop)
+"T" = (
+/turf/open/floor/wood/airless,
+/area/template_noop)
+"V" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/template_noop)
+"W" = (
+/turf/closed/wall/mineral/titanium,
+/area/template_noop)
+"X" = (
+/obj/machinery/deepfryer,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/item/reagent_containers/food/snacks/deadmouse/fat,
+/turf/open/floor/wood/airless/broken/three,
+/area/template_noop)
+
+(1,1,1) = {"
+C
+W
+a
+a
+a
+a
+V
+V
+V
+a
+g
+B
+"}
+(2,1,1) = {"
+W
+a
+l
+K
+d
+d
+n
+i
+J
+a
+E
+B
+"}
+(3,1,1) = {"
+a
+H
+T
+D
+o
+d
+w
+f
+t
+a
+a
+W
+"}
+(4,1,1) = {"
+a
+z
+F
+u
+o
+d
+d
+d
+d
+O
+P
+m
+"}
+(5,1,1) = {"
+a
+y
+Q
+u
+o
+d
+d
+d
+d
+e
+L
+c
+"}
+(6,1,1) = {"
+a
+X
+I
+b
+o
+d
+n
+f
+J
+a
+a
+W
+"}
+(7,1,1) = {"
+W
+a
+A
+q
+j
+p
+w
+i
+t
+a
+g
+B
+"}
+(8,1,1) = {"
+C
+W
+a
+a
+a
+a
+V
+V
+V
+a
+E
+B
+"}

--- a/_maps/templates/shipbreaker/old_repair.dmm
+++ b/_maps/templates/shipbreaker/old_repair.dmm
@@ -5,11 +5,6 @@
 	},
 /turf/open/floor/plating,
 /area/template_noop)
-"b" = (
-/obj/machinery/shuttle_manipulator,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mineral/titanium/airless,
-/area/template_noop)
 "c" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
@@ -166,8 +161,8 @@
 /turf/open/floor/mineral/titanium/blue/airless,
 /area/template_noop)
 "D" = (
-/obj/machinery/modular_computer,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer,
 /turf/open/floor/mineral/titanium/airless,
 /area/template_noop)
 "E" = (
@@ -329,7 +324,7 @@ a
 r
 D
 n
-b
+j
 E
 g
 p

--- a/_maps/templates/shipbreaker/old_repair.dmm
+++ b/_maps/templates/shipbreaker/old_repair.dmm
@@ -1,0 +1,397 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"a" = (
+/obj/machinery/shuttle/engine{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"b" = (
+/obj/machinery/shuttle_manipulator,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/titanium/airless,
+/area/template_noop)
+"c" = (
+/obj/structure/reagent_dispensers/fueltank,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/titanium/airless,
+/area/template_noop)
+"d" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/template_noop)
+"e" = (
+/turf/template_noop,
+/area/template_noop)
+"f" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/template_noop)
+"g" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/template_noop)
+"j" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/titanium/airless,
+/area/template_noop)
+"k" = (
+/obj/effect/turf_decal{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/titanium/airless,
+/area/template_noop)
+"l" = (
+/obj/machinery/door/airlock/external/glass{
+	req_access_txt = "150"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"m" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"n" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/titanium/airless,
+/area/template_noop)
+"o" = (
+/obj/effect/turf_decal/stripes/full,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/poddoor/shutters/window{
+	id = "shipbreaker_repair"
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"p" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue/airless,
+/area/template_noop)
+"r" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"s" = (
+/obj/effect/turf_decal{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/titanium/airless,
+/area/template_noop)
+"u" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod Airlock"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"v" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/template_noop)
+"w" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/button{
+	id = "shipbreaker_repair"
+	},
+/turf/open/floor/mineral/titanium/airless,
+/area/template_noop)
+"x" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless,
+/area/template_noop)
+"y" = (
+/obj/machinery/shuttle/engine{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"z" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/color/fyellow{
+	pixel_y = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/clothing/gloves/color/fyellow,
+/obj/item/storage/belt/utility,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/glasses/meson/engine,
+/turf/open/floor/mineral/titanium/airless,
+/area/template_noop)
+"C" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	pixel_y = 27
+	},
+/turf/open/floor/mineral/titanium/blue/airless,
+/area/template_noop)
+"D" = (
+/obj/machinery/modular_computer,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/titanium/airless,
+/area/template_noop)
+"E" = (
+/obj/effect/turf_decal,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/decal/cleanable/oil,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/titanium/airless,
+/area/template_noop)
+"F" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/toolbox/electrical,
+/turf/open/floor/mineral/titanium/airless,
+/area/template_noop)
+"H" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/toolbox/emergency{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/emergency,
+/turf/open/floor/mineral/titanium/airless,
+/area/template_noop)
+"I" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/template_noop)
+"L" = (
+/turf/closed/wall/mineral/titanium,
+/area/template_noop)
+"M" = (
+/obj/structure/girder,
+/turf/open/floor/plating,
+/area/template_noop)
+"N" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/emcloset,
+/turf/open/floor/mineral/titanium/airless,
+/area/template_noop)
+"O" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/power/engine_capacitor_bank{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/template_noop)
+"Q" = (
+/obj/effect/turf_decal{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/mineral/titanium/airless,
+/area/template_noop)
+"R" = (
+/obj/effect/turf_decal,
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/mineral/titanium/airless,
+/area/template_noop)
+"S" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/mineral/titanium/airless,
+/area/template_noop)
+"U" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom,
+/turf/open/floor/mineral/titanium/airless,
+/area/template_noop)
+"X" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/metal/ten{
+	pixel_y = -1
+	},
+/obj/item/stack/sheet/glass{
+	pixel_x = 2;
+	pixel_y = 5
+	},
+/turf/open/floor/mineral/titanium/airless,
+/area/template_noop)
+"Y" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/mineral/titanium{
+	amount = 10;
+	pixel_x = -1
+	},
+/obj/item/stack/sheet/titaniumglass{
+	amount = 10;
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/turf/open/floor/mineral/titanium/airless,
+/area/template_noop)
+
+(1,1,1) = {"
+e
+L
+g
+g
+g
+o
+o
+o
+g
+g
+L
+e
+"}
+(2,1,1) = {"
+L
+g
+X
+Y
+R
+v
+x
+f
+s
+c
+O
+a
+"}
+(3,1,1) = {"
+r
+w
+j
+j
+R
+y
+u
+y
+k
+z
+O
+a
+"}
+(4,1,1) = {"
+r
+D
+n
+b
+E
+g
+p
+g
+s
+F
+O
+a
+"}
+(5,1,1) = {"
+r
+D
+n
+j
+R
+g
+C
+g
+s
+S
+O
+a
+"}
+(6,1,1) = {"
+r
+U
+j
+j
+R
+M
+d
+L
+s
+H
+O
+a
+"}
+(7,1,1) = {"
+L
+g
+N
+j
+R
+f
+I
+m
+Q
+c
+O
+a
+"}
+(8,1,1) = {"
+e
+L
+g
+l
+g
+o
+o
+o
+g
+g
+L
+e
+"}

--- a/yogstation/code/modules/shipbreaker/shipbreaker.dm
+++ b/yogstation/code/modules/shipbreaker/shipbreaker.dm
@@ -56,3 +56,33 @@
 	template_id = "old_Stealth_Cutter"
 	description = "mapshaker_old_stealth_cutter"
 	mappath = "_maps/templates/shipbreaker/old_stealth_cutter.dmm"
+
+/datum/map_template/shipbreaker/altar_old
+	name = "Old Ashwalker Altar Ship"
+	template_id = "old_altar"
+	description = "mapshaker_old_altar"
+	mappath = "_maps/templates/shipbreaker/old_altar.dmm"
+
+/datum/map_template/shipbreaker/banana_old
+	name = "Old Honk Ship"
+	template_id = "old_banana"
+	description = "mapshaker_old_banana"
+	mappath = "_maps/templates/shipbreaker/old_banana.dmm"
+
+/datum/map_template/shipbreaker/clockwork_old
+	name = "Old Clockwork Ship"
+	template_id = "old_clockwork"
+	description = "mapshaker_old_clockwork"
+	mappath = "_maps/templates/shipbreaker/old_clockwork.dmm"
+
+/datum/map_template/shipbreaker/diner_old
+	name = "Old Diner Ship"
+	template_id = "old_diner"
+	description = "mapshaker_old_diner"
+	mappath = "_maps/templates/shipbreaker/old_diner.dmm"
+
+/datum/map_template/shipbreaker/repair_old
+	name = "Old Repair Ship"
+	template_id = "old_repair"
+	description = "mapshaker_old_repair"
+	mappath = "_maps/templates/shipbreaker/old_repair.dmm"


### PR DESCRIPTION
Full credit for these ships goes to ckey "crazy_drakkon" as they made all of these, and wanted me to PR them!

# Document the changes in your pull request

Adds 5 new ships to be broken:

The Old Altar Ship
The Old Banana Ship
The Old Clockwork Ship
The Old Diner Ship
The Old Repair Ship

# Why is this good for the game?

More is more is more, without any less is more!

# Testing

<details closed>
<summary>Ship Layouts/Loot</summary>
<br>

Old diner - Notable loot: 
Jukebox
Frying Pan

![image](https://github.com/yogstation13/Yogstation/assets/75333826/7e714a06-4240-458c-8799-2e2a4216162b)

Old Repair - Notable loot:
Engineering Gear

![image](https://github.com/yogstation13/Yogstation/assets/75333826/98b4253b-027b-4fe3-9eee-146846b03dbf)

Old Altar - Notable loot:
Ritual dagger

![image](https://github.com/yogstation13/Yogstation/assets/75333826/62695915-4f1b-4882-bc90-13343913ea0b)

Old Honk - Notable Loot:
Shit ton of bananium
costumedrobe

![image](https://github.com/yogstation13/Yogstation/assets/75333826/209e2957-c788-40cb-a03f-fdb1617bd57d)

Old Clockwork - Notable Loot:
Full set of clockwork tools

![image](https://github.com/yogstation13/Yogstation/assets/75333826/add70f39-c922-4c5c-9775-b8709d973d32)

</details>

# Wiki Documentation

Will add this to the wiki page

# Changelog

:cl:  Cowbot92 & crazy_drakkon

mapping: Adds 5 more shipbreaking maps

/:cl:
