### PR TITLE
[PORT] Gas canister color customization

### DIFF
--- a/code/modules/admin/greyscale_modify_menu.dm
+++ b/code/modules/admin/greyscale_modify_menu.dm
@@ -256,6 +256,7 @@ This is highly likely to cause massive amounts of lag as every object in the gam
 	for(var/i in length(split_colors) + 1 to config.expected_colors)
 		LAZYADD(split_colors, rgb(100, 100, 100))
 	var/list/used_colors = split_colors.Copy(1, config.expected_colors+1)
+	split_colors = used_colors
 
 	sprite_data = list()
 

--- a/code/modules/admin/greyscale_modify_menu.dm
+++ b/code/modules/admin/greyscale_modify_menu.dm
@@ -35,11 +35,15 @@
 	/// Whether the menu is currently locked down to prevent abuse from players. Currently is only unlocked when opened from vv.
 	var/unlocked = FALSE
 
-/datum/greyscale_modify_menu/New(atom/target, client/user, list/allowed_configs, datum/callback/apply_callback, starting_icon_state="", starting_config, starting_colors)
+	/// If defined, the always state will be used, and the user will be able to set the alpha channel of the colors too.
+	var/vv_mode = FALSE
+
+/datum/greyscale_modify_menu/New(atom/target, client/user, list/allowed_configs, datum/callback/apply_callback, starting_icon_state="", starting_config, starting_colors, vv_mode = FALSE)
 	src.target = target
 	src.user = user
 	src.apply_callback = apply_callback || CALLBACK(src, PROC_REF(DefaultApply))
 	icon_state = starting_icon_state
+	src.vv_mode = vv_mode
 
 	SetupConfigOwner()
 
@@ -68,7 +72,7 @@
 	return ..()
 
 /datum/greyscale_modify_menu/ui_state(mob/user)
-	return GLOB.always_state
+	return vv_mode ? GLOB.always_state : GLOB.greyscale_menu_state
 
 /datum/greyscale_modify_menu/ui_close()
 	qdel(src)
@@ -135,14 +139,13 @@
 		if("recolor")
 			var/index = text2num(params["color_index"])
 			var/new_color = lowertext(params["new_color"])
-			if(split_colors[index] != new_color)
+			if(split_colors[index] != new_color && (findtext(new_color, GLOB.is_color) || (vv_mode && findtext(new_color, GLOB.is_alpha_color))))
 				split_colors[index] = new_color
 				queue_refresh()
 
 		if("recolor_from_string")
 			var/full_color_string = lowertext(params["color_string"])
-			if(full_color_string != split_colors.Join())
-				ReadColorsFromString(full_color_string)
+			if(full_color_string != split_colors.Join() && ReadColorsFromString(full_color_string))
 				queue_refresh()
 
 		if("pick_color")
@@ -222,10 +225,15 @@ This is highly likely to cause massive amounts of lag as every object in the gam
 			config.EnableAutoRefresh(config_owner_type)
 
 /datum/greyscale_modify_menu/proc/ReadColorsFromString(colorString)
-	var/list/raw_colors = splittext(colorString, "#")
-	split_colors = list()
-	for(var/i in 2 to length(raw_colors))
-		split_colors += "#[raw_colors[i]]"
+	var/list/new_split_colors = list()
+	var/list/colors = splittext(colorString, "#")
+	for(var/index in 2 to min(length(colors), config.expected_colors + 1))
+		var/color = "#[colors[index]]"
+		if(!findtext(color, GLOB.is_color) && (!vv_mode || !findtext(color, GLOB.is_alpha_color)))
+			return FALSE
+		new_split_colors += color
+	split_colors = new_split_colors
+	return TRUE
 
 /datum/greyscale_modify_menu/proc/randomize_color(color_index)
 	var/new_color = "#"
@@ -246,7 +254,7 @@ This is highly likely to cause massive amounts of lag as every object in the gam
 
 /datum/greyscale_modify_menu/proc/refresh_preview()
 	for(var/i in length(split_colors) + 1 to config.expected_colors)
-		split_colors += rgb(100, 100, 100)
+		LAZYADD(split_colors, rgb(100, 100, 100))
 	var/list/used_colors = split_colors.Copy(1, config.expected_colors+1)
 
 	sprite_data = list()

--- a/code/modules/admin/view_variables/topic_basic.dm
+++ b/code/modules/admin/view_variables/topic_basic.dm
@@ -96,7 +96,7 @@
 	if(href_list[VV_HK_MODIFY_GREYSCALE])
 		if(!check_rights(NONE))
 			return
-		var/datum/greyscale_modify_menu/menu = new(target, usr, SSgreyscale.configurations)
+		var/datum/greyscale_modify_menu/menu = new(target, usr, SSgreyscale.configurations, vv_mode = TRUE)
 		menu.Unlock()
 		menu.ui_interact(usr)
 

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -478,6 +478,9 @@
 	if(..())
 		return
 	switch(action)
+		if("recolor")
+			select_colors()
+			. = TRUE
 		if("relabel")
 			var/label = tgui_input_list(usr, "New canister label", "Canister", label2types)
 			if(isnull(label))
@@ -575,6 +578,24 @@
 				replace_tank(usr, FALSE)
 				. = TRUE
 	update_appearance(UPDATE_ICON)
+
+/obj/machinery/portable_atmospherics/canister/proc/select_colors()
+	var/atom/fake_atom = src
+	var/list/allowed_configs = list("[/datum/greyscale_config/canister/base]",
+									"[/datum/greyscale_config/canister/stripe]",
+									"[/datum/greyscale_config/canister/double_stripe]",
+									"[/datum/greyscale_config/canister/hazard]",
+									)
+	var/datum/greyscale_modify_menu/menu = new(
+		src, usr, allowed_configs, CALLBACK(src, PROC_REF(recolor)),
+		starting_icon_state=initial(fake_atom.icon_state),
+		starting_config=initial(fake_atom.greyscale_config),
+		starting_colors=initial(fake_atom.greyscale_colors)
+	)
+	menu.ui_interact(usr)
+
+/obj/machinery/portable_atmospherics/canister/proc/recolor(datum/greyscale_modify_menu/menu)
+	set_greyscale(menu.split_colors)
 
 /obj/machinery/portable_atmospherics/canister/examine(mob/dead/observer/user)
 	if(istype(user))

--- a/code/modules/atmospherics/machinery/portable/canister.dm
+++ b/code/modules/atmospherics/machinery/portable/canister.dm
@@ -40,6 +40,12 @@
 
 	//list of canister types for relabeling
 	var/static/list/label2types = list(
+		"generic" = /obj/machinery/portable_atmospherics/canister/generic,
+		"generic-stripe" = /obj/machinery/portable_atmospherics/canister/generic/stripe,
+		"generic-x2stripe" = /obj/machinery/portable_atmospherics/canister/generic/stripe_double,
+		"generic-hazard" = /obj/machinery/portable_atmospherics/canister/generic/hazard,
+		"caution" = /obj/machinery/portable_atmospherics/canister,
+		"fusion-danger" = /obj/machinery/portable_atmospherics/canister/fusion,
 		"n2" = /obj/machinery/portable_atmospherics/canister/nitrogen,
 		"o2" = /obj/machinery/portable_atmospherics/canister/oxygen,
 		"co2" = /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -71,17 +77,33 @@
 		return
 	..()
 
+/obj/machinery/portable_atmospherics/canister/generic
+	greyscale_config = /datum/greyscale_config/canister
+	greyscale_colors = "#808080"
+
+/obj/machinery/portable_atmospherics/canister/generic/stripe
+	greyscale_config = /datum/greyscale_config/canister/stripe
+	greyscale_colors = "#808080#eeeeee"
+
+/obj/machinery/portable_atmospherics/canister/generic/stripe_double
+	greyscale_config = /datum/greyscale_config/canister/double_stripe
+	greyscale_colors = "#808080#eeeeee"
+
+/obj/machinery/portable_atmospherics/canister/generic/hazard
+	greyscale_config = /datum/greyscale_config/canister/hazard
+	greyscale_colors = "#808080#1a1a1a"
+
 /obj/machinery/portable_atmospherics/canister/nitrogen
 	name = "Nitrogen canister"
 	desc = "Nitrogen gas. Reportedly useful for something."
 	greyscale_config = /datum/greyscale_config/canister
-	greyscale_colors = "#1b6d1b"
+	greyscale_colors = "#009823"
 	gas_type = GAS_N2
 
 /obj/machinery/portable_atmospherics/canister/oxygen
 	name = "Oxygen canister"
 	desc = "Oxygen. Necessary for human life."
-	greyscale_config = /datum/greyscale_config/canister/stripe
+	greyscale_config = /datum/greyscale_config/canister/double_stripe
 	greyscale_colors = "#2786e5#e8fefe"
 	gas_type = GAS_O2
 
@@ -89,14 +111,14 @@
 	name = "Carbon dioxide canister"
 	desc = "Carbon dioxide. What the fuck is carbon dioxide?"
 	greyscale_config = /datum/greyscale_config/canister
-	greyscale_colors = "#4e4c48"
+	greyscale_colors = "#1c1c1c"
 	gas_type = GAS_CO2
 
 /obj/machinery/portable_atmospherics/canister/plasma
 	name = "Plasma canister"
 	desc = "Plasma gas. The reason YOU are here. Highly toxic."
 	greyscale_config = /datum/greyscale_config/canister/hazard
-	greyscale_colors = "#f63400#000000"
+	greyscale_colors = "#f63800#000000"
 	gas_type = GAS_PLASMA
 
 /obj/machinery/portable_atmospherics/canister/bz
@@ -110,7 +132,7 @@
 	name = "Nitrous oxide canister"
 	desc = "Nitrous oxide gas. Known to cause drowsiness."
 	greyscale_config = /datum/greyscale_config/canister/double_stripe
-	greyscale_colors = "#1b6d1b#ffffff"
+	greyscale_colors = "#009823#ffffff"
 	gas_type = GAS_NITROUS
 
 /obj/machinery/portable_atmospherics/canister/air
@@ -130,14 +152,14 @@
 	name = "Hyper-noblium canister"
 	desc = "Hyper-Noblium. More noble than all other gases."
 	greyscale_config = /datum/greyscale_config/canister/double_stripe
-	greyscale_colors = "#6399fc#b2b2b2"
+	greyscale_colors = "#009823#f8c344"
 	gas_type = GAS_HYPERNOB
 
 /obj/machinery/portable_atmospherics/canister/nitrium
 	name = "Nitrium canister"
 	desc = "Nitrium gas. Feels great 'til the acid eats your lungs."
-	greyscale_config = /datum/greyscale_config/canister
-	greyscale_colors = "#7b4732"
+	greyscale_config = /datum/greyscale_config/canister/double_stripe
+	greyscale_colors = "#793b15#ffffff"
 	gas_type = GAS_NITRIUM
 
 /obj/machinery/portable_atmospherics/canister/pluoxium
@@ -151,7 +173,7 @@
 	name = "Water vapor canister"
 	desc = "Water vapor. We get it, you vape."
 	greyscale_config = /datum/greyscale_config/canister/double_stripe
-	greyscale_colors = "#17c3c7#ffffff"
+	greyscale_colors = "#17c3c7#007dc3"
 	gas_type = GAS_H2O
 	filled = 1
 
@@ -197,8 +219,8 @@
 /obj/machinery/portable_atmospherics/canister/pluonium
 	name = "Pluonium canister"
 	desc = "Pluonium, reacts differently with various gases."
-	greyscale_config = /datum/greyscale_config/canister
-	greyscale_colors = "#2786e5"
+	greyscale_config = /datum/greyscale_config/canister/double_stripe
+	greyscale_colors = "#178842#71e382"
 	gas_type = GAS_PLUONIUM
 	filled = 1
 
@@ -206,7 +228,7 @@
 	name = "Halon canister"
 	desc = "Halon, remove oxygen from high temperature fires and cool down the area."
 	greyscale_config = /datum/greyscale_config/canister/double_stripe
-	greyscale_colors = "#9b5d7f#368bff"
+	greyscale_colors = "#943d98#00ccff"
 	gas_type = GAS_HALON
 	filled = 1
 
@@ -215,7 +237,7 @@
 	desc = "Hexane, highly flammable, what a shame."
 
 	greyscale_config = /datum/greyscale_config/canister/double_stripe
-	greyscale_colors = "#9b608b#fd89fd"
+	greyscale_colors = "#943d98#fd89fd"
 	gas_type = GAS_HEXANE
 	filled = 1
 
@@ -223,7 +245,7 @@
 	name = "Zauker canister"
 	desc = "Zauker, highly toxic"
 	greyscale_config = /datum/greyscale_config/canister/double_stripe
-	greyscale_colors = "#009a00#006600"
+	greyscale_colors = "#178842#214b4b"
 	gas_type = GAS_ZAUKER
 	filled = 1
 
@@ -479,7 +501,22 @@
 		return
 	switch(action)
 		if("recolor")
-			select_colors()
+			var/initial_config = greyscale_config
+			var/list/allowed_configs = list("[/datum/greyscale_config/canister]",
+											"[/datum/greyscale_config/canister/stripe]",
+											"[/datum/greyscale_config/canister/double_stripe]",
+											"[/datum/greyscale_config/canister/hazard]",
+											)
+			if(isnull(initial_config))
+				return FALSE
+
+			var/datum/greyscale_modify_menu/menu = new(
+				src, usr, allowed_configs, CALLBACK(src, PROC_REF(recolor)),
+				starting_icon_state = initial(icon_state),
+				starting_config = greyscale_config,
+				starting_colors = greyscale_colors
+			)
+			menu.ui_interact(usr)
 			. = TRUE
 		if("relabel")
 			var/label = tgui_input_list(usr, "New canister label", "Canister", label2types)
@@ -579,23 +616,8 @@
 				. = TRUE
 	update_appearance(UPDATE_ICON)
 
-/obj/machinery/portable_atmospherics/canister/proc/select_colors()
-	var/atom/fake_atom = src
-	var/list/allowed_configs = list("[/datum/greyscale_config/canister/base]",
-									"[/datum/greyscale_config/canister/stripe]",
-									"[/datum/greyscale_config/canister/double_stripe]",
-									"[/datum/greyscale_config/canister/hazard]",
-									)
-	var/datum/greyscale_modify_menu/menu = new(
-		src, usr, allowed_configs, CALLBACK(src, PROC_REF(recolor)),
-		starting_icon_state=initial(fake_atom.icon_state),
-		starting_config=initial(fake_atom.greyscale_config),
-		starting_colors=initial(fake_atom.greyscale_colors)
-	)
-	menu.ui_interact(usr)
-
 /obj/machinery/portable_atmospherics/canister/proc/recolor(datum/greyscale_modify_menu/menu)
-	set_greyscale(menu.split_colors)
+	set_greyscale(menu.split_colors, menu.config.type)
 
 /obj/machinery/portable_atmospherics/canister/examine(mob/dead/observer/user)
 	if(istype(user))
@@ -606,7 +628,8 @@
 	name = "Fusion Canister"
 	desc = "A violent mix of gases resulting in a fusion reaction inside the canister. <br>\
 			A note on the side reads: \"DANGER: DO NOT OPEN\""
-	icon_state = "danger"
+	greyscale_config = /datum/greyscale_config/canister/hazard
+	greyscale_colors = "#0099ff#ff3300"
 
 /* yog- ADMEME CANISTERS */
 
@@ -614,7 +637,8 @@
 /obj/machinery/portable_atmospherics/canister/fusion_test
 	name = "Fusion Test Canister"
 	desc = "This should never be spawned in game."
-	icon_state = "danger"
+	greyscale_config = /datum/greyscale_config/canister/hazard
+	greyscale_colors = "#0099ff#ff3300"
 
 /obj/machinery/portable_atmospherics/canister/fusion_test/create_gas()
 	air_contents.set_moles(GAS_TRITIUM, 10)
@@ -627,7 +651,9 @@
  /obj/machinery/portable_atmospherics/canister/fusion_test_2
 	name = "Fusion Test Canister"
 	desc = "This should never be spawned in game."
-	icon_state = "danger"
+	greyscale_config = /datum/greyscale_config/canister/hazard
+	greyscale_colors = "#0099ff#ff3300"
+
 /obj/machinery/portable_atmospherics/canister/fusion_test_2/create_gas()
 	air_contents.set_moles(GAS_TRITIUM, 10)
 	air_contents.set_moles(GAS_PLASMA, 15000)
@@ -639,7 +665,9 @@
 /obj/machinery/portable_atmospherics/canister/fusion_test_3
 	name = "Fusion Test Canister"
 	desc = "This should never be spawned in game."
-	icon_state = "danger"
+	greyscale_config = /datum/greyscale_config/canister/hazard
+	greyscale_colors = "#0099ff#ff3300"
+
 /obj/machinery/portable_atmospherics/canister/fusion_test_3/create_gas()
 	air_contents.set_moles(GAS_TRITIUM, 1000)
 	air_contents.set_moles(GAS_PLASMA, 4500)
@@ -651,7 +679,9 @@
 /obj/machinery/portable_atmospherics/canister/fusion_test_4
 	name = "Cold Fusion Test Canister"
 	desc = "This should never be spawned in game. Contains dilithium for cold fusion."
-	icon_state = "danger"
+	greyscale_config = /datum/greyscale_config/canister/hazard
+	greyscale_colors = "#0099ff#ff3300"
+
 /obj/machinery/portable_atmospherics/canister/fusion_test_4/create_gas()
 	air_contents.set_moles(GAS_TRITIUM, 1000)
 	air_contents.set_moles(GAS_PLASMA, 4500)
@@ -663,7 +693,9 @@
 /obj/machinery/portable_atmospherics/canister/stimball_test
 	name = "Stimball Test Canister"
 	desc = "This should never be spawned in game except for testing purposes."
-	icon_state = "danger"
+	greyscale_config = /datum/greyscale_config/canister/hazard
+	greyscale_colors = "#0099ff#ff3300"
+
 /obj/machinery/portable_atmospherics/canister/stimball_test/create_gas()
 	air_contents.set_moles(GAS_NITRIUM, 1000)
 	air_contents.set_moles(GAS_PLASMA, 1000)

--- a/tgui/packages/tgui/interfaces/Canister.js
+++ b/tgui/packages/tgui/interfaces/Canister.js
@@ -40,6 +40,7 @@ export const Canister = (props, context) => {
                 icon="pencil-alt"
                 content="Relabel"
                 onClick={() => act('relabel')} />
+              <Button icon="palette" onClick={() => act('recolor')} />
             </>
           )}>
           <LabeledControls justify="center">

--- a/tgui/states/greyscale_menu.dm
+++ b/tgui/states/greyscale_menu.dm
@@ -1,0 +1,11 @@
+/**
+ * tgui state: greyscale menu
+ *
+ * Checks that the target var of the greyscale menu meets the default can_use_topic criteria
+ */
+
+GLOBAL_DATUM_INIT(greyscale_menu_state, /datum/ui_state/greyscale_menu_state, new)
+
+/datum/ui_state/greyscale_menu_state/can_use_topic(src_object, mob/user)
+	var/datum/greyscale_modify_menu/menu = src_object
+	return GLOB.default_state.can_use_topic(menu.target, user)

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -3995,6 +3995,7 @@
 #include "interface\menu.dm"
 #include "interface\stylesheet.dm"
 #include "interface\skin.dmf"
+#include "tgui\states\greyscale_menu.dm"
 #include "yogstation\code\__HELPERS\_lists.dm"
 #include "yogstation\code\__HELPERS\_logging.dm"
 #include "yogstation\code\__HELPERS\game.dm"


### PR DESCRIPTION
* ports https://github.com/tgstation/tgstation/pull/75842, https://github.com/tgstation/tgstation/pull/77798, partially https://github.com/tgstation/tgstation/pull/80145, https://github.com/tgstation/tgstation/pull/77165, https://github.com/tgstation/tgstation/pull/77208

the original pr only has 1 label... so i added 4 of existing one

# Document the changes in your pull request
you can now set gas canister color with your desire
Fixed an issue with the "recolor from string" option in the greyscale modify menu that resulted in invisible icons,
Change all unique canister colors back to the old colors
Re-add missing canister labels

# Why is this good for the game?
allows more interesting colors for canister without having to add each by each

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/89688125/74e1b2b8-1aa7-4ccd-a326-5d05da015ec9)





# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl: Warface1234455, Wallemations, SyncIt21, Ghommie
tweak: you can now set gas canister color with your desire
tweak: Change all unique canister colors back to the old colors
tweak: Re-add missing canister labels
bugfix: Fixed an issue with the "recolor from string" option in the greyscale modify menu that resulted in invisible icons.
/:cl:
