### PR TITLE
Healium tweaks, p2

### DIFF
--- a/code/game/objects/items/grenades/atmos_grenades.dm
+++ b/code/game/objects/items/grenades/atmos_grenades.dm
@@ -49,10 +49,11 @@
 		for(var/mob/living/carbon/live_mob in turf_loc)
 			live_mob.adjustStaminaLoss(stamina_damage / distance_from_center)
 			live_mob.adjust_bodytemperature(-150 / distance_from_center)
-			var/existing = live_mob.reagents.get_reagent_amount(/datum/reagent/healium)
-			if(existing)
-				live_mob.reagents.del_reagent(/datum/reagent/healium)
-			live_mob.reagents.add_reagent(/datum/reagent/healium, 10)
+			if(live_mob.stat == (DEAD|UNCONSCIOUS|SOFT_CRIT) || live_mob.health <= 20)
+				var/existing = live_mob.reagents.get_reagent_amount(/datum/reagent/healium)
+				if(existing)
+					live_mob.reagents.del_reagent(/datum/reagent/healium)
+				live_mob.reagents.add_reagent(/datum/reagent/healium, 10)
 	qdel(src)
 
 /obj/item/grenade/gas_crystal/pluonium_crystal

--- a/code/game/objects/items/grenades/atmos_grenades.dm
+++ b/code/game/objects/items/grenades/atmos_grenades.dm
@@ -49,7 +49,7 @@
 		for(var/mob/living/carbon/live_mob in turf_loc)
 			live_mob.adjustStaminaLoss(stamina_damage / distance_from_center)
 			live_mob.adjust_bodytemperature(-150 / distance_from_center)
-			if(live_mob.stat == (DEAD|UNCONSCIOUS|SOFT_CRIT) || live_mob.health <= 20)
+			if(live_mob.stat > CONSCIOUS) || live_mob.health <= 20))
 				var/existing = live_mob.reagents.get_reagent_amount(/datum/reagent/healium)
 				if(existing)
 					live_mob.reagents.del_reagent(/datum/reagent/healium)

--- a/code/game/objects/items/grenades/atmos_grenades.dm
+++ b/code/game/objects/items/grenades/atmos_grenades.dm
@@ -49,6 +49,10 @@
 		for(var/mob/living/carbon/live_mob in turf_loc)
 			live_mob.adjustStaminaLoss(stamina_damage / distance_from_center)
 			live_mob.adjust_bodytemperature(-150 / distance_from_center)
+			var/existing = live_mob.reagents.get_reagent_amount(/datum/reagent/healium)
+			if(existing)
+				live_mob.reagents.del_reagent(/datum/reagent/healium)
+			live_mob.reagents.add_reagent(/datum/reagent/healium, 10)
 	qdel(src)
 
 /obj/item/grenade/gas_crystal/pluonium_crystal

--- a/code/game/objects/items/grenades/atmos_grenades.dm
+++ b/code/game/objects/items/grenades/atmos_grenades.dm
@@ -52,7 +52,7 @@
 			if(live_mob.stat > CONSCIOUS || live_mob.health <= 20)
 				var/existing = live_mob.reagents.get_reagent_amount(/datum/reagent/healium)
 				if(existing)
-					live_mob.reagents.del_reagent(/datum/reagent/healium)
+					live_mob.reagents.del_reagent(/datum/reagent/healium) //for retriggering
 				live_mob.reagents.add_reagent(/datum/reagent/healium, 10)
 	qdel(src)
 

--- a/code/game/objects/items/grenades/atmos_grenades.dm
+++ b/code/game/objects/items/grenades/atmos_grenades.dm
@@ -49,7 +49,7 @@
 		for(var/mob/living/carbon/live_mob in turf_loc)
 			live_mob.adjustStaminaLoss(stamina_damage / distance_from_center)
 			live_mob.adjust_bodytemperature(-150 / distance_from_center)
-			if(live_mob.stat > CONSCIOUS) || live_mob.health <= 20))
+			if(live_mob.stat > CONSCIOUS || live_mob.health <= 20)
 				var/existing = live_mob.reagents.get_reagent_amount(/datum/reagent/healium)
 				if(existing)
 					live_mob.reagents.del_reagent(/datum/reagent/healium)

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -255,6 +255,9 @@
 		set_on(FALSE)
 		playsound(src, 'sound/machines/cryo_warning.ogg', volume) // Bug the doctors.
 		var/msg = "Healium injection completed."
+		if(autoeject) // Eject if configured.
+			msg += " Auto ejecting patient now."
+			open_machine()
 		radio.talk_into(src, msg, radio_channel)
 		return
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -254,8 +254,7 @@
 			return
 		set_on(FALSE)
 		playsound(src, 'sound/machines/cryo_warning.ogg', volume) // Bug the doctors.
-		var/msg = "Healium injection completed. Ejecting patient."
-		open_machine()
+		var/msg = "Healium injection completed."
 		radio.talk_into(src, msg, radio_channel)
 		return
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -238,10 +238,25 @@
 	if(!occupant)
 		return
 
+	var/datum/gas_mixture/air1 = airs[1]
 	var/mob/living/mob_occupant = occupant
 	if(mob_occupant.on_fire)
 		mob_occupant.extinguish_mob()
-	if(mob_occupant.stat == DEAD) // We don't bother with dead people.
+	if(mob_occupant.stat == DEAD) // We don't bother with dead people except if we got healium.
+		var/existing = mob_occupant.reagents.get_reagent_amount(/datum/reagent/healium)
+		if(existing)
+			mob_occupant.reagents.del_reagent(/datum/reagent/healium)
+			mob_occupant.reagents.add_reagent(/datum/reagent/healium, existing)
+		else if(!existing && air1.get_moles(GAS_HEALIUM) > 1)
+			mob_occupant.reagents.add_reagent(/datum/reagent/healium, 1)
+			air1.set_moles(GAS_HEALIUM, -max(0, air1.get_moles(GAS_HEALIUM) - 0.1 / efficiency))
+		else
+			return
+		set_on(FALSE)
+		playsound(src, 'sound/machines/cryo_warning.ogg', volume) // Bug the doctors.
+		var/msg = "Healium injection completed. Ejecting patient."
+		open_machine()
+		radio.talk_into(src, msg, radio_channel)
 		return
 
 	var/mob/living/carbon/C
@@ -252,8 +267,6 @@
 	if(iscarbon(mob_occupant))
 		for(var/obj/item/bodypart/limb in C.get_damaged_bodyparts(TRUE, TRUE, FALSE, BODYPART_ROBOTIC))
 			robotic_limb_damage += limb.get_damage(stamina=FALSE)
-
-	var/datum/gas_mixture/air1 = airs[1]
 
 	if(mob_occupant.health >= mob_occupant.getMaxHealth() - robotic_limb_damage) // Don't bother with fully healed people. Now takes robotic limbs into account.
 		var/has_wound = FALSE

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1535,7 +1535,7 @@
 	. = ..()
 	for(var/obj/item/organ/organs in L.internal_organs)
 		if(organs.status == ORGAN_ORGANIC)
-			organs.damage -= 10
+			organs.applyOrganDamage(-20)
 			if(organs.organ_flags & ORGAN_FAILING)
 				organs.organ_flags &= ~ORGAN_FAILING
 	if(L.stat == DEAD)
@@ -1576,7 +1576,7 @@
 	M.adjustCloneLoss(-5*heal_factor*REM)
 	for(var/obj/item/organ/organs in M.internal_organs)
 		if(organs.status == ORGAN_ORGANIC)
-			organs.damage = max(0, -2*heal_factor*REM)
+			organs.applyOrganDamage(-2*heal_factor*REM)
 	REMOVE_TRAIT(M, TRAIT_DISFIGURED, TRAIT_GENERIC)
 	..()
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1543,8 +1543,6 @@
 			L.adjustBruteLoss(-(L.getBruteLoss() - MAX_REVIVE_FIRE_DAMAGE + 50))
 		if(L.getFireLoss() >= MAX_REVIVE_FIRE_DAMAGE)
 			L.adjustFireLoss(-(L.getFireLoss() - MAX_REVIVE_FIRE_DAMAGE + 50))
-		if(HAS_TRAIT(L, TRAIT_HUSK))
-			L.cure_husk()
 	ADD_TRAIT(L, TRAIT_PRESERVED_ORGANS, "healium")
 
 /datum/reagent/healium/on_mob_delete(mob/living/carbon/L)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1540,9 +1540,9 @@
 				organs.organ_flags &= ~ORGAN_FAILING
 	if(L.stat == DEAD)
 		if(L.getBruteLoss() >= MAX_REVIVE_BRUTE_DAMAGE)
-			L.adjustBruteLoss(-L.getBruteLoss()-MAX_REVIVE_BRUTE_DAMAGE+10)
+			L.adjustBruteLoss(-(L.getBruteLoss() - MAX_REVIVE_FIRE_DAMAGE + 50))
 		if(L.getFireLoss() >= MAX_REVIVE_FIRE_DAMAGE)
-			L.adjustFireLoss(-L.getFireLoss()-MAX_REVIVE_FIRE_DAMAGE+10)
+			L.adjustFireLoss(-(L.getFireLoss() - MAX_REVIVE_FIRE_DAMAGE + 50))
 		if(HAS_TRAIT(L, TRAIT_HUSK))
 			L.cure_husk()
 	ADD_TRAIT(L, TRAIT_PRESERVED_ORGANS, "healium")

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1540,9 +1540,9 @@
 				organs.organ_flags &= ~ORGAN_FAILING
 	if(L.stat == DEAD)
 		if(L.getBruteLoss() >= MAX_REVIVE_BRUTE_DAMAGE)
-			L.adjustBruteLoss(-L.getBruteLoss()-MAX_REVIVE_BRUTE_DAMAGE+50)
+			L.adjustBruteLoss(-L.getBruteLoss()-MAX_REVIVE_BRUTE_DAMAGE+10)
 		if(L.getFireLoss() >= MAX_REVIVE_FIRE_DAMAGE)
-			L.adjustFireLoss(-L.getFireLoss()-MAX_REVIVE_FIRE_DAMAGE+50)
+			L.adjustFireLoss(-L.getFireLoss()-MAX_REVIVE_FIRE_DAMAGE+10)
 		if(HAS_TRAIT(L, TRAIT_HUSK))
 			L.cure_husk()
 	ADD_TRAIT(L, TRAIT_PRESERVED_ORGANS, "healium")

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1524,18 +1524,30 @@
 	can_synth = FALSE
 	taste_description = "rubbery"
 
-/datum/reagent/healium/on_mob_metabolize(mob/living/L)
+/datum/reagent/healium/on_mob_metabolize(mob/living/carbon/L)
 	. = ..()
 	L.SetSleeping(1000)
 	L.SetUnconscious(1000)
 	L.add_movespeed_modifier(type, update=TRUE, priority=100, multiplicative_slowdown=0.5, blacklisted_movetypes=(FLYING|FLOATING)) // slowdown for if you're awake
 	ADD_TRAIT(L, TRAIT_SURGERY_PREPARED, "healium")
 
-/datum/reagent/healium/on_mob_add(mob/living/L)
+/datum/reagent/healium/on_mob_add(mob/living/carbon/L)
 	. = ..()
+	for(var/obj/item/organ/organs in L.internal_organs)
+		if(organs.status == ORGAN_ORGANIC)
+			organs.damage -= 10
+			if(organs.organ_flags & ORGAN_FAILING)
+				organs.organ_flags &= ~ORGAN_FAILING
+	if(L.stat == DEAD)
+		if(L.getBruteLoss() >= MAX_REVIVE_BRUTE_DAMAGE)
+			L.adjustBruteLoss(-L.getBruteLoss()-MAX_REVIVE_BRUTE_DAMAGE+50)
+		if(L.getFireLoss() >= MAX_REVIVE_FIRE_DAMAGE)
+			L.adjustFireLoss(-L.getFireLoss()-MAX_REVIVE_FIRE_DAMAGE+50)
+		if(HAS_TRAIT(L, TRAIT_HUSK))
+			L.cure_husk()
 	ADD_TRAIT(L, TRAIT_PRESERVED_ORGANS, "healium")
 
-/datum/reagent/healium/on_mob_delete(mob/living/L)
+/datum/reagent/healium/on_mob_delete(mob/living/carbon/L)
 	REMOVE_TRAIT(L, TRAIT_PRESERVED_ORGANS, "healium")
 	return ..()
 
@@ -1564,7 +1576,7 @@
 	M.adjustCloneLoss(-5*heal_factor*REM)
 	for(var/obj/item/organ/organs in M.internal_organs)
 		if(organs.status == ORGAN_ORGANIC)
-			organs.healing_factor = max(organs.healing_factor, 2*heal_factor*REM)
+			organs.damage = max(0, -2*heal_factor*REM)
 	REMOVE_TRAIT(M, TRAIT_DISFIGURED, TRAIT_GENERIC)
 	..()
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1562,6 +1562,9 @@
 	M.adjustToxLoss(-5*heal_factor*REM)
 	M.adjustBruteLoss(-5*heal_factor*REM)
 	M.adjustCloneLoss(-5*heal_factor*REM)
+	for(var/obj/item/organ/organs in M.internal_organs)
+		if(organs.status == ORGAN_ORGANIC)
+			organs.healing_factor = max(organs.healing_factor, 2*heal_factor*REM)
 	REMOVE_TRAIT(M, TRAIT_DISFIGURED, TRAIT_GENERIC)
 	..()
 


### PR DESCRIPTION
# Document the changes in your pull request
Healium now heal organic organs
Cryo tube can now inject healium into dead body
Healium when applied to dead body now heals organic organs (can fix the failure organs aswell), brutes and burns, to a safe level for defibbing.
Healium grenade now injects healium into nearby mobs if they their overall health is below or equal to 20, softcrit, dead, or unconscious


# Why is this good for the game?
Makes sense for healium, it can already interact with organic body to replicate and repair the body, so it should be able to heal the overall of the organic body. Gives atmos tech more interactions with medical to help them during blood hours (medbay is understaffed and filled with dead bodies).

# Testing


https://github.com/yogstation13/Yogstation/assets/89688125/1611b6f0-591d-4632-89a4-34a74416a7a2




# Wiki Documentation
in doc of change

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: Healium now heal organic organs
tweak: Cryo tube can now inject healium into dead body
tweak: Healium when applied to dead body now heals organic organs (can fix the failure organs aswell), brutes and burns, to a safe level for defibbing.
tweak: Healium grenade now injects healium into nearby mobs if they their overall health is below or equal to 20, softcrit, dead, or unconscious
/:cl:
