### PR TITLE
Revert "Allow drones to understand common (not speak)", This is NT, not Super Earth.

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -253,9 +253,9 @@ Key procs
 
 /datum/language_holder/drone
 	understood_languages = list(/datum/language/drone = list(LANGUAGE_ATOM),
-								/datum/language/machine = list(LANGUAGE_ATOM),
-                                /datum/language/common = list(LANGUAGE_ATOM))
+								/datum/language/machine = list(LANGUAGE_ATOM))
 	spoken_languages = list(/datum/language/drone = list(LANGUAGE_ATOM))
+	blocked_languages = list(/datum/language/common = list(LANGUAGE_ATOM))
 
 /datum/language_holder/drone/syndicate
 	blocked_languages = list()


### PR DESCRIPTION
Reverts yogstation13/Yogstation#22138

-I don't believe drones have the capability or responsibility to not abuse commons, this gives them an unfair advantage of knowing more about the round, antags or such by sheer walking around. Which then those stupid drones will use to blackmail our poor yoggites.

Guys.... I ask you, should Drones? The mindless bots be allowed to understand sophistication like us? No.... They should just be allowed the bare minimal and do their job.

Thank you, this was sponsored by the NT-Saviors.