### PR TITLE
Simplifies Preterni

### DIFF
--- a/yogstation.dme
+++ b/yogstation.dme
@@ -4037,7 +4037,6 @@
 #include "yogstation\code\datums\components\storage\storage.dm"
 #include "yogstation\code\datums\diseases\_MobProcs.dm"
 #include "yogstation\code\datums\diseases\cluwnification.dm"
-#include "yogstation\code\datums\diseases\advance\advance.dm"
 #include "yogstation\code\datums\diseases\advance\symptoms\confusion.dm"
 #include "yogstation\code\datums\diseases\advance\symptoms\heal.dm"
 #include "yogstation\code\datums\looping_sounds\darkspawn.dm"

--- a/yogstation/code/datums/diseases/advance/advance.dm
+++ b/yogstation/code/datums/diseases/advance/advance.dm
@@ -1,9 +1,0 @@
-/datum/disease/advance/Refresh(new_name)
-	..()
-	if(affected_mob?.dna)
-		var/datum/species/S = affected_mob.dna.species
-		properties["resistance"] += S.virus_resistance_boost
-		properties["stealth"] += S.virus_stealth_boost
-		properties["stage_rate"] += S.virus_stage_rate_boost
-		properties["transmittable"] += S.virus_transmittable_boost
-	AssignProperties() //this is a bit inefficent because its called twice but modularization amiright?

--- a/yogstation/code/modules/mob/living/carbon/human/species.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species.dm
@@ -4,10 +4,6 @@
 /datum/species
 	var/yogs_draw_robot_hair = FALSE //DAMN ROBOTS STEALING OUR HAIR AND AIR
 	var/yogs_virus_infect_chance = 100
-	var/virus_resistance_boost = 0
-	var/virus_stealth_boost = 0
-	var/virus_stage_rate_boost = 0
-	var/virus_transmittable_boost = 0
 
 /datum/species/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
 	. = ..()

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
@@ -125,13 +125,6 @@
 	cold_level_2_damage = 4
 	cold_level_3_threshold = 220
 	cold_level_3_damage = 6
-
-	heat_level_1_threshold = 500
-	heat_level_1_damage = 4
-	heat_level_2_threshold = 1000
-	heat_level_2_damage = 7
-	heat_level_3_threshold = 35000 //are you on the fucking surface of the sun or something?
-	heat_level_3_damage = 25 //you should already be dead
 	
 ///////////////////////////////////////////////////////////
 //---------------------Preternis Stomach-----------------//

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -17,7 +17,6 @@
 	disliked_food = GROSS | VEGETABLES
 
 	//stat mods
-	burnmod = 1.2 //The plasteel has a really high heat capacity, however, it's not great at dispersing the heat to concentrated heat is gonna burn
 	coldmod = 3 //The plasteel around them saps their body heat quickly if it gets cold
 	heatmod = 2 //Once the heat gets through it's gonna BURN
 	tempmod = 0.15 //The high heat capacity of the plasteel makes it take far longer to heat up or cool down
@@ -27,9 +26,6 @@
 	punchdamagehigh = 7 //not built for large high speed acts like punches
 	punchstunthreshold = 7 //technically better stunning
 	siemens_coeff = 1.75 //Circuits REALLY don't like extra electricity flying around
-	yogs_virus_infect_chance = 25
-	virus_resistance_boost = 10 //YEOUTCH,good luck getting it out
-	virus_stage_rate_boost = 5 //Not designed with viruses in mind since it doesn't usually get in
 
 	//organs
 	mutanteyes = /obj/item/organ/eyes/robotic/preternis
@@ -73,7 +69,6 @@
 		BP.render_like_organic = TRUE 	// Makes limbs render like organic limbs instead of augmented limbs, check bodyparts.dm
 		BP.emp_reduction = EMP_LIGHT
 		BP.burn_reduction = 1
-		BP.brute_reduction = 1
 		if(BP.body_zone == BODY_ZONE_CHEST)
 			continue
 		if(BP.body_zone == BODY_ZONE_HEAD)
@@ -94,7 +89,6 @@
 		BP.change_bodypart_status(ORGAN_ORGANIC,FALSE,TRUE)
 		BP.emp_reduction = initial(BP.emp_reduction)
 		BP.burn_reduction = initial(BP.burn_reduction)
-		BP.brute_reduction = initial(BP.brute_reduction)
 
 	UnregisterSignal(C, COMSIG_MOB_ALTCLICKON)
 


### PR DESCRIPTION
Removes limb brute resistance
-it wasn't easy to convey they got this, and now that the limbs have innate emp resistance rather than the species, they still have a reason to not swap to borg limbs
-matters more in combat than burn reduction

Removes burnmod
-their limbs already have burn reduction, which makes it sorta counter-intuitive, "are they weak to burn? strong against it?"

Removes lung interactions to heat
-the intention was to make them resistant to breathing hot gases, but all it did was make it do more damage, but at different breakpoints
-when i initially added this, i didn't know how breathing hot gases dealt damage

Removes virus resistance(?)
-Virus resistance, much like rad resistance, is binary, either you're immune or you're not
-Had no effect on gameplay aside from confusing people into thinking they're like IPCs (who are immune)


# Why is this good for the game?
aint no one got time to read all that
![image](https://github.com/yogstation13/Yogstation/assets/108117184/7d3ad0a9-11f1-49ba-96d7-77d51c6bf151)
they also have minor things that just aren't clear without code diving

# Testing
just number changes

:cl:  
tweak: Removes preternis inconsistent virus interactions
tweak: Removes burnmod from preternis
tweak: Removes brute resistance from preternis limbs
tweak: Removes preternis lungs acting weirdly with hot gases
/:cl:
