### PR TITLE
Fixes kleptomaniac not kleptoing

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -736,7 +736,7 @@
 				return
 		if(!H.get_active_held_item())
 			to_chat(quirk_holder, span_danger("You can't keep your eyes off [I.name]."))
-			H.UnarmedAttack(I)
+			H.UnarmedAttack(I, TRUE, list())
 
 /datum/quirk/ineloquent
 	name = "Ineloquent"


### PR DESCRIPTION
was broken with the combat mode update since unarmed attack requires additional parameters now

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/ce4c452f-e055-46ca-afc6-48f64d97905d)

:cl:  
bugfix: Fixes kleptomaniac not kleptoing
/:cl:
