### PR TITLE
Mobile Kitchen Shenanigans

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2435,6 +2435,22 @@
 					)
 	crate_name = "grilling fuel kit crate"
 
+/datum/supply_pack/organic/food_cart
+	name = "Food Cart Crate"
+	desc = "Contains a food cart for all your mobile food needs."
+	cost = 5000
+	crate_type = /obj/structure/closet/crate/large
+	contains = list(/obj/machinery/food_cart)
+	crate_name = "food cart crate"
+
+/datum/supply_pack/organic/icecream_vat
+	name = "Ice cream Vat Crate"
+	desc = "A vat of ice-cold icecream for those hot shifts in Atmospherics."
+	cost = 5000
+	crate_type = /obj/structure/closet/crate/large
+	contains = list(/obj/machinery/icecream_vat)
+	crate_name = "ice cream vat crate"
+
 //////////////////////////////////////////////////////////////////////////////
 ////////////////////////////// Livestock /////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
# Document the changes in your pull request

Adds the food cart and ice cream vat as orderable items from cargo. They're both in the "Food & Hydroponics" category of the cargo console and each cost $5,000.

# Why is this good for the game?

They're fun items that are not craftable. With this PR, if the round start ones are destroyed, chefs can just buy new ones.

# Testing

Them in the console:
![image](https://github.com/yogstation13/Yogstation/assets/113869252/61bc18eb-e2f3-45e3-a5f9-abe5a5229ab2)

Them unpacked after coming in:
![image](https://github.com/yogstation13/Yogstation/assets/113869252/7b21020e-6e28-470e-9c24-c523d13117b8)

# Wiki Documentation

All needed info in documented changes.

# Changelog

:cl:  

tweak: Food carts and ice cream vats are now orderable from cargo.

/:cl:
