### PR TITLE
buffs antinob-hypernob chemical explosion reaction

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -474,7 +474,7 @@
 	name = "Hypernoblium-Antinoblium Annihilation"
 	id = "noblium_annihilation"
 	required_reagents = list(/datum/reagent/hypernoblium = 1, /datum/reagent/antinoblium = 1)
-	strengthdiv = 150
+	strengthdiv = 0.1
 	noblium_suppression = FALSE
 	mob_react = FALSE // no
 

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -474,7 +474,7 @@
 	name = "Hypernoblium-Antinoblium Annihilation"
 	id = "noblium_annihilation"
 	required_reagents = list(/datum/reagent/hypernoblium = 1, /datum/reagent/antinoblium = 1)
-	strengthdiv = 1
+	strengthdiv = 150
 	noblium_suppression = FALSE
 	mob_react = FALSE // no
 

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -474,7 +474,7 @@
 	name = "Hypernoblium-Antinoblium Annihilation"
 	id = "noblium_annihilation"
 	required_reagents = list(/datum/reagent/hypernoblium = 1, /datum/reagent/antinoblium = 1)
-	strengthdiv = 0.1
+	strengthdiv = 0.5
 	noblium_suppression = FALSE
 	mob_react = FALSE // no
 


### PR DESCRIPTION
can always be nerfed later,

this is before buff (600u)

https://github.com/yogstation13/Yogstation/assets/89688125/62a41a3c-b6b0-459c-99a3-ef3d343f47aa


# Document the changes in your pull request
buffs antinob-hypernob chemical explosion reaction strength by x2

# Why is this good for the game?
my man, the efforts to make this stuff just for it to explode for a few tiles is fucked up It should cause a wide range of explosion, same as the explosion of the hypernob-antinob HFR fuel mix.

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/89688125/2392fce4-5a04-404f-b3a1-3d795b01efa7)

this is 600u of antinob and hypernob





# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: buffs antinob-hypernob chemical explosion reaction strength by x2
/:cl:
