### PR TITLE
Stomach pump can now be done on husked corpse

### DIFF
--- a/code/modules/surgery/stomachpump.dm
+++ b/code/modules/surgery/stomachpump.dm
@@ -17,8 +17,6 @@
 
 /datum/surgery/stomach_pump/can_start(mob/user, mob/living/carbon/target)
 	var/obj/item/organ/stomach/target_stomach = target.getorganslot(ORGAN_SLOT_STOMACH)
-	if(HAS_TRAIT(target, TRAIT_HUSK))
-		return FALSE
 	if(!target_stomach)
 		return FALSE
 	return ..()


### PR DESCRIPTION


# Document the changes in your pull request
Stomach pump can now be done on husked corpse
# Why is this good for the game?
don't see a bad reason for this to be restricted, what if someone got 1000u of chems in a husk body??? clone them??? is that we do shit now? cloning??? 

# Testing
YES I GOT THE SURGERYYY WORKING ON HUSKKK





# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: Stomach pump can now be done on husked corpse
/:cl:
