### PR TITLE
Removes asteroid and donutstation from map rotation until they get maintained again

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -32,12 +32,10 @@ endmap
 
 map asteroidstation
 	minplayers 40
-	votable
 endmap
 
 map donutstation
 	maxplayers 50
-	votable
 endmap
 
 # Debug-only maps.


### PR DESCRIPTION
# Why is this good for the game?
manatee (exmin) disappeared after dropping asteroid so it's not been maintained
cark has been to busy to maintain donut and they plan to eventually rework it or replace it with their underwater map
we don't have the mapping team to keep them up to date

# Testing
simple config change

:cl:  
rscdel: Removes asteroid and donutstation from map rotation until they get maintained again
/:cl:
