### PR TITLE
Adds themes to backrooms

### DIFF
--- a/_maps/map_files/generic/MaintStation.dmm
+++ b/_maps/map_files/generic/MaintStation.dmm
@@ -1,6 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "d" = (
 /turf/open/genturf,
+/turf/open/floor/plating/backrooms,
 /area/procedurally_generated/maintenance/the_backrooms)
 
 (1,1,1) = {"

--- a/code/datums/mapgen/dungeon_generators/generator_theme.dm
+++ b/code/datums/mapgen/dungeon_generators/generator_theme.dm
@@ -25,7 +25,7 @@
 
 //Library themed
 /datum/generator_theme/wooden
-	weight = 15
+	weight = 20
 	weighted_possible_floor_types = list(
 		/turf/open/floor/carpet = 1
 		)

--- a/code/datums/mapgen/dungeon_generators/generator_theme.dm
+++ b/code/datums/mapgen/dungeon_generators/generator_theme.dm
@@ -113,7 +113,7 @@
 		/turf/closed/wall/mineral/bamboo = 1
 		)
 
-	var/list/weighted_againstwall_spawn_list = list(
+	weighted_againstwall_spawn_list = list(
 		/obj/machinery/space_heater = 3,
 		/obj/structure/closet/emcloset = 6,
 		/obj/structure/closet/firecloset = 6,

--- a/code/datums/mapgen/dungeon_generators/generator_theme.dm
+++ b/code/datums/mapgen/dungeon_generators/generator_theme.dm
@@ -1,0 +1,126 @@
+//both the definition and the default maintenance theme, everything else is relative to this
+/datum/generator_theme
+	///Weight for use in picking this theme
+	var/weight = 50
+	///Weighted list of floorings for the generator to choose from
+	var/list/weighted_possible_floor_types = list()
+	///Weighted list of walls for the generator to choose from
+	var/list/weighted_possible_wall_types = list()
+	///Weighted list of extra features that can spawn in the area, such as closets.
+	var/list/weighted_feature_spawn_list = list(
+		/obj/machinery/space_heater = 2,
+		/obj/structure/closet/emcloset = 2,
+		/obj/structure/closet/firecloset = 2,
+		/obj/structure/closet/toolcloset = 1,
+		list(/obj/structure/table, /obj/effect/spawner/lootdrop/maintenance) = 1,
+		list(/obj/structure/rack, /obj/effect/spawner/lootdrop/maintenance) = 1
+	)
+	///Weighted list of extra obstructions that can spawn in the area, such as grilles and girders. (also spawns out in the open (mostly for flavour))
+	var/list/weighted_obstruction_spawn_list = list(
+		/obj/structure/grille = 3,
+		/obj/structure/grille/broken = 4,
+		/obj/structure/girder/displaced = 2,
+		/obj/effect/spawner/lootdrop/maintenance = 2 //technically not an obstruction
+	)
+
+//Library themed
+/datum/generator_theme/wooden
+	weight = 15
+	weighted_possible_floor_types = list(
+		/turf/open/floor/carpet = 1
+		)
+
+	weighted_possible_wall_types  = list(
+		/turf/closed/wall/mineral/wood = 1
+		)
+
+	weighted_feature_spawn_list = list(
+		/obj/machinery/space_heater = 2,
+		/obj/structure/closet/emcloset = 2,
+		/obj/structure/closet/firecloset = 2,
+		/obj/structure/closet/toolcloset = 1,
+		list(/obj/structure/table, /obj/effect/spawner/lootdrop/maintenance) = 1,
+		list(/obj/structure/rack, /obj/effect/spawner/lootdrop/maintenance) = 1,
+		/obj/item/book/random = 1
+		)
+
+	weighted_obstruction_spawn_list = list(
+		/obj/structure/bookcase/random = 3,
+		/obj/effect/spawner/lootdrop/maintenance = 2,
+		/obj/item/book/random = 2,
+		)
+
+//dungeon themed
+/datum/generator_theme/meatlocker
+	weight = 10
+	weighted_possible_floor_types = list(
+		/turf/open/floor/stone = 1
+		)
+
+	weighted_possible_wall_types  = list(
+		/turf/closed/wall/mineral/iron = 1
+		)
+
+	weighted_feature_spawn_list = list(
+		/obj/machinery/space_heater = 2,
+		/obj/structure/closet/emcloset = 2,
+		/obj/structure/closet/firecloset = 2,
+		/obj/structure/closet/toolcloset = 1,
+		list(/obj/structure/table, /obj/effect/spawner/lootdrop/maintenance) = 1,
+		list(/obj/structure/rack, /obj/effect/spawner/lootdrop/maintenance) = 1,
+		list(/obj/effect/spawner/lootdrop/random_meat, /obj/effect/gibspawner/generic) = 1,
+		/obj/effect/decal/remains/human = 1,
+		/obj/effect/gibspawner/human = 1,
+		)
+
+	weighted_obstruction_spawn_list = list(
+		/obj/structure/kitchenspike = 3,
+		/obj/effect/spawner/lootdrop/maintenance = 2,
+		/obj/effect/spawner/lootdrop/random_meat = 2,
+		list(/obj/effect/spawner/lootdrop/random_meat, /obj/effect/gibspawner/generic) = 1,
+		/obj/effect/decal/remains/human = 1,
+		/obj/effect/gibspawner/human = 1,
+		)
+
+//jungle themed
+/datum/generator_theme/jungle
+	weight = 10
+	weighted_possible_floor_types = list(
+		/turf/open/floor/plating/dirt/jungleland/backrooms = 1
+		)
+
+	weighted_possible_wall_types  = list(
+		/turf/closed/wall/mineral/bamboo = 1
+		)
+
+	weighted_feature_spawn_list = list(
+		/obj/machinery/space_heater = 3,
+		/obj/structure/closet/emcloset = 3,
+		/obj/structure/closet/firecloset = 3,
+		/obj/structure/closet/toolcloset = 2,
+		list(/obj/structure/table, /obj/effect/spawner/lootdrop/maintenance) = 2,
+		list(/obj/structure/rack, /obj/effect/spawner/lootdrop/maintenance) = 2,
+		/obj/structure/flora/ausbushes = 1,
+		/obj/structure/flora/ausbushes/leafybush = 1,
+		/obj/structure/flora/ausbushes/sunnybush = 1,
+		/obj/structure/flora/ausbushes/lavendergrass = 1,
+		/obj/structure/flora/ausbushes/ywflowers = 1,
+		/obj/structure/flora/ausbushes/ppflowers = 1,
+		/obj/structure/flora/ausbushes/fullgrass = 1,
+		/obj/structure/flora/tree/jungle = 1,
+		)
+
+	weighted_obstruction_spawn_list = list(
+		/obj/effect/spawner/lootdrop/maintenance = 2,
+		/obj/structure/flora/ausbushes = 1,
+		/obj/structure/flora/ausbushes/leafybush = 1,
+		/obj/structure/flora/ausbushes/sunnybush = 1,
+		/obj/structure/flora/ausbushes/lavendergrass = 1,
+		/obj/structure/flora/ausbushes/ywflowers = 1,
+		/obj/structure/flora/ausbushes/ppflowers = 1,
+		/obj/structure/flora/ausbushes/fullgrass = 1,
+		)
+
+/turf/open/floor/plating/dirt/jungleland/backrooms //fullbright backrooms? in this economy?
+	light_power = 1
+	light_range = 2

--- a/code/datums/mapgen/dungeon_generators/generator_theme.dm
+++ b/code/datums/mapgen/dungeon_generators/generator_theme.dm
@@ -6,21 +6,29 @@
 	var/list/weighted_possible_floor_types = list()
 	///Weighted list of walls for the generator to choose from
 	var/list/weighted_possible_wall_types = list()
-	///Weighted list of extra features that can spawn in the area, such as closets.
-	var/list/weighted_feature_spawn_list = list(
-		/obj/machinery/space_heater = 2,
+	///Weighted list of extra features that spawn against walls.
+	var/list/weighted_againstwall_spawn_list = list(
+		/obj/machinery/space_heater = 1,
 		/obj/structure/closet/emcloset = 2,
 		/obj/structure/closet/firecloset = 2,
 		/obj/structure/closet/toolcloset = 1,
-		list(/obj/structure/table, /obj/effect/spawner/lootdrop/maintenance) = 1,
+		list(/obj/structure/table, /obj/effect/spawner/lootdrop/maintenance) = 1, //we do it this way so we can spawn things in groups
 		list(/obj/structure/rack, /obj/effect/spawner/lootdrop/maintenance) = 1
 	)
-	///Weighted list of extra obstructions that can spawn in the area, such as grilles and girders. (also spawns out in the open (mostly for flavour))
-	var/list/weighted_obstruction_spawn_list = list(
+	///Weighted list of extra features that spawn out in the open
+	var/list/weighted_openfloor_spawn_list = list(
 		/obj/structure/grille = 3,
 		/obj/structure/grille/broken = 4,
 		/obj/structure/girder/displaced = 2,
-		/obj/effect/spawner/lootdrop/maintenance = 2 //technically not an obstruction
+		/obj/structure/girder = 2,
+		/obj/effect/spawner/lootdrop/maintenance = 2
+	)
+	///Weighted list of extra features that spawn in narrow hallways
+	var/list/weighted_hallway_spawn_list = list(
+		/obj/structure/grille = 3,
+		/obj/structure/grille/broken = 4,
+		/obj/structure/girder/displaced = 2,
+		/obj/effect/spawner/lootdrop/maintenance = 2
 	)
 
 //Library themed
@@ -34,18 +42,22 @@
 		/turf/closed/wall/mineral/wood = 1
 		)
 
-	weighted_feature_spawn_list = list(
-		/obj/machinery/space_heater = 2,
+	weighted_againstwall_spawn_list = list(
+		/obj/machinery/space_heater = 1,
 		/obj/structure/closet/emcloset = 2,
 		/obj/structure/closet/firecloset = 2,
 		/obj/structure/closet/toolcloset = 1,
 		list(/obj/structure/table, /obj/effect/spawner/lootdrop/maintenance) = 1,
-		list(/obj/structure/rack, /obj/effect/spawner/lootdrop/maintenance) = 1,
-		/obj/item/book/random = 1
+		list(/obj/structure/rack, /obj/effect/spawner/lootdrop/maintenance) = 1
 		)
 
-	weighted_obstruction_spawn_list = list(
-		/obj/structure/bookcase/random = 3,
+	weighted_openfloor_spawn_list = list(
+		/obj/structure/bookcase/random = 4,
+		/obj/effect/spawner/lootdrop/maintenance = 2,
+		/obj/item/book/random = 3,
+		)
+
+	weighted_hallway_spawn_list = list(
 		/obj/effect/spawner/lootdrop/maintenance = 2,
 		/obj/item/book/random = 2,
 		)
@@ -61,8 +73,8 @@
 		/turf/closed/wall/mineral/iron = 1
 		)
 
-	weighted_feature_spawn_list = list(
-		/obj/machinery/space_heater = 2,
+	weighted_againstwall_spawn_list = list(
+		/obj/machinery/space_heater = 1,
 		/obj/structure/closet/emcloset = 2,
 		/obj/structure/closet/firecloset = 2,
 		/obj/structure/closet/toolcloset = 1,
@@ -73,9 +85,17 @@
 		/obj/effect/gibspawner/human = 1,
 		)
 
-	weighted_obstruction_spawn_list = list(
-		/obj/structure/kitchenspike = 3,
+	weighted_openfloor_spawn_list = list(
+		/obj/structure/kitchenspike = 4,
 		/obj/effect/spawner/lootdrop/maintenance = 2,
+		/obj/effect/spawner/lootdrop/random_meat = 2,
+		list(/obj/effect/spawner/lootdrop/random_meat, /obj/effect/gibspawner/generic) = 1,
+		/obj/effect/decal/remains/human = 1,
+		/obj/effect/gibspawner/human = 1,
+		)
+
+	weighted_hallway_spawn_list = list(
+		/obj/effect/spawner/lootdrop/maintenance = 3,
 		/obj/effect/spawner/lootdrop/random_meat = 2,
 		list(/obj/effect/spawner/lootdrop/random_meat, /obj/effect/gibspawner/generic) = 1,
 		/obj/effect/decal/remains/human = 1,
@@ -93,13 +113,13 @@
 		/turf/closed/wall/mineral/bamboo = 1
 		)
 
-	weighted_feature_spawn_list = list(
+	var/list/weighted_againstwall_spawn_list = list(
 		/obj/machinery/space_heater = 3,
-		/obj/structure/closet/emcloset = 3,
-		/obj/structure/closet/firecloset = 3,
-		/obj/structure/closet/toolcloset = 2,
-		list(/obj/structure/table, /obj/effect/spawner/lootdrop/maintenance) = 2,
-		list(/obj/structure/rack, /obj/effect/spawner/lootdrop/maintenance) = 2,
+		/obj/structure/closet/emcloset = 6,
+		/obj/structure/closet/firecloset = 6,
+		/obj/structure/closet/toolcloset = 3,
+		list(/obj/structure/table, /obj/effect/spawner/lootdrop/maintenance) = 3, //we do it this way so we can spawn things in groups
+		list(/obj/structure/rack, /obj/effect/spawner/lootdrop/maintenance) = 3,
 		/obj/structure/flora/ausbushes = 1,
 		/obj/structure/flora/ausbushes/leafybush = 1,
 		/obj/structure/flora/ausbushes/sunnybush = 1,
@@ -107,10 +127,9 @@
 		/obj/structure/flora/ausbushes/ywflowers = 1,
 		/obj/structure/flora/ausbushes/ppflowers = 1,
 		/obj/structure/flora/ausbushes/fullgrass = 1,
-		/obj/structure/flora/tree/jungle = 1,
-		)
+	)
 
-	weighted_obstruction_spawn_list = list(
+	weighted_openfloor_spawn_list = list(
 		/obj/effect/spawner/lootdrop/maintenance = 2,
 		/obj/structure/flora/ausbushes = 1,
 		/obj/structure/flora/ausbushes/leafybush = 1,
@@ -119,6 +138,18 @@
 		/obj/structure/flora/ausbushes/ywflowers = 1,
 		/obj/structure/flora/ausbushes/ppflowers = 1,
 		/obj/structure/flora/ausbushes/fullgrass = 1,
+		/obj/structure/flora/tree/jungle = 5
+		)
+
+	weighted_hallway_spawn_list = list(
+		/obj/effect/spawner/lootdrop/maintenance = 2,
+		/obj/structure/flora/ausbushes = 1,
+		/obj/structure/flora/ausbushes/leafybush = 1,
+		/obj/structure/flora/ausbushes/sunnybush = 1,
+		/obj/structure/flora/ausbushes/lavendergrass = 1,
+		/obj/structure/flora/ausbushes/ywflowers = 1,
+		/obj/structure/flora/ausbushes/ppflowers = 1,
+		/obj/structure/flora/ausbushes/fullgrass = 1
 		)
 
 /turf/open/floor/plating/dirt/jungleland/backrooms //fullbright backrooms? in this economy?

--- a/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_generator.dm
+++ b/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_generator.dm
@@ -19,7 +19,24 @@
 	///Boolean, wether or not apcs are added to the maintenance
 	var/include_apcs = TRUE
 
-	//var/list/used_spawn_points = list()
+	///Weighted list of extra features that can spawn in the area, such as closets.
+	var/list/weighted_feature_spawn_list = list(
+		/obj/machinery/space_heater = 2,
+		/obj/structure/closet/emcloset = 2,
+		/obj/structure/closet/firecloset = 2,
+		/obj/structure/closet/toolcloset = 1,
+		list(/obj/structure/table, /obj/effect/spawner/lootdrop/maintenance) = 1, //we do it this way so we can spawn things in groups
+		list(/obj/structure/rack, /obj/effect/spawner/lootdrop/maintenance) = 1
+	)
+	///Weighted list of extra obstructions that can spawn in the area, such as grilles and girders.
+	var/list/weighted_obstruction_spawn_list = list(
+		/obj/structure/grille = 3,
+		/obj/structure/grille/broken = 4,
+		/obj/structure/girder/displaced = 2,
+		/obj/effect/spawner/lootdrop/maintenance = 2 //technically not an obstruction
+	)
+	///multiplied by the number of valid turf to decide how many things should be spawned
+	var/feature_spawn_ratio = 0.15
 
 /datum/map_generator/dungeon_generator/maintenance/build_dungeon()
 	. = ..()
@@ -78,7 +95,7 @@
 /datum/map_generator/dungeon_generator/maintenance/proc/add_maint_loot()
 	//Gax maints typically ends up being about 2000 turfs, so this would end up being ~200 items, structures, and decals to decorate maint with
 	var/list/valid_spawn_points = typecache_filter_list(working_turfs, typecacheof(/turf/open/floor))
-	var/items_to_spawn = ROUND_UP(valid_spawn_points.len * 0.15)
+	var/items_to_spawn = ROUND_UP(valid_spawn_points.len * feature_spawn_ratio)
 	var/max_attempts = 5
 	var/attempts = max_attempts
 
@@ -108,48 +125,24 @@
 			//what the fuck how did you get here
 			brazil = TRUE
 
+		var/list/things_to_spawn = list()
+
 		if(brazil)
-			new /obj/item/toy/plush/lizard/azeel(spawn_point)
-			items_to_spawn--
-		
+			things_to_spawn = /obj/item/toy/plush/lizard/azeel
 		else if(blocking_passage)
-			switch(rand(1,10))
-				if(1 to 6)
-					new /obj/structure/grille/broken(spawn_point)
-					
-				else
-					new /obj/structure/grille(spawn_point)
-			items_to_spawn--
+			things_to_spawn = pick_weight(weighted_obstruction_spawn_list)
 		else if(against_wall)
-			switch(rand(1,10))
-				if(1 to 3)
-					if(prob(50))
-						new /obj/structure/table(spawn_point)
-					else
-						new /obj/structure/rack(spawn_point)
-					items_to_spawn--
-					new /obj/effect/spawner/lootdrop/maintenance(spawn_point)
-				if(4 to 5)
-					new /obj/machinery/space_heater(spawn_point)
-				if(6 to 7)
-					new /obj/structure/closet/emcloset(spawn_point)
-				if(8 to 9)
-					new /obj/structure/closet/firecloset(spawn_point)
-				if(10)
-					new /obj/structure/closet/toolcloset(spawn_point)
-			items_to_spawn--
+			things_to_spawn = pick_weight(weighted_feature_spawn_list)
 		else
-			switch(rand(1,10))
-				if(1 to 3)
-					new /obj/structure/grille/broken(spawn_point)
-				if(4 to 6)
-					new /obj/structure/girder/displaced(spawn_point)
-				if(7 to 9)
-					new /obj/structure/grille(spawn_point)
-				else
-					new /obj/effect/spawner/lootdrop/maintenance(spawn_point)
-			items_to_spawn--
-		//used_spawn_points += spawn_point
+			things_to_spawn = pick_weight(weighted_obstruction_spawn_list)
+
+		if(!islist(things_to_spawn)) //we're expecting a list, but most things in the list won't be one
+			things_to_spawn = list(things_to_spawn) //so we put them in a list
+
+		for(var/i in things_to_spawn)
+			new i(spawn_point)
+		items_to_spawn--
+			
 		attempts = max_attempts
 
 /datum/map_generator/dungeon_generator/maintenance/proc/add_apcs()
@@ -294,18 +287,24 @@
 //------------Generator specifically for the Z level----------//
 ////////////////////////////////////////////////////////////////
 /datum/map_generator/dungeon_generator/maintenance/backrooms
-
-	//since there are no firelocks, the place needs to be hard to space and replenish air automatically
-	weighted_open_turf_types = list(
-		/turf/open/floor/plating/backrooms = 10, 
-		/turf/open/floor/plating/rust = 1,
-		)
-
-	probability_room_types = list(ROOM_TYPE_RUIN = 75)
+	probability_room_types = list(ROOM_TYPE_RUIN = 75) //remove the space
+	feature_spawn_ratio = 0.2 //slightly more dense in features than regular maints
 
 	//removes firelocks and apcs as the area is large enough that it annihilates the server if it has a bunch of firelocks
 	atmos_control = null
 	include_apcs = FALSE
+
+/datum/map_generator/dungeon_generator/maintenance/backrooms/New(area/generate_in)
+	if(SSbackrooms.picked_theme)
+		var/datum/generator_theme/picked_theme = SSbackrooms.picked_theme
+		if(length(picked_theme.weighted_possible_floor_types))
+			weighted_open_turf_types = picked_theme.weighted_possible_floor_types
+		if(length(picked_theme.weighted_possible_wall_types))
+			weighted_closed_turf_types = picked_theme.weighted_possible_wall_types
+		//never let walls and floor be reduced to nothing, but let features be reduced to nothing
+		weighted_feature_spawn_list = picked_theme.weighted_feature_spawn_list
+		weighted_obstruction_spawn_list = picked_theme.weighted_obstruction_spawn_list
+	return ..()
 
 /turf/open/floor/plating/backrooms
 	baseturfs = /turf/open/floor/plating/backrooms	

--- a/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_generator.dm
+++ b/code/datums/mapgen/dungeon_generators/maintenance_generator/maintenance_generator.dm
@@ -19,8 +19,8 @@
 	///Boolean, wether or not apcs are added to the maintenance
 	var/include_apcs = TRUE
 
-	///Weighted list of extra features that can spawn in the area, such as closets.
-	var/list/weighted_feature_spawn_list = list(
+	///Weighted list of extra features that spawn against walls.
+	var/list/weighted_againstwall_spawn_list = list(
 		/obj/machinery/space_heater = 2,
 		/obj/structure/closet/emcloset = 2,
 		/obj/structure/closet/firecloset = 2,
@@ -28,12 +28,19 @@
 		list(/obj/structure/table, /obj/effect/spawner/lootdrop/maintenance) = 1, //we do it this way so we can spawn things in groups
 		list(/obj/structure/rack, /obj/effect/spawner/lootdrop/maintenance) = 1
 	)
-	///Weighted list of extra obstructions that can spawn in the area, such as grilles and girders.
-	var/list/weighted_obstruction_spawn_list = list(
+	///Weighted list of extra features that spawn out in the open
+	var/list/weighted_openfloor_spawn_list = list(
 		/obj/structure/grille = 3,
 		/obj/structure/grille/broken = 4,
 		/obj/structure/girder/displaced = 2,
-		/obj/effect/spawner/lootdrop/maintenance = 2 //technically not an obstruction
+		/obj/effect/spawner/lootdrop/maintenance = 2
+	)
+	///Weighted list of extra features that spawn in narrow hallways
+	var/list/weighted_hallway_spawn_list = list(
+		/obj/structure/grille = 3,
+		/obj/structure/grille/broken = 4,
+		/obj/structure/girder/displaced = 2,
+		/obj/effect/spawner/lootdrop/maintenance = 2
 	)
 	///multiplied by the number of valid turf to decide how many things should be spawned
 	var/feature_spawn_ratio = 0.15
@@ -130,11 +137,11 @@
 		if(brazil)
 			things_to_spawn = /obj/item/toy/plush/lizard/azeel
 		else if(blocking_passage)
-			things_to_spawn = pick_weight(weighted_obstruction_spawn_list)
+			things_to_spawn = pick_weight(weighted_hallway_spawn_list)
 		else if(against_wall)
-			things_to_spawn = pick_weight(weighted_feature_spawn_list)
+			things_to_spawn = pick_weight(weighted_againstwall_spawn_list)
 		else
-			things_to_spawn = pick_weight(weighted_obstruction_spawn_list)
+			things_to_spawn = pick_weight(weighted_openfloor_spawn_list)
 
 		if(!islist(things_to_spawn)) //we're expecting a list, but most things in the list won't be one
 			things_to_spawn = list(things_to_spawn) //so we put them in a list
@@ -288,7 +295,7 @@
 ////////////////////////////////////////////////////////////////
 /datum/map_generator/dungeon_generator/maintenance/backrooms
 	probability_room_types = list(ROOM_TYPE_RUIN = 75) //remove the space
-	feature_spawn_ratio = 0.2 //slightly more dense in features than regular maints
+	feature_spawn_ratio = 0.20 //slightly more dense in features than regular maints
 
 	//removes firelocks and apcs as the area is large enough that it annihilates the server if it has a bunch of firelocks
 	atmos_control = null
@@ -302,8 +309,9 @@
 		if(length(picked_theme.weighted_possible_wall_types))
 			weighted_closed_turf_types = picked_theme.weighted_possible_wall_types
 		//never let walls and floor be reduced to nothing, but let features be reduced to nothing
-		weighted_feature_spawn_list = picked_theme.weighted_feature_spawn_list
-		weighted_obstruction_spawn_list = picked_theme.weighted_obstruction_spawn_list
+		weighted_againstwall_spawn_list = picked_theme.weighted_againstwall_spawn_list
+		weighted_openfloor_spawn_list = picked_theme.weighted_openfloor_spawn_list
+		weighted_hallway_spawn_list = picked_theme.weighted_hallway_spawn_list
 	return ..()
 
 /turf/open/floor/plating/backrooms

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -430,6 +430,14 @@
 	loot = list(pick(soups) = 1,pick(salads) = 1,pick(mains) = 1)
 	. = ..()
 
+/obj/effect/spawner/lootdrop/random_meat
+	name = "meat loot spawner"
+
+/obj/effect/spawner/lootdrop/random_meat/Initialize(mapload)
+	var/item = pick(typesof(/obj/item/reagent_containers/food/snacks/meat/slab))
+	new item(loc)
+	return INITIALIZE_HINT_QDEL
+
 /obj/effect/spawner/lootdrop/maintenance
 	name = "maintenance loot spawner"
 	// see code/_globalvars/lists/maintenance_loot.dm for loot table

--- a/code/game/turfs/closed/indestructible.dm
+++ b/code/game/turfs/closed/indestructible.dm
@@ -232,16 +232,3 @@ INITIALIZE_IMMEDIATE(/turf/closed/indestructible/splashscreen)
 	smoothing_flags = SMOOTH_CORNERS
 	smoothing_groups = SMOOTH_GROUP_HIERO_WALL
 	canSmoothWith = SMOOTH_GROUP_HIERO_WALL
-
-/turf/closed/indestructible/backrooms
-	name = "wall"
-	desc = "A huge chunk of metal used to separate rooms."
-	icon = 'icons/turf/walls/wall.dmi'
-	icon_state = "wall-0"
-	base_icon_state = "wall"
-
-	baseturfs = /turf/open/floor/plating/backrooms
-
-	smoothing_flags = SMOOTH_BITMASK
-	smoothing_groups = SMOOTH_GROUP_WALLS + SMOOTH_GROUP_CLOSED_TURFS
-	canSmoothWith = SMOOTH_GROUP_WALLS

--- a/code/game/turfs/closed/walls.dm
+++ b/code/game/turfs/closed/walls.dm
@@ -98,6 +98,8 @@
 	return TRUE
 
 /turf/closed/wall/proc/dismantle_wall(devastated = FALSE, explode = FALSE)
+	if(resistance_flags & INDESTRUCTIBLE)
+		return
 	if(devastated)
 		devastate_wall()
 	else
@@ -126,6 +128,8 @@
 		new /obj/item/stack/sheet/metal(src)
 
 /turf/closed/wall/ex_act(severity, target)
+	if(resistance_flags & INDESTRUCTIBLE)
+		return
 	if(target == src)
 		dismantle_wall(TRUE, TRUE)
 		return

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -807,6 +807,7 @@
 #include "code\datums\mapgen\Cavegens\LavalandGenerator.dm"
 #include "code\datums\mapgen\dungeon_generators\dungeon_room.dm"
 #include "code\datums\mapgen\dungeon_generators\dungeon_room_theme.dm"
+#include "code\datums\mapgen\dungeon_generators\generator_theme.dm"
 #include "code\datums\mapgen\dungeon_generators\maintenance_generator\maintenance_generator.dm"
 #include "code\datums\mapgen\dungeon_generators\maintenance_generator\maintenance_room.dm"
 #include "code\datums\mapgen\dungeon_generators\maintenance_generator\maintenance_room_theme.dm"


### PR DESCRIPTION
Adding new themes is really simple, just make a new theme datum following the examples of the others and it will automatically be added to the list

# Why is this good for the game?
whenever the job gets implemented, it will add visual variation between rounds

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/d850f052-a88f-44fc-b215-3e2266423ce7)
next two are with fullbright ghost vision because otherwise they'd be hard to see
![image](https://github.com/yogstation13/Yogstation/assets/108117184/fad1b230-ba45-4597-99f5-02ad407acf02)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/a82beea3-e2f4-4d2a-9a81-d099a5ace588)

:cl:  
rscadd: Adds a themes system to the backrooms
rscadd: Adds 3 new themes to the backrooms
/:cl:
