### PR TITLE
Makes it possible to examine the tank currently attached to an anesthetic stand

### DIFF
--- a/code/modules/surgery/anesthesia_machine.dm
+++ b/code/modules/surgery/anesthesia_machine.dm
@@ -31,6 +31,10 @@
 	if(attached_tank)
 		. += "tank_on"
 
+/obj/machinery/anesthetic_machine/examine(mob/user)
+	. = ..()
+	if(attached_tank)
+		. +=span_notice("There is a [attached_tank] attached to it.")
 
 /obj/machinery/anesthetic_machine/attack_hand(mob/living/user)
 	. = ..()

--- a/code/modules/surgery/anesthesia_machine.dm
+++ b/code/modules/surgery/anesthesia_machine.dm
@@ -1,6 +1,6 @@
 /obj/machinery/anesthetic_machine
 	name = "Anesthetic Tank Holder"
-	desc = "A wheeled machine that can hold an anesthetic tank and distribute the air using a breath mask."
+	desc = "A wheeled machine that can hold a tank and distribute the gas inside using a breath mask."
 	icon = 'icons/obj/iv_drip.dmi'
 	icon_state = "breath_machine"
 	anchored = FALSE
@@ -34,7 +34,7 @@
 /obj/machinery/anesthetic_machine/examine(mob/user)
 	. = ..()
 	if(attached_tank)
-		. +=span_notice("There is a [attached_tank] attached to it.")
+		. += span_notice("[attached_tank] is attached to it.")
 
 /obj/machinery/anesthetic_machine/attack_hand(mob/living/user)
 	. = ..()


### PR DESCRIPTION
# Why is this good for the game?
imagine attaching a plasma tank and using it for plasmemes to breathe
you'd probably want to be able to tell which stand holds which tank

# Testing
showing it works, i've since fixed the grammar issues
![image](https://github.com/yogstation13/Yogstation/assets/108117184/6511a679-f285-41ee-a968-50834181a62e)

:cl:  
tweak: Makes it possible to examine the tank currently attached to an anesthetic stand
/:cl:
