### PR TITLE
Changes how the TEG engine room is laid out roundstart

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/engine_teg.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/engine_teg.dmm
@@ -32,25 +32,30 @@
 /turf/closed/wall,
 /area/engine/engineering)
 "aH" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/mapping_helpers/teleport_anchor,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aQ" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aX" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "aY" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Atmos to External Gas"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -66,7 +71,7 @@
 "bg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark/corner{
@@ -106,9 +111,6 @@
 /area/engine/engineering)
 "cm" = (
 /obj/structure/table,
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 1
-	},
 /obj/machinery/button/ignition{
 	id = "teghotburn";
 	pixel_x = 7;
@@ -121,9 +123,8 @@
 	req_access_txt = "10";
 	pixel_y = 8
 	},
-/obj/item/analyzer{
-	pixel_y = 5;
-	pixel_x = -11
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
@@ -162,28 +163,27 @@
 "de" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/machinery/atmospherics/components/binary/valve/on{
 	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"dA" = (
-/obj/effect/mapping_helpers/teleport_anchor,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
+"dp" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 9
 	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "dD" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8;
-	filter_type = list(/datum/gas/water_vapor)
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/mob/living/simple_animal/opossum/poppy,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "dG" = (
@@ -194,7 +194,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 1
+	dir = 10
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -204,10 +204,9 @@
 /area/space/nearstation)
 "ej" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 6
 	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "er" = (
@@ -244,11 +243,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "fo" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/teleport_anchor,
-/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "fF" = (
@@ -294,8 +291,8 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "hN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10
+/obj/effect/turf_decal/trimline/red/filled/corner{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -323,7 +320,7 @@
 	name = "TEG Room";
 	req_access_txt = "10"
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "iX" = (
@@ -347,21 +344,17 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "kB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/tank/toxins{
-	dir = 8;
-	volume = 6e+006
+/obj/machinery/atmospherics/components/trinary/mixer/flipped{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "kD" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/machinery/meter,
-/obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "kZ" = (
@@ -388,10 +381,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "lV" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "External Gas to Cold Loop"
-	},
-/obj/effect/mapping_helpers/teleport_anchor,
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "lZ" = (
@@ -419,13 +411,6 @@
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/space/nearstation)
-"mp" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "mC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -442,28 +427,19 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "nh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "nw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/dark/visible{
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
 	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"nL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 5
-	},
-/obj/machinery/meter,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "nQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 9
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -527,16 +503,18 @@
 /turf/template_noop,
 /area/space/nearstation)
 "pw" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"pP" = (
+/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 1
 	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"pP" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "qt" = (
@@ -568,7 +546,7 @@
 /obj/machinery/light_switch{
 	pixel_y = -23
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -617,11 +595,12 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "te" = (
-/obj/effect/turf_decal/trimline/red/filled/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/circulator{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/tank/toxins{
+	dir = 8;
+	volume = 6e+006
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -641,10 +620,6 @@
 /obj/structure/lattice/catwalk,
 /turf/template_noop,
 /area/space/nearstation)
-"tJ" = (
-/obj/machinery/atmospherics/pipe/manifold/dark/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "ue" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos{
 	dir = 1;
@@ -675,13 +650,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"vh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "vE" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
@@ -694,32 +662,31 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "vW" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "wd" = (
 /obj/effect/mapping_helpers/teleport_anchor,
-/obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "we" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "wv" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "External Gas to Burn Chamber"
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/airless,
 /area/engine/engineering)
 "wU" = (
 /obj/effect/turf_decal/stripes/line,
@@ -732,9 +699,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Atmos to External Gas"
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -758,40 +724,25 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"xP" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "xW" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/visible,
+/obj/machinery/atmospherics/components/trinary/filter/critical{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "ye" = (
 /obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"yk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "yz" = (
 /turf/open/floor/engine/airless,
 /area/engine/engineering)
 "yN" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Atmos to External Gas"
+/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "yU" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -813,32 +764,21 @@
 	dir = 4
 	},
 /area/engine/engineering)
-"zv" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/dark/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "zC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/tank/oxygen{
-	dir = 8;
-	volume = 9e+006
-	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "zQ" = (
-/obj/machinery/atmospherics/components/trinary/mixer/flipped{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "zT" = (
-/obj/machinery/atmospherics/pipe/manifold4w/dark/visible,
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "zW" = (
@@ -851,9 +791,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Ag" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/meter,
+/obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Am" = (
@@ -888,7 +828,7 @@
 /turf/template_noop,
 /area/space/nearstation)
 "Bi" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 1
 	},
 /turf/open/floor/engine/airless,
@@ -909,9 +849,7 @@
 /area/space/nearstation)
 "BX" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Ci" = (
@@ -930,16 +868,11 @@
 	},
 /area/engine/engineering)
 "Db" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Dr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
@@ -967,8 +900,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "EE" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 1
+	dir = 10
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -992,12 +926,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"FG" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "FL" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -1011,12 +939,6 @@
 "Gh" = (
 /obj/machinery/atmospherics/components/binary/circulator{
 	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"Gt" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1035,12 +957,11 @@
 	},
 /area/engine/engineering)
 "Iz" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Gas to TEG"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1079,7 +1000,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -1095,6 +1016,7 @@
 /obj/structure/sign/warning/fire{
 	pixel_y = -32
 	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "JR" = (
@@ -1179,7 +1101,7 @@
 	},
 /area/engine/engineering)
 "LA" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
@@ -1205,8 +1127,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Mi" = (
-/obj/machinery/atmospherics/pipe/manifold/dark/visible{
-	dir = 1
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1249,10 +1172,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Nw" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "NH" = (
 /obj/effect/turf_decal/stripes/line{
@@ -1263,13 +1186,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"NP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1319,16 +1235,16 @@
 /turf/open/floor/engine/airless,
 /area/engine/engineering)
 "OX" = (
-/obj/machinery/status_display/ai{
-	pixel_y = 32
+/obj/machinery/firealarm{
+	pixel_y = 26
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/engineering)
 "Pu" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -1353,7 +1269,9 @@
 /turf/template_noop,
 /area/space/nearstation)
 "PV" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+	dir = 8
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "PZ" = (
@@ -1361,8 +1279,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Gas to Cooling Loop"
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1376,7 +1293,10 @@
 "QA" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 1
 	},
 /turf/open/floor/engine,
@@ -1388,21 +1308,20 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Rl" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"Rp" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 1
 	},
 /obj/machinery/meter,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
+/turf/open/floor/engine,
+/area/engine/engineering)
+"Rp" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Rr" = (
@@ -1433,11 +1352,12 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "Sj" = (
-/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
-/turf/open/floor/plating,
-/area/space/nearstation)
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "Sz" = (
-/mob/living/simple_animal/opossum/poppy,
 /obj/machinery/computer/atmos_control/tank{
 	dir = 1;
 	input_tag = "teghot_in";
@@ -1475,21 +1395,8 @@
 /area/engine/engineering)
 "TA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"TC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Gas to TEG"
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1499,6 +1406,9 @@
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1522,22 +1432,16 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Uu" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "UM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"US" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 8
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Atmos to External Gas"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "UW" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -1554,16 +1458,10 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "VS" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 8
+/obj/effect/mapping_helpers/teleport_anchor,
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 1
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"VX" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Wh" = (
@@ -1572,7 +1470,10 @@
 /obj/machinery/status_display/ai{
 	pixel_y = -32
 	},
-/obj/machinery/atmospherics/pipe/manifold/purple/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Wk" = (
@@ -1594,7 +1495,7 @@
 /area/engine/engineering)
 "WB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark/side,
@@ -1615,22 +1516,19 @@
 	},
 /area/engine/engineering)
 "WG" = (
-/obj/machinery/atmospherics/pipe/simple/dark/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "WL" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
+/obj/machinery/status_display/ai{
+	pixel_x = 32
 	},
-/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/tank/oxygen{
+	dir = 8;
+	volume = 9e+006
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1652,16 +1550,14 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Xf" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 9
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "XF" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "Yz" = (
@@ -1672,15 +1568,13 @@
 /turf/template_noop,
 /area/space/nearstation)
 "YG" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "External Gas to Loop"
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/cyan/visible,
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "YS" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 1
+/obj/machinery/atmospherics/components/binary/circulator{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1690,6 +1584,9 @@
 	pixel_y = -32
 	},
 /obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 5
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Zn" = (
@@ -1704,10 +1601,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "ZP" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "External Gas to TEG"
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
 	},
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
 
@@ -2023,14 +1920,14 @@ dG
 ad
 Ni
 pe
+cA
 tw
-lw
 lw
 Rl
 Xf
-lw
+cA
 wd
-oK
+Wk
 wU
 Si
 ei
@@ -2051,9 +1948,9 @@ dG
 ac
 FL
 MW
-VX
+fb
+Wk
 Gh
-ia
 ia
 ia
 ia
@@ -2079,14 +1976,14 @@ dG
 ac
 FL
 oj
-vW
+tw
 YG
-nw
+TA
 nw
 nw
 zT
 WG
-Uu
+oK
 wU
 Si
 ei
@@ -2107,14 +2004,14 @@ sT
 ad
 Um
 cA
+od
 Wk
 eB
 xv
 rz
 NS
-VS
 cA
-Wk
+Sj
 Zh
 ad
 ei
@@ -2136,13 +2033,13 @@ ad
 Sg
 cA
 fo
+VS
 sN
 JG
-Rp
-lw
+pP
 Db
 BX
-oK
+Xf
 TF
 ad
 sT
@@ -2163,18 +2060,18 @@ dG
 Zn
 Xc
 rZ
+Rp
 Bs
 Am
 vI
 Md
-fb
 aQ
 dA
 Uu
 JH
 ad
 ad
-sT
+dG
 Si
 yz
 OF
@@ -2191,20 +2088,20 @@ dG
 ac
 is
 cA
+fo
 mW
-kD
+lV
 JG
 kp
-nL
 nQ
 MA
-TC
+PV
 we
 cm
-Si
+pw
 LA
 XF
-Bi
+wv
 ue
 yz
 Si
@@ -2219,17 +2116,17 @@ dG
 Zn
 is
 cA
-US
+fo
+ZP
 AD
 Ji
-te
 hN
-yk
+cA
 Dr
 xW
 dD
 Sz
-Sj
+Si
 sT
 Si
 yz
@@ -2247,19 +2144,19 @@ dG
 ad
 fc
 cA
-mp
+fo
 EE
 PV
-pP
+PV
+Mi
 Ic
-TA
 UW
-dp
+vW
 QA
 Pu
-Si
-LA
-XF
+yN
+Nw
+yN
 Bi
 qt
 yz
@@ -2275,18 +2172,18 @@ dG
 ad
 KJ
 cA
-ZP
-pw
-lV
+fo
+cA
+nh
 aH
 nh
-Nw
+fb
 oa
-dp
+QT
 rk
 ad
 ad
-sT
+dG
 Si
 yz
 OF
@@ -2303,14 +2200,14 @@ dG
 ac
 ht
 fb
-zv
-xP
+fo
 cA
-FG
-sY
-vh
+cA
+cA
+cA
+fb
 YS
-wv
+od
 Wh
 ad
 dG
@@ -2331,13 +2228,13 @@ sT
 ac
 Ci
 kZ
-Gt
+fo
 ej
-fb
-QT
+kB
+sY
 zQ
 Ag
-cA
+zQ
 dp
 de
 ad
@@ -2359,12 +2256,12 @@ dG
 ad
 er
 AB
-Mi
-tJ
+fo
+QT
+kD
+QT
+cA
 fb
-yN
-od
-NP
 fb
 ye
 eb
@@ -2389,10 +2286,10 @@ ac
 mC
 xr
 WL
-Rr
+te
 Jv
 zC
-kB
+zC
 Rr
 Ws
 ad

--- a/_maps/RandomRuins/StationRuins/BoxStation/engine_teg.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/engine_teg.dmm
@@ -32,10 +32,7 @@
 /turf/closed/wall,
 /area/engine/engineering)
 "aH" = (
-/obj/effect/mapping_helpers/teleport_anchor,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/orange/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aQ" = (
@@ -170,7 +167,7 @@
 /area/engine/engineering)
 "dp" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 9
+	dir = 6
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -203,11 +200,10 @@
 /turf/template_noop,
 /area/space/nearstation)
 "ej" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/engine/airless,
 /area/engine/engineering)
 "er" = (
 /obj/effect/turf_decal/stripes/line{
@@ -245,6 +241,13 @@
 "fo" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"fu" = (
+/obj/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 10
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -352,8 +355,8 @@
 /area/engine/engineering)
 "kD" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
+/obj/structure/window/plasma/reinforced{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -427,7 +430,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "nh" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
+/obj/structure/window/plasma/reinforced{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "nw" = (
@@ -444,7 +449,13 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "oa" = (
-/obj/item/wrench,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 1
+	},
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "od" = (
@@ -668,7 +679,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "wd" = (
-/obj/effect/mapping_helpers/teleport_anchor,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "we" = (
@@ -732,6 +745,9 @@
 /area/engine/engineering)
 "ye" = (
 /obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 9
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "yz" = (
@@ -791,10 +807,8 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Ag" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/meter,
-/obj/effect/mapping_helpers/teleport_anchor,
-/turf/open/floor/engine,
+/obj/machinery/atmospherics/components/unary/vent_pump,
+/turf/open/floor/engine/airless,
 /area/engine/engineering)
 "Am" = (
 /obj/structure/cable/yellow{
@@ -882,6 +896,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"Ec" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "Ej" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -901,8 +920,8 @@
 /area/engine/engineering)
 "EE" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -925,6 +944,17 @@
 	req_access_txt = "10"
 	},
 /turf/open/floor/plasteel,
+/area/engine/engineering)
+"FE" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/wrench,
+/obj/structure/window/plasma/reinforced{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 1
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "FL" = (
 /obj/structure/cable/yellow{
@@ -1035,7 +1065,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/teleport_anchor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1127,8 +1156,7 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Mi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+/obj/structure/window/plasma/reinforced{
 	dir = 8
 	},
 /turf/open/floor/engine,
@@ -1386,7 +1414,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/space)
+/area/space/nearstation)
 "Tc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -1458,7 +1486,6 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "VS" = (
-/obj/effect/mapping_helpers/teleport_anchor,
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
 	},
@@ -1532,12 +1559,17 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"WT" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "WW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/mapping_helpers/teleport_anchor,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "Xc" = (
@@ -1926,7 +1958,7 @@ lw
 Rl
 Xf
 cA
-wd
+cA
 Wk
 wU
 Si
@@ -2121,7 +2153,7 @@ ZP
 AD
 Ji
 hN
-cA
+YS
 Dr
 xW
 dD
@@ -2146,11 +2178,11 @@ fc
 cA
 fo
 EE
-PV
-PV
-Mi
+WT
+oa
 Ic
-UW
+Ic
+aH
 vW
 QA
 Pu
@@ -2173,12 +2205,12 @@ ad
 KJ
 cA
 fo
-cA
+Dr
 nh
-aH
+ad
 nh
 fb
-oa
+Dr
 QT
 rk
 ad
@@ -2201,13 +2233,13 @@ ac
 ht
 fb
 fo
-cA
-cA
-cA
-cA
-fb
-YS
-od
+fu
+ej
+yz
+Ag
+FE
+UW
+QT
 Wh
 ad
 dG
@@ -2229,13 +2261,13 @@ ac
 Ci
 kZ
 fo
-ej
-kB
-sY
-zQ
-Ag
-zQ
-dp
+fb
+kD
+Mi
+Mi
+cA
+cA
+od
 de
 ad
 dG
@@ -2257,12 +2289,12 @@ ad
 er
 AB
 fo
-QT
-kD
-QT
-cA
-fb
-fb
+dp
+kB
+sY
+zQ
+wd
+Ec
 ye
 eb
 fL

--- a/_maps/RandomRuins/StationRuins/BoxStation/engine_teg.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/engine_teg.dmm
@@ -96,21 +96,36 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "bZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
 	},
 /area/engine/engineering)
 "cm" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
+/obj/machinery/button/ignition{
+	id = "teghotburn";
+	pixel_x = 7;
+	pixel_y = -2
+	},
+/obj/machinery/button/door{
+	id = "teghot";
+	name = "Burn Chamber Vent";
+	pixel_x = 7;
+	req_access_txt = "10";
+	pixel_y = 8
+	},
+/obj/item/analyzer{
+	pixel_y = 5;
+	pixel_x = -11
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cu" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -145,12 +160,8 @@
 /turf/template_noop,
 /area/space/nearstation)
 "de" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/light,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "dp" = (
@@ -160,42 +171,32 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "dA" = (
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 4;
-	name = "Cold to Waste"
-	},
 /obj/effect/mapping_helpers/teleport_anchor,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 10
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "dD" = (
-/obj/structure/window/plasma/reinforced,
-/obj/machinery/button/ignition{
-	id = "teghotburn";
-	pixel_x = -26;
-	pixel_y = -2
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 8;
+	filter_type = list(/datum/gas/water_vapor)
 	},
-/obj/machinery/button/door{
-	id = "teghot";
-	name = "Hot Chamber Vent";
-	pixel_x = -26;
-	pixel_y = 8;
-	req_access_txt = "10"
-	},
-/mob/living/simple_animal/opossum/poppy,
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/window,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "dG" = (
 /turf/template_noop,
 /area/space)
 "eb" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 1
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "ei" = (
 /obj/structure/lattice/catwalk,
@@ -247,15 +248,14 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/teleport_anchor,
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "fF" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/obj/structure/lattice,
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/space/nearstation)
 "fL" = (
 /obj/effect/spawner/structure/window/plasma/reinforced/shutter,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -294,10 +294,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "hN" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 10
 	},
-/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "ia" = (
@@ -411,21 +410,15 @@
 /turf/template_noop,
 /area/space/nearstation)
 "mf" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera{
-	c_tag = "Engineering TEG Aft";
-	dir = 1;
-	network = list("ss13","engine");
-	pixel_x = 23
+/obj/machinery/button/door{
+	id = "teghot";
+	name = "Burn Chamber Vent";
+	pixel_x = 26;
+	req_access_txt = "10"
 	},
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = -23
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/obj/structure/lattice/catwalk,
+/turf/template_noop,
+/area/space/nearstation)
 "mp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
@@ -461,9 +454,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "nL" = (
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 5
 	},
+/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "nQ" = (
@@ -474,9 +468,6 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "oa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
 /obj/item/wrench,
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -516,11 +507,6 @@
 /turf/template_noop,
 /area/space/nearstation)
 "oK" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -573,10 +559,17 @@
 /area/engine/engineering)
 "rk" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 4;
-	name = "Burn to Waste"
+/obj/machinery/camera{
+	c_tag = "Engineering TEG Aft";
+	dir = 1;
+	network = list("ss13","engine");
+	pixel_x = 23
+	},
+/obj/machinery/light_switch{
+	pixel_y = -23
+	},
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -618,8 +611,8 @@
 /turf/template_noop,
 /area/space/nearstation)
 "sY" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Cooling Loop Bypass"
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -707,43 +700,29 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "wd" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 1
-	},
 /obj/effect/mapping_helpers/teleport_anchor,
+/obj/machinery/atmospherics/components/binary/valve,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "we" = (
-/obj/structure/window/plasma/reinforced,
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_x = -7;
-	pixel_y = 5
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
+	dir = 8
 	},
-/obj/item/pen{
-	pixel_x = -8;
-	pixel_y = 3
-	},
-/obj/machinery/door/firedoor/window,
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "wv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "External Gas to Burn Chamber"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "wU" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "xr" = (
@@ -786,40 +765,32 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "xW" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8;
-	filter_type = list(/datum/gas/water_vapor)
-	},
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "ye" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 4
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 10
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "yk" = (
-/obj/machinery/button/door{
-	id = "teghot";
-	name = "Hot Chamber Vent";
-	pixel_x = 26;
-	req_access_txt = "10"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 8
 	},
-/obj/structure/lattice/catwalk,
-/turf/template_noop,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "yz" = (
 /turf/open/floor/engine/airless,
 /area/engine/engineering)
 "yN" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Atmos to External Gas"
 	},
-/obj/machinery/meter,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "yU" = (
@@ -861,8 +832,8 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "zQ" = (
-/obj/machinery/atmospherics/components/trinary/mixer{
-	dir = 1
+/obj/machinery/atmospherics/components/trinary/mixer/flipped{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -876,12 +847,6 @@
 	},
 /obj/machinery/light{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/airalarm{
-	dir = 4;
-	locked = 0;
-	pixel_x = -24
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -932,8 +897,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -974,8 +939,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Dr" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -995,7 +961,9 @@
 /obj/machinery/status_display/ai{
 	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "EE" = (
@@ -1054,8 +1022,8 @@
 /area/engine/engineering)
 "Ic" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1067,12 +1035,12 @@
 	},
 /area/engine/engineering)
 "Iz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
 	name = "Gas to TEG"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1094,10 +1062,8 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "IQ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Atmos to External Gas"
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1114,7 +1080,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
+	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1124,8 +1090,12 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "JH" = (
-/obj/structure/lattice,
-/turf/template_noop,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/fire{
+	pixel_y = -32
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "JR" = (
 /obj/structure/sign/warning/fire,
@@ -1137,7 +1107,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/firealarm{
-	dir = 8;
+	dir = 4;
 	pixel_x = -26
 	},
 /obj/machinery/light{
@@ -1218,8 +1188,7 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "teghot"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating/burnt,
 /area/engine/engineering)
 "LZ" = (
 /obj/structure/sign/warning/fire{
@@ -1249,9 +1218,8 @@
 /turf/open/floor/engine/airless,
 /area/engine/engineering)
 "MA" = (
-/obj/machinery/atmospherics/components/unary/heat_exchanger,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 6
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1327,8 +1295,8 @@
 /area/engine/engineering)
 "Ov" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark/side{
 	dir = 4
@@ -1359,6 +1327,12 @@
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/engineering)
+"Pu" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "Pv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -1375,13 +1349,11 @@
 /area/engine/engineering)
 "PH" = (
 /obj/structure/grille,
+/obj/structure/lattice,
 /turf/template_noop,
 /area/space/nearstation)
 "PV" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Gas to TEG"
-	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "PZ" = (
@@ -1392,7 +1364,6 @@
 	dir = 8;
 	name = "Gas to Cooling Loop"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Qg" = (
@@ -1403,22 +1374,17 @@
 /turf/template_noop,
 /area/space/nearstation)
 "QA" = (
-/obj/structure/window/plasma/reinforced,
-/obj/machinery/computer/atmos_control/tank{
-	dir = 8;
-	input_tag = "teghot_in";
-	name = "TEG Chamber Control";
-	output_tag = "teghot_out";
-	sensors = list("tegburn_sensor" = "Chamber")
-	},
-/obj/machinery/door/firedoor/window,
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/purple/visible{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "QT" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Rl" = (
@@ -1441,9 +1407,6 @@
 /area/engine/engineering)
 "Rr" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
 /turf/open/floor/engine,
@@ -1470,18 +1433,19 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "Sj" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/obj/effect/spawner/structure/window/plasma/reinforced/shutter,
+/turf/open/floor/plating,
+/area/space/nearstation)
 "Sz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10
+/mob/living/simple_animal/opossum/poppy,
+/obj/machinery/computer/atmos_control/tank{
+	dir = 1;
+	input_tag = "teghot_in";
+	name = "TEG Chamber Control";
+	output_tag = "teghot_out";
+	sensors = list("tegburn_sensor" = "Chamber")
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "SC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -1496,20 +1460,16 @@
 	network = list("ss13","engine")
 	},
 /turf/template_noop,
-/area/engine/engineering)
+/area/space/nearstation)
 "ST" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
 	dir = 1
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/turf/open/floor/plating/airless,
+/area/space)
 "Tc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1518,27 +1478,27 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 8
 	},
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 1;
-	name = "Hot to Waste"
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "TC" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/purple/visible{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"TF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	name = "External Gas to Burn Chamber"
+	dir = 1;
+	name = "Gas to TEG"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"TF" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1562,11 +1522,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Uu" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/sign/warning/fire{
-	pixel_y = -32
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "UM" = (
@@ -1582,7 +1540,9 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "UW" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Vd" = (
@@ -1594,8 +1554,8 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "VS" = (
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1616,12 +1576,8 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Wk" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
-	},
-/obj/structure/sign/poster/official/safety_eye_protection{
-	pixel_y = -32
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1629,10 +1585,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "WB" = (
@@ -1728,13 +1685,11 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Zh" = (
-/obj/machinery/atmospherics/components/unary/heat_exchanger{
-	dir = 1
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/sign/poster/official/safety_eye_protection{
+	pixel_y = -32
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 8
-	},
+/obj/machinery/light,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "Zn" = (
@@ -2017,18 +1972,18 @@ ad
 ad
 ad
 bS
-ad
+Si
 Si
 bS
 ad
+ad
+ei
 ei
 dG
-dG
 sT
 dG
 dG
 sT
-dG
 dG
 dG
 dG
@@ -2048,6 +2003,7 @@ PZ
 zW
 Tc
 Iz
+IQ
 ad
 ei
 dG
@@ -2055,7 +2011,6 @@ dG
 sT
 dG
 dG
-sT
 sT
 sT
 sT
@@ -2073,17 +2028,17 @@ lw
 lw
 Rl
 Xf
-sY
+lw
 wd
 oK
-ad
+wU
+Si
 ei
 sT
 sT
 sT
 dG
 dG
-sT
 dG
 dG
 dG
@@ -2103,12 +2058,12 @@ ia
 ia
 ia
 fb
-fF
+Wk
+wU
 Si
 ei
 dG
-sT
-sT
+dG
 sT
 sT
 sT
@@ -2131,18 +2086,18 @@ nw
 nw
 zT
 WG
-Sj
+Uu
+wU
 Si
 ei
 sT
 sT
 sT
 dG
-dG
 sT
 dG
 dG
-sT
+dG
 IF
 eu
 IF
@@ -2152,7 +2107,7 @@ sT
 ad
 Um
 cA
-yN
+Wk
 eB
 xv
 rz
@@ -2160,16 +2115,16 @@ NS
 VS
 cA
 Wk
+Zh
 ad
 ei
-yk
+ei
+mf
 ei
 ei
 ei
 ei
 rn
-dG
-dG
 dG
 IF
 eu
@@ -2187,17 +2142,17 @@ Rp
 lw
 Db
 BX
-wU
+oK
+TF
 ad
 sT
+dG
 ad
 LS
 LS
 LS
 ad
 ei
-sT
-sT
 sT
 IF
 eu
@@ -2216,16 +2171,16 @@ fb
 aQ
 dA
 Uu
+JH
 ad
-dG
+ad
+sT
 Si
 yz
 OF
 yz
 Si
 ei
-dG
-dG
 dG
 IF
 eu
@@ -2241,10 +2196,12 @@ kD
 JG
 kp
 nL
-Zh
+nQ
 MA
 TC
 we
+cm
+Si
 LA
 XF
 Bi
@@ -2252,8 +2209,6 @@ ue
 yz
 Si
 ei
-dG
-sT
 sT
 IF
 eu
@@ -2269,10 +2224,12 @@ AD
 Ji
 te
 hN
-nQ
+yk
 Dr
 xW
 dD
+Sz
+Sj
 sT
 Si
 yz
@@ -2280,9 +2237,7 @@ Mx
 yz
 ad
 LZ
-sT
-sT
-sT
+dG
 IF
 eu
 IF
@@ -2299,8 +2254,10 @@ pP
 Ic
 TA
 UW
-cm
+dp
 QA
+Pu
+Si
 LA
 XF
 Bi
@@ -2308,8 +2265,6 @@ qt
 yz
 Si
 ei
-dG
-sT
 sT
 IF
 eu
@@ -2327,7 +2282,9 @@ aH
 nh
 Nw
 oa
-mf
+dp
+rk
+ad
 ad
 sT
 Si
@@ -2337,8 +2294,6 @@ yz
 Si
 ei
 dG
-dG
-dG
 IF
 eu
 IF
@@ -2347,16 +2302,18 @@ dG
 (22,1,1) = {"
 ac
 ht
-kZ
+fb
 zv
 xP
+cA
 FG
-YS
-YS
+sY
 vh
-TF
+YS
+wv
 Wh
 ad
+dG
 dG
 JR
 Si
@@ -2364,8 +2321,6 @@ Si
 Si
 ad
 ei
-sT
-sT
 sT
 IF
 eu
@@ -2375,26 +2330,26 @@ sT
 (23,1,1) = {"
 ac
 Ci
-wv
+kZ
 Gt
 ej
-ST
+fb
 QT
 zQ
 Ag
+cA
 dp
-rk
+de
 ad
-JH
-sT
+dG
+dG
 dG
 sT
 ei
 ei
 ei
-sT
+ei
 dG
-sT
 IF
 eu
 IF
@@ -2406,23 +2361,23 @@ er
 AB
 Mi
 tJ
-IQ
-cA
+fb
+yN
 od
 NP
-Sz
+fb
 ye
-fL
 eb
+fL
+ST
 dG
 dG
-sT
+fF
 ei
-sT
 dG
 sT
 dG
-sT
+dG
 IF
 eu
 IF
@@ -2434,7 +2389,7 @@ ac
 mC
 xr
 WL
-de
+Rr
 Jv
 zC
 kB
@@ -2443,7 +2398,7 @@ Ws
 ad
 ad
 ad
-sT
+dG
 SD
 ei
 sT


### PR DESCRIPTION
# Document the changes in your pull request

**At the time of posting, this is a work-in-progress.**

The current TEG engine does not work with the design given to players at roundstart. The goal with this PR is to fix that problem by providing a friendlier layout, and adding things that will let non-atmos savvy engineers work this thing with minimal effort, and minimal instruction.

<details><summary>BEFORE</summary>
<p>

![image](https://github.com/yogstation13/Yogstation/assets/143908044/b0c4a3eb-7c98-4cc0-a8bc-eb8a4a173682)

</p>
</details> 



<details><summary>AFTER</summary>
<p>

![image](https://github.com/yogstation13/Yogstation/assets/143908044/48a3fb89-cee5-4f59-950a-e0160eafd8c5)

</p>
</details> 



# Why is this good for the game?
A lot of people hate the TEG right now for a plethora of reasons. I've even tried setting it up myself and witnessed firsthand how dysfunctional it is in-game. So in an effort to keep an engine (something we have very little variety of) in the game, this is my shot to try and make it work from a mapping perspective.

# Testing
Will do

# Wiki Documentation
I'll get around to it if it gets merged don't let me forget

Been working on this design along with @missatessatessy who asked someone to make a PR to fix the TEG, so credit to her too

# Changelog
:cl: AMyriad, Tessa
mapping: The TEG engine template has been redesigned for the sake of our engineers' sanity
wip: If you're seeing this from the PR alert, this design is 100% WIP and subject to change
/:cl:
