### PR TITLE
Nerfs sepia slime core passive

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -701,8 +701,8 @@ datum/status_effect/stabilized/blue/on_remove()
 /datum/status_effect/stabilized/sepia/on_apply()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		owner.next_move_modifier *= 0.7
-		H.physiology.do_after_speed *= 0.7
+		owner.next_move_modifier *= 0.85
+		H.physiology.do_after_speed *= 0.85
 		H.physiology.stamina_mod *= 1.5
 		H.physiology.stun_mod *= 1.5
 	return ..()
@@ -710,8 +710,8 @@ datum/status_effect/stabilized/blue/on_remove()
 /datum/status_effect/stabilized/sepia/on_remove()
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		owner.next_move_modifier /= 0.7
-		H.physiology.do_after_speed /= 0.7
+		owner.next_move_modifier /= 0.85
+		H.physiology.do_after_speed /= 0.85
 		H.physiology.stamina_mod /= 1.5
 		H.physiology.stun_mod /= 1.5
 	return ..()


### PR DESCRIPTION
# Document the changes in your pull request

reduce sepia slime core action speed reduction from .7 to .85

# Why is this good for the game?

I was informed .7 was a bit too strong, and .85 is a bit more fair for how easy they are to produce

# Testing

no

# Wiki Documentation

reduce from .7 to .85

# Changelog

:cl:  

tweak: reduces sepia slime effectiveness

/:cl:
