### PR TITLE
donut boxes start closed

### DIFF
--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -68,10 +68,9 @@
 	name = "donut box"
 	desc = "Mmm. Donuts."
 	icon = 'icons/obj/food/containers.dmi'
-	icon_state = "donutbox_inner"
+	icon_state = "donutbox"
 	icon_type = "donut"
 	spawn_type = /obj/item/reagent_containers/food/snacks/donut
-	fancy_open = TRUE
 	appearance_flags = KEEP_TOGETHER
 
 /obj/item/storage/fancy/donut_box/Initialize(mapload)


### PR DESCRIPTION
# Document the changes in your pull request

Makes donut boxes start closed instead of open.

# Why is this good for the game?
It upsets me that they don't. idk what else to say. I wish we had a nicer donut box sprite though

# Testing
idk if there's a better way to do this, all i know is this works and i cant see any issues in game with it
![image](https://github.com/yogstation13/Yogstation/assets/122807629/425fb0f0-1be9-41d7-830a-bdd5ecb5a7ae)
![image](https://github.com/yogstation13/Yogstation/assets/122807629/be51c385-da0a-4458-bfef-bdcd6c3942a4)

:cl:  ktlwjec 
tweak: Donut boxes start closed.
/:cl: