### PR TITLE
Gives blood brothers a box filled with random shitty traitor items

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -4,6 +4,29 @@ GLOBAL_LIST_EMPTY(uplinks)
 #define NT_ERT_TROOPER 1
 #define NT_ERT_MEDIC 2
 #define NT_ERT_ENGINEER 3
+
+#define UPLINK_CATEGORY_DISCOUNTS "Discounts"
+#define UPLINK_CATEGORY_BUNDLES "Bundles"
+#define UPLINK_CATEGORY_CONSPICUOUS "Conspicuous Weapons"
+#define UPLINK_CATEGORY_STEALTH_WEAPONS "Stealthy Weapons"
+#define UPLINK_CATEGORY_AMMO "Ammunition"
+#define UPLINK_CATEGORY_EXPLOSIVES "Explosives"
+#define UPLINK_CATEGORY_SUPPORT "Support and Exosuits"
+#define UPLINK_CATEGORY_STEALTH_GADGETS "Stealth Gadgets"
+#define UPLINK_CATEGORY_SPACE_SUITS "Space Suits"
+#define UPLINK_CATEGORY_IMPLANTS "Implants"
+#define UPLINK_CATEGORY_INFILTRATION "Infiltration Gear"
+#define UPLINK_CATEGORY_SPECIES "Species-Restricted"
+#define UPLINK_CATEGORY_ROLE "Role-Restricted"
+#define UPLINK_CATEGORY_MISC "Misc. Gadgets"
+#define UPLINK_CATEGORY_BADASS "(Pointless) Badassery"
+#define UPLINK_CATEGORY_ENERGY "Energy Weapons"
+#define UPLINK_CATEGORY_BALLISTIC "Ballistic Weapons"
+#define UPLINK_CATEGORY_EXOSUITS "Exosuits"
+#define UPLINK_CATEGORY_CQC "Close Quarters Combat"
+#define UPLINK_CATEGORY_NT_SUPPORT "Support"
+#define UPLINK_CATEGORY_HARDSUITS "Armor & Hardsuits"
+#define UPLINK_CATEGORY_OTHER "Other Gear"
 /**
  * Uplinks
  *

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -262,10 +262,7 @@
 		var/item = pick(uplink_items[category])
 		var/datum/uplink_item/I = uplink_items[category][item]
 
-		if(I.cost > item_value_cap)
-			uplink_items[category] -= uplink_items[category][item] //remove it so it can't keep getting picked despite being invalid
-			continue
-		if(I.cost > remaining_value)
+		if(I.cost > item_value_cap || I.cost > remaining_value)
 			uplink_items[category] -= uplink_items[category][item] //remove it so it can't keep getting picked despite being invalid
 			continue
 		remaining_value -= I.cost

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -248,7 +248,7 @@
 	///maximum amount of tc any individual item can be
 	var/item_value_cap = 2
 	///list of categories that items are allowed to come from
-	var/list/allowed_categories = list("Stealth Gadgets", "Misc. Gadgets", "(Pointless) Badassery")
+	var/list/allowed_categories = list(UPLINK_CATEGORY_STEALTH_GADGETS, UPLINK_CATEGORY_MISC, UPLINK_CATEGORY_BADASS)
 
 /obj/item/storage/box/bloodbrother/PopulateContents()
 	var/list/uplink_items = get_uplink_items(null, FALSE)

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -33,7 +33,7 @@
 	W.on_reading_finished(brother)
 	qdel(W)
 
-	var/T = new /obj/item/storage/box/bloodbrother()
+	var/obj/item/storage/box/bloodbrother/T = new()
 	if(brother.equip_to_slot(T, ITEM_SLOT_BACKPACK)) //except for here, where it will fail because there's no backpack slot to equip to
 		SEND_SIGNAL(brother.back, COMSIG_TRY_STORAGE_SHOW, brother)// which is fine, because it'll just not do anything and give a notice (probably)
 	else

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -28,14 +28,14 @@
 	return ..()
 
 /datum/antagonist/brother/proc/equip_brother()
-	var/mob/living/carbon/human/brother = owner.current
+	var/mob/living/carbon/brother = owner.current
 	var/obj/item/book/granter/crafting_recipe/weapons/W = new
 	W.on_reading_finished(brother)
 	qdel(W)
 
 	if(istype(brother))
 		var/obj/item/storage/box/bloodbrother/T = new()
-		if(brother.equip_to_slot(T, ITEM_SLOT_BACKPACK))
+		if(brother.equip_to_slot_or_del(T, ITEM_SLOT_BACKPACK))
 			SEND_SIGNAL(brother.back, COMSIG_TRY_STORAGE_SHOW, brother)
 			return
 	

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -28,16 +28,19 @@
 	return ..()
 
 /datum/antagonist/brother/proc/equip_brother()
-	var/mob/living/carbon/human/brother = owner.current //it's probably fine if we cast this directly to human, because the procs being called don't care
+	var/mob/living/carbon/human/brother = owner.current
 	var/obj/item/book/granter/crafting_recipe/weapons/W = new
 	W.on_reading_finished(brother)
 	qdel(W)
 
-	var/obj/item/storage/box/bloodbrother/T = new()
-	if(brother.equip_to_slot(T, ITEM_SLOT_BACKPACK)) //except for here, where it will fail because there's no backpack slot to equip to
-		SEND_SIGNAL(brother.back, COMSIG_TRY_STORAGE_SHOW, brother)// which is fine, because it'll just not do anything and give a notice (probably)
-	else
-		to_chat(brother, span_userdanger("Unfortunately, you weren't able to get a keepsake box. This is bad and you should adminhelp (press F1)."))
+	if(istype(brother))
+		var/obj/item/storage/box/bloodbrother/T = new()
+		if(brother.equip_to_slot(T, ITEM_SLOT_BACKPACK))
+			SEND_SIGNAL(brother.back, COMSIG_TRY_STORAGE_SHOW, brother)
+			return
+	
+	//this only prints if it fails to give the box
+	to_chat(brother, span_userdanger("Unfortunately, you weren't able to get a keepsake box. This is bad and you should adminhelp (press F1)."))
 
 /datum/antagonist/brother/on_removal()
 	SSticker.mode.brothers -= owner

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -28,23 +28,22 @@
 	return ..()
 
 /datum/antagonist/brother/proc/equip_brother()
-	var/mob/living/brother = owner.current
+	var/mob/living/carbon/human/brother = owner.current //it's probably fine if we cast this directly to human, because the procs being called don't care
 	var/obj/item/book/granter/crafting_recipe/weapons/W = new
 	W.on_reading_finished(brother)
 	qdel(W)
 
 	var/T = new /obj/item/storage/box/bloodbrother()
-	if(brother.equip_to_slot(T, ITEM_SLOT_BACKPACK))
-		SEND_SIGNAL(brother.back, COMSIG_TRY_STORAGE_SHOW, H)
+	if(brother.equip_to_slot(T, ITEM_SLOT_BACKPACK)) //except for here, where it will fail because there's no backpack slot to equip to
+		SEND_SIGNAL(brother.back, COMSIG_TRY_STORAGE_SHOW, brother)// which is fine, because it'll just not do anything and give a notice (probably)
 	else
-		to_chat(brother, span_userdanger("Unfortunately, you weren't able to get a goodie box. This is bad and you should adminhelp (press F1)."))
+		to_chat(brother, span_userdanger("Unfortunately, you weren't able to get a keepsake box. This is bad and you should adminhelp (press F1)."))
 
 /obj/item/storage/box/bloodbrother
-	name = "Goodie box"
-	desc = "A dusty crate from the back of the Syndicate warehouse. Rumored to contain a valuable assortment of items, \
-			but you never know. Contents are sorted to always be worth 50 TC."
-	///maximum tc cost that can be inside the box
-	var/max_box_value = 5
+	name = "Keepsake box"
+	desc = "A box full of unusual items found in the maintenance hallways."
+	///total tc cost that can be inside the box
+	var/total_box_value = 5
 	///maximum amount of tc any individual item can be
 	var/item_value_cap = 2
 	///list of categories that items are allowed to come from
@@ -52,7 +51,7 @@
 
 /obj/item/storage/box/bloodbrother/PopulateContents()
 	var/list/uplink_items = get_uplink_items(null, FALSE)
-	var/remaining_value = max_box_value
+	var/remaining_value = total_box_value
 	while(remaining_value)
 		var/category = pick(allowed_categories)
 		var/item = pick(uplink_items[category])
@@ -60,10 +59,10 @@
 
 		if(I.cost > item_value_cap)
 			continue
-		if(remaining_value < I.cost)
+		if(I.cost > remaining_value)
 			continue
 		remaining_value -= I.cost
-		var/obj/goods = new I.item(src)
+		new I.item(src)
 
 /datum/antagonist/brother/on_removal()
 	SSticker.mode.brothers -= owner

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -241,7 +241,7 @@
 
 //box given to every bloodbrother
 /obj/item/storage/box/bloodbrother
-	name = "Keepsake box"
+	name = "keepsake box"
 	desc = "A box full of unusual items found in the maintenance hallways."
 	///total tc cost that can be inside the box
 	var/total_box_value = 5
@@ -253,7 +253,11 @@
 /obj/item/storage/box/bloodbrother/PopulateContents()
 	var/list/uplink_items = get_uplink_items(null, FALSE)
 	var/remaining_value = total_box_value
-	while(remaining_value)
+
+	for(var/i = 50; i > 0; i--) //only iterate 50 times, so it doesn't get stuck in an infinite loop
+		if(remaining_value <= 0)
+			break
+
 		var/category = pick(allowed_categories)
 		var/item = pick(uplink_items[category])
 		var/datum/uplink_item/I = uplink_items[category][item]
@@ -264,3 +268,6 @@
 			continue
 		remaining_value -= I.cost
 		new I.item(src)
+
+	if(remaining_value > 0)
+		message_admins("a blood brother has spawned with a keepsake box that has less than the usual value of items, please alert a coder")

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -28,9 +28,42 @@
 	return ..()
 
 /datum/antagonist/brother/proc/equip_brother()
+	var/mob/living/brother = owner.current
 	var/obj/item/book/granter/crafting_recipe/weapons/W = new
-	W.on_reading_finished(owner.current)
+	W.on_reading_finished(brother)
 	qdel(W)
+
+	var/T = new /obj/item/storage/box/bloodbrother()
+	if(brother.equip_to_slot(T, ITEM_SLOT_BACKPACK))
+		SEND_SIGNAL(brother.back, COMSIG_TRY_STORAGE_SHOW, H)
+	else
+		to_chat(brother, span_userdanger("Unfortunately, you weren't able to get a goodie box. This is bad and you should adminhelp (press F1)."))
+
+/obj/item/storage/box/bloodbrother
+	name = "Goodie box"
+	desc = "A dusty crate from the back of the Syndicate warehouse. Rumored to contain a valuable assortment of items, \
+			but you never know. Contents are sorted to always be worth 50 TC."
+	///maximum tc cost that can be inside the box
+	var/max_box_value = 5
+	///maximum amount of tc any individual item can be
+	var/item_value_cap = 2
+	///list of categories that items are allowed to come from
+	var/list/allowed_categories = list("Stealth Gadgets", "Misc. Gadgets", "(Pointless) Badassery")
+
+/obj/item/storage/box/bloodbrother/PopulateContents()
+	var/list/uplink_items = get_uplink_items(null, FALSE)
+	var/remaining_value = max_box_value
+	while(remaining_value)
+		var/category = pick(allowed_categories)
+		var/item = pick(uplink_items[category])
+		var/datum/uplink_item/I = uplink_items[category][item]
+
+		if(I.cost > item_value_cap)
+			continue
+		if(remaining_value < I.cost)
+			continue
+		remaining_value -= I.cost
+		var/obj/goods = new I.item(src)
 
 /datum/antagonist/brother/on_removal()
 	SSticker.mode.brothers -= owner

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -253,7 +253,7 @@
 /obj/item/storage/box/bloodbrother/PopulateContents()
 	var/list/uplink_items = get_uplink_items(null, FALSE)
 	var/remaining_value = total_box_value
-	while(remaining_value)
+	while(remaining_value > 0)
 		var/category = pick(allowed_categories)
 		var/item = pick(uplink_items[category])
 		var/datum/uplink_item/I = uplink_items[category][item]

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -263,8 +263,10 @@
 		var/datum/uplink_item/I = uplink_items[category][item]
 
 		if(I.cost > item_value_cap)
+			uplink_items[category] -= uplink_items[category][item] //remove it so it can't keep getting picked despite being invalid
 			continue
 		if(I.cost > remaining_value)
+			uplink_items[category] -= uplink_items[category][item] //remove it so it can't keep getting picked despite being invalid
 			continue
 		remaining_value -= I.cost
 		new I.item(src)

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -39,31 +39,6 @@
 	else
 		to_chat(brother, span_userdanger("Unfortunately, you weren't able to get a keepsake box. This is bad and you should adminhelp (press F1)."))
 
-/obj/item/storage/box/bloodbrother
-	name = "Keepsake box"
-	desc = "A box full of unusual items found in the maintenance hallways."
-	///total tc cost that can be inside the box
-	var/total_box_value = 5
-	///maximum amount of tc any individual item can be
-	var/item_value_cap = 2
-	///list of categories that items are allowed to come from
-	var/list/allowed_categories = list("Stealth Gadgets", "Misc. Gadgets", "(Pointless) Badassery")
-
-/obj/item/storage/box/bloodbrother/PopulateContents()
-	var/list/uplink_items = get_uplink_items(null, FALSE)
-	var/remaining_value = total_box_value
-	while(remaining_value)
-		var/category = pick(allowed_categories)
-		var/item = pick(uplink_items[category])
-		var/datum/uplink_item/I = uplink_items[category][item]
-
-		if(I.cost > item_value_cap)
-			continue
-		if(I.cost > remaining_value)
-			continue
-		remaining_value -= I.cost
-		new I.item(src)
-
 /datum/antagonist/brother/on_removal()
 	SSticker.mode.brothers -= owner
 	if(owner.current)
@@ -262,3 +237,30 @@
 
 /datum/team/brother_team/antag_listing_name()
 	return "[name] blood brothers"
+
+
+//box given to every bloodbrother
+/obj/item/storage/box/bloodbrother
+	name = "Keepsake box"
+	desc = "A box full of unusual items found in the maintenance hallways."
+	///total tc cost that can be inside the box
+	var/total_box_value = 5
+	///maximum amount of tc any individual item can be
+	var/item_value_cap = 2
+	///list of categories that items are allowed to come from
+	var/list/allowed_categories = list("Stealth Gadgets", "Misc. Gadgets", "(Pointless) Badassery")
+
+/obj/item/storage/box/bloodbrother/PopulateContents()
+	var/list/uplink_items = get_uplink_items(null, FALSE)
+	var/remaining_value = total_box_value
+	while(remaining_value)
+		var/category = pick(allowed_categories)
+		var/item = pick(uplink_items[category])
+		var/datum/uplink_item/I = uplink_items[category][item]
+
+		if(I.cost > item_value_cap)
+			continue
+		if(I.cost > remaining_value)
+			continue
+		remaining_value -= I.cost
+		new I.item(src)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -139,11 +139,11 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 //Discounts (dynamically filled above)
 /datum/uplink_item/discounts
-	category = "Discounts"
+	category = UPLINK_CATEGORY_DISCOUNTS
 
 //All bundles and telecrystals
 /datum/uplink_item/bundles_TC
-	category = "Bundles"
+	category = UPLINK_CATEGORY_BUNDLES
 	surplus = 0
 	cant_discount = TRUE
 
@@ -325,7 +325,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 // Dangerous Items
 /datum/uplink_item/dangerous
-	category = "Conspicuous Weapons"
+	category = UPLINK_CATEGORY_CONSPICUOUS
 
 /datum/uplink_item/dangerous/busterarm
 	name = "Buster Arm"
@@ -649,7 +649,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 // Stealthy Weapons
 /datum/uplink_item/stealthy_weapons
-	category = "Stealthy Weapons"
+	category = UPLINK_CATEGORY_STEALTH_WEAPONS
 
 /datum/uplink_item/stealthy_weapons/combatglovesplus
 	name = "Combat Gloves Plus"
@@ -781,7 +781,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 // Ammunition
 /datum/uplink_item/ammo
-	category = "Ammunition"
+	category = UPLINK_CATEGORY_AMMO
 	surplus = 40
 
 /datum/uplink_item/ammo/pistol
@@ -1147,7 +1147,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 //Grenades and Explosives
 /datum/uplink_item/explosives
-	category = "Explosives"
+	category = UPLINK_CATEGORY_EXPLOSIVES
 
 /datum/uplink_item/explosives/bioterrorfoam
 	name = "Bioterror Foam Grenade"
@@ -1383,7 +1383,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 //Support and Mechs
 /datum/uplink_item/support
-	category = "Support and Exosuits"
+	category = UPLINK_CATEGORY_SUPPORT
 	surplus = 0
 	include_modes = list(/datum/game_mode/nuclear)
 
@@ -1468,7 +1468,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 // Stealth Items
 /datum/uplink_item/stealthy_tools
-	category = "Stealth Gadgets"
+	category = UPLINK_CATEGORY_STEALTH_GADGETS
 
 /datum/uplink_item/stealthy_tools/spy_bug
 	name = "Box of Spy Bugs"
@@ -1646,7 +1646,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 //Space Suits and Hardsuits
 /datum/uplink_item/suits
-	category = "Space Suits"
+	category = UPLINK_CATEGORY_SPACE_SUITS
 	surplus = 40
 
 /datum/uplink_item/suits/space_suit
@@ -1689,7 +1689,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 // Devices and Tools
 /datum/uplink_item/device_tools
-	category = "Misc. Gadgets"
+	category = UPLINK_CATEGORY_MISC
 
 /datum/uplink_item/device_tools/cutouts
 	name = "Adaptive Cardboard Cutouts"
@@ -2113,7 +2113,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 // Implants
 /datum/uplink_item/implants
-	category = "Implants"
+	category = UPLINK_CATEGORY_IMPLANTS
 	surplus = 50
 
 
@@ -2329,7 +2329,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 //Infiltrator shit
 /datum/uplink_item/infiltration
-	category = "Infiltration Gear"
+	category = UPLINK_CATEGORY_INFILTRATION
 	include_modes = list(/datum/game_mode/infiltration)
 	surplus = 0
 
@@ -2348,7 +2348,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 //Race-specific items
 /datum/uplink_item/race_restricted
-	category = "Species-Restricted"
+	category = UPLINK_CATEGORY_SPECIES
 	surplus = 0
 
 /datum/uplink_item/race_restricted/syndilamp
@@ -2415,7 +2415,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 // Role-specific items
 /datum/uplink_item/role_restricted
-	category = "Role-Restricted"
+	category = UPLINK_CATEGORY_ROLE
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 	surplus = 0
 
@@ -2759,7 +2759,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 // Pointless
 /datum/uplink_item/badass
-	category = "(Pointless) Badassery"
+	category = UPLINK_CATEGORY_BADASS
 	surplus = 0
 
 /datum/uplink_item/badass/costumes/obvious_chameleon
@@ -2892,7 +2892,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	var/required_ert_uplink = null //Do we need a specific uplink? Defaults to universal.
 
 /datum/uplink_item/nt/energy_weps
-	category = "Energy Weapons"
+	category = UPLINK_CATEGORY_ENERGY
 
 /datum/uplink_item/nt/energy_weps/egun
 	name = "Energy Gun"
@@ -2959,7 +2959,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 100
 
 /datum/uplink_item/nt/ball_weps
-	category = "Ballistic Weapons"
+	category = UPLINK_CATEGORY_BALLISTIC
 	required_ert_uplink = NT_ERT_TROOPER
 
 /datum/uplink_item/nt/ball_weps/boarder
@@ -3004,7 +3004,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	limited_stock = 2 // SAY HELLO TO MY LITTLE FRIEND
 
 /datum/uplink_item/nt/ammo
-	category = "Ammunition"
+	category = UPLINK_CATEGORY_AMMO
 	required_ert_uplink = NT_ERT_TROOPER
 
 /datum/uplink_item/nt/ammo/recharger
@@ -3118,7 +3118,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 1
 
 /datum/uplink_item/nt/mech
-	category = "Exosuits"
+	category = UPLINK_CATEGORY_EXOSUITS
 	required_ert_uplink = NT_ERT_ENGINEER
 
 /datum/uplink_item/nt/mech/marauder
@@ -3206,7 +3206,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 1
 
 /datum/uplink_item/nt/cqc
-	category = "Close Quarters Combat"
+	category = UPLINK_CATEGORY_CQC
 
 /datum/uplink_item/nt/cqc/esword
 	name = "Energy Sword"
@@ -3270,7 +3270,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 1
 
 /datum/uplink_item/nt/support
-	category = "Support"
+	category = UPLINK_CATEGORY_NT_SUPPORT
 
 /datum/uplink_item/nt/support/c4
 	name = "Composition C-4"
@@ -3376,7 +3376,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	required_ert_uplink = NT_ERT_ENGINEER
 
 /datum/uplink_item/nt/hardsuit
-	category = "Armor & Hardsuits"
+	category = UPLINK_CATEGORY_HARDSUITS
 
 /datum/uplink_item/nt/hardsuit/armor
 	name = "Armor Vest"
@@ -3459,7 +3459,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cant_discount = TRUE
 
 /datum/uplink_item/nt/gear
-	category = "Other Gear"
+	category = UPLINK_CATEGORY_OTHER
 
 /datum/uplink_item/nt/gear/secbelt
 	name = "Stocked Security Belt"


### PR DESCRIPTION
All blood brothers will spawn with a carboard box filled with items that total 5tc
no individual item will cost more than 2 tc
can only come from the categories of

- Stealth Gadgets
- Misc. Gadgets
- (Pointless) Badassery

# Why is this good for the game?
Can give bloodbrothers some unusual items that are otherwise unobtainable
Lets items that are rarely if ever bought by a traitor have a chance to possibly shine

can always add a specific item blacklist if they end up being bad

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/f8983a72-b8ae-44e6-a7e3-bac4c35dae01)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/479d106d-5dd7-49de-b601-d1624bdb1eba)

:cl:  
rscadd: Gives blood brothers a box filled with random shitty traitor items
/:cl:
