### PR TITLE
Catches a stack_trace warning about possible runtimes

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -173,8 +173,12 @@
 			continue
 
 		if(extended_safety_checks)
-			var/datum/component/lingering/safety_check = F.GetComponent(/datum/component/lingering)
-			if(safety_check && !safety_check.is_safe()) //chasms aren't /floor, and so are pre-filtered
+			var/list/components = F.GetComponents(/datum/component/lingering)
+			var/safe = TRUE
+			for(var/datum/component/lingering/safety_check as anything in components)
+				if(safety_check)
+					safe = (safe && safety_check.is_safe())
+			if(!safe)
 				continue
 					
 		// Check that we're not warping onto a table or window

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/swarmer.dm
@@ -141,8 +141,12 @@ GLOBAL_LIST_INIT(AISwarmerCapsByType, list(/mob/living/simple_animal/hostile/swa
 /mob/living/simple_animal/hostile/swarmer/ai/Move(atom/newloc)
 	if(newloc)
 		if(newloc.z == z) //so these actions are Z-specific
-			var/datum/component/lingering/safety_check = newloc.GetComponent(/datum/component/lingering)
-			if(safety_check && !safety_check.is_safe()) 
+			var/list/components = src.GetComponents(/datum/component/lingering)
+			var/safe = TRUE
+			for(var/datum/component/lingering/safety_check as anything in components)
+				if(safety_check)
+					safe = (safe && safety_check.is_safe())
+			if(!safe)
 				StartAction(20)
 				new /obj/structure/lattice/catwalk/swarmer_catwalk(newloc)
 				return FALSE

--- a/code/modules/swarmers/swarmer_act.dm
+++ b/code/modules/swarmers/swarmer_act.dm
@@ -64,8 +64,12 @@
 	return FALSE
 
 /turf/open/lava/swarmer_act()
-	var/datum/component/lingering/safety_check = src.GetComponent(/datum/component/lingering)
-	if(safety_check && !safety_check.is_safe()) //chasms aren't /floor, and so are pre-filtered
+	var/list/components = src.GetComponents(/datum/component/lingering)
+	var/safe = TRUE
+	for(var/datum/component/lingering/safety_check as anything in components)
+		if(safety_check)
+			safe = (safe && safety_check.is_safe())
+	if(!safe)
 		new /obj/structure/lattice/catwalk/swarmer_catwalk(src)
 	return FALSE
 


### PR DESCRIPTION
i changed lava to be a more general component, and let it be stackable as a result
just had to update getComponent() to use getComponents() instead

# Testing
(those aren't mine)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/cdd3d366-fcdc-4cc7-9f72-820d8c792554)

:cl:  
nothing player facing
/:cl:
