### PR TITLE
Change decon unit and cryo tube layer to OBJ_LAYER to show the item above it

### DIFF
--- a/code/game/machinery/decontamination.dm
+++ b/code/game/machinery/decontamination.dm
@@ -7,7 +7,7 @@
 	density = TRUE
 	max_integrity = 300
 	circuit = /obj/item/circuitboard/machine/decontamination_unit
-	layer = ABOVE_WINDOW_LAYER
+	layer = OBJ_LAYER
 								// if you add more storage slots, update cook() to clear their radiation too.
 
 	var/max_n_of_items = 53

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -62,7 +62,7 @@
 	density = TRUE
 	max_integrity = 350
 	armor = list(MELEE = 0, BULLET = 0, LASER = 0, ENERGY = 100, BOMB = 0, BIO = 100, RAD = 100, FIRE = 30, ACID = 30)
-	layer = MOB_LAYER
+	layer = OBJ_LAYER
 	state_open = FALSE
 	circuit = /obj/item/circuitboard/machine/cryo_tube
 	pipe_flags = PIPING_ONE_PER_TURF | PIPING_DEFAULT_LAYER_ONLY


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request
Change decon unit and cryo tube layer to OBJ_LAYER to show the item above it

# Why is this good for the game?
It's weird that these things hide items underneath it..

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/89688125/49f07b8b-705c-4c67-8b75-35b5288bd148)



# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

tweak: Change decon unit and cryo tube layer to OBJ_LAYER to show the item above it
/:cl:
