### PR TITLE
Soda now tastes good

### DIFF
--- a/code/__DEFINES/food.dm
+++ b/code/__DEFINES/food.dm
@@ -39,6 +39,7 @@
 	"CLOTH", \
 )
 
+#define DRINK_SODA 0.5
 #define DRINK_NICE	1
 #define DRINK_GOOD	2
 #define DRINK_VERYGOOD	3

--- a/code/datums/mood_events/drink_events.dm
+++ b/code/datums/mood_events/drink_events.dm
@@ -2,6 +2,11 @@
 	mood_change = 3
 	description = "<span class='nicegreen'>Everything just feels better after a drink or two.</span>\n"
 
+/datum/mood_event/soda
+	description = "<span class='nicegreen'>That drink was sugary sweet!</span>\n"
+	mood_change = 3
+	timeout = 2 MINUTES // sugar high wears off fast
+
 /datum/mood_event/quality_nice
 	description = "<span class='nicegreen'>That drink wasn't bad at all.</span>\n"
 	mood_change = 5

--- a/code/datums/mood_events/drink_events.dm
+++ b/code/datums/mood_events/drink_events.dm
@@ -3,7 +3,7 @@
 	description = "<span class='nicegreen'>Everything just feels better after a drink or two.</span>\n"
 
 /datum/mood_event/soda
-	description = "<span class='nicegreen'>That drink was sugary sweet!</span>\n"
+	description = "<span class='nicegreen'>That was sugary sweet!</span>\n"
 	mood_change = 3
 	timeout = 2 MINUTES // sugar high wears off fast
 

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -459,6 +459,7 @@
 	name = "Iced Tea"
 	description = "No relation to a certain rap artist/actor."
 	color = "#104038" // rgb: 16, 64, 56
+	quality = DRINK_SODA // sweet tea is sugary
 	nutriment_factor = 0
 	taste_description = "sweet tea"
 	glass_icon_state = "icedteaglass"
@@ -479,6 +480,7 @@
 	name = "Cola"
 	description = "A refreshing beverage."
 	color = "#100800" // rgb: 16, 8, 0
+	quality = DRINK_SODA
 	taste_description = "cola"
 	glass_icon_state  = "glass_brown"
 	glass_name = "glass of Space Cola"
@@ -493,6 +495,7 @@
 	name = "Root Beer"
 	description = "Beer, but not."
 	color = "#251505" // rgb: 16, 8, 0
+	quality = DRINK_SODA
 	taste_description = "root and beer"
 	glass_icon_state  = "glass_brown"
 	glass_name = "glass of root beer"
@@ -562,6 +565,7 @@
 	name = "SM Wind"
 	description = "Blows right through you like a space wind."
 	color = "#102000" // rgb: 16, 32, 0
+	quality = DRINK_SODA
 	taste_description = "sweet citrus soda"
 	glass_icon_state = "Space_mountain_wind_glass"
 	glass_name = "glass of Space Mountain Wind"
@@ -579,6 +583,7 @@
 	name = "Dr. Gibb"
 	description = "A delicious blend of 42 different flavours."
 	color = "#102000" // rgb: 16, 32, 0
+	quality = DRINK_SODA
 	taste_description = "cherry soda" // FALSE ADVERTISING
 	glass_icon_state = "dr_gibb_glass"
 	glass_name = "glass of Dr. Gibb"
@@ -593,6 +598,7 @@
 	name = "Space-Up"
 	description = "Tastes like a hull breach in your mouth."
 	color = "#00FF00" // rgb: 0, 255, 0
+	quality = DRINK_SODA
 	taste_description = "cherry soda"
 	glass_icon_state = "space-up_glass"
 	glass_name = "glass of Space-Up"
@@ -607,6 +613,7 @@
 	name = "Spite"
 	description = "A tangy substance made of 0.5% natural citrus!"
 	color = "#8CFF00" // rgb: 135, 255, 0
+	quality = DRINK_SODA
 	taste_description = "tangy lime and lemon soda"
 	glass_icon_state = "glass_yellow"
 	glass_name = "glass of lemon-lime"
@@ -621,6 +628,7 @@
 	name = "Pwr Game"
 	description = "The only drink with the PWR that true gamers crave."
 	color = "#9385bf" // rgb: 58, 52, 75
+	quality = DRINK_SODA
 	taste_description = "sweet and salty tang"
 	glass_icon_state = "glass_red"
 	glass_name = "glass of Pwr Game"
@@ -634,6 +642,7 @@
 	name = "Shambler's Juice"
 	description = "~Shake me up some of that Shambler's Juice!~"
 	color = "#f00060" // rgb: 94, 0, 38
+	quality = DRINK_SODA
 	taste_description = "carbonated metallic soda"
 	glass_icon_state = "glass_red"
 	glass_name = "glass of Shambler's juice"
@@ -678,6 +687,7 @@
 	name = "Monkey Energy"
 	description = "The only drink that will make you unleash the ape."
 	color = "#f39b03" // rgb: 243, 155, 3
+	quality = DRINK_SODA
 	taste_description = "barbecue and nostalgia"
 	glass_icon_state = "monkey_energy_glass"
 	glass_name = "glass of Monkey Energy"

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -26,6 +26,8 @@
 	if(methods & INGEST)
 		if (quality && !HAS_TRAIT(M, TRAIT_AGEUSIA))
 			switch(quality)
+				if (DRINK_SODA)
+					SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "quality_drink", /datum/mood_event/soda)
 				if (DRINK_NICE)
 					SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "quality_drink", /datum/mood_event/quality_nice)
 				if (DRINK_GOOD)
@@ -174,6 +176,7 @@
 	description = "The organic compound commonly known as table sugar and sometimes called saccharose. This white, odorless, crystalline powder has a pleasing, sweet taste."
 	reagent_state = SOLID
 	color = "#FFFFFF" // rgb: 255, 255, 255
+	quality = DRINK_SODA
 	taste_mult = 1.5 // stop sugar drowning out other flavours
 	nutriment_factor = 2 * REAGENTS_METABOLISM
 	metabolization_rate = 2 * REAGENTS_METABOLISM


### PR DESCRIPTION
# Document the changes in your pull request
I made this PR while drinking Coca-Cola® Vanilla (unaffiliated)

Added a new drink moodlet dedicated to soda

All soda is included as well as Monkey Energy, sweet tea, and sugar

This gives 3 mood points and only for 2 minutes¸ as opposed to "DRINK_NICE" which previously was the lowest grade, providing 5 mood points for 5 minutes

This also makes every sugar-containing food provide a brief minor mood boost

# Why is this good for the game?
![image](https://github.com/yogstation13/Yogstation/assets/28408322/de9ae576-d413-450f-8249-98794bf35017)
Soda vendor no longer objectively useless 99% of the time

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/28408322/9d6bdcc9-82f9-4e00-9138-7195b585184f)

# Wiki Documentation
Relevant drinks & sugary foods provide 3 mood for 2 minutes

# Changelog

:cl:  
tweak: Sugary drinks like soda and sweet tea now give short-term positive mood effects
tweak: Sugar in general makes you happier, briefly
/:cl:
