### PR TITLE
Fix teg overlay bugs

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
@@ -124,7 +124,7 @@
 	else
 		if(!last_pressure_delta)
 			set_light(1)
-			SSvis_overlays.add_vis_overlay(src, icon, "circ-off", ABOVE_LIGHTING_PLANE, dir)
+			SSvis_overlays.add_vis_overlay(src, icon, "circ-off", LIGHTING_PRIMARY_LAYER, ABOVE_LIGHTING_PLANE, dir)
 			return
 		else
 			if(last_pressure_delta > ONE_ATMOSPHERE) //fast
@@ -132,15 +132,15 @@
 					set_light(3,2,"#4F82FF")
 				else
 					set_light(3,2,"#FF3232")
-				SSvis_overlays.add_vis_overlay(src, icon, "circ-ex[mode?"cold":"hot"]", ABOVE_LIGHTING_PLANE, dir)
-				SSvis_overlays.add_vis_overlay(src, icon, "circ-run", ABOVE_LIGHTING_PLANE, dir)
+				SSvis_overlays.add_vis_overlay(src, icon, "circ-ex[mode?"cold":"hot"]", LIGHTING_PRIMARY_LAYER, ABOVE_LIGHTING_PLANE, dir)
+				SSvis_overlays.add_vis_overlay(src, icon, "circ-run", LIGHTING_PRIMARY_LAYER, ABOVE_LIGHTING_PLANE, dir)
 			else	//slow
 				if(mode)
 					set_light(2,1,"#4F82FF")
 				else
 					set_light(2,1,"#FF3232")
-				SSvis_overlays.add_vis_overlay(src, icon, "circ-[mode?"cold":"hot"]", ABOVE_LIGHTING_PLANE, dir)
-				SSvis_overlays.add_vis_overlay(src, icon, "circ-slow", ABOVE_LIGHTING_PLANE, dir)
+				SSvis_overlays.add_vis_overlay(src, icon, "circ-[mode?"cold":"hot"]", LIGHTING_PRIMARY_LAYER, ABOVE_LIGHTING_PLANE, dir)
+				SSvis_overlays.add_vis_overlay(src, icon, "circ-slow", LIGHTING_PRIMARY_LAYER, ABOVE_LIGHTING_PLANE, dir)
 
 /obj/machinery/atmospherics/components/binary/circulator/wrench_act(mob/living/user, obj/item/I)
 	if(user.combat_mode)

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -58,7 +58,7 @@
 
 	var/L = min(round(lastgenlev/100000), 11)
 	if(L != 0)
-		SSvis_overlays.add_vis_overlay(src, icon, "teg-op[L]", ABOVE_LIGHTING_PLANE, dir)
+		SSvis_overlays.add_vis_overlay(src, icon, "teg-op[L]", LIGHTING_PRIMARY_LAYER, ABOVE_LIGHTING_PLANE, dir)
 
 #define GENRATE 800		// generator output coefficient from Q
 


### PR DESCRIPTION

![image](https://github.com/yogstation13/Yogstation/assets/89688125/0fef9851-d6cc-4ef0-bcd9-5579829bbab0)



as you can see theres a bright red light coming out of the hotside, but it isnt spinning, the red light only turn on when the hotside is spinning, so clearly as you can see the overlay is bugged


# Document the changes in your pull request
Fix teg overlay bugs




# Testing
![image](https://github.com/yogstation13/Yogstation/assets/89688125/030a758d-af24-456b-89c2-f27733a3391f)

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  

bugfix: Fix teg overlay bugs
/:cl:
