### PR TITLE
Allow drones to understand common (not speak)

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -253,9 +253,9 @@ Key procs
 
 /datum/language_holder/drone
 	understood_languages = list(/datum/language/drone = list(LANGUAGE_ATOM),
-								/datum/language/machine = list(LANGUAGE_ATOM))
+								/datum/language/machine = list(LANGUAGE_ATOM),
+                                /datum/language/commom = list(LANGUAGE_ATOM))
 	spoken_languages = list(/datum/language/drone = list(LANGUAGE_ATOM))
-	blocked_languages = list(/datum/language/common = list(LANGUAGE_ATOM))
 
 /datum/language_holder/drone/syndicate
 	blocked_languages = list()

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -254,7 +254,7 @@ Key procs
 /datum/language_holder/drone
 	understood_languages = list(/datum/language/drone = list(LANGUAGE_ATOM),
 								/datum/language/machine = list(LANGUAGE_ATOM),
-                                /datum/language/commom = list(LANGUAGE_ATOM))
+                                /datum/language/common = list(LANGUAGE_ATOM))
 	spoken_languages = list(/datum/language/drone = list(LANGUAGE_ATOM))
 
 /datum/language_holder/drone/syndicate


### PR DESCRIPTION
I coded this on the bus because my bus was 1 hour late and is going to take another hour, please kill me.

# Document the changes in your pull request

Removed common from the blocked language list for drones.

Added common to the understood languages list for drones.


# Why is this good for the game?

**1. Enhanced Rule Adherence**

- Understanding Situations: Allowing drones to understand speech would help them better comprehend the current status of the station and prioritize their tasks more effectively. This can also help them identify critical areas needing maintenance or emergency repairs without misinterpretation.

**2. Increased Efficiency**
- Preventing Redundancy: Drones can avoid duplicating efforts if they understand that a task is already being handled by a crew member, optimizing resource and time management.

**3. Better Situational Awareness**
- Emergency Situations: In emergencies, understanding speech can enable drones to avoid hazardous areas where they might get destroyed or where their presence could exacerbate the situation. For example, avoiding areas with a known bomb threat or active firefight.

**4. Non-Interference Clarity**
- Knowing When to Step Back: Understanding speech can help drones discern when their actions might interfere with crew operations or antagonist activities, ensuring they adhere to their non-interference law more precisely.
- Identifying Non-Compliance: Drones can better identify situations where their actions might inadvertently break their laws, such as interfering with player conflicts, and adjust their behavior accordingly.

**5. Gameplay Enrichment**
- Role-Playing Opportunities: Allowing drones to understand speech can enhance the role-playing experience. It can create more depth and realism, as drones become more responsive and integrated into the station’s ecosystem.
- Player Engagement: Crew members can engage with drones more meaningfully, knowing that their commands or warnings are understood, even if the drones cannot respond. This interaction can add a layer of immersion and strategy.

**Conclusion**
Allowing drones to understand speech can significantly enhance their ability to follow their laws, increase their efficiency, and enrich the overall gameplay experience. By ensuring they remain neutral and focused on maintenance tasks, this change can be implemented without disrupting the game’s balance or core dynamics

# Wiki Documentation

Drone page needs to changed once again to say drones can understand but not speak common.

# Changelog

:cl:  
tweak: drones can understand but not speak common
/:cl:
