### PR TITLE
Adds Lemoline to Chemical Dispenser @ Emagged List

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -76,7 +76,8 @@
 		/datum/reagent/gold,
 		/datum/reagent/diethylamine,
 		/datum/reagent/saltpetre,
-		/datum/reagent/medicine/charcoal
+		/datum/reagent/medicine/charcoal,
+		/datum/reagent/lemoline
 	)
 	var/list/emagged_reagents = list(
 		/datum/reagent/toxin/carpotoxin,

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -76,8 +76,8 @@
 		/datum/reagent/gold,
 		/datum/reagent/diethylamine,
 		/datum/reagent/saltpetre,
-		/datum/reagent/medicine/charcoal,
-		/datum/reagent/lemoline
+		/datum/reagent/medicine/charcoal
+		
 	)
 	var/list/emagged_reagents = list(
 		/datum/reagent/toxin/carpotoxin,
@@ -85,7 +85,8 @@
 		/datum/reagent/medicine/morphine,
 		/datum/reagent/drug/space_drugs,
 		/datum/reagent/toxin,
-		/datum/reagent/uranium
+		/datum/reagent/uranium,
+		/datum/reagent/lemoline
 	)
 
 	var/list/saved_recipes = list()


### PR DESCRIPTION
# Document the changes in your pull request

Adds Lemoline to Chemical Dispenser when upgraded to Emagged List
# Why is this good for the game?
Gives subversive method for people to use, to avoid cargo in obtaining Lemoline.

# Testing
Simple, no testing required.

# Wiki Documentation

Add Lemoline under 'Emagged' of Chem Dispenser

# Changelog

:cl:  

tweak: tweaks Chemical Dispenser Emagged List.
/:cl:
