### PR TITLE
Remove null items from donor eorg choices

### DIFF
--- a/code/modules/client/preferences/donor.dm
+++ b/code/modules/client/preferences/donor.dm
@@ -162,6 +162,8 @@
 			continue
 		if(initial(path.cost) > TELECRYSTALS_DEFAULT)
 			continue
+		if(!initial(path.item))
+			continue
 		values += "[path]"
 
 	return values


### PR DESCRIPTION
# Document the changes in your pull request
Fixes "item name" and other potential null entries

This was already checked for when spawning EORG items, but not when generating the choice list

# Changelog

:cl:   
bugfix: fixed non-spawning items showing up in End-Round Item choices (donator feature)
/:cl:
