### PR TITLE
Balance change for kudzu

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -403,7 +403,7 @@
 		if(myseed)
 			qdel(myseed)
 			myseed = null
-		var/newWeed = pick(/obj/item/seeds/liberty, /obj/item/seeds/angel, /obj/item/seeds/nettle/death, /obj/item/seeds/kudzu)
+		var/newWeed = pick(/obj/item/seeds/liberty, /obj/item/seeds/angel, /obj/item/seeds/nettle/death)
 		myseed = new newWeed
 		dead = 0
 		hardmutate()


### PR DESCRIPTION
# Document the changes in your pull request

Removes kudzu from the weed mutation pool

# Why is this good for the game?

Crew will no longer have to deal with a botanist spamming kudzu throughout the entire station and the early shuttle calls that can result from that.

# Testing

Not tested.

# Changelog

:cl:

rscdel: removes kudzu from list of growable plants.

/:cl: