### PR TITLE
[DONUT] new disposals and minor changes

### DIFF
--- a/_maps/map_files/DonutStation/DonutStation.dmm
+++ b/_maps/map_files/DonutStation/DonutStation.dmm
@@ -16,6 +16,12 @@
 /obj/effect/landmark/observer_start,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"aas" = (
+/obj/machinery/mineral/stacking_unit_console{
+	machinedir = 1
+	},
+/turf/closed/wall,
+/area/maintenance/disposal)
 "aat" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
@@ -58,6 +64,13 @@
 /area/medical/chemistry)
 "abp" = (
 /obj/structure/girder,
+/turf/open/floor/plating,
+/area/maintenance/aft)
+"abA" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "abM" = (
@@ -353,16 +366,6 @@
 "ahA" = (
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"ahG" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/mail_sorting/science/research,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "ahK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastleft{
@@ -381,14 +384,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"aib" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "aiI" = (
 /obj/machinery/pipedispenser,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -1122,6 +1117,10 @@
 /obj/structure/closet/bombcloset/security,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"avS" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "awh" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
@@ -1131,18 +1130,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
-"awo" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "awv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1293,18 +1280,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"azS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "aBa" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1464,6 +1439,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"aDt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"aDQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "aDT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -1518,12 +1508,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
-"aFB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "aFL" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
@@ -1554,17 +1538,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/bridge)
-"aGg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aGn" = (
 /turf/template_noop,
 /area/maintenance/aft)
@@ -1644,21 +1617,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
-"aHG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "aHH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -1875,6 +1833,12 @@
 	initial_gas_mix = "n2=1000;TEMP=293.15"
 	},
 /area/engine/atmos)
+"aMA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "aME" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
@@ -1913,6 +1877,13 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"aNc" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "aNh" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
@@ -2065,15 +2036,6 @@
 	icon_state = "damaged3"
 	},
 /area/space/nearstation)
-"aQB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "aQK" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey{
@@ -2512,13 +2474,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/fore)
-"bay" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/machinery/disposal/bin/tagger,
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
 "baH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -2566,6 +2521,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"bbr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/junction/flip,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "bbG" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -2686,21 +2650,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"bdU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "bdW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -2967,6 +2916,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
+"bir" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "biw" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -3157,19 +3111,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"blu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
-"blN" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "blO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -3519,16 +3460,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bsZ" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "btE" = (
 /obj/structure/sign/departments/custodian{
 	pixel_y = -32
@@ -3640,15 +3571,6 @@
 /obj/machinery/pool_filter,
 /turf/open/indestructible/sound/pool/end,
 /area/crew_quarters/fitness/recreation)
-"bvr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "bvJ" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Surgery Observation"
@@ -3835,6 +3757,11 @@
 /obj/structure/table/wood,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"byJ" = (
+/obj/structure/grille/broken,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "byL" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Maintenance";
@@ -5009,6 +4936,14 @@
 "bXH" = (
 /turf/open/floor/plating/broken/three,
 /area/maintenance/central)
+"bXJ" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "bYg" = (
 /obj/structure/rack,
 /obj/item/storage/belt/utility{
@@ -5054,20 +4989,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"bYP" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 9
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"bYW" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "bYZ" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/machinery/button/door{
@@ -5089,6 +5010,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/storage/tools)
+"bZx" = (
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/mail_sorting/science/toxins,
+/obj/effect/mapping_helpers/mail_sorting/science/xenobiology,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "bZz" = (
 /obj/machinery/light/small,
 /obj/effect/turf_decal/trimline/yellow/arrow_cw,
@@ -5495,6 +5424,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"cfL" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/science/research)
 "cfN" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 10
@@ -5715,6 +5648,18 @@
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"ckt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cku" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -5780,21 +5725,6 @@
 "clM" = (
 /turf/template_noop,
 /area/maintenance/port/aft)
-"clR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "cmA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -5904,6 +5834,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"cnB" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "cnI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -6149,15 +6086,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
-"cuj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/junction,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "cuq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -6536,13 +6464,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/engine/atmos)
-"cAh" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/landmark/start/cargo_technician,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "cAl" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -6939,6 +6860,14 @@
 "cIr" = (
 /turf/closed/wall,
 /area/lawoffice)
+"cIG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/sorting/mail,
+/obj/effect/mapping_helpers/mail_sorting/service/chapel,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "cII" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth"
@@ -7411,11 +7340,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"cQU" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/plasticflaps/opaque,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "cQX" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
@@ -7899,6 +7823,10 @@
 "dbJ" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/secondarydatacore)
+"dcf" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "dcv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -8333,6 +8261,11 @@
 	},
 /turf/open/floor/plasteel/burnt,
 /area/maintenance/disposal)
+"dmq" = (
+/obj/structure/grille,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "dms" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -8403,26 +8336,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"dnC" = (
-/obj/structure/chair,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/kitchen)
-"dnK" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/kitchen)
 "dnV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -8729,10 +8642,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"duF" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "dvb" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -8943,15 +8852,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"dzT" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "dAf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -9062,6 +8962,12 @@
 /obj/item/seeds/glowshroom,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"dDf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "dDu" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -9929,21 +9835,6 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
-"dUa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "dUh" = (
 /obj/effect/turf_decal/trimline/white/filled/corner/lower{
 	dir = 1
@@ -10591,6 +10482,18 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"eiC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "eiL" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -10840,6 +10743,17 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"epN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "epS" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
@@ -11089,12 +11003,6 @@
 "eun" = (
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
-"euu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "euM" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -11111,6 +11019,12 @@
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"evi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "evF" = (
 /obj/machinery/button/flasher{
 	id = "executionflash";
@@ -11285,6 +11199,14 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"ezZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port)
 "eAb" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -11560,18 +11482,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"eFK" = (
-/obj/structure/window/reinforced{
-	layer = 2.9
-	},
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/quartermaster/sorting)
 "eGa" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
@@ -11581,15 +11491,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"eGe" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "eGr" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/door/firedoor/border_only{
@@ -11782,6 +11683,14 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"eKo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port)
 "eKG" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 4
@@ -12238,14 +12147,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"eTu" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/mail_sorting/science/toxins,
-/obj/effect/mapping_helpers/mail_sorting/science/xenobiology,
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "eTx" = (
 /obj/structure/sign/departments/security{
 	pixel_x = 32
@@ -12841,22 +12742,6 @@
 "ffF" = (
 /turf/open/floor/plasteel/stairs/goon/wood_stairs_middle,
 /area/library)
-"ffL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/mail_sorting/service/theater,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "ffW" = (
 /obj/machinery/airalarm/tcomms{
 	dir = 4;
@@ -12988,12 +12873,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"fhD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "fhP" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/solars/solar_96,
@@ -13076,6 +12955,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fju" = (
+/obj/structure/grille,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "fjF" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -13209,6 +13095,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fnl" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/kitchen)
 "fnu" = (
 /obj/machinery/telecomms/message_server/preset,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -13262,6 +13155,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"foR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "fpe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -13296,18 +13198,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"fpP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "fpS" = (
 /obj/machinery/air_sensor/atmos/carbon_tank,
 /turf/open/floor/engine/co2{
@@ -13624,13 +13514,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/fore)
-"fuK" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
 "fva" = (
 /obj/structure/girder,
 /obj/effect/turf_decal/stripes/corner{
@@ -14018,6 +13901,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"fAC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "fAQ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plating,
@@ -14236,6 +14128,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"fGi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "fGB" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -14294,6 +14195,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
+"fIx" = (
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "fIB" = (
 /obj/effect/landmark/start/botanist,
 /obj/structure/cable{
@@ -14957,18 +14869,6 @@
 "fWj" = (
 /turf/closed/wall,
 /area/security/main)
-"fWu" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "fWP" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
@@ -15061,6 +14961,11 @@
 "fYU" = (
 /turf/closed/wall,
 /area/janitor)
+"fYX" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "fZc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15206,14 +15111,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
-"gcc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "gcp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -15343,6 +15240,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"gey" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "geB" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -15683,6 +15591,19 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/ai_monitored/secondarydatacore)
+"gmO" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/kitchen)
 "gmR" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -16322,12 +16243,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"gCx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "gDs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -16527,19 +16442,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"gII" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "gIJ" = (
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -16644,6 +16546,10 @@
 /obj/machinery/vending/wardrobe/chem_wardrobe,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"gLx" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "gLB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -16745,13 +16651,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
-"gOb" = (
-/obj/item/kirbyplants/random,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "gOc" = (
 /obj/machinery/power/smes/engineering{
 	charge = 5e+006;
@@ -17313,12 +17212,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"hay" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/science/research)
 "haC" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/shaker,
@@ -17348,13 +17241,15 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"hbp" = (
+"hcf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/kitchen)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "hcg" = (
 /obj/structure/chair{
 	dir = 1
@@ -17657,17 +17552,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
-"hko" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "hkC" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -18111,11 +17995,6 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"hsZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/hydroponics)
 "htb" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
@@ -18151,6 +18030,21 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/fore)
+"htB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "hub" = (
 /turf/closed/wall/r_wall,
 /area/security/prison)
@@ -18285,11 +18179,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"hwG" = (
-/obj/structure/grille/broken,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "hwH" = (
 /obj/effect/turf_decal/pool{
 	dir = 4
@@ -18335,11 +18224,6 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"hxo" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "hxt" = (
 /obj/machinery/gulag_processor,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -18347,6 +18231,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"hxv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "hxy" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -18449,21 +18339,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"hzB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "hAd" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -18591,17 +18466,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"hBX" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "hCk" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -18728,6 +18592,15 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
+"hEs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "hEu" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -18884,18 +18757,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
-"hIq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "hIt" = (
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
@@ -19027,24 +18888,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"hKe" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
-/obj/machinery/door/window{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "hKh" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering - Entrance";
@@ -19113,6 +18956,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"hMJ" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "hMK" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/pump,
@@ -19459,15 +19306,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"hVU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "hWo" = (
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/plasteel/showroomfloor,
@@ -20203,11 +20041,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
-"iol" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/turf/open/floor/plating,
-/area/maintenance/central)
+"ioe" = (
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "iop" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -20305,6 +20145,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"iqf" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
 "iqk" = (
 /turf/template_noop,
 /area/maintenance/starboard)
@@ -20410,18 +20257,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"itQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "iuk" = (
 /obj/machinery/food_cart,
 /obj/machinery/firealarm{
@@ -20723,6 +20558,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"iBc" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "iBp" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -20732,6 +20573,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"iBC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "iBI" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -21492,13 +21339,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
-"iUr" = (
-/obj/structure/grille,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "iUz" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/effect/turf_decal/tile/green/opposingcorners{
@@ -21595,6 +21435,21 @@
 	dir = 4
 	},
 /area/chapel/main)
+"iVQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "iWh" = (
 /obj/machinery/griddle,
 /turf/open/floor/plasteel/cafeteria{
@@ -21846,6 +21701,31 @@
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"jbG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/aft)
+"jbU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/mail_sorting/service/theater,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "jcf" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/structure/cable/orange{
@@ -22077,13 +21957,24 @@
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/bar)
-"jgY" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+"jhj" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plating,
-/area/science/research)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "jhk" = (
 /obj/structure/table,
 /obj/item/hand_tele,
@@ -22144,6 +22035,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"jiC" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/mail_sorting/security/detectives_office,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "jiF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -22214,6 +22121,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"jiZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "jjc" = (
 /obj/structure/rack,
 /obj/item/electronics/airlock,
@@ -22263,24 +22175,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
-"jkr" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "jkC" = (
 /obj/machinery/microwave{
 	pixel_y = 4
@@ -22361,6 +22255,18 @@
 /obj/structure/flora/bush,
 /turf/open/floor/grass,
 /area/tcommsat/computer)
+"jlA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jlB" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -22556,6 +22462,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
+"jpr" = (
+/obj/item/kirbyplants/random,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jpv" = (
 /obj/structure/table,
 /obj/item/storage/box/firingpins,
@@ -22617,6 +22530,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"jqx" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "jqN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22742,15 +22667,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"jtU" = (
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "jtW" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -22858,6 +22774,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"jwC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "jxw" = (
 /obj/machinery/light,
 /obj/structure/chair/office/light{
@@ -23133,18 +23064,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"jBY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "jBZ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -23450,13 +23369,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jHg" = (
-/obj/effect/landmark/blobstart,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "jHy" = (
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
@@ -23585,15 +23497,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"jKn" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/junction/flip,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "jKB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -23641,12 +23544,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jKQ" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/courtroom)
 "jLn" = (
 /obj/machinery/atmospherics/miner/oxygen{
 	max_ext_kpa = 2500
@@ -23802,6 +23699,18 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"jOt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/research)
+"jOC" = (
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "jOG" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics Maintenance";
@@ -24260,19 +24169,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
-"jXU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 1;
-	pixel_y = -1
-	},
-/obj/effect/mapping_helpers/mail_sorting/engineering/general,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jYb" = (
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/plating,
@@ -24533,6 +24429,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"kcm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/science/research)
 "kct" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
@@ -24821,6 +24723,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"kjp" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 9
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "kjs" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -24917,6 +24829,12 @@
 "kkZ" = (
 /turf/open/floor/plasteel,
 /area/escapepodbay)
+"kli" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "klw" = (
 /obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
@@ -25058,12 +24976,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"knq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/junction/flip,
-/turf/open/floor/wood,
-/area/crew_quarters/kitchen)
 "knF" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
@@ -25093,6 +25005,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"koL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "kpj" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -25108,10 +25032,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"kpT" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "kqm" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -25216,11 +25136,6 @@
 "ksy" = (
 /turf/closed/wall,
 /area/storage/tech)
-"ksB" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/turf/open/floor/wood,
-/area/medical/psych)
 "ksC" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -25273,6 +25188,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"ktV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "ktX" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/machinery/light_switch{
@@ -25341,12 +25271,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"kwN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "kwT" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
@@ -25480,6 +25404,10 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"kAt" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "kAI" = (
 /obj/machinery/door/airlock{
 	name = "Unit B"
@@ -25556,6 +25484,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"kEe" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "kEi" = (
 /obj/effect/landmark/start/security_officer,
 /obj/structure/chair{
@@ -25730,6 +25665,12 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
+"kJx" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/central)
 "kJE" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -26099,15 +26040,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"kRf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "kRs" = (
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
@@ -26156,12 +26088,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"kSt" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "kSy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -26234,19 +26160,6 @@
 	},
 /turf/open/floor/catwalk_floor/telecomms,
 /area/ai_monitored/secondarydatacore)
-"kUa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "kUg" = (
 /obj/machinery/power/apc{
 	areastring = "/area/escapepodbay";
@@ -26489,12 +26402,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
-"kZh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "kZs" = (
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
@@ -26544,15 +26451,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"lat" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "lav" = (
 /obj/structure/table,
 /turf/open/floor/plasteel,
@@ -26589,11 +26487,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"lbr" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "lbA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -26798,13 +26691,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"lfS" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "lgl" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/camera{
@@ -27059,14 +26945,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"lmg" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/sorting/mail,
-/obj/effect/mapping_helpers/mail_sorting/service/chapel,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "lmq" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -27156,15 +27034,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"lor" = (
-/obj/effect/turf_decal/trimline/brown/warning/lower{
-	dir = 1
-	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "packageSort2"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
 "lot" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -27335,6 +27204,16 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"lrM" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/mail_sorting/science/research,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "lsc" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 5
@@ -27542,13 +27421,21 @@
 /obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/plasteel,
 /area/clerk)
-"lwE" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line/lower,
+"lwQ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "lxy" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -27566,6 +27453,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"lyb" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "lym" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -27836,12 +27730,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"lEc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "lEi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -27894,6 +27782,18 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"lFc" = (
+/obj/structure/window/reinforced{
+	layer = 2.9
+	},
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/quartermaster/sorting)
 "lFB" = (
 /obj/machinery/conveyor/inverted{
 	id = "garbage";
@@ -28220,6 +28120,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"lMF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "lML" = (
 /obj/structure/table/wood,
 /obj/item/stack/packageWrap,
@@ -28644,6 +28556,18 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"lUZ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "lVi" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
@@ -28892,6 +28816,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"mbO" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "mbW" = (
 /obj/machinery/meter{
 	pixel_x = -5;
@@ -29444,6 +29377,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"moq" = (
+/obj/effect/turf_decal/trimline/brown/warning/lower{
+	dir = 1
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "packageSort2"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "mot" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
@@ -29667,22 +29609,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"msx" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/mail_sorting/security/detectives_office,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "msP" = (
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 10
@@ -29803,12 +29729,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"muG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "muH" = (
 /obj/machinery/light/small,
 /turf/open/floor/engine/n2o{
@@ -29875,13 +29795,6 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
-"mvU" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "mwB" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -30134,6 +30047,12 @@
 /obj/item/weldingtool,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"mCx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "mCF" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/stripes/line{
@@ -30229,10 +30148,6 @@
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
-/area/science/research)
-"mEz" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
 /area/science/research)
 "mFd" = (
 /obj/machinery/vending/sustenance,
@@ -30477,14 +30392,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"mJF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/central)
 "mJL" = (
 /obj/item/reagent_containers/spray/plantbgone{
 	pixel_y = 3
@@ -30557,15 +30464,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"mLT" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "mLX" = (
 /obj/machinery/computer/cargo/request{
 	dir = 8
@@ -30610,6 +30508,15 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"mNq" = (
+/obj/structure/disposalpipe/broken{
+	dir = 1
+	},
+/obj/structure/disposalpipe/broken{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "mNJ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/rnd,
@@ -30658,6 +30565,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"mPp" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "mPv" = (
 /obj/machinery/light{
 	dir = 8
@@ -31503,6 +31420,12 @@
 /obj/effect/landmark/secequipment,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"ndN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "nee" = (
 /obj/machinery/field/generator{
 	anchored = 1;
@@ -32076,17 +31999,6 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
-"noo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "noC" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -32227,6 +32139,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"ntZ" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plating,
+/area/science/research)
 "nuh" = (
 /turf/closed/wall,
 /area/quartermaster/sorting)
@@ -32477,12 +32396,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"nBi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "nBj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -32756,11 +32669,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"nFX" = (
-/obj/structure/grille,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "nGg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -32787,15 +32695,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
-"nGw" = (
-/obj/structure/disposalpipe/broken{
-	dir = 4
-	},
-/obj/structure/disposalpipe/broken{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "nGL" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
@@ -33088,18 +32987,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"nKF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "nKK" = (
 /obj/machinery/suit_storage_unit/standard_unit{
 	suit_type = /obj/item/clothing/suit/space/paramedic
@@ -33438,6 +33325,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"nRA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "nRC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -33606,6 +33506,11 @@
 /obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"nVu" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/turf/open/floor/wood,
+/area/medical/psych)
 "nVx" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -34352,21 +34257,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"oko" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "okw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -34489,6 +34379,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"onf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "onj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
@@ -34629,6 +34534,15 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"orI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction/flip,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "osb" = (
 /obj/structure/table,
 /obj/item/plant_analyzer,
@@ -34645,6 +34559,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"osq" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "osy" = (
 /turf/closed/wall,
 /area/crew_quarters/dorms)
@@ -34855,12 +34781,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ovO" = (
-/obj/machinery/mineral/stacking_unit_console{
-	machinedir = 1
-	},
-/turf/closed/wall,
-/area/maintenance/disposal)
 "ovV" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -35084,14 +35004,6 @@
 /obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"oCO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/port)
 "oCS" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -35185,6 +35097,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"oFu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "oFD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -35320,6 +35238,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"oIa" = (
+/obj/effect/landmark/blobstart,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "oIj" = (
 /obj/machinery/light{
 	dir = 4
@@ -35665,6 +35590,15 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
+"oPx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "oPG" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -35720,6 +35654,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"oQA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "oRd" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/table_frame,
@@ -35746,13 +35686,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"oRA" = (
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+"oRv" = (
 /obj/structure/disposalpipe/segment{
-	dir = 9
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "oRF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -36347,6 +36286,16 @@
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
+"pjQ" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/mail_sorting/service/library,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "pjU" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -36432,6 +36381,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
+"pmC" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Office";
+	req_access_txt = "50"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "pmD" = (
 /obj/item/radio/intercom{
 	pixel_x = 30
@@ -36613,6 +36576,21 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"ppT" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "pqa" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -36944,10 +36922,6 @@
 	icon_state = "damaged5"
 	},
 /area/space/nearstation)
-"pvJ" = (
-/obj/structure/disposalpipe/broken,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "pww" = (
 /turf/closed/wall,
 /area/quartermaster/office)
@@ -37369,14 +37343,6 @@
 /obj/effect/mapping_helpers/mail_sorting/service/bar,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"pFj" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "pFo" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -37555,12 +37521,17 @@
 /obj/machinery/light,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
-"pJW" = (
+"pJG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/science/research)
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/machinery/door/window/brigdoor,
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "pKm" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/effect/turf_decal/tile/green/opposingcorners{
@@ -37787,6 +37758,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"pNF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "pNI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
@@ -38105,6 +38087,11 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"pTr" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "pTs" = (
 /obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
 	dir = 8
@@ -38424,18 +38411,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"qaV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "qbc" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -28
@@ -38485,6 +38460,21 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"qbK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "qce" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -38680,6 +38670,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"qgz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
 "qgC" = (
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -38761,12 +38757,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"qiz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
 "qiM" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
@@ -38968,13 +38958,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"qml" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "qmC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -39173,6 +39156,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"qpN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qqe" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -39361,12 +39355,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"qtt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "qtI" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
@@ -39987,13 +39975,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
-"qIw" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "qIz" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/assistant,
@@ -40317,18 +40298,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
-"qRq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "qRr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -40394,6 +40363,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"qSb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "qSt" = (
 /turf/closed/wall,
 /area/medical/medbay/central)
@@ -40511,27 +40488,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"qUP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"qVc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "qVf" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 6
@@ -40561,12 +40517,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"qWi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "qWl" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
@@ -40579,6 +40529,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"qWm" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
+/obj/machinery/door/window{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "qWF" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/effect/turf_decal/tile/green/opposingcorners{
@@ -40863,22 +40831,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"raT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
+"raF" = (
+/obj/structure/disposalpipe/broken,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "rba" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -40911,12 +40867,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"rcv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "rcJ" = (
 /obj/structure/particle_accelerator/particle_emitter/center{
 	dir = 1
@@ -41141,6 +41091,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"rim" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "rio" = (
 /obj/machinery/door/poddoor{
 	id = "trash";
@@ -41223,6 +41179,19 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"rjJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "rjK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -41280,6 +41249,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"rkF" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rkM" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_x = -32
@@ -41419,16 +41398,6 @@
 "rpg" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
-"rps" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "rpt" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41597,6 +41566,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"rsk" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/landmark/start/cargo_technician,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "rsm" = (
 /obj/machinery/portable_atmospherics/canister/bz,
 /obj/effect/turf_decal/bot,
@@ -41643,6 +41619,12 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"rty" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "rtP" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
@@ -41732,18 +41714,6 @@
 	dir = 1
 	},
 /area/science/xenobiology)
-"rvO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "rwh" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/structure/lattice/catwalk,
@@ -41842,12 +41812,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
-"ryp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "ryw" = (
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -42233,11 +42197,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"rFX" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/science/xenobiology)
 "rGc" = (
 /obj/structure/noticeboard,
 /turf/closed/wall/r_wall,
@@ -42568,6 +42527,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"rMX" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "rNb" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
@@ -42648,6 +42614,21 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/entry)
+"rOD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "rOI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -42688,15 +42669,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"rPa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "rPb" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Two"
@@ -42744,6 +42716,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"rPJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "rPO" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
@@ -42767,12 +42750,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"rQv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+"rQC" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/central)
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "rQN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -42810,6 +42793,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"rRY" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "rSz" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/kitchen)
@@ -42834,15 +42822,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"rSW" = (
-/obj/structure/disposalpipe/broken{
-	dir = 1
-	},
-/obj/structure/disposalpipe/broken{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "rTz" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -42869,21 +42848,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"rUq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "rUI" = (
 /obj/structure/sign/warning/pods{
 	pixel_y = 32
@@ -42999,6 +42963,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"rXz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "rXM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -43151,6 +43127,15 @@
 	initial_gas_mix = "n2o=1000;TEMP=293.15"
 	},
 /area/engine/atmos)
+"scH" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "scY" = (
 /obj/structure/chair/office/dark,
 /obj/effect/turf_decal/stripes/corner{
@@ -43239,12 +43224,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"sfF" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "sfV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -43798,21 +43777,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
-"sqQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "srj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -43988,17 +43952,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"svr" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/plating,
-/area/maintenance/central)
-"svy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "svz" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "47"
@@ -44652,6 +44605,14 @@
 "sGJ" = (
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"sGN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/central)
 "sHp" = (
 /obj/structure/closet/firecloset,
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
@@ -44941,6 +44902,23 @@
 /mob/living/simple_animal/pet/fox/Renault,
 /turf/open/floor/carpet,
 /area/bridge)
+"sMJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/plasticflaps/opaque,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"sMY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "sNB" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
@@ -45016,6 +44994,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"sOF" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "sOL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -45056,15 +45038,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"sPt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
+"sPw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "sPW" = (
@@ -45080,15 +45057,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"sQd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "sQo" = (
 /turf/open/floor/wood,
 /area/hallway/primary/central)
@@ -45434,6 +45402,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"sWT" = (
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "sWY" = (
 /obj/machinery/light{
 	dir = 4
@@ -45710,12 +45687,6 @@
 "teY" = (
 /turf/closed/wall/r_wall,
 /area/janitor)
-"tfa" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "tfk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -45993,12 +45964,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
-"tlB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "tlY" = (
 /obj/machinery/atmospherics/components/binary/pump/on/layer2{
 	dir = 4;
@@ -46753,6 +46718,13 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"tAr" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/machinery/disposal/bin/tagger,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "tAD" = (
 /obj/structure/table,
 /turf/open/floor/plating,
@@ -47050,6 +47022,11 @@
 	},
 /turf/open/floor/engine,
 /area/maintenance/disposal/incinerator)
+"tHu" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/hydroponics)
 "tHB" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -47849,14 +47826,6 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
-"tXt" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = null;
-	req_access_txt = "4;12"
-	},
-/turf/open/floor/plating,
-/area/security/detectives_office)
 "tXW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -48324,6 +48293,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"uhu" = (
+/obj/structure/chair,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/kitchen)
 "uhA" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/window/reinforced,
@@ -48609,17 +48585,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"uox" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "uoK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -48643,6 +48608,13 @@
 /obj/machinery/microwave,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"uoP" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "uoT" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
@@ -49016,6 +48988,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"uxY" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "uyv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -49153,21 +49133,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"uBy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "uBE" = (
 /obj/structure/closet/crate,
 /obj/item/clothing/head/wig/random,
@@ -49746,6 +49711,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"uMK" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "uMZ" = (
 /obj/structure/table,
 /obj/item/paper/fluff/holodeck/disclaimer,
@@ -49842,18 +49812,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"uPu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "uPv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/structure/cable{
@@ -49864,6 +49822,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
+"uPz" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "uPG" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
@@ -50055,6 +50020,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"uTX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "uUa" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/effect/turf_decal/tile/green/opposingcorners{
@@ -50102,6 +50073,15 @@
 	initial_gas_mix = "plasma=1000;TEMP=293.15"
 	},
 /area/engine/atmos)
+"uUj" = (
+/obj/structure/disposalpipe/broken{
+	dir = 4
+	},
+/obj/structure/disposalpipe/broken{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "uUo" = (
 /obj/machinery/computer/message_monitor{
 	dir = 4
@@ -50331,17 +50311,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet)
-"vad" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/machinery/door/window/brigdoor,
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
 "vae" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -50890,14 +50859,6 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"vkR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "vlp" = (
 /obj/structure/filingcabinet{
 	pixel_x = 3
@@ -51062,6 +51023,18 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"vqy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "vra" = (
 /turf/closed/wall,
 /area/security/brig)
@@ -51467,24 +51440,16 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"vzS" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Office";
-	req_access_txt = "50"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
 "vAa" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"vAg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "vAm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -51521,13 +51486,6 @@
 /obj/machinery/rnd/server/master,
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
-"vAV" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "vBd" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -51562,11 +51520,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"vBL" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/science/mixing)
 "vBX" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -51639,6 +51592,22 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
+"vEc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "vEG" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
@@ -51936,13 +51905,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"vJS" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "vJX" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -52037,6 +51999,18 @@
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
+"vMX" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "vNc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -52138,11 +52112,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"vPh" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "vPD" = (
 /obj/structure/table/glass,
 /obj/machinery/photocopier/faxmachine{
@@ -52420,6 +52389,11 @@
 	},
 /turf/open/floor/wood,
 /area/tcommsat/computer)
+"vUq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/science/mixing)
 "vUt" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 8
@@ -52757,18 +52731,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"wcA" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "wcC" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
@@ -52917,6 +52879,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
+"weO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wfc" = (
 /obj/machinery/light{
 	dir = 1
@@ -53131,14 +53105,6 @@
 /obj/effect/turf_decal/trimline/green,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"wlz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/port)
 "wlF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -53387,6 +53353,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wrC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/junction/flip,
+/turf/open/floor/wood,
+/area/crew_quarters/kitchen)
 "wrF" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -53574,6 +53546,21 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/storage/primary)
+"wvp" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "wvt" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -53734,6 +53721,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"wxB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wxH" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -53844,10 +53843,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"wzE" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "wzH" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 1
@@ -54045,6 +54040,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"wCx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "wCA" = (
 /obj/structure/ethernet_cable{
 	icon_state = "1-2"
@@ -54079,6 +54089,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"wDI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "wDU" = (
 /obj/machinery/button/door{
 	id = "engsm";
@@ -54262,12 +54281,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/solars/port/fore)
-"wHN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "wHY" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -54352,6 +54365,18 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"wKi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "wKn" = (
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice,
@@ -54433,18 +54458,6 @@
 "wLx" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/science)
-"wLE" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "wLL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -54467,12 +54480,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"wLY" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/central)
 "wMk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
@@ -54568,6 +54575,14 @@
 /mob/living/simple_animal/hostile/asteroid/hivelord,
 /turf/open/floor/plating/asteroid/airless,
 /area/space/nearstation)
+"wOO" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = null;
+	req_access_txt = "4;12"
+	},
+/turf/open/floor/plating,
+/area/security/detectives_office)
 "wOT" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -54942,6 +54957,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"wVs" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "wVz" = (
 /obj/machinery/camera{
 	c_tag = "Research - Xenobiology Cell 1";
@@ -55187,6 +55211,15 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"xaP" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "xbc" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -55752,18 +55785,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"xmB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "xmJ" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -55974,15 +55995,6 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
-"xqa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/junction/flip,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "xqf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -56255,6 +56267,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"xvC" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 1;
+	pixel_y = -1
+	},
+/obj/effect/mapping_helpers/mail_sorting/engineering/general,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "xwr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -56424,21 +56449,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"xyI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "xyV" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -56557,12 +56567,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
-"xBn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "xBX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -57063,6 +57067,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"xMG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "xMH" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/structure/cable{
@@ -57442,16 +57452,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"xSP" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/mail_sorting/service/library,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "xSQ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -57603,6 +57603,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"xWI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "xWL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -57684,13 +57690,6 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"xYl" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "xYx" = (
 /obj/structure/table/wood,
 /obj/effect/landmark/event_spawn,
@@ -57720,10 +57719,6 @@
 /obj/item/bedsheet/prisoner,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"yae" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "yan" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -57898,6 +57893,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"ycR" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "ycU" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/chemistry";
@@ -57971,33 +57978,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"yeb" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "yep" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
-"yev" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "yeL" = (
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -58097,6 +58083,14 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"ygX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "yht" = (
 /obj/machinery/meter{
 	layer = 3.4
@@ -58191,6 +58185,12 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/fore)
+"yiZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "yjk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -74163,17 +74163,17 @@ xSu
 xSu
 jyB
 vgR
-ryp
-yae
-yae
-yae
+hxv
+dcf
+dcf
+dcf
 cxl
-nFX
+dmq
 xmc
-yae
-yae
-yae
-kwN
+dcf
+dcf
+dcf
+evi
 vgR
 jyB
 xSu
@@ -74420,7 +74420,7 @@ ylr
 xSu
 jyB
 pSD
-fWu
+osq
 hIt
 hIt
 hIt
@@ -74687,8 +74687,8 @@ sGJ
 sGJ
 sGJ
 hIt
-awo
-wcA
+ycR
+vMX
 jyB
 jyB
 jyB
@@ -74934,7 +74934,7 @@ ylr
 ylr
 jyB
 vgR
-iUr
+fju
 hIt
 sGJ
 sGJ
@@ -75448,7 +75448,7 @@ jyB
 jyB
 jyB
 vgR
-jHg
+oIa
 hIt
 hIt
 eXf
@@ -75959,10 +75959,10 @@ ylr
 xSu
 jyB
 vgR
-ryp
-yae
-yae
-fhD
+hxv
+dcf
+dcf
+iBC
 hIt
 vOk
 dhn
@@ -75973,10 +75973,10 @@ eVD
 fnz
 hIt
 gEE
-aFB
-yae
-yae
-kwN
+dDf
+dcf
+dcf
+evi
 vgR
 jsz
 jyB
@@ -76216,7 +76216,7 @@ hpU
 wSb
 jyB
 moN
-wlz
+ezZ
 hIt
 hIt
 hIt
@@ -76473,7 +76473,7 @@ pMc
 joc
 xEO
 fyd
-oCO
+eKo
 hIt
 wod
 cku
@@ -78783,8 +78783,8 @@ eVZ
 eVZ
 atc
 wld
-vBL
-lfS
+vUq
+rMX
 wGR
 sOZ
 hIt
@@ -80331,7 +80331,7 @@ dRU
 smy
 nUz
 tgP
-rFX
+jiZ
 ojt
 pWs
 jfb
@@ -80589,7 +80589,7 @@ ggw
 ggw
 cvX
 ems
-uox
+pNF
 sOL
 pyz
 xBX
@@ -81101,7 +81101,7 @@ grI
 bRa
 sEy
 iNa
-raT
+vEc
 bDJ
 hIt
 hIt
@@ -81127,7 +81127,7 @@ mCF
 bQC
 cGa
 whA
-ksB
+nVu
 uOw
 tav
 dYn
@@ -82163,7 +82163,7 @@ quE
 fpe
 wgO
 wgO
-aHG
+lwQ
 gIJ
 vDp
 gIJ
@@ -82420,7 +82420,7 @@ rfB
 hVl
 nKK
 wgO
-aHG
+lwQ
 gIJ
 vDp
 gIJ
@@ -83414,8 +83414,8 @@ vyi
 wDE
 wDE
 nBg
-sqQ
-qWi
+ktV
+aDQ
 gVO
 pIW
 pev
@@ -83448,7 +83448,7 @@ rXq
 fFJ
 suK
 wgO
-aHG
+lwQ
 gIJ
 vDp
 gIJ
@@ -83666,18 +83666,18 @@ qtI
 pmZ
 kin
 asZ
-sQd
+hcf
 ero
-sQd
+hcf
 aYO
-sQd
+hcf
 mHn
-eTu
+bZx
 muq
 syf
 bhc
 lyY
-qIw
+cnB
 dAp
 rOQ
 uhX
@@ -83941,7 +83941,7 @@ rRg
 xcn
 kgD
 pMJ
-svy
+yiZ
 xXV
 wHe
 ikA
@@ -83962,7 +83962,7 @@ pkJ
 lDH
 yjm
 hOu
-aHG
+lwQ
 gIJ
 vDp
 gIJ
@@ -84219,7 +84219,7 @@ pkJ
 bsP
 gIJ
 hOu
-aHG
+lwQ
 gIJ
 vDp
 gIJ
@@ -84476,7 +84476,7 @@ pkJ
 vZq
 gIJ
 hOu
-aHG
+lwQ
 gIJ
 vDp
 xkg
@@ -84733,7 +84733,7 @@ pkJ
 nkr
 gIJ
 hOu
-aHG
+lwQ
 gIJ
 vDp
 vDp
@@ -84951,11 +84951,11 @@ oiq
 vrb
 ocI
 qte
-vPh
+rRY
 fus
-mEz
-mEz
-hay
+cfL
+cfL
+kcm
 eUu
 ibK
 vxV
@@ -84990,7 +84990,7 @@ pkJ
 gIJ
 gIJ
 kkN
-aHG
+lwQ
 gIJ
 vDp
 clM
@@ -85212,7 +85212,7 @@ uRq
 tEL
 qqt
 ibK
-pJW
+jOt
 fXw
 ibK
 ibK
@@ -85469,7 +85469,7 @@ uRq
 tEL
 qes
 fvS
-jgY
+ntZ
 tEL
 tEL
 tEL
@@ -85505,7 +85505,7 @@ gIJ
 jTD
 hOu
 gIJ
-hzB
+jwC
 vDp
 clM
 clM
@@ -85742,7 +85742,7 @@ dNw
 eQm
 cCv
 eEu
-gCx
+oRv
 dlt
 eVA
 dlt
@@ -85762,7 +85762,7 @@ tzj
 dlR
 hOu
 gIJ
-hzB
+jwC
 vDp
 vDp
 vDp
@@ -85999,7 +85999,7 @@ xMZ
 qsm
 fME
 xId
-gCx
+oRv
 dlt
 dlt
 dlt
@@ -86019,7 +86019,7 @@ rml
 vDp
 vDp
 gIJ
-hzB
+jwC
 hOu
 xcP
 heq
@@ -86276,7 +86276,7 @@ clM
 lBV
 vDp
 asW
-hzB
+jwC
 gIJ
 gIJ
 gIJ
@@ -86492,7 +86492,7 @@ cCE
 iNa
 dpM
 dpM
-uPu
+sMY
 xKR
 wTa
 loc
@@ -86532,12 +86532,12 @@ clM
 clM
 clM
 xAq
-rUq
+htB
 xwJ
 eIh
-hVU
-hVU
-hVU
+foR
+foR
+foR
 wlF
 wCr
 gIJ
@@ -86749,7 +86749,7 @@ uku
 dot
 iNa
 dpM
-fpP
+vqy
 blq
 bXE
 bYZ
@@ -86789,7 +86789,7 @@ clM
 clM
 clM
 vDp
-hzB
+jwC
 gIJ
 jTD
 gIJ
@@ -86797,9 +86797,9 @@ xkg
 nnr
 tcj
 quY
-hVU
-hVU
-hVU
+foR
+foR
+foR
 ukP
 gIJ
 gIJ
@@ -87046,9 +87046,9 @@ vDp
 rml
 vDp
 vDp
-ffL
-duF
-uBy
+jbU
+avS
+onf
 gIJ
 fOG
 fOG
@@ -87078,7 +87078,7 @@ xSu
 xSu
 xSu
 fTO
-bay
+tAr
 xKD
 vCt
 cEj
@@ -87301,11 +87301,11 @@ arA
 jjD
 pEW
 rba
-hVU
-rPa
-bdU
+foR
+hEs
+rOD
 gIJ
-hzB
+jwC
 fOG
 fOG
 kwU
@@ -88800,10 +88800,10 @@ oRL
 osy
 jsG
 raj
-mLT
-ahG
-qml
-xSP
+wVs
+lrM
+uoP
+pjQ
 syW
 fEz
 bWN
@@ -89057,7 +89057,7 @@ osy
 osy
 lTH
 foJ
-xBn
+sPw
 fEz
 swM
 eDH
@@ -89086,7 +89086,7 @@ iAu
 bcM
 swM
 vcr
-hIq
+koL
 bSw
 vxr
 esC
@@ -89309,13 +89309,13 @@ okE
 okE
 okE
 osy
-gOb
+jpr
 rUM
 mPv
 gjP
 fEz
 cmA
-jBY
+ckt
 cPC
 rkl
 cAV
@@ -89563,14 +89563,14 @@ wVK
 wVK
 okE
 okE
-muG
+rty
 foJ
 foJ
-xBn
+sPw
 fEz
 swM
 xTs
-jBY
+ckt
 fYG
 bZP
 qAi
@@ -89832,7 +89832,7 @@ qAi
 qAi
 qAi
 jqY
-blu
+wDI
 wra
 sJa
 wtn
@@ -90089,13 +90089,13 @@ qAi
 tQT
 xpH
 ewZ
-qtt
+ndN
 ewZ
 sJa
 oLn
 pJl
 bXr
-fuK
+iqf
 ffF
 mwV
 skC
@@ -90131,7 +90131,7 @@ xpG
 dMI
 pYw
 uLk
-dnC
+uhu
 dMI
 pYw
 vvk
@@ -90352,7 +90352,7 @@ sJa
 kxF
 kxF
 bXr
-fuK
+iqf
 rAR
 sdB
 hlb
@@ -90388,12 +90388,12 @@ uLk
 uLk
 iQQ
 vFF
-hbp
+fnl
 bex
 nmk
 vNc
 xnw
-knq
+wrC
 xnw
 xnw
 hEa
@@ -90591,7 +90591,7 @@ xJA
 txm
 jgE
 fEz
-jBY
+ckt
 rdo
 jFY
 jFY
@@ -90603,7 +90603,7 @@ iTP
 ewZ
 ewZ
 ewZ
-qtt
+ndN
 sJa
 sJa
 cNy
@@ -90650,7 +90650,7 @@ dMI
 pYw
 uLk
 nwQ
-dnK
+gmO
 pYw
 uLk
 vvv
@@ -90858,15 +90858,15 @@ rpg
 rpg
 rpg
 rpg
-iol
-rQv
-qtt
+uMK
+vAg
+ndN
 sJa
 tYm
 pJl
 eGM
 xFT
-qiz
+qgz
 cNq
 pdc
 sJa
@@ -90875,7 +90875,7 @@ pZj
 sJa
 sJa
 sRu
-aib
+uxY
 qAi
 uWp
 eBL
@@ -91116,8 +91116,8 @@ ygl
 ygl
 rpg
 rpg
-qtt
-qtt
+ndN
+ndN
 sJa
 tYm
 pJl
@@ -91373,14 +91373,14 @@ jwl
 rIV
 ivY
 rpg
-qtt
-qtt
+ndN
+ndN
 sJa
 wRd
 pJl
 lyF
 pJl
-qiz
+qgz
 pJl
 qKF
 sJa
@@ -91630,8 +91630,8 @@ kmu
 ydM
 syB
 rpg
-mJF
-qtt
+sGN
+ndN
 sJa
 wRd
 aLg
@@ -91645,8 +91645,8 @@ sJa
 sJa
 sJa
 sJa
-pvJ
-lEc
+raF
+xMG
 qAi
 iFJ
 oAH
@@ -91665,7 +91665,7 @@ bTJ
 bTJ
 bTJ
 byk
-hsZ
+tHu
 uoK
 fLc
 ggg
@@ -91874,7 +91874,7 @@ wJB
 wJB
 sSu
 fEz
-qVc
+weO
 rdo
 bTk
 bTk
@@ -91887,8 +91887,8 @@ pUf
 ydM
 bWH
 rpg
-qtt
-mJF
+ndN
+sGN
 sJa
 sJa
 sJa
@@ -91943,7 +91943,7 @@ kIz
 mvc
 xnb
 mew
-hzB
+jwC
 fTd
 vDp
 ylr
@@ -92130,7 +92130,7 @@ dYW
 hQp
 iuw
 vvB
-rvO
+wxB
 cPC
 kPR
 bTk
@@ -92144,13 +92144,13 @@ iTa
 rIV
 cxT
 rpg
-qtt
-rcv
-kpT
-kpT
-kpT
-kpT
-mvU
+ndN
+oFu
+sOF
+sOF
+sOF
+sOF
+uPz
 gDs
 wra
 ewZ
@@ -92200,7 +92200,7 @@ hWo
 mvc
 fSn
 mew
-hzB
+jwC
 bZz
 vDp
 vDp
@@ -92401,7 +92401,7 @@ ygl
 ygl
 rpg
 rpg
-qtt
+ndN
 ewZ
 qAi
 qAi
@@ -92657,8 +92657,8 @@ rpg
 rpg
 rpg
 rpg
-wHN
-lEc
+mCx
+xMG
 ewZ
 qEt
 ylr
@@ -92903,18 +92903,18 @@ cPC
 aen
 mQx
 pOs
-hBX
-aQB
-hxo
-kpT
-hwG
-kpT
-kpT
-kpT
-wLY
-kpT
-kpT
-lEc
+fIx
+fAC
+fYX
+sOF
+byJ
+sOF
+sOF
+sOF
+kJx
+sOF
+sOF
+xMG
 ewZ
 qEt
 qEt
@@ -92971,7 +92971,7 @@ mew
 mew
 mew
 mew
-hzB
+jwC
 gIJ
 gIJ
 fTd
@@ -93161,7 +93161,7 @@ dGG
 ccu
 nTT
 qAi
-dzT
+xaP
 ewZ
 ewZ
 csM
@@ -93228,7 +93228,7 @@ nKe
 gIJ
 vDp
 dyp
-aHG
+lwQ
 gIJ
 gIJ
 fTd
@@ -93418,7 +93418,7 @@ rTA
 yfd
 qAi
 qAi
-qtt
+ndN
 ewZ
 qAi
 qAi
@@ -93485,7 +93485,7 @@ nKe
 gIJ
 vDp
 nfI
-aHG
+lwQ
 gIJ
 gIJ
 vwN
@@ -93675,7 +93675,7 @@ iOl
 cPC
 qAi
 uTF
-qtt
+ndN
 ewZ
 qAi
 ylr
@@ -93727,10 +93727,10 @@ jvn
 khu
 dfT
 foJ
-kSt
+rim
 jSm
 hcg
-blN
+kAt
 fgA
 oqE
 nAq
@@ -93743,22 +93743,22 @@ gIJ
 epV
 gIJ
 sXI
-hVU
-hko
-hVU
-hVU
-hVU
-hVU
+foR
+gey
+foR
+foR
+foR
+foR
 bsD
 bbd
-xmB
-xmB
-xmB
+wKi
+wKi
+wKi
 dLW
-xmB
+wKi
 ogw
-xmB
-xmB
+wKi
+wKi
 qSK
 gUe
 gUe
@@ -93921,10 +93921,10 @@ sqv
 vNC
 wvA
 gOp
-lat
+aDt
 dCw
 sLx
-lat
+aDt
 sbq
 kYt
 kYt
@@ -93932,7 +93932,7 @@ yfZ
 cPC
 qAi
 wKZ
-qtt
+ndN
 ewZ
 qAi
 xSu
@@ -93988,7 +93988,7 @@ aqy
 lmJ
 gKs
 tGP
-azS
+rXz
 oqE
 isM
 rsm
@@ -94001,7 +94001,7 @@ vDp
 gIJ
 gIJ
 gIJ
-yev
+kli
 gIJ
 gIJ
 gIJ
@@ -94022,7 +94022,7 @@ oLK
 oLK
 uix
 cwn
-xmB
+wKi
 dGL
 flF
 flF
@@ -94189,7 +94189,7 @@ iOl
 gGr
 qAi
 iTP
-qtt
+ndN
 ewZ
 qAi
 xSu
@@ -94258,7 +94258,7 @@ vDp
 vDp
 qmO
 nGh
-vAV
+lyb
 gIJ
 geT
 gIJ
@@ -94445,8 +94445,8 @@ cPC
 sQt
 cPC
 qAi
-svr
-lEc
+pTr
+xMG
 ewZ
 qAi
 qAi
@@ -94783,7 +94783,7 @@ uix
 eYz
 qKy
 ths
-gII
+nRA
 wsV
 fYs
 vLb
@@ -95718,7 +95718,7 @@ qJL
 aBt
 lwl
 awv
-qUP
+fGi
 igx
 cOe
 usN
@@ -95775,7 +95775,7 @@ bPr
 fho
 dMR
 sDs
-jXU
+xvC
 amE
 enu
 mqo
@@ -96038,7 +96038,7 @@ aQN
 hKh
 dMR
 hyJ
-rvO
+iOl
 aqy
 uix
 rGO
@@ -96288,7 +96288,7 @@ kFW
 iGX
 jcf
 bZW
-rps
+rkF
 agh
 cqa
 agh
@@ -96743,8 +96743,8 @@ uJQ
 mIc
 gNx
 bdW
-bYW
-bYW
+hMJ
+hMJ
 cAv
 vfV
 wsx
@@ -96998,9 +96998,9 @@ qhu
 tue
 mki
 bSU
-gcc
+ygX
 fiz
-gcc
+ygX
 wvM
 xLx
 lRa
@@ -97511,11 +97511,11 @@ qhu
 dcG
 eXu
 pTe
-cAh
+rsk
 cRl
 vGG
-tfa
-jkr
+rQC
+jhj
 ktX
 pww
 lSz
@@ -97773,7 +97773,7 @@ xwz
 pww
 bsp
 cVx
-vzS
+pmC
 nuh
 jUv
 agl
@@ -97876,9 +97876,9 @@ xSu
 xSu
 xSu
 uix
-dUa
-kRf
-xyI
+qbK
+jbG
+wCx
 bpb
 xbB
 xbB
@@ -98028,7 +98028,7 @@ xor
 xor
 nuh
 nuh
-eFK
+lFc
 bFF
 mZT
 nuh
@@ -98285,7 +98285,7 @@ yep
 wEP
 nuh
 meM
-vad
+pJG
 ffl
 pnR
 nuh
@@ -98385,12 +98385,12 @@ rQg
 imH
 xSu
 oLK
-dUa
-kRf
-kRf
-kRf
-kRf
-xyI
+qbK
+jbG
+jbG
+jbG
+jbG
+wCx
 uJr
 uJr
 uJr
@@ -99056,7 +99056,7 @@ bOO
 sVV
 nuh
 qSJ
-lor
+moq
 sst
 ptF
 xfr
@@ -99412,8 +99412,8 @@ xSu
 xSu
 uix
 dGe
-noo
-xyI
+epN
+wCx
 kQk
 klP
 uJr
@@ -99584,7 +99584,7 @@ jkL
 fpH
 opr
 tqN
-nKF
+jlA
 fRv
 qAi
 hPb
@@ -99907,11 +99907,11 @@ ijq
 dDP
 uJr
 trq
-kRf
-kRf
-kRf
+jbG
+jbG
+jbG
 sPW
-pFj
+bXJ
 nQq
 ouZ
 aPm
@@ -99926,7 +99926,7 @@ dNe
 dNe
 dNe
 xkI
-euu
+aMA
 xbB
 aGn
 aGn
@@ -100183,7 +100183,7 @@ uJr
 uJr
 uJr
 uJr
-euu
+aMA
 bPu
 aGn
 aGn
@@ -100409,7 +100409,7 @@ bqR
 dwa
 gIx
 msR
-jKQ
+jOC
 wTN
 ocw
 ocw
@@ -100419,7 +100419,7 @@ mFm
 mFm
 mFm
 gwb
-kRf
+jbG
 qYW
 nQq
 nQq
@@ -100440,7 +100440,7 @@ vDs
 vil
 uJr
 uJr
-vJS
+abA
 xbB
 aGn
 aGn
@@ -100663,7 +100663,7 @@ kYt
 kYt
 diP
 auI
-oRA
+ioe
 pAQ
 eBH
 eBH
@@ -100871,7 +100871,7 @@ tho
 ksy
 iny
 eKG
-nKF
+jlA
 azs
 cQq
 fNl
@@ -100934,7 +100934,7 @@ uTe
 sgr
 ijq
 uJr
-yeb
+wvp
 nQq
 jHy
 jHy
@@ -101173,7 +101173,7 @@ ofi
 ofi
 tJo
 eaP
-rvO
+wxB
 cPC
 ioM
 iEQ
@@ -101191,7 +101191,7 @@ oxu
 oxu
 ijq
 uJr
-yeb
+wvp
 nQq
 tmJ
 jHy
@@ -101430,7 +101430,7 @@ ofi
 tJo
 eaP
 gRd
-jBY
+ckt
 qoB
 qWX
 iEQ
@@ -101448,7 +101448,7 @@ iSC
 nOQ
 ijq
 uJr
-yeb
+wvp
 nQq
 tmJ
 jHy
@@ -101619,7 +101619,7 @@ fwZ
 cOt
 bur
 uzK
-ovO
+aas
 kqW
 jFa
 jBL
@@ -101645,7 +101645,7 @@ smr
 gDt
 xvm
 foJ
-clR
+iVQ
 nWv
 sEb
 fnh
@@ -101686,7 +101686,7 @@ uNK
 uNK
 hoL
 swM
-jBY
+ckt
 qoB
 sAd
 iEQ
@@ -101705,7 +101705,7 @@ jpX
 nOQ
 ijq
 rLc
-yeb
+wvp
 nQq
 cxk
 jWb
@@ -101941,7 +101941,7 @@ cPC
 gRd
 auh
 eLW
-jBY
+ckt
 qoB
 gGv
 sAd
@@ -102131,7 +102131,7 @@ oPS
 tjp
 hdN
 uzK
-hKe
+qWm
 oPS
 oPS
 eGX
@@ -102195,7 +102195,7 @@ cPC
 cPC
 cPC
 gRd
-jBY
+ckt
 qoB
 fOK
 gGv
@@ -102389,7 +102389,7 @@ bgx
 dYG
 bur
 ruG
-cQU
+sMJ
 nHI
 fGZ
 jFa
@@ -102671,7 +102671,7 @@ iqk
 iqk
 brs
 jFa
-oko
+ppT
 qkO
 hhB
 ioA
@@ -102684,17 +102684,17 @@ gGv
 gGv
 vYJ
 ukp
-aGg
-kUa
+rPJ
+rjJ
 kYt
 frG
 kYt
 kYt
 kYt
-sPt
+qpN
 pDO
 xxb
-xqa
+orI
 dsM
 kYt
 kYt
@@ -102928,7 +102928,7 @@ iqk
 iqk
 sJl
 jFa
-oko
+ppT
 ykQ
 hhB
 nZg
@@ -103165,7 +103165,7 @@ lyQ
 xQM
 pZM
 pZM
-lmg
+cIG
 agW
 jFa
 pOg
@@ -103185,7 +103185,7 @@ iqk
 iqk
 brs
 sBp
-oko
+ppT
 lyQ
 hhB
 tGN
@@ -103232,7 +103232,7 @@ vra
 aBK
 dKd
 vra
-bYP
+kjp
 tSq
 qhm
 aFL
@@ -103241,9 +103241,9 @@ dkN
 jzR
 vfk
 uJr
-dUa
-bvr
-bvr
+qbK
+oPx
+oPx
 wiS
 rsR
 faC
@@ -103442,7 +103442,7 @@ iqk
 iqk
 brs
 jFa
-oko
+ppT
 kWC
 hhB
 nQB
@@ -103489,7 +103489,7 @@ vra
 vBx
 mzt
 fsl
-jtU
+sWT
 cVD
 qEj
 rvi
@@ -103699,9 +103699,9 @@ brs
 brs
 brs
 jFa
-msx
+jiC
 nHI
-tXt
+wOO
 wPm
 gMZ
 gMZ
@@ -103722,7 +103722,7 @@ leC
 ouG
 gHm
 eRv
-lwE
+kEe
 mfu
 prH
 iQb
@@ -103746,7 +103746,7 @@ fkv
 kjA
 cVD
 uLb
-nBi
+uTX
 pST
 qEj
 rdK
@@ -103952,7 +103952,7 @@ pZM
 pZM
 ire
 bxr
-jKn
+bbr
 dEz
 oaI
 oaI
@@ -103979,7 +103979,7 @@ dBR
 ouG
 kPn
 tPX
-lwE
+kEe
 mfu
 vRh
 iQb
@@ -103993,7 +103993,7 @@ vra
 vBx
 ghg
 qhm
-bsZ
+mPp
 qhm
 mzt
 uBS
@@ -104010,9 +104010,9 @@ dbb
 qHt
 oua
 tAX
-kRf
-kRf
-xyI
+jbG
+jbG
+wCx
 uJr
 uJr
 eJH
@@ -104250,13 +104250,13 @@ vra
 avf
 kTF
 qEj
-nBi
+uTX
 qEj
 cVD
 qEj
 qEj
 kNh
-itQ
+lUZ
 gYk
 fWj
 fWj
@@ -104493,7 +104493,7 @@ sIn
 ouG
 tyS
 eRv
-eGe
+mbO
 otq
 fED
 iQb
@@ -104507,7 +104507,7 @@ jYf
 qjo
 kTF
 qEj
-nBi
+uTX
 qEj
 bOr
 tym
@@ -104750,7 +104750,7 @@ mTZ
 cde
 niS
 iqN
-vkR
+qSb
 iqN
 iqN
 ccv
@@ -104764,7 +104764,7 @@ noV
 iWv
 kiM
 noV
-cuj
+scH
 noV
 rBR
 gYk
@@ -104788,7 +104788,7 @@ uJr
 uJr
 rEi
 uJr
-rSW
+mNq
 uJr
 nQq
 jHy
@@ -104980,7 +104980,7 @@ kSm
 smZ
 jgH
 gNd
-qaV
+eiC
 nPH
 twP
 egt
@@ -105007,7 +105007,7 @@ ouG
 ouG
 gKD
 eRv
-xYl
+aNc
 xJk
 xJk
 xJk
@@ -105045,7 +105045,7 @@ rsK
 rsK
 rsK
 rsK
-nGw
+uUj
 uJr
 nQq
 nQq
@@ -105237,7 +105237,7 @@ gxC
 mVH
 jgH
 brs
-qaV
+eiC
 nPH
 owH
 jFa
@@ -105302,7 +105302,7 @@ rFh
 cwh
 qod
 rsK
-euu
+aMA
 uJr
 xbB
 ylr
@@ -105494,7 +105494,7 @@ gxC
 uua
 ksJ
 ufM
-qaV
+eiC
 eit
 jFa
 tUg
@@ -105750,8 +105750,8 @@ ylr
 gxC
 qXg
 ksJ
-lbr
-qRq
+bir
+lMF
 eit
 pOg
 jFa
@@ -106330,7 +106330,7 @@ ixN
 kvm
 yda
 rsK
-euu
+aMA
 uJr
 mMC
 ylr
@@ -106587,7 +106587,7 @@ rsK
 rsK
 rsK
 rsK
-wLE
+jqx
 sAg
 xbB
 ylr
@@ -106840,11 +106840,11 @@ epS
 cJk
 aHr
 cJk
-kZh
-wzE
-wzE
-wzE
-tlB
+oQA
+gLx
+gLx
+gLx
+xWI
 uJr
 xbB
 ylr
@@ -107097,7 +107097,7 @@ sQr
 mjO
 xGX
 cJk
-sfF
+iBc
 uJr
 uJr
 uJr

--- a/_maps/map_files/DonutStation/DonutStation.dmm
+++ b/_maps/map_files/DonutStation/DonutStation.dmm
@@ -4,7 +4,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -124,6 +123,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "aco" = (
@@ -209,13 +209,11 @@
 "aen" = (
 /obj/structure/sign/directions/medical{
 	dir = 8;
-	icon_state = "direction_med";
 	pixel_x = -31;
 	pixel_y = 32
 	},
 /obj/structure/sign/directions/science{
 	dir = 8;
-	icon_state = "direction_sci";
 	pixel_x = -31;
 	pixel_y = 24
 	},
@@ -309,9 +307,6 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/structure/cable{
@@ -515,8 +510,8 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "alt" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "alz" = (
@@ -529,8 +524,7 @@
 /area/maintenance/starboard)
 "alK" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 4;
-	icon_state = "heater"
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -578,9 +572,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/sorting/mail{
-	sortType = 5
-	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/item/paper_bin{
@@ -589,6 +580,10 @@
 	},
 /obj/item/pen,
 /obj/structure/table/glass,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/mail_sorting/engineering/ce_office,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "amN" = (
@@ -676,6 +671,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aoi" = (
@@ -733,12 +731,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"aoW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/kitchen)
 "apw" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -798,6 +790,12 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"aqY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "arm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -824,6 +822,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "arB" = (
@@ -845,22 +844,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"asF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "asK" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -890,6 +873,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "atc" = (
@@ -899,6 +885,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "atk" = (
@@ -930,6 +917,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "atx" = (
@@ -948,6 +938,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -1003,7 +996,6 @@
 	location = "RIGHTBOTTOM";
 	name = "navigation beacon (RIGHTBOTTOM)"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -1046,12 +1038,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "auQ" = (
@@ -1139,11 +1129,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -1214,6 +1204,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ayj" = (
@@ -1256,9 +1249,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
@@ -1272,9 +1262,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 2
-	},
+/obj/structure/disposalpipe/junction,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "azA" = (
@@ -1443,11 +1431,11 @@
 "aDT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aEl" = (
@@ -1484,8 +1472,7 @@
 /area/chapel/office)
 "aFm" = (
 /obj/structure/particle_accelerator/power_box{
-	dir = 1;
-	icon_state = "power_box"
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -1561,6 +1548,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "aGC" = (
@@ -1624,6 +1614,15 @@
 /obj/item/soap/nanotrasen,
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
+"aIF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "aII" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/ale,
@@ -1693,7 +1692,6 @@
 "aJV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -1739,9 +1737,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aKB" = (
@@ -1770,8 +1766,7 @@
 "aLg" = (
 /obj/machinery/camera{
 	c_tag = "Civilian - Library Lounge";
-	dir = 8;
-	network = list("ss13")
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -1831,9 +1826,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aMI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
@@ -1917,15 +1909,16 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/mail_sorting/security/general,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aOe" = (
@@ -1936,6 +1929,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/tcommsat/computer)
 "aOw" = (
@@ -1979,15 +1973,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"aQq" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "aQs" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Foyer";
-	req_access_txt = "0";
 	req_one_access_txt = "24;10"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -2046,6 +2043,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "aRE" = (
@@ -2093,9 +2093,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -28
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
 "aTf" = (
@@ -2126,11 +2123,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/camera{
 	c_tag = "Research - Toxins Storage";
-	dir = 2;
 	network = list("ss13","Research")
 	},
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/electrolyzer,
@@ -2155,8 +2150,7 @@
 /area/hallway/primary/central)
 "aUq" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	dir = 8;
-	icon_state = "freezer_1"
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/server)
@@ -2182,8 +2176,7 @@
 /area/escapepodbay)
 "aUK" = (
 /obj/machinery/computer/station_alert{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/machinery/light_switch{
 	pixel_x = -24
@@ -2211,12 +2204,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"aVD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/hallway/primary/central)
 "aVO" = (
 /obj/machinery/status_display/ai{
 	pixel_y = 32
@@ -2235,6 +2222,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -2301,6 +2291,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "aXG" = (
@@ -2334,9 +2325,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aXN" = (
@@ -2382,9 +2370,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aYn" = (
@@ -2412,6 +2397,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "aZh" = (
@@ -2478,14 +2464,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bbd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -2496,6 +2481,7 @@
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bbg" = (
@@ -2506,9 +2492,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -2571,11 +2554,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
+"bcs" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "bcF" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bcM" = (
@@ -2591,11 +2579,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bcQ" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -2615,15 +2605,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
-"bdh" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "bdC" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -2644,7 +2625,7 @@
 /area/space/nearstation)
 "bdW" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -2658,6 +2639,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bef" = (
@@ -2684,13 +2666,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -2740,7 +2722,6 @@
 /obj/structure/table/glass,
 /obj/machinery/power/apc{
 	areastring = "/area/medical/virology";
-	dir = 2;
 	name = "Virology APC";
 	pixel_y = -23
 	},
@@ -2782,7 +2763,11 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "bgx" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/conveyor/inverted{
+	dir = 10;
+	id = "garbage";
+	name = "recycler conveyor belt"
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
 "bgM" = (
@@ -2790,6 +2775,10 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "bha" = (
@@ -2805,6 +2794,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bhj" = (
@@ -2828,9 +2818,6 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
 "bhn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -2867,7 +2854,6 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Security - Cell 4";
-	dir = 2;
 	network = list("ss13","Security")
 	},
 /obj/item/bedsheet/prisoner,
@@ -2880,9 +2866,7 @@
 	pixel_y = 28
 	},
 /obj/machinery/camera{
-	c_tag = "Civilian - Chapel Office";
-	dir = 2;
-	network = list("ss13")
+	c_tag = "Civilian - Chapel Office"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
@@ -2973,13 +2957,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
-"biO" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/brown/warning/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
 "bjl" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -3020,6 +2997,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "bjP" = (
@@ -3033,13 +3011,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bkk" = (
@@ -3077,7 +3055,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -3085,6 +3062,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "blf" = (
@@ -3095,9 +3073,6 @@
 "blq" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/machinery/light_switch{
 	pixel_y = -24
@@ -3152,6 +3127,9 @@
 /area/space/nearstation)
 "bnW" = (
 /mob/living/simple_animal/opossum/poppy,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "boj" = (
@@ -3325,11 +3303,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -3364,6 +3342,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"bsc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/kitchen)
 "bsf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -3387,6 +3372,9 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "bsp" = (
@@ -3400,6 +3388,18 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"bsu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "bsw" = (
 /obj/machinery/bluespace_beacon,
 /obj/effect/turf_decal/stripes/line,
@@ -3414,6 +3414,7 @@
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bsI" = (
@@ -3446,14 +3447,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"btw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel/chapel{
-	dir = 8
-	},
-/area/chapel/main)
 "btE" = (
 /obj/structure/sign/departments/custodian{
 	pixel_y = -32
@@ -3475,6 +3468,9 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "btM" = (
@@ -3529,12 +3525,14 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "buM" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/machinery/disposal/bin/tagger{
+	name = "sample delivery unit"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 10
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -3609,6 +3607,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bwr" = (
@@ -3669,6 +3670,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bxw" = (
@@ -3689,6 +3691,7 @@
 "bxC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/tcommsat/computer)
 "bxF" = (
@@ -3697,11 +3700,11 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -3729,6 +3732,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bym" = (
@@ -3786,9 +3790,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/science/research)
 "bAm" = (
@@ -3801,9 +3802,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "bAp" = (
@@ -3812,6 +3810,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
+"bAu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "bBh" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -3850,7 +3863,6 @@
 /area/engine/engineering)
 "bBN" = (
 /obj/docking_port/stationary{
-	dir = 1;
 	dwidth = 1;
 	height = 4;
 	name = "escape pod four loader";
@@ -3940,11 +3952,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bDs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
 	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -3962,18 +3974,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bEV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "bEY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
@@ -3986,6 +3993,10 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/mail_sorting/medbay/chemistry,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bFf" = (
@@ -4011,7 +4022,6 @@
 /area/crew_quarters/kitchen)
 "bFx" = (
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -4024,29 +4034,16 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "bFF" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Office";
-	req_access_txt = "50"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -4070,9 +4067,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
@@ -4111,7 +4105,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bGy" = (
@@ -4194,6 +4187,13 @@
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
 /area/space)
+"bIM" = (
+/obj/effect/landmark/blobstart,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "bIW" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
@@ -4242,6 +4242,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bJt" = (
@@ -4256,6 +4259,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bJy" = (
@@ -4307,7 +4311,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -4363,6 +4366,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "bMM" = (
@@ -4390,7 +4396,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "bNK" = (
-/obj/machinery/disposal/bin,
+/obj/machinery/disposal/bin/tagger,
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Medical - Chief Medical Officer's Office";
@@ -4425,7 +4431,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "bOz" = (
@@ -4500,6 +4505,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bPo" = (
@@ -4521,8 +4527,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bPq" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/structure/railing/corner{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
@@ -4589,6 +4596,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bQH" = (
@@ -4608,11 +4618,6 @@
 /obj/effect/turf_decal/trimline/chemorange/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"bQL" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/siding/wood,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bRa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -4641,6 +4646,9 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bRA" = (
@@ -4654,6 +4662,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -4679,6 +4690,14 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bSa" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/central)
 "bSc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -4689,6 +4708,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bSi" = (
@@ -4710,7 +4732,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -4731,7 +4752,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
@@ -4756,6 +4776,7 @@
 "bTJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bTZ" = (
@@ -4764,6 +4785,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/tcommsat/computer)
 "bUh" = (
@@ -4875,6 +4897,18 @@
 /obj/structure/closet/crate/rcd,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"bWJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bWM" = (
 /obj/structure/rack,
 /obj/item/aicard,
@@ -4891,12 +4925,20 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bXc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "bXq" = (
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
@@ -4972,7 +5014,6 @@
 "bYZ" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/machinery/button/door{
-	dir = 2;
 	id = "robotics2";
 	name = "Shutters Control Button";
 	pixel_y = 24;
@@ -5113,6 +5154,7 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
 "cbl" = (
@@ -5227,7 +5269,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -5236,6 +5277,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hop)
 "cdj" = (
@@ -5255,6 +5297,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "cdo" = (
@@ -5271,6 +5316,7 @@
 /obj/effect/turf_decal/siding/wood/corner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/library)
 "cdJ" = (
@@ -5279,7 +5325,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medical - Genetics";
-	dir = 2;
 	network = list("ss13","Medical")
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
@@ -5333,6 +5378,22 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/dark,
 /area/security/interrogation)
+"cew" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/mail_sorting/security/detectives_office,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "ceN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -5348,9 +5409,6 @@
 /area/security/prison)
 "ceS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
@@ -5379,10 +5437,10 @@
 	},
 /area/maintenance/port/fore)
 "cfw" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "packageSort2"
-	},
 /obj/effect/turf_decal/trimline/brown/warning/lower{
+	dir = 1
+	},
+/obj/structure/disposalpipe/sorting/wrap/flip{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -5405,9 +5463,6 @@
 /area/engine/engineering)
 "cfO" = (
 /obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
 "cgm" = (
@@ -5427,9 +5482,6 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/vending/cigarette,
@@ -5468,6 +5520,19 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
+"chD" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 1;
+	pixel_y = -1
+	},
+/obj/effect/mapping_helpers/mail_sorting/engineering/general,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "chE" = (
 /obj/item/stack/cable_coil/cut/red,
 /turf/open/floor/plasteel/airless{
@@ -5482,6 +5547,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "chZ" = (
@@ -5501,6 +5567,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cif" = (
@@ -5555,6 +5624,14 @@
 /obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/janitor)
+"ciO" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "ciX" = (
 /obj/machinery/light/small,
 /obj/machinery/camera/motion{
@@ -5657,15 +5734,12 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 22
+	dir = 8
 	},
+/obj/effect/mapping_helpers/mail_sorting/service/janitor_closet,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "clw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -5675,11 +5749,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -5694,7 +5768,6 @@
 	location = "LEFTTOP";
 	name = "navigation beacon (LEFTTOP)"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -5784,6 +5857,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cny" = (
@@ -5800,9 +5874,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -5894,8 +5965,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Main 2";
-	dir = 8;
-	network = list("ss13")
+	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28
@@ -5939,9 +6009,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
@@ -6026,6 +6093,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/barricade/wooden,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "ctN" = (
@@ -6047,9 +6115,6 @@
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
 "cuq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
@@ -6081,7 +6146,6 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Security - Cell 3";
-	dir = 2;
 	network = list("ss13","Security")
 	},
 /obj/item/bedsheet/prisoner,
@@ -6112,7 +6176,6 @@
 /turf/open/floor/plating,
 /area/science/server)
 "cvE" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
@@ -6128,6 +6191,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cvV" = (
@@ -6153,6 +6217,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cwh" = (
@@ -6178,8 +6245,20 @@
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"cwv" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "cww" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -6203,9 +6282,7 @@
 /area/medical/storage)
 "cwM" = (
 /obj/machinery/camera{
-	c_tag = "Civilian - Chapel Main 2";
-	dir = 2;
-	network = list("ss13")
+	c_tag = "Civilian - Chapel Main 2"
 	},
 /obj/machinery/light_switch{
 	pixel_y = 24
@@ -6227,6 +6304,7 @@
 	name = "4maintenance loot spawner"
 	},
 /obj/item/storage/box/lights/mixed,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "cxr" = (
@@ -6280,26 +6358,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
-"cya" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/hallway/primary/central)
 "cyh" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "cyk" = (
 /obj/machinery/computer/rdconsole/core{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/science/lab)
 "cyJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "CloningDoor";
 	name = "Cloning Lab";
@@ -6327,6 +6397,9 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "cyW" = (
@@ -6335,8 +6408,7 @@
 /obj/item/screwdriver,
 /obj/machinery/camera{
 	c_tag = "Cargo - Main 1";
-	dir = 4;
-	network = list("ss13")
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/quartermaster/office";
@@ -6361,6 +6433,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -6410,13 +6485,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "czS" = (
@@ -6453,6 +6528,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/mail_sorting/supply/cargo_bay,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "cAC" = (
@@ -6488,6 +6567,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cCh" = (
@@ -6512,6 +6594,7 @@
 /obj/effect/mapping_helpers/airlock/unres{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "cCy" = (
@@ -6531,7 +6614,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "cCL" = (
@@ -6659,8 +6741,7 @@
 	req_access_txt = "20"
 	},
 /obj/machinery/camera{
-	c_tag = "Bridge - Captain's Office";
-	dir = 2
+	c_tag = "Bridge - Captain's Office"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
@@ -6866,11 +6947,7 @@
 "cIU" = (
 /obj/machinery/camera{
 	c_tag = "Security - Main Hall 3";
-	dir = 2;
 	network = list("ss13","Security")
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -6897,7 +6974,6 @@
 "cKp" = (
 /obj/machinery/camera{
 	c_tag = "Research - Main 4";
-	dir = 2;
 	network = list("ss13","Research")
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
@@ -6912,9 +6988,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -6926,7 +6999,6 @@
 	c_tag = "Bridge - Main 2";
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
 	dir = 8
 	},
@@ -6958,12 +7030,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cLR" = (
 /obj/machinery/conveyor/inverted{
 	dir = 10;
-	id = "garbage"
+	id = "garbage";
+	name = "recycler conveyor belt"
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -7039,6 +7115,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "cMw" = (
@@ -7050,6 +7129,9 @@
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -7091,6 +7173,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"cNm" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "cNq" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/wood,
@@ -7156,6 +7245,9 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -7240,11 +7332,11 @@
 "cPG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -7279,6 +7371,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "cQX" = (
@@ -7296,7 +7391,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medical - Treatment Centre";
-	dir = 2;
 	network = list("ss13","Medical")
 	},
 /turf/open/floor/plasteel/white,
@@ -7335,17 +7429,12 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cTq" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -7420,20 +7509,27 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Office";
+	req_access_txt = "50"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/quartermaster/office)
+/area/quartermaster/sorting)
 "cVD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -7458,12 +7554,12 @@
 /area/security/checkpoint/medical)
 "cVG" = (
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/light_switch{
 	pixel_y = -24
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -7545,6 +7641,10 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/mail_sorting/science/toxins,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "cWw" = (
@@ -7567,7 +7667,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -7587,11 +7686,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -7703,8 +7802,7 @@
 /area/science/xenobiology)
 "daq" = (
 /obj/machinery/computer/prisoner{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
@@ -7751,6 +7849,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "dbJ" = (
@@ -7771,9 +7870,6 @@
 /area/science/robotics/lab)
 "dcE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
@@ -7810,9 +7906,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -7845,9 +7938,6 @@
 /obj/machinery/holopad,
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
@@ -7927,27 +8017,21 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"deM" = (
-/obj/structure/chair,
-/obj/effect/landmark/start/assistant,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/crew_quarters/kitchen)
 "deY" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"dfg" = (
+"dfs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/lab)
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port)
 "dfE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -7970,12 +8054,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/mail_sorting/engineering/atmospherics,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "dfZ" = (
@@ -8010,6 +8095,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -8061,6 +8149,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dis" = (
@@ -8100,15 +8189,13 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "djm" = (
@@ -8202,13 +8289,11 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "dlT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/conveyor_switch/oneway{
-	dir = 8;
+/obj/machinery/recycler,
+/obj/machinery/conveyor{
 	id = "garbage";
-	name = "disposal conveyor"
+	name = " recycler conveyor belt";
+	dir = 4
 	},
 /turf/open/floor/plasteel/burnt,
 /area/maintenance/disposal)
@@ -8238,6 +8323,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"dmO" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "dmS" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenocontainment";
@@ -8276,6 +8373,9 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -8359,13 +8459,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "dpM" = (
@@ -8406,9 +8506,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "dqK" = (
@@ -8440,9 +8540,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "drp" = (
@@ -8461,7 +8558,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
@@ -8491,9 +8587,6 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -8501,6 +8594,9 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -8565,9 +8661,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "dtM" = (
@@ -8614,8 +8707,7 @@
 "dvH" = (
 /obj/machinery/camera{
 	c_tag = "Civilian - Chapel Main 1";
-	dir = 4;
-	network = list("ss13")
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/hallway/primary/central)
@@ -8623,19 +8715,22 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "dwa" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/mail_sorting/service/law_office,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "dwp" = (
@@ -8681,11 +8776,11 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -8716,6 +8811,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dxs" = (
@@ -8748,9 +8846,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -8776,11 +8871,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Docking Bay South";
-	dir = 1;
-	network = list("ss13")
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
@@ -8816,7 +8907,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "dAo" = (
@@ -8847,18 +8937,6 @@
 /obj/structure/table/glass,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"dAJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "dAQ" = (
 /obj/machinery/camera{
 	c_tag = "Secure - EVA";
@@ -8912,6 +8990,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "dCz" = (
@@ -8936,8 +9015,7 @@
 /area/maintenance/port/aft)
 "dDI" = (
 /obj/machinery/camera{
-	c_tag = "Bridge - AI Upload 1";
-	dir = 2
+	c_tag = "Bridge - AI Upload 1"
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -8995,6 +9073,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "dEJ" = (
@@ -9127,6 +9206,9 @@
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "dGO" = (
@@ -9134,9 +9216,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -9161,12 +9240,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"dHB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
 "dHD" = (
 /turf/open/floor/plating/rust,
 /area/maintenance/starboard)
@@ -9182,7 +9255,6 @@
 /obj/effect/turf_decal/trimline/secred/warning/lower/corner{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "dIl" = (
@@ -9211,7 +9283,6 @@
 "dIw" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/checkpoint/science";
-	dir = 2;
 	name = "Science Checkpoint APC";
 	pixel_y = -23
 	},
@@ -9280,8 +9351,7 @@
 /area/security/brig)
 "dKr" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 4;
-	icon_state = "freezer"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -9320,7 +9390,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "dLA" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/research/glass{
 	name = "Genetics Research";
 	req_access_txt = "5; 9; 68"
@@ -9334,6 +9403,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "dLE" = (
@@ -9377,6 +9447,7 @@
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "dMg" = (
@@ -9422,14 +9493,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
@@ -9443,13 +9514,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "dOa" = (
@@ -9517,6 +9588,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "dOv" = (
@@ -9525,14 +9599,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"dOS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/chapel{
-	dir = 8
-	},
-/area/chapel/main)
 "dPb" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -9553,11 +9619,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -9674,7 +9740,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 8
 	},
 /obj/item/kirbyplants/random,
@@ -9690,6 +9755,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "dSi" = (
@@ -9704,6 +9772,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -9791,6 +9862,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "dTU" = (
@@ -9822,12 +9896,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"dUQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/kitchen)
 "dUS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -9949,6 +10017,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "dYk" = (
@@ -9964,9 +10035,8 @@
 /turf/open/floor/wood,
 /area/medical/psych)
 "dYG" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/railing/corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
@@ -9986,7 +10056,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medical - Virology Backroom";
-	dir = 2;
 	network = list("ss13","Medical")
 	},
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -10004,12 +10073,12 @@
 /area/maintenance/port/fore)
 "dZo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
@@ -10027,6 +10096,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"dZF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "dZN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -10036,6 +10114,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "dZZ" = (
@@ -10102,6 +10181,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "eaI" = (
@@ -10122,6 +10204,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -10169,9 +10254,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/light_switch{
 	pixel_y = 27
 	},
@@ -10204,9 +10286,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "edn" = (
@@ -10243,7 +10322,6 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -10257,6 +10335,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "eev" = (
@@ -10287,9 +10366,6 @@
 "eeQ" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -10366,12 +10442,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"egN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
 "ehj" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -10518,7 +10588,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -10612,6 +10681,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "emA" = (
@@ -10626,7 +10696,6 @@
 /area/medical/virology)
 "emS" = (
 /obj/docking_port/stationary{
-	dir = 1;
 	dwidth = 5;
 	height = 7;
 	name = "Cargo Bay";
@@ -10642,6 +10711,15 @@
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/bar)
+"eno" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "enu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10660,9 +10738,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
@@ -10689,7 +10764,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -10740,10 +10814,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"eqm" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "eqM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -10773,26 +10848,16 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1
 	},
+/obj/effect/mapping_helpers/mail_sorting/science/rd_office,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"erF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
+"erz" = (
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/quartermaster/office)
 "erJ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -10868,6 +10933,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "etb" = (
@@ -10889,7 +10957,6 @@
 "etj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
@@ -10907,13 +10974,14 @@
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	sortTypes = list("4","5")
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/mail_sorting/engineering/general,
+/obj/effect/mapping_helpers/mail_sorting/engineering/ce_office,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "etv" = (
@@ -10935,8 +11003,7 @@
 "etK" = (
 /obj/machinery/camera{
 	c_tag = "Civilian - Dorm Main 1";
-	dir = 4;
-	network = list("ss13")
+	dir = 4
 	},
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
@@ -10945,11 +11012,9 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/library)
 "eui" = (
@@ -10975,6 +11040,12 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"eul" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "eun" = (
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
@@ -10988,10 +11059,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
+/obj/structure/disposalpipe/junction,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "evF" = (
@@ -11022,6 +11093,14 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"ewb" = (
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/mail_sorting/science/toxins,
+/obj/effect/mapping_helpers/mail_sorting/science/xenobiology,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "ewp" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 5
@@ -11044,13 +11123,13 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "ewV" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
 	pixel_x = 25
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "ewY" = (
@@ -11148,6 +11227,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "eyR" = (
@@ -11158,6 +11240,15 @@
 /obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"ezB" = (
+/obj/effect/turf_decal/trimline/brown/warning/lower{
+	dir = 1
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "packageSort2"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "ezI" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -11188,9 +11279,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "eAp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
@@ -11239,17 +11327,11 @@
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"eAW" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "eBk" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/requests_console{
@@ -11342,19 +11424,14 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"eDG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "eDH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -11363,9 +11440,6 @@
 /turf/template_noop,
 /area/maintenance/aft)
 "eEu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
@@ -11374,6 +11448,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -11424,7 +11501,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -11456,7 +11532,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "eGa" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
@@ -11500,6 +11575,9 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -11588,6 +11666,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "eIl" = (
@@ -11604,9 +11683,6 @@
 	dir = 4
 	},
 /obj/structure/table/wood,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -11627,6 +11703,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "eII" = (
@@ -11643,12 +11720,6 @@
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
-"eJG" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/wood,
-/area/crew_quarters/kitchen)
 "eJH" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/aft)
@@ -11678,7 +11749,7 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "eKO" = (
-/obj/machinery/disposal/bin,
+/obj/machinery/disposal/bin/tagger,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -11686,15 +11757,13 @@
 /area/crew_quarters/heads/hor)
 "eKV" = (
 /obj/machinery/computer/aifixer{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Research - Research Director's Office";
-	dir = 2;
 	network = list("ss13","Research")
 	},
 /turf/open/floor/carpet/purple,
@@ -11733,9 +11802,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 1
@@ -11821,7 +11887,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -11909,8 +11974,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/camera{
-	c_tag = "Hallway - Central West 2";
-	dir = 2
+	c_tag = "Hallway - Central West 2"
 	},
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
@@ -11938,6 +12002,15 @@
 /obj/item/stack/cable_coil/cut/red,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"ePy" = (
+/obj/structure/disposalpipe/broken{
+	dir = 4
+	},
+/obj/structure/disposalpipe/broken{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "ePE" = (
 /obj/machinery/computer/cloning{
 	dir = 8
@@ -11948,6 +12021,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
+"ePT" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Office";
+	req_access_txt = "50"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "ePY" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -11960,6 +12047,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "eQD" = (
@@ -12012,8 +12100,7 @@
 	req_access_txt = "5"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 8;
-	icon_state = "airlock_unres_helper"
+	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -12023,9 +12110,6 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
@@ -12089,26 +12173,17 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"eSU" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/security/brig)
+/area/hallway/primary/central)
 "eSX" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/effect/turf_decal/siding/yellow{
@@ -12146,9 +12221,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "eTV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -12159,15 +12231,16 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/mail_sorting/medbay/cmo_office,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "eTX" = (
@@ -12195,9 +12268,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "eUs" = (
@@ -12245,6 +12316,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "eVt" = (
@@ -12265,7 +12337,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/computer/security/telescreen{
 	dir = 4;
-	icon_state = "telescreen";
 	name = "Test Chamber Monitor";
 	network = list("xeno");
 	pixel_y = 2
@@ -12277,9 +12348,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "eVV" = (
@@ -12291,7 +12360,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -12303,6 +12371,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "eWk" = (
@@ -12330,7 +12399,9 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 5
 	},
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "eWG" = (
@@ -12364,9 +12435,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -12381,6 +12449,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "eXD" = (
@@ -12399,16 +12470,14 @@
 "eXI" = (
 /obj/structure/frame/computer{
 	anchored = 1;
-	dir = 8;
-	icon_state = "0"
+	dir = 8
 	},
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/wood,
 /area/quartermaster/warehouse)
 "eXN" = (
 /obj/machinery/computer/apc_control{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/item/radio/intercom{
 	pixel_x = -28
@@ -12450,13 +12519,13 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -12537,6 +12606,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "faX" = (
@@ -12566,9 +12636,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
@@ -12584,20 +12651,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"fcD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "fds" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -12616,11 +12669,11 @@
 /area/maintenance/central)
 "fec" = (
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile{
 	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -12680,6 +12733,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "ffe" = (
@@ -12695,13 +12751,16 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/warning/lower{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -12740,7 +12799,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -12799,6 +12858,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "fgC" = (
@@ -12820,6 +12882,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/public/glass{
 	name = "Telecommunications Foyer"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
@@ -12848,9 +12913,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -12905,6 +12967,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/solars/port/fore)
 "fib" = (
@@ -12919,15 +12984,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 2;
-	sortType = 2
-	},
 /mob/living/simple_animal/pet/fox/fennec/Autumn,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "fiA" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
@@ -12939,6 +12999,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "fiB" = (
@@ -12958,10 +13019,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"fjw" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+"fjA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "fjF" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -12983,9 +13055,6 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -13069,6 +13138,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "fmF" = (
@@ -13078,17 +13150,20 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"fnh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"fnh" = (
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -13101,9 +13176,6 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "fnW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -13118,6 +13190,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/tcommsat/computer)
@@ -13145,6 +13220,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"foR" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/central)
 "fpe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -13211,8 +13292,7 @@
 /area/engine/atmos)
 "fra" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	dir = 8;
-	icon_state = "freezer_1"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -13288,10 +13368,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/junction,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/junction,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "frJ" = (
@@ -13310,12 +13390,12 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "frQ" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/light_switch{
 	pixel_x = 24
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "fse" = (
@@ -13349,7 +13429,6 @@
 /area/security/brig)
 "fsv" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "NTMSLoad2";
 	name = "on ramp"
 	},
@@ -13378,14 +13457,11 @@
 "ftc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ftn" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
@@ -13399,7 +13475,6 @@
 "ftr" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Nitrous Oxide Tank";
-	dir = 2;
 	network = list("ss13","Atmospherics")
 	},
 /turf/open/floor/engine/n2o{
@@ -13473,12 +13548,10 @@
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "47"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/science/research)
 "fuA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
@@ -13487,6 +13560,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -13500,10 +13576,20 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/fore)
+"fuJ" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "fva" = (
 /obj/structure/girder,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -13514,11 +13600,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -13533,24 +13619,19 @@
 	icon_state = "0-4"
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
 	pixel_y = -27
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
-	broadcasting = 0;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
 	pixel_y = 20
 	},
 /obj/item/radio/intercom{
-	broadcasting = 0;
 	freerange = 1;
-	listening = 1;
 	name = "Common Channel";
 	pixel_y = -37
 	},
@@ -13593,9 +13674,6 @@
 "fvM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 8
@@ -13603,9 +13681,7 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fvS" = (
@@ -13632,6 +13708,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "fvU" = (
@@ -13644,9 +13723,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -13655,6 +13731,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
@@ -13671,14 +13750,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -13734,9 +13813,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "fxD" = (
@@ -13764,6 +13841,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "fyd" = (
@@ -13771,6 +13851,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -13786,6 +13867,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"fyE" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "fyF" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -13809,6 +13902,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -13847,13 +13943,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/tcommsat/computer)
 "fAc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
@@ -13901,6 +13997,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "fBl" = (
@@ -14067,9 +14166,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -14105,10 +14201,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "fGB" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 10
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
@@ -14117,6 +14209,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -14132,6 +14227,9 @@
 "fGZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -14262,9 +14360,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "fKR" = (
@@ -14285,12 +14380,13 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/mail_sorting/service/hydroponics,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "fLh" = (
@@ -14311,14 +14407,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -14350,6 +14446,9 @@
 "fLR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -14395,7 +14494,6 @@
 	c_tag = "Holodeck"
 	},
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
@@ -14432,6 +14530,9 @@
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/aft)
@@ -14505,8 +14606,7 @@
 /area/crew_quarters/theatre)
 "fOJ" = (
 /obj/machinery/computer/rdservercontrol{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -14636,9 +14736,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -14737,6 +14834,10 @@
 /obj/machinery/light_switch{
 	pixel_x = 24
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "fTE" = (
@@ -14746,23 +14847,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/tcommsat/computer)
-"fTF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "fTO" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -14848,9 +14937,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -14877,7 +14963,6 @@
 "fXR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -14921,12 +15006,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"fYB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet/purple,
-/area/chapel/main)
 "fYG" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel,
@@ -14941,6 +15020,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "fZd" = (
@@ -15007,7 +15087,6 @@
 /obj/structure/fireaxecabinet{
 	pixel_x = -32
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
 	dir = 8
 	},
@@ -15112,6 +15191,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"gcD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gcF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -15128,9 +15222,6 @@
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
@@ -15140,6 +15231,9 @@
 /obj/structure/closet/wardrobe/miner,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/effect/turf_decal/stripes/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "gdL" = (
@@ -15160,12 +15254,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/interrogation)
-"gdU" = (
-/obj/machinery/conveyor{
-	id = "garbage"
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "gec" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
@@ -15177,8 +15265,7 @@
 "geq" = (
 /obj/structure/frame/computer{
 	anchored = 1;
-	dir = 4;
-	icon_state = "0"
+	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
@@ -15195,14 +15282,14 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -15265,13 +15352,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"ggf" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner/lower{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "ggg" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -15287,7 +15367,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "ggw" = (
@@ -15310,6 +15389,9 @@
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -15348,6 +15430,9 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -15389,7 +15474,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ghI" = (
-/obj/structure/disposalpipe/segment,
 /mob/living/carbon/monkey/punpun,
 /turf/open/floor/carpet/black,
 /area/crew_quarters/bar)
@@ -15430,6 +15514,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gjQ" = (
@@ -15460,6 +15547,7 @@
 	dir = 8;
 	network = list("ss13","Medical")
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "gke" = (
@@ -15503,19 +15591,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"gkZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "glh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15528,9 +15603,6 @@
 "gmA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -15601,6 +15673,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/science/research)
 "gnn" = (
@@ -15642,6 +15717,9 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -15730,7 +15808,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_x = -2;
 	pixel_y = 25;
@@ -15779,11 +15856,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -15797,9 +15874,6 @@
 "gsr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -15844,9 +15918,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "gtn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/machinery/light_switch{
 	pixel_x = -4;
 	pixel_y = -24
@@ -15975,9 +16046,7 @@
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -32
 	},
-/obj/machinery/computer/communications{
-	dir = 2
-	},
+/obj/machinery/computer/communications,
 /obj/structure/sign/plaques/golden/captain{
 	pixel_y = 32
 	},
@@ -15997,6 +16066,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/aft)
 "gwm" = (
@@ -16032,9 +16102,7 @@
 /area/ai_monitored/secondarydatacore)
 "gxo" = (
 /obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -16043,6 +16111,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"gxx" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/mail_sorting/service/library,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gxy" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
@@ -16146,7 +16224,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "gAQ" = (
@@ -16169,6 +16246,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "gBM" = (
@@ -16176,6 +16256,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gBR" = (
@@ -16212,6 +16295,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "gDt" = (
@@ -16229,7 +16315,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "gDN" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -16299,10 +16384,10 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "gFE" = (
@@ -16354,24 +16439,17 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/camera{
-	c_tag = "Bridge - Entrance";
-	dir = 2
+	c_tag = "Bridge - Entrance"
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"gHn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "gHs" = (
 /obj/machinery/door/window/brigdoor/northright{
 	name = "Filing Room";
@@ -16382,6 +16460,9 @@
 /area/medical/psych)
 "gHH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -16402,11 +16483,11 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Courtroom"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "gIJ" = (
@@ -16426,9 +16507,6 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "gJH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -16437,6 +16515,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -16473,9 +16554,6 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
@@ -16490,9 +16568,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
 	dir = 1
@@ -16647,6 +16722,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "gOA" = (
@@ -16778,7 +16856,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "gQN" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
@@ -16790,6 +16867,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "gQT" = (
@@ -16803,9 +16881,6 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/structure/cable{
@@ -16895,13 +16970,15 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "gTx" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -16918,6 +16995,7 @@
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "gUj" = (
@@ -16942,6 +17020,9 @@
 "gUD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -16971,6 +17052,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "gVz" = (
@@ -17001,6 +17083,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
+"gVY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "gWd" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -17030,28 +17123,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"gXm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/green/filled/corner/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "gXv" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
@@ -17062,11 +17136,11 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -17114,11 +17188,11 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -17153,6 +17227,18 @@
 	dir = 4
 	},
 /area/crew_quarters/dorms)
+"gZj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gZz" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
@@ -17233,6 +17319,7 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "hcl" = (
@@ -17256,6 +17343,10 @@
 /area/quartermaster/warehouse)
 "hdb" = (
 /obj/machinery/light,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "hdg" = (
@@ -17323,11 +17414,13 @@
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
 "hdN" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 1
+/obj/machinery/conveyor_switch/oneway{
+	dir = 8;
+	id = "garbage";
+	name = "disposal conveyor"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/structure/railing{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
@@ -17494,12 +17587,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"hjG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "hjU" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -17529,6 +17616,9 @@
 	},
 /obj/item/kirbyplants/random,
 /obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/library)
 "hkJ" = (
@@ -17607,10 +17697,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness)
+"hmw" = (
+/obj/structure/grille,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "hmE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -17682,7 +17774,6 @@
 	dir = 4
 	},
 /obj/item/radio/intercom{
-	dir = 2;
 	pixel_y = -28
 	},
 /obj/structure/cable{
@@ -17760,7 +17851,6 @@
 /obj/machinery/ntnet_relay,
 /obj/machinery/power/apc{
 	areastring = "/area/tcommsat/server";
-	dir = 2;
 	name = "Telecomms Servers APC";
 	pixel_y = -23
 	},
@@ -17769,14 +17859,20 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"hoD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction/flip,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hoL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
@@ -17805,6 +17901,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -17881,6 +17980,9 @@
 	name = "Psychiatrists office";
 	req_access_txt = "5"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/medical/psych)
 "hqF" = (
@@ -17919,6 +18021,11 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"hrC" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "hrW" = (
 /obj/structure/sign/departments/science{
 	pixel_y = 32
@@ -17933,6 +18040,9 @@
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 9
 	},
+/obj/machinery/disposal/bin{
+	name = "sample disposal unit"
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "hsh" = (
@@ -17940,6 +18050,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/grille/broken,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "hst" = (
@@ -17961,12 +18074,12 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "hte" = (
@@ -17979,6 +18092,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "hth" = (
@@ -17988,6 +18104,33 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/fore)
+"htA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
+"htP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hub" = (
 /turf/closed/wall/r_wall,
 /area/security/prison)
@@ -18023,6 +18166,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -18055,6 +18199,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -18097,7 +18244,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "hwt" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -18109,6 +18255,7 @@
 	req_access_txt = null;
 	req_one_access_txt = "28;35"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "hwv" = (
@@ -18189,9 +18336,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
@@ -18264,9 +18408,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -18300,6 +18441,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
@@ -18341,6 +18485,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "hAR" = (
@@ -18350,8 +18495,7 @@
 "hBm" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks/beer{
-	dir = 4;
-	icon_state = "booze_dispenser"
+	dir = 4
 	},
 /obj/structure/sign/poster/official/high_class_martini{
 	pixel_x = -32
@@ -18408,8 +18552,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Telecomms - Hallway North";
-	dir = 4;
-	network = list("ss13")
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -18452,18 +18595,16 @@
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hDH" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
+/obj/machinery/disposal/bin/tagger,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -18488,9 +18629,6 @@
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
 "hDR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -18521,9 +18659,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
 "hEb" = (
@@ -18553,9 +18689,11 @@
 /turf/open/water/safe,
 /area/hydroponics/garden)
 "hFw" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -18588,6 +18726,9 @@
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "hFZ" = (
@@ -18596,6 +18737,9 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -18625,26 +18769,19 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
 /obj/machinery/light_switch{
 	pixel_x = 24
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "hGO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"hHk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/kitchen)
 "hHm" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
@@ -18699,14 +18836,14 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "hIy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -18773,18 +18910,6 @@
 /obj/effect/landmark/stationroom/maint/fivexthree,
 /turf/template_noop,
 /area/maintenance/port/aft)
-"hJf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "hJy" = (
 /obj/machinery/computer/pandemic,
 /obj/machinery/light,
@@ -18794,13 +18919,24 @@
 /obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"hJA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "hJD" = (
 /obj/machinery/vending/clothing,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "hJN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
@@ -18811,8 +18947,7 @@
 /area/chapel/office)
 "hJO" = (
 /obj/machinery/computer/shuttle/labor{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /obj/machinery/airalarm{
 	dir = 1;
@@ -18858,6 +18993,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"hLg" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "hLr" = (
 /obj/structure/table/wood,
 /obj/effect/landmark/event_spawn,
@@ -18870,9 +19013,7 @@
 "hLG" = (
 /obj/machinery/washing_machine,
 /obj/machinery/camera{
-	c_tag = "Civilian - Dorm Laundry Room";
-	dir = 2;
-	network = list("ss13")
+	c_tag = "Civilian - Dorm Laundry Room"
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
@@ -18918,6 +19059,12 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/virology)
+"hMX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "hNi" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=RIGHTTOP";
@@ -18938,15 +19085,21 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"hNn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "hNs" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -19008,7 +19161,6 @@
 /obj/item/clothing/mask/breath,
 /obj/machinery/power/apc{
 	areastring = "/area/medical/genetics/cloning";
-	dir = 2;
 	name = "Cloning Lab APC";
 	pixel_y = -23
 	},
@@ -19121,6 +19273,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/stairs/goon/wood_stairs_middle,
 /area/tcommsat/computer)
 "hSE" = (
@@ -19203,7 +19356,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -19243,8 +19395,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Library Main 1";
-	dir = 8;
-	network = list("ss13")
+	dir = 8
 	},
 /obj/machinery/light_switch{
 	pixel_x = 24
@@ -19307,7 +19458,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
 	dir = 8
 	},
@@ -19321,13 +19471,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1;
-	sortType = 3
-	},
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -19337,9 +19486,6 @@
 "hXY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
@@ -19389,9 +19535,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/starboard";
 	dir = 4;
@@ -19400,6 +19543,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -19418,9 +19564,6 @@
 "hZJ" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/assistant,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
 "hZY" = (
@@ -19450,11 +19593,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -19469,9 +19612,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -19498,9 +19638,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -19579,7 +19716,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -19598,7 +19734,6 @@
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "idc" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
@@ -19610,6 +19745,7 @@
 /obj/vehicle/ridden/wheelchair{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "idk" = (
@@ -19618,8 +19754,11 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "idl" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/railing/corner{
 	dir = 4
+	},
+/obj/structure/railing/corner{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -19648,6 +19787,15 @@
 "iei" = (
 /turf/closed/wall,
 /area/storage/tools)
+"iey" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ifi" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
@@ -19662,6 +19810,10 @@
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/mail_sorting/science/robotics,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ifz" = (
@@ -19699,8 +19851,7 @@
 /area/maintenance/aft)
 "igP" = (
 /obj/machinery/computer/security/labor{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -19711,6 +19862,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "ihh" = (
@@ -19733,6 +19885,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "iii" = (
@@ -19758,13 +19911,13 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "ijk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -19790,9 +19943,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "ijQ" = (
@@ -19865,6 +20016,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "ilD" = (
@@ -19913,7 +20067,6 @@
 /obj/machinery/button/door{
 	id = "podescape";
 	name = "Pod Bay Control";
-	normaldoorcontrol = 0;
 	pixel_x = 8;
 	pixel_y = 24
 	},
@@ -19931,14 +20084,14 @@
 /area/crew_quarters/theatre)
 "imG" = (
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
 	dir = 5
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -19954,12 +20107,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "inc" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "garbage"
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 10
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbage"
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -19987,22 +20140,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"inC" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/mail_sorting/science/research,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "inM" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
-"iof" = (
-/obj/effect/turf_decal/trimline/white/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "iop" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -20121,6 +20274,12 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"iqG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "iqL" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -20147,6 +20306,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "irf" = (
@@ -20166,6 +20326,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"isB" = (
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "isK" = (
 /obj/item/circuitboard/machine/generator,
 /obj/structure/frame/machine,
@@ -20183,7 +20352,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -20233,6 +20401,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"iuY" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "6;12;50"
+	},
+/turf/open/floor/plating,
+/area/security/detectives_office)
 "ivd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20241,10 +20416,16 @@
 /area/crew_quarters/kitchen)
 "ivq" = (
 /obj/machinery/conveyor{
-	dir = 4;
-	id = "garbage"
+	id = "garbage";
+	name = " recycler conveyor belt";
+	dir = 4
 	},
-/obj/machinery/recycler,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "ivt" = (
@@ -20307,16 +20488,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"ixn" = (
-/obj/structure/chair/stool,
-/obj/effect/landmark/start/assistant,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/carpet/purple,
-/area/chapel/main)
 "ixs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -20367,7 +20543,6 @@
 	pixel_y = 7
 	},
 /obj/item/flashlight/lamp/green{
-	light_on = 0;
 	pixel_x = 6;
 	pixel_y = 6
 	},
@@ -20404,9 +20579,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -20500,9 +20672,6 @@
 /obj/machinery/door/airlock{
 	name = "Theatre Backstage";
 	req_access_txt = "46"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -20604,7 +20773,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "iEu" = (
-/obj/machinery/disposal/bin,
+/obj/machinery/disposal/bin/tagger,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
@@ -20625,6 +20794,13 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/storage/art)
+"iEG" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "iEQ" = (
 /turf/closed/wall/r_wall,
 /area/security/interrogation)
@@ -20679,6 +20855,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "iGX" = (
@@ -20706,6 +20885,13 @@
 	dir = 8
 	},
 /area/chapel/main)
+"iIo" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "iIy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20718,13 +20904,15 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 2
+	},
+/obj/effect/mapping_helpers/mail_sorting/security/general,
+/obj/effect/mapping_helpers/mail_sorting/security/hos_office,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "iIH" = (
@@ -20739,15 +20927,6 @@
 "iIJ" = (
 /turf/open/floor/plasteel/stairs/goon/wood_stairs_wide,
 /area/tcommsat/computer)
-"iIL" = (
-/obj/effect/turf_decal/trimline/green/filled/line/lower{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "iIS" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -20839,14 +21018,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"iLc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
 "iLy" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
@@ -20889,6 +21065,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "iMb" = (
@@ -20928,9 +21108,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
+/obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "iMN" = (
@@ -21018,9 +21196,6 @@
 	},
 /area/space/nearstation)
 "iOj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access";
 	req_access_txt = "47"
@@ -21033,6 +21208,9 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -21061,7 +21239,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -21122,9 +21299,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "iQu" = (
@@ -21185,8 +21360,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Quartermaster's Office";
-	dir = 4;
-	network = list("ss13")
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 9
@@ -21239,15 +21413,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"iTk" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "iTt" = (
 /obj/item/wrench/medical,
 /turf/open/floor/plating{
@@ -21353,6 +21518,9 @@
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "iVj" = (
@@ -21365,14 +21533,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "0"
-	},
+/obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -21386,9 +21555,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 4
@@ -21412,6 +21578,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "iWz" = (
@@ -21447,6 +21614,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "iXh" = (
@@ -21471,8 +21641,7 @@
 /area/maintenance/port/fore)
 "iXv" = (
 /obj/machinery/computer/atmos_sim{
-	dir = 8;
-	mode = 1
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
@@ -21537,9 +21706,6 @@
 /area/engine/atmos)
 "iYU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
 	},
@@ -21604,7 +21770,6 @@
 	dir = 1
 	},
 /obj/machinery/button/door{
-	dir = 2;
 	id = "QMLoaddoor";
 	layer = 4;
 	name = "Loading Doors";
@@ -21612,8 +21777,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/camera{
-	c_tag = "Cargo - Docking Bay North";
-	network = list("ss13")
+	c_tag = "Cargo - Docking Bay North"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -21647,6 +21811,18 @@
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"jcb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jcf" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/structure/cable/orange{
@@ -21658,6 +21834,11 @@
 /obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"jcu" = (
+/obj/effect/spawner/lootdrop/organ_spawner,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "jcZ" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
@@ -21681,9 +21862,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -21748,15 +21926,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"jes" = (
-/obj/structure/chair/stool,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel/chapel{
-	dir = 1
-	},
-/area/chapel/main)
 "jex" = (
 /obj/machinery/power/smes/fullycharged,
 /obj/structure/cable{
@@ -21772,7 +21941,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "jfb" = (
@@ -21796,6 +21964,12 @@
 	pixel_y = -10;
 	req_access_txt = "55"
 	},
+/obj/machinery/disposal/bin{
+	name = "sample disposal unit"
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "jfm" = (
@@ -21814,6 +21988,9 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -21845,21 +22022,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"jgd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "jgg" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Server Room";
@@ -21926,9 +22088,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
@@ -21949,6 +22108,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "jin" = (
@@ -21957,6 +22119,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"jix" = (
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "jiF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -21974,6 +22147,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "jiI" = (
@@ -22008,6 +22185,9 @@
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "jiP" = (
@@ -22040,10 +22220,10 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "jjg" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "jjD" = (
@@ -22051,6 +22231,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/corner,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "jjV" = (
@@ -22078,6 +22259,9 @@
 "jkK" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "jkL" = (
@@ -22171,9 +22355,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -22232,9 +22413,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
-/obj/structure/disposalpipe/junction/flip,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -22253,6 +22436,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
@@ -22279,6 +22465,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "jol" = (
@@ -22410,7 +22597,6 @@
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/chief";
-	dir = 2;
 	name = "Chief Engineer's Office APC";
 	pixel_y = -23
 	},
@@ -22465,9 +22651,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
@@ -22476,6 +22659,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -22524,12 +22710,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"jtH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "jtW" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -22563,11 +22743,8 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "jvg" = (
@@ -22603,6 +22780,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "jwl" = (
@@ -22631,6 +22811,9 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -22687,6 +22870,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "jyj" = (
@@ -22709,12 +22895,6 @@
 	},
 /turf/open/floor/catwalk_floor/telecomms,
 /area/ai_monitored/turret_protected/ai)
-"jyr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal)
 "jyB" = (
 /turf/closed/wall,
 /area/maintenance/port)
@@ -22810,6 +22990,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "jAC" = (
@@ -22882,15 +23065,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "jBC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "jBL" = (
@@ -22902,9 +23083,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -22947,7 +23125,6 @@
 "jCt" = (
 /obj/machinery/camera{
 	c_tag = "Research - Server Room";
-	dir = 2;
 	network = list("ss13","Research")
 	},
 /obj/machinery/airalarm/server{
@@ -22962,6 +23139,12 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/science/server)
+"jCD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "jCJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -22973,10 +23156,16 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "jCN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -23010,6 +23199,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "jDO" = (
@@ -23017,7 +23209,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -23047,9 +23238,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -23063,6 +23251,9 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -23103,9 +23294,7 @@
 /area/library)
 "jEs" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip,
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
@@ -23130,11 +23319,11 @@
 /obj/effect/turf_decal/pool{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -23146,9 +23335,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -23172,8 +23358,7 @@
 /area/quartermaster/storage)
 "jFz" = (
 /obj/structure/particle_accelerator/fuel_chamber{
-	dir = 1;
-	icon_state = "fuel_chamber"
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -23239,11 +23424,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"jHB" = (
-/obj/structure/plasticflaps/opaque,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "jHI" = (
 /obj/structure/chair{
 	dir = 1
@@ -23258,21 +23438,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"jIe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "jIw" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
@@ -23402,14 +23567,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -23450,9 +23615,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "jMl" = (
@@ -23467,6 +23629,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction/yjunction{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23521,6 +23686,7 @@
 "jNk" = (
 /obj/structure/table/wood,
 /obj/item/coin/silver,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "jND" = (
@@ -23551,10 +23717,10 @@
 /area/maintenance/port/fore)
 "jNU" = (
 /obj/machinery/disposal/bin,
+/obj/machinery/light,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/machinery/light,
 /turf/open/floor/wood,
 /area/library)
 "jOp" = (
@@ -23582,14 +23748,11 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"jOP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "jPa" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -23632,7 +23795,6 @@
 /obj/structure/closet/radiation,
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Main 4";
-	dir = 2;
 	network = list("ss13","Atmospherics")
 	},
 /turf/open/floor/plasteel,
@@ -23683,6 +23845,18 @@
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"jQd" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "jQg" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -23716,6 +23890,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "jQK" = (
@@ -23735,6 +23912,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "jQV" = (
@@ -23753,6 +23931,9 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
 	name = "bridge blast door"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -23799,10 +23980,14 @@
 	pixel_x = -9;
 	pixel_y = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "jSI" = (
 /obj/item/chair/stool,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "jTk" = (
@@ -23820,6 +24005,9 @@
 "jTp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -23892,9 +24080,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -23915,7 +24100,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "jVt" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
@@ -24002,21 +24186,10 @@
 "jWo" = (
 /obj/machinery/camera{
 	c_tag = "Research - Xenobiology Cell 3";
-	dir = 2;
 	network = list("ss13","Research","Xenobiology")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"jWs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/space/basic,
-/area/solar/port/fore)
 "jWt" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
@@ -24034,6 +24207,11 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"jYe" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "jYf" = (
 /obj/machinery/light{
 	dir = 8
@@ -24041,15 +24219,11 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "jYh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/holopad,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "jYs" = (
@@ -24059,28 +24233,23 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "jYA" = (
+/obj/structure/window/reinforced/spawner/east,
 /obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel/broken/two,
+/turf/open/floor/plasteel/broken,
 /area/maintenance/disposal)
 "jYC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -24130,7 +24299,6 @@
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "jZn" = (
@@ -24183,7 +24351,6 @@
 /obj/machinery/requests_console{
 	department = "AI";
 	departmentType = 5;
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/circuit/telecomms/server,
@@ -24270,6 +24437,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "kbQ" = (
@@ -24299,9 +24469,6 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "kct" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 5
 	},
@@ -24310,6 +24477,10 @@
 "kcC" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder,
+/obj/item/storage/secure/safe{
+	pixel_y = -28;
+	pixel_x = 6
+	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
 "kcX" = (
@@ -24326,12 +24497,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/mail_sorting/supply/disposals,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "kdf" = (
@@ -24352,6 +24524,24 @@
 /obj/machinery/nanite_program_hub,
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
+"kdA" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
+/obj/machinery/door/window{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "kes" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -24481,9 +24671,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "kgz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access";
 	req_access_txt = "47"
@@ -24503,6 +24690,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "kgD" = (
@@ -24517,10 +24707,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"khg" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/crew_quarters/kitchen)
 "khu" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
@@ -24532,9 +24718,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "kib" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
@@ -24543,12 +24726,6 @@
 "kie" = (
 /turf/open/floor/plating,
 /area/engine/engineering)
-"kih" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "kin" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
@@ -24594,6 +24771,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "kjs" = (
@@ -24693,9 +24871,6 @@
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "klw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
 	dir = 1
 	},
@@ -24705,14 +24880,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "klx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -24724,9 +24899,6 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/fore)
 "klG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access";
 	req_access_txt = "47"
@@ -24788,6 +24960,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/tcommsat/computer)
 "kmu" = (
@@ -24838,6 +25011,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
+"knu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "knF" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
@@ -24961,15 +25140,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"ksh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "ksm" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -24988,13 +25158,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/interrogation)
-"ksq" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "kst" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/circuit,
@@ -25026,6 +25189,9 @@
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "ktA" = (
@@ -25095,7 +25261,6 @@
 "kvv" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/cmo";
-	dir = 2;
 	name = "CMO's Office APC";
 	pixel_y = -23
 	},
@@ -25110,6 +25275,8 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "kwi" = (
@@ -25145,7 +25312,6 @@
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
 	c_tag = "Secure - External Telecomm Sat South";
-	dir = 2;
 	network = list("Telecom")
 	},
 /turf/open/space/basic,
@@ -25156,7 +25322,6 @@
 /area/library)
 "kxJ" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "NTMSLoad2";
 	name = "on ramp"
 	},
@@ -25201,8 +25366,7 @@
 "kyZ" = (
 /obj/machinery/modular_computer/console/preset/engineering,
 /obj/machinery/camera{
-	c_tag = "Bridge - Main 3";
-	dir = 2
+	c_tag = "Bridge - Main 3"
 	},
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 1
@@ -25318,6 +25482,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"kDr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/junction/flip,
+/turf/open/floor/wood,
+/area/crew_quarters/kitchen)
 "kDP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
@@ -25347,9 +25517,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "kEO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
@@ -25361,9 +25528,6 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/structure/cable{
@@ -25496,6 +25660,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "kJg" = (
@@ -25508,11 +25675,12 @@
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
 "kJE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/wood,
 /area/library)
 "kJQ" = (
@@ -25533,6 +25701,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "kLb" = (
@@ -25565,11 +25734,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -25617,10 +25782,10 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "kNi" = (
@@ -25650,6 +25815,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/lawoffice)
 "kNt" = (
@@ -25669,7 +25836,6 @@
 "kNH" = (
 /obj/machinery/camera{
 	c_tag = "Research - Experimentor Bay";
-	dir = 2;
 	network = list("ss13","Research")
 	},
 /turf/open/floor/engine,
@@ -25715,6 +25881,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "kOP" = (
@@ -25731,9 +25900,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "kPh" = (
@@ -25755,11 +25922,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -25767,7 +25934,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment{
-	dir = 9
+	dir = 10
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -25777,6 +25944,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
@@ -25817,6 +25987,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 10
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/maintenance/solars/port/fore)
 "kQk" = (
@@ -25825,8 +25996,7 @@
 /area/maintenance/aft)
 "kQo" = (
 /obj/machinery/camera{
-	c_tag = "Bridge - AI Upload 2";
-	dir = 2
+	c_tag = "Bridge - AI Upload 2"
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -25851,15 +26021,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/freezer,
 /area/maintenance/aft)
-"kQx" = (
-/obj/machinery/conveyor{
-	id = "garbage"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "kQR" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -25868,9 +26029,6 @@
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
 "kRb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -25878,6 +26036,9 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -25919,6 +26080,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "kSm" = (
@@ -25943,6 +26107,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -25999,7 +26166,6 @@
 "kUg" = (
 /obj/machinery/power/apc{
 	areastring = "/area/escapepodbay";
-	dir = 2;
 	name = "Podbay APC";
 	pixel_y = -23
 	},
@@ -26193,9 +26359,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "kYn" = (
@@ -26272,9 +26436,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -26339,8 +26500,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 2
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -26353,6 +26514,9 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -26463,7 +26627,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -26474,6 +26637,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/janitor)
 "lex" = (
@@ -26500,23 +26664,31 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/grille/broken,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "lfp" = (
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"lfB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "lfL" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -26581,9 +26753,6 @@
 /area/engine/atmos)
 "lgO" = (
 /obj/structure/chair/stool,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
 "lgZ" = (
@@ -26613,7 +26782,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "lhK" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
 	req_access_txt = "63"
@@ -26661,9 +26829,7 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
 	dir = 8
 	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "liC" = (
@@ -26676,23 +26842,12 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "liD" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"lja" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "ljf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/cafeteria,
@@ -26813,12 +26968,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"lmI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/lab)
 "lmJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -26829,9 +26978,6 @@
 /turf/open/floor/carpet/green,
 /area/quartermaster/warehouse)
 "lnf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
@@ -26840,6 +26986,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -26860,6 +27009,16 @@
 /obj/item/folder/red,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"lnV" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "lnZ" = (
 /obj/structure/closet/secure_closet/bar{
 	req_access_txt = "25"
@@ -26895,9 +27054,6 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "lot" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -26923,6 +27079,12 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
+"lpu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "lpx" = (
 /obj/machinery/door/window/eastright{
 	name = "Test Chamber";
@@ -27020,6 +27182,19 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
+"lqI" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/kitchen)
 "lrh" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -27122,6 +27297,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/tcommsat/computer)
 "lty" = (
@@ -27288,7 +27464,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "lym" = (
@@ -27307,22 +27482,18 @@
 /area/maintenance/starboard)
 "lyY" = (
 /obj/effect/landmark/blobstart,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"lzf" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
+"lzc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1;
-	sortType = 19
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/kitchen)
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "lzm" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -27332,7 +27503,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medical - Front Lobby";
-	dir = 2;
 	network = list("ss13","Medical")
 	},
 /turf/open/floor/plasteel/white,
@@ -27381,7 +27551,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27400,6 +27569,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27441,8 +27613,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "lBI" = (
 /obj/structure/bodycontainer/morgue{
-	dir = 1;
-	icon_state = "morgue1"
+	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
@@ -27564,25 +27735,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "lEa" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"lEf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 2;
-	sortType = 29
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -27611,6 +27770,9 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "lEQ" = (
@@ -27622,7 +27784,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
 "lET" = (
@@ -27637,13 +27798,13 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "lFB" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "garbage"
+/obj/machinery/conveyor/inverted{
+	id = "garbage";
+	name = "recycler conveyor belt"
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/machinery/door/poddoor/preopen{
+	id = "Disposal Exit";
+	name = "disposal exit vent"
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -27746,9 +27907,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -27761,9 +27919,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -27790,11 +27945,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/structure/sign/departments/evac{
 	pixel_y = 32
@@ -27892,12 +28043,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port)
-"lJF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "lJG" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -27935,6 +28080,9 @@
 "lLh" = (
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -28017,6 +28165,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "lNs" = (
@@ -28055,6 +28206,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "lNP" = (
@@ -28084,6 +28238,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "lOx" = (
@@ -28096,7 +28253,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -28111,6 +28268,21 @@
 "lOT" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
+"lPe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "lPi" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -28162,13 +28334,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"lQZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "lRa" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -28188,9 +28353,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
@@ -28251,9 +28413,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "lSn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
@@ -28270,6 +28429,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "lSz" = (
@@ -28277,10 +28439,6 @@
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "lSS" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1;
-	sortType = 27
-	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
 	},
@@ -28296,14 +28454,15 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/mail_sorting/medbay/general,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "lTg" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -28346,6 +28505,9 @@
 "lTH" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -28485,7 +28647,7 @@
 /turf/open/floor/wood,
 /area/hallway/primary/central)
 "lXC" = (
-/obj/machinery/disposal/bin,
+/obj/machinery/disposal/bin/tagger,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
@@ -28554,6 +28716,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"lZn" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/hydroponics)
 "lZq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -28572,6 +28739,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -28606,6 +28776,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"mas" = (
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "maw" = (
 /obj/machinery/light,
 /obj/machinery/light_switch{
@@ -28619,6 +28796,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"maD" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "maH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -28631,21 +28813,6 @@
 	},
 /turf/open/floor/catwalk_floor/telecomms,
 /area/ai_monitored/turret_protected/ai)
-"maL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "mbt" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
@@ -28680,11 +28847,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -28750,7 +28917,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medical - Main";
-	dir = 2;
 	network = list("ss13","Medical")
 	},
 /turf/open/floor/plasteel/white,
@@ -28768,7 +28934,9 @@
 	},
 /mob/living/simple_animal/parrot/Poly,
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "meL" = (
@@ -28784,11 +28952,11 @@
 /obj/structure/disposaloutlet{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	layer = 2.9
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
@@ -28799,9 +28967,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /turf/open/floor/plasteel,
@@ -28873,6 +29039,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "mgl" = (
@@ -28899,7 +29066,6 @@
 "mgV" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Distro Loop";
-	dir = 2;
 	network = list("ss13","Atmospherics")
 	},
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -28936,6 +29102,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
@@ -28983,6 +29152,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
 "mjn" = (
@@ -28996,9 +29169,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mjx" = (
@@ -29010,6 +29180,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
@@ -29026,10 +29199,24 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"mka" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "mki" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
-	req_access_txt = "0";
 	req_one_access_txt = "31;48"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -29041,7 +29228,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
@@ -29068,6 +29254,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"mkM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "mln" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/light{
@@ -29199,11 +29400,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -29229,7 +29430,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "moA" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
@@ -29281,6 +29481,13 @@
 	},
 /turf/open/floor/grass,
 /area/medical/genetics)
+"mpR" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "mqb" = (
 /obj/structure/bed/dogbed/ian,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -29438,9 +29645,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "msR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "msT" = (
@@ -29486,6 +29691,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "mtD" = (
@@ -29520,9 +29728,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -29543,14 +29748,9 @@
 	id = "Biohazard";
 	name = "biohazard containment door"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/science/research)
-"muu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/courtroom)
 "muC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -29574,13 +29774,13 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 20
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/mail_sorting/service/kitchen,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mvu" = (
@@ -29591,7 +29791,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "mvx" = (
@@ -29678,8 +29877,7 @@
 /area/library)
 "mwX" = (
 /obj/machinery/computer/telecomms/server{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
@@ -29697,6 +29895,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -29732,21 +29933,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"mye" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "myf" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -29822,9 +30008,6 @@
 /area/maintenance/port/aft)
 "mAD" = (
 /obj/effect/landmark/event_spawn,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
 "mAK" = (
@@ -29858,9 +30041,7 @@
 "mBf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "mBt" = (
@@ -29893,12 +30074,6 @@
 "mBL" = (
 /obj/structure/table,
 /obj/item/weldingtool,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"mCs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "mCF" = (
@@ -29992,12 +30167,11 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"mEX" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
 "mFd" = (
 /obj/machinery/vending/sustenance,
 /obj/effect/decal/cleanable/dirt,
@@ -30013,6 +30187,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "mFx" = (
@@ -30031,9 +30206,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "mGr" = (
@@ -30051,6 +30223,18 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
+"mGJ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "mGP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -30086,6 +30270,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "mHy" = (
@@ -30147,7 +30332,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
-/obj/structure/disposalpipe/junction/flip,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -30156,9 +30340,6 @@
 "mIo" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -30191,6 +30372,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "mJe" = (
@@ -30199,6 +30383,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -30216,13 +30403,13 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "mJi" = (
@@ -30314,8 +30501,7 @@
 /area/quartermaster/storage)
 "mLX" = (
 /obj/machinery/computer/cargo/request{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 5
@@ -30412,6 +30598,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "mPx" = (
@@ -30445,6 +30632,9 @@
 "mPR" = (
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -30486,7 +30676,6 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 5
 	},
 /obj/machinery/light{
@@ -30504,7 +30693,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/junction{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -30530,11 +30719,11 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -30543,6 +30732,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -30570,12 +30762,6 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"mRz" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "mRB" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -30634,6 +30820,10 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
+"mSi" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "mSs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -30668,7 +30858,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -30679,6 +30868,7 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "mTG" = (
@@ -30694,13 +30884,15 @@
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "mTO" = (
 /obj/machinery/camera{
 	c_tag = "Psychiatrist Office";
-	dir = 4;
-	network = list("ss13")
+	dir = 4
 	},
 /obj/machinery/light_switch{
 	pixel_x = -23;
@@ -30790,6 +30982,9 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "mUP" = (
@@ -30802,7 +30997,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "mVo" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
@@ -30938,9 +31132,6 @@
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/fore)
 "mYm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
@@ -31013,41 +31204,42 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "mZS" = (
-/obj/structure/railing{
+/obj/machinery/button/massdriver{
+	id = "trash";
+	pixel_x = 1;
+	pixel_y = -24
+	},
+/obj/machinery/button/door{
+	id = "Disposal Exit";
+	name = "Disposal Vent Control";
+	pixel_x = -8;
+	pixel_y = -23;
+	req_access_txt = "12"
+	},
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/railing/corner{
 	dir = 8
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/structure/railing/corner{
+	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel/burnt/two,
+/turf/open/floor/plasteel/broken/three,
 /area/maintenance/disposal)
 "mZT" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Office";
-	req_access_txt = "50"
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "mZY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/mail_sorting/science/genetics,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "nam" = (
@@ -31102,6 +31294,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "naJ" = (
@@ -31120,18 +31315,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "naO" = (
-/obj/machinery/light/small/built{
-	dir = 2
-	},
+/obj/machinery/light/small/built,
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
 "naS" = (
@@ -31143,9 +31336,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "naU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
@@ -31185,9 +31375,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31243,9 +31430,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/wood,
 /area/hallway/primary/central)
@@ -31273,7 +31462,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /obj/structure/closet/emcloset,
@@ -31284,9 +31472,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -31369,19 +31554,16 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "ngA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ngH" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -31391,12 +31573,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "nha" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
@@ -31429,15 +31609,11 @@
 /area/ai_monitored/turret_protected/ai_upload_foyer)
 "nhn" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "nhR" = (
 /obj/machinery/requests_console{
 	department = "Tool Storage";
-	departmentType = 0;
 	pixel_x = -30
 	},
 /turf/open/floor/plasteel,
@@ -31447,7 +31623,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -31474,6 +31649,9 @@
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 10
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "nio" = (
@@ -31483,12 +31661,10 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "niG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
 "niP" = (
@@ -31504,15 +31680,14 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	sortType = 15
-	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -31557,6 +31732,9 @@
 	c_tag = "Gravity Generator Hall";
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "njB" = (
@@ -31575,6 +31753,9 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
 "njL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -31594,9 +31775,6 @@
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "nkH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
@@ -31625,9 +31803,6 @@
 "nkY" = (
 /obj/structure/sign/departments/evac{
 	pixel_y = 32
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -31728,7 +31903,6 @@
 	},
 /obj/structure/sign/directions/supply{
 	dir = 1;
-	icon_state = "direction_supply";
 	pixel_y = 42
 	},
 /obj/structure/sign/directions/command{
@@ -31783,11 +31957,11 @@
 /turf/open/floor/wood,
 /area/library)
 "nnd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "nne" = (
@@ -31869,6 +32043,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "npE" = (
@@ -31901,6 +32076,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "nrc" = (
@@ -31923,17 +32099,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"nrN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "nrZ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -31973,7 +32138,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -32030,15 +32194,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/entry)
-"nvb" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nvl" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/airalarm{
@@ -32073,8 +32228,7 @@
 /obj/machinery/power/solar_control{
 	dir = 8;
 	id = "aftstarboard";
-	name = "Starboard Quarter Solar Control";
-	track = 0
+	name = "Starboard Quarter Solar Control"
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -32090,6 +32244,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -32158,14 +32315,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko{
 	pixel_x = -6;
 	pixel_y = 6
 	},
 /obj/structure/table/glass,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "nxU" = (
@@ -32193,6 +32350,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"nzh" = (
+/obj/structure/grille/broken,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "nzq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -32260,9 +32422,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -32323,9 +32482,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -32361,8 +32517,17 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"nCP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "nCU" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 4
@@ -32398,6 +32563,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "nDz" = (
@@ -32458,13 +32624,13 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "nEU" = (
@@ -32489,7 +32655,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
@@ -32524,6 +32689,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "nGg" = (
@@ -32535,9 +32703,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
@@ -32603,9 +32768,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
@@ -32667,11 +32829,11 @@
 	location = "BOTTOMRIGHT";
 	name = "navigation beacon (BOTTOMRIGHT)"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -32687,9 +32849,6 @@
 /area/escapepodbay)
 "nIf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -32796,6 +32955,9 @@
 /area/security/main)
 "nJA" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "nJG" = (
@@ -32887,14 +33049,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"nKY" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "nKZ" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -32912,11 +33066,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -32994,9 +33148,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "nMu" = (
@@ -33015,9 +33166,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "nMK" = (
@@ -33030,15 +33178,22 @@
 /obj/machinery/light,
 /turf/open/floor/catwalk_floor/telecomms,
 /area/ai_monitored/secondarydatacore)
+"nMP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "nMR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "nMU" = (
@@ -33114,6 +33269,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "nOQ" = (
@@ -33126,10 +33284,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"nPK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "nPM" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/sign/warning/pods{
@@ -33143,6 +33297,17 @@
 "nQq" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"nQx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "nQy" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -33167,6 +33332,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
@@ -33226,7 +33394,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -33244,6 +33412,9 @@
 /area/maintenance/port/aft)
 "nSr" = (
 /obj/structure/grille,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "nSs" = (
@@ -33322,6 +33493,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "nUI" = (
@@ -33330,6 +33502,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "nUO" = (
@@ -33345,16 +33518,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"nVh" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
 "nVt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -33369,9 +33532,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "nVx" = (
@@ -33437,6 +33598,9 @@
 	pixel_x = 6;
 	pixel_y = 3
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/science/lab)
 "nWv" = (
@@ -33479,6 +33643,9 @@
 "nXP" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -33540,24 +33707,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/tcommsat/computer)
 "nZf" = (
-/obj/machinery/button/door{
-	id = "Disposal Exit";
-	name = "Disposal Vent Control";
-	pixel_x = -25;
-	pixel_y = 4;
-	req_access_txt = "12"
-	},
-/obj/machinery/button/massdriver{
-	id = "trash";
-	pixel_x = -26;
-	pixel_y = -6
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/machinery/conveyor{
+	id = "garbage";
+	name = " recycler conveyor belt";
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
@@ -33566,10 +33723,16 @@
 	pixel_y = 32
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 10
+	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"nZi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "nZt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -33580,14 +33743,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "nZN" = (
@@ -33630,12 +33791,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/landmark/start/station_engineer,
 /obj/structure/chair/stool{
 	pixel_y = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -33651,11 +33812,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "oaM" = (
 /obj/effect/landmark/start/clown,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
 "oaO" = (
@@ -33719,7 +33883,6 @@
 	dir = 8
 	},
 /obj/machinery/button/door{
-	dir = 2;
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
 	pixel_x = 24;
@@ -33771,6 +33934,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "oci" = (
@@ -33784,10 +33950,14 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ocw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "ocx" = (
@@ -33807,9 +33977,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
@@ -33825,6 +33992,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "odE" = (
@@ -33833,9 +34003,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
@@ -33900,6 +34068,9 @@
 /obj/machinery/door/poddoor/shutters{
 	id = "disposalshutters"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "ofh" = (
@@ -33936,9 +34107,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
 "ofy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/wood,
 /area/library)
 "ofN" = (
@@ -33951,6 +34120,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "ofQ" = (
@@ -33987,6 +34159,9 @@
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ogN" = (
@@ -34006,24 +34181,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
-"ogY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"ohe" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "packageSort2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/quartermaster/sorting)
 "ohE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -34106,6 +34263,7 @@
 /area/construction/mining/aux_base)
 "ojt" = (
 /obj/machinery/smartfridge/extract/preloaded,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "ojJ" = (
@@ -34182,7 +34340,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /obj/structure/closet/emcloset,
@@ -34256,15 +34413,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"ons" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/crew_quarters/kitchen)
 "onE" = (
 /obj/effect/landmark/event_spawn,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port)
 "onV" = (
@@ -34296,9 +34449,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "ooO" = (
@@ -34312,21 +34462,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/security/processing)
-"opf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 7
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "opl" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "opn" = (
@@ -34391,7 +34533,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Incinerator Main 1";
-	dir = 2;
 	network = list("ss13","Atmospherics")
 	},
 /turf/open/floor/plasteel,
@@ -34408,6 +34549,14 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"orT" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/sorting/mail,
+/obj/effect/mapping_helpers/mail_sorting/service/chapel,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "osb" = (
 /obj/structure/table,
 /obj/item/plant_analyzer,
@@ -34444,6 +34593,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/mail_sorting/medbay/virology,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "osF" = (
@@ -34462,6 +34615,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
@@ -34499,6 +34655,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "ouj" = (
@@ -34553,7 +34710,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Incinerator Access Hall";
-	dir = 2;
 	network = list("ss13","Atmospherics")
 	},
 /obj/machinery/airalarm{
@@ -34579,9 +34735,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -34611,8 +34764,7 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 8;
-	icon_state = "airlock_unres_helper"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -34626,9 +34778,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ovV" = (
@@ -34729,13 +34881,13 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "oyM" = (
 /obj/structure/chair/stool,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/chapel{
 	dir = 4
 	},
@@ -34851,9 +35003,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "oCS" = (
@@ -34901,7 +35051,6 @@
 "oDF" = (
 /obj/machinery/space_heater,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -34942,12 +35091,12 @@
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
 "oFh" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "oFD" = (
@@ -34985,9 +35134,6 @@
 /area/engine/atmos)
 "oGa" = (
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
 	dir = 10
 	},
@@ -35003,9 +35149,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "oGB" = (
@@ -35020,7 +35164,6 @@
 /area/engine/atmos)
 "oGK" = (
 /obj/machinery/door/window/westleft{
-	dir = 8;
 	name = "Monkey Pen";
 	req_access_txt = "9"
 	},
@@ -35046,9 +35189,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
 "oHa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Treatment";
 	req_access_txt = "5"
@@ -35070,8 +35210,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 8;
-	icon_state = "airlock_unres_helper"
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -35085,7 +35224,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Main 3";
-	dir = 2;
 	network = list("ss13","Atmospherics")
 	},
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -35132,6 +35270,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "oJi" = (
@@ -35152,15 +35293,15 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
 	name = "bridge blast door"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -35199,6 +35340,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "oKL" = (
@@ -35320,6 +35464,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "oNt" = (
@@ -35392,23 +35539,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "oOW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -35437,11 +35581,11 @@
 /area/crew_quarters/cryopods)
 "oPG" = (
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 10
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -35585,6 +35729,10 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -32
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
 "oSJ" = (
@@ -35600,9 +35748,6 @@
 /area/medical/genetics)
 "oUm" = (
 /obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
 "oUA" = (
@@ -35615,6 +35760,9 @@
 	pixel_x = -4;
 	pixel_y = 33;
 	req_access_txt = "25"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/bar)
@@ -35698,7 +35846,6 @@
 /area/security/courtroom)
 "oWP" = (
 /obj/docking_port/stationary/random{
-	dir = 1;
 	name = "lavaland";
 	shuttle_id = "pod_lavaland2"
 	},
@@ -35783,9 +35930,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "oYX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -35795,21 +35939,6 @@
 "oZu" = (
 /turf/closed/wall/r_wall,
 /area/storage/tech)
-"oZy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "pal" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/plasteel/showroomfloor,
@@ -35926,6 +36055,9 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/stripes/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "pdH" = (
@@ -35966,6 +36098,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "peD" = (
@@ -35977,6 +36112,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "peP" = (
@@ -35986,14 +36122,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
-"peT" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
 "pfl" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end,
 /turf/open/floor/plating/airless,
@@ -36019,9 +36147,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel,
@@ -36057,7 +36182,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -36126,8 +36250,7 @@
 /area/maintenance/disposal/incinerator)
 "pjJ" = (
 /obj/machinery/computer/med_data{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
@@ -36173,6 +36296,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "pkR" = (
@@ -36188,21 +36314,8 @@
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"plu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "plB" = (
 /obj/structure/closet/secure_closet/psych,
 /obj/machinery/light{
@@ -36245,8 +36358,7 @@
 /obj/machinery/lapvend,
 /obj/machinery/camera{
 	c_tag = "Cargo - Front Lobby";
-	dir = 4;
-	network = list("ss13")
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -36323,6 +36435,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "pom" = (
@@ -36345,9 +36458,6 @@
 /area/maintenance/fore)
 "poF" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "poH" = (
@@ -36402,11 +36512,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -36429,6 +36535,12 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
+"pqM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "pqQ" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -36505,6 +36617,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"prL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "prO" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large{
@@ -36540,6 +36667,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "psl" = (
@@ -36594,6 +36724,12 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
+"psI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/research)
 "psN" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -36645,9 +36781,7 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 2
-	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ptj" = (
@@ -36744,12 +36878,6 @@
 	icon_state = "damaged5"
 	},
 /area/space/nearstation)
-"pvV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
 "pww" = (
 /turf/closed/wall,
 /area/quartermaster/office)
@@ -36793,10 +36921,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"pxd" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "pxf" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable,
@@ -36819,14 +36943,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "pxv" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "garbage"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Disposal Exit";
-	name = "disposal exit vent"
-	},
+/obj/machinery/conveyor/inverted,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "pyc" = (
@@ -36836,9 +36953,6 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "pyk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
@@ -36874,10 +36988,10 @@
 /obj/effect/turf_decal/pool{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36890,8 +37004,7 @@
 /area/engine/engineering)
 "pze" = (
 /obj/machinery/computer/atmos_alert{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
@@ -36951,8 +37064,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Tool Storage";
-	dir = 4;
-	network = list("ss13")
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -37039,13 +37151,13 @@
 /area/maintenance/fore)
 "pCZ" = (
 /obj/effect/landmark/event_spawn,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -37090,6 +37202,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "pDO" = (
@@ -37102,13 +37215,13 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 2;
-	sortType = 15
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 2
+	},
+/obj/effect/mapping_helpers/mail_sorting/service/hop_office,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "pDR" = (
@@ -37180,6 +37293,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 2
+	},
+/obj/effect/mapping_helpers/mail_sorting/service/bar,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "pFo" = (
@@ -37208,6 +37325,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
+"pFO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "pFT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -37219,6 +37342,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "pGn" = (
@@ -37228,9 +37354,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
@@ -37279,6 +37402,9 @@
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "pHO" = (
@@ -37293,12 +37419,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	sortType = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -37415,6 +37540,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/tcommsat/computer)
 "pLt" = (
@@ -37445,7 +37571,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "pLU" = (
-/obj/effect/turf_decal/loading_area{
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37453,6 +37582,7 @@
 "pMc" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "pMf" = (
@@ -37532,7 +37662,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "pNq" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -37563,6 +37692,9 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "pNE" = (
@@ -37583,7 +37715,6 @@
 	dir = 1
 	},
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/white,
@@ -37597,7 +37728,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/button/door{
 	id = "kanyewest";
 	name = "Privacy Shutters";
@@ -37617,12 +37747,9 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"pOm" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/carpet/black,
-/area/crew_quarters/bar)
 "pOs" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "pOv" = (
@@ -37649,11 +37776,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "pOV" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "6;12;50"
 	},
 /obj/structure/cable{
@@ -37712,10 +37841,14 @@
 /turf/open/floor/carpet,
 /area/library)
 "pPE" = (
-/obj/structure/closet/l3closet/scientist,
-/obj/item/extinguisher,
 /obj/machinery/light_switch{
 	pixel_x = 24
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin/tagger{
+	name = "sample delivery unit"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -37748,6 +37881,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "pQN" = (
@@ -37776,6 +37912,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "pRm" = (
@@ -37801,12 +37940,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"pRu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "pRw" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/light{
@@ -37927,9 +38060,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
@@ -37941,6 +38071,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"pUi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/mail_sorting/service/theater,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "pUv" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable/yellow,
@@ -37971,6 +38117,15 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
+"pVT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "pWb" = (
 /turf/closed/wall/r_wall,
 /area/chapel/main)
@@ -37978,6 +38133,7 @@
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "pWC" = (
@@ -37999,13 +38155,13 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "pWK" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "pWL" = (
@@ -38030,9 +38186,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "pXj" = (
@@ -38110,8 +38264,7 @@
 /area/crew_quarters/fitness)
 "pYL" = (
 /obj/machinery/modular_computer/console/preset/command{
-	dir = 8;
-	icon_state = "console"
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
 	dir = 6
@@ -38171,9 +38324,9 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "pZP" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "qaj" = (
@@ -38183,9 +38336,6 @@
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -38217,11 +38367,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -38309,9 +38455,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "qcR" = (
@@ -38322,14 +38465,14 @@
 	dir = 4
 	},
 /obj/structure/table/wood,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/item/toy/cards/deck{
 	pixel_x = 2
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -38393,11 +38536,15 @@
 /obj/structure/disposaloutlet{
 	dir = 8
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /turf/open/floor/plating,
 /area/space/nearstation)
+"qeC" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
 "qeI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -38412,7 +38559,6 @@
 	name = "Bridge RC";
 	pixel_x = -30
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
 	dir = 8
 	},
@@ -38425,8 +38571,7 @@
 	req_access_txt = "5"
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	dir = 8;
-	icon_state = "airlock_unres_helper"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -38439,9 +38584,6 @@
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
@@ -38459,6 +38601,22 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
+"qfy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "qfT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -38521,6 +38679,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -38587,7 +38748,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 10
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -38598,6 +38759,10 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/mail_sorting/service/dormitories,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "qjh" = (
@@ -38621,6 +38786,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "qjj" = (
@@ -38634,7 +38802,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "qjp" = (
@@ -38693,6 +38860,7 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "qkO" = (
@@ -38712,9 +38880,6 @@
 "qla" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
@@ -38762,9 +38927,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -38783,6 +38945,9 @@
 	name = "disposals shutter control";
 	pixel_x = -5;
 	pixel_y = -25
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -38842,8 +39007,7 @@
 "qoh" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks{
-	dir = 4;
-	icon_state = "soda_dispenser"
+	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Service - Bar Counter";
@@ -38890,6 +39054,9 @@
 /obj/item/target/clown,
 /obj/item/target/syndicate,
 /obj/item/target/syndicate,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "qpr" = (
@@ -38943,8 +39110,24 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"qpL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "qqe" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -39005,6 +39188,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/tcommsat/computer)
 "qqY" = (
@@ -39093,9 +39277,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "qsT" = (
@@ -39117,6 +39299,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "qtm" = (
@@ -39195,6 +39380,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "qvf" = (
@@ -39207,13 +39395,11 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "qvg" = (
@@ -39250,7 +39436,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Starboard Aux Solars Access";
-	dir = 2;
 	network = list("ss13","Engineering")
 	},
 /turf/open/floor/plating,
@@ -39306,10 +39491,10 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "qxi" = (
@@ -39318,7 +39503,6 @@
 "qxv" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
-	req_access_txt = "0";
 	req_one_access_txt = "31;48"
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
@@ -39461,36 +39645,28 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 2
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "qAF" = (
-/obj/machinery/mineral/stacking_machine{
-	input_dir = 4;
-	output_dir = 4;
-	stack_amt = 10
-	},
+/obj/machinery/mineral/stacking_machine,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "qAG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
 "qAT" = (
@@ -39566,9 +39742,6 @@
 /turf/open/floor/catwalk_floor/telecomms,
 /area/ai_monitored/secondarydatacore)
 "qEb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
@@ -39656,6 +39829,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/morgue)
+"qFM" = (
+/obj/structure/grille,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "qGg" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -39675,6 +39855,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -39699,8 +39882,7 @@
 /area/maintenance/disposal/incinerator)
 "qHn" = (
 /obj/machinery/computer/mech_bay_power_console{
-	dir = 1;
-	icon_state = "computer"
+	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -39722,14 +39904,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "63";
-	req_one_access_txt = "0"
+	req_access_txt = "63"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "qHw" = (
@@ -39738,6 +39920,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
+"qHy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qHI" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -39769,9 +39964,6 @@
 "qIC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
@@ -39895,6 +40087,9 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
 	dir = 8
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "qKF" = (
@@ -39953,6 +40148,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -40001,6 +40199,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"qOZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "qPm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -40010,6 +40220,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/maintenance/solars/port/fore)
 "qPJ" = (
@@ -40018,6 +40229,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "qQh" = (
@@ -40079,6 +40291,16 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
+"qRg" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "qRr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -40121,7 +40343,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "qRF" = (
@@ -40185,13 +40406,16 @@
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "qTz" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/bar)
 "qTP" = (
@@ -40234,13 +40458,11 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Garden Main 1";
-	dir = 4;
-	network = list("ss13")
+	dir = 4
 	},
 /obj/effect/turf_decal/siding/wideplating,
 /turf/open/floor/grass,
@@ -40285,12 +40507,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"qVx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/main)
 "qVH" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -40302,6 +40518,9 @@
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -40319,7 +40538,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /obj/structure/closet/firecloset,
@@ -40391,9 +40609,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -40438,6 +40653,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Telecommunications Foyer"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/tcommsat/computer)
 "qYe" = (
@@ -40479,17 +40695,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "qYB" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 2;
-	sortType = 11
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
@@ -40502,9 +40714,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -40523,6 +40732,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -40585,6 +40797,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ran" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "raC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -40605,6 +40823,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "rca" = (
@@ -40629,8 +40848,7 @@
 /area/quartermaster/warehouse)
 "rcJ" = (
 /obj/structure/particle_accelerator/particle_emitter/center{
-	dir = 1;
-	icon_state = "emitter_center"
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -40669,7 +40887,6 @@
 "rdK" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/brig";
-	dir = 2;
 	name = "Brig APC";
 	pixel_y = -23
 	},
@@ -40700,6 +40917,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "rdY" = (
@@ -40789,12 +41007,14 @@
 	name = "Telecomms";
 	req_one_access_txt = "19; 61"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "rgs" = (
 /obj/structure/sign/directions/command{
 	dir = 4;
-	icon_state = "direction_bridge";
 	pixel_x = 32;
 	pixel_y = 24
 	},
@@ -40804,16 +41024,11 @@
 	},
 /obj/structure/sign/directions/security{
 	dir = 4;
-	icon_state = "direction_sec";
 	pixel_x = 32;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"rgv" = (
-/obj/effect/spawner/lootdrop/organ_spawner,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "rhm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -40823,6 +41038,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "rhx" = (
@@ -40932,6 +41148,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"rjI" = (
+/obj/structure/chair,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/kitchen)
 "rjK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -40945,6 +41168,9 @@
 /area/hydroponics)
 "rjP" = (
 /obj/effect/turf_decal/stripes,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/tcommsat/computer)
 "rjT" = (
@@ -41049,26 +41275,17 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 6
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "rmU" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/nuke_storage)
-"rny" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "rnQ" = (
 /obj/structure/window/reinforced,
 /obj/structure/transit_tube/curved{
@@ -41145,6 +41362,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "rpA" = (
@@ -41169,6 +41389,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -41333,6 +41556,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "rsU" = (
@@ -41367,7 +41591,6 @@
 /area/space)
 "ruf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
 	},
@@ -41398,12 +41621,19 @@
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment{
-	dir = 2
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "ruG" = (
-/obj/machinery/light/small,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/conveyor/inverted{
+	dir = 4;
+	id = "garbage";
+	name = "recycler conveyor belt"
+	},
 /turf/open/floor/plasteel/broken/three,
 /area/maintenance/disposal)
 "rvi" = (
@@ -41433,10 +41663,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -41470,7 +41696,9 @@
 /obj/structure/disposaloutlet{
 	dir = 8
 	},
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "rwt" = (
@@ -41506,6 +41734,9 @@
 	dir = 4
 	},
 /obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "rxq" = (
@@ -41520,7 +41751,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -41531,20 +41761,21 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
 "ryw" = (
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
 "ryz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -41573,6 +41804,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "rzy" = (
@@ -41583,7 +41817,6 @@
 /obj/structure/cable/orange{
 	icon_state = "1-4"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -41592,6 +41825,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -41614,7 +41850,6 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Medical - Virology Isolation A";
-	dir = 2;
 	network = list("ss13","Medical","Virology")
 	},
 /obj/item/bedsheet/medical/virology,
@@ -41626,8 +41861,7 @@
 /area/maintenance/disposal/incinerator)
 "rAA" = (
 /obj/machinery/camera{
-	c_tag = "Telecomms - Observatory";
-	dir = 2
+	c_tag = "Telecomms - Observatory"
 	},
 /turf/open/floor/wood,
 /area/tcommsat/computer)
@@ -41684,9 +41918,6 @@
 /obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "rBt" = (
@@ -41709,6 +41940,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "rBS" = (
@@ -41761,9 +41993,6 @@
 "rCM" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
@@ -41904,6 +42133,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "rFJ" = (
@@ -41931,13 +42163,15 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "rGl" = (
 /obj/structure/table,
 /obj/machinery/camera{
 	c_tag = "Medical - Virology Isolation B";
-	dir = 2;
 	network = list("ss13","Medical","Virology")
 	},
 /turf/open/floor/plasteel/white,
@@ -42002,12 +42236,11 @@
 	},
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 4;
-	sortType = 17
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -42065,6 +42298,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "rJj" = (
@@ -42074,13 +42308,6 @@
 "rJF" = (
 /turf/closed/wall,
 /area/security/checkpoint/medical)
-"rJO" = (
-/obj/effect/spawner/structure/window,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/chapel/main)
 "rJR" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder,
@@ -42124,6 +42351,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/tcommsat/computer)
 "rKF" = (
@@ -42150,11 +42380,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/structure/sign/departments/evac{
 	pixel_y = 32
@@ -42234,9 +42460,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "rMu" = (
@@ -42269,6 +42492,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"rNo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "rNq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -42363,12 +42595,6 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/dorms)
-"rOW" = (
-/obj/machinery/mineral/stacking_unit_console{
-	machinedir = 8
-	},
-/turf/closed/wall,
-/area/maintenance/disposal)
 "rOX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -42406,6 +42632,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "rPh" = (
@@ -42426,6 +42655,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"rPK" = (
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "rPO" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
@@ -42455,10 +42690,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"rQR" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "rQY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -42499,11 +42730,11 @@
 /obj/machinery/light_switch{
 	pixel_x = 24
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
@@ -42564,6 +42795,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "rVc" = (
@@ -42623,6 +42855,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"rWK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
 "rXd" = (
 /obj/machinery/airalarm/all_access{
 	pixel_y = 24
@@ -42655,9 +42893,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
 "rXM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -42666,6 +42901,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -42705,6 +42943,7 @@
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "rZA" = (
@@ -42725,10 +42964,6 @@
 	codes_txt = "patrol;next_patrol=LEFTTOP";
 	location = "LEFTMID";
 	name = "navigation beacon (LEFTMID)"
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 1;
-	sortType = 16
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -42758,16 +42993,16 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "saU" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
+/obj/machinery/disposal/bin/tagger,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 10
 	},
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
@@ -42790,6 +43025,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "sbZ" = (
@@ -42840,8 +43076,7 @@
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/camera{
 	c_tag = "Civilian - Library Main 2";
-	dir = 8;
-	network = list("ss13")
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -42866,6 +43101,12 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"seK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "seM" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -42879,14 +43120,14 @@
 /area/science/research)
 "sfl" = (
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
 	dir = 10
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -42947,6 +43188,9 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "sgT" = (
@@ -43016,7 +43260,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -43031,14 +43274,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/chemorange/filled/corner/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -43065,9 +43308,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -43114,9 +43354,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "siS" = (
@@ -43137,15 +43374,18 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"sjj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "sjn" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -43210,6 +43450,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"skI" = (
+/obj/structure/disposalpipe/broken,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "slw" = (
 /obj/structure/chair/office/light,
 /obj/effect/turf_decal/trimline/secred/warning/lower,
@@ -43247,7 +43491,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
 "smq" = (
@@ -43287,6 +43530,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "smS" = (
@@ -43313,9 +43559,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -43324,6 +43567,9 @@
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -43394,6 +43640,17 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/plating,
 /area/medical/sleeper)
+"soG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/machinery/door/window/brigdoor,
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "spx" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -43463,6 +43720,9 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/solars/port/fore)
 "srp" = (
@@ -43501,6 +43761,9 @@
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -43591,22 +43854,9 @@
 /obj/structure/closet/secure_closet/paramedic,
 /turf/open/floor/plasteel,
 /area/medical/paramedic)
-"suY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 2;
-	sortType = 30
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "sve" = (
 /obj/machinery/computer/station_alert{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/machinery/requests_console{
 	department = "Atmospherics";
@@ -43634,6 +43884,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "svz" = (
@@ -43662,12 +43913,6 @@
 	icon_state = "damaged3"
 	},
 /area/space/nearstation)
-"swz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
 "swE" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
@@ -43682,10 +43927,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"swH" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
 "swM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -43726,6 +43967,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -43793,14 +44037,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -43823,6 +44067,7 @@
 	id = "Biohazard";
 	name = "biohazard containment door"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "syh" = (
@@ -43883,7 +44128,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -43896,15 +44141,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"szl" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "szo" = (
 /obj/machinery/light{
 	dir = 1
@@ -43957,6 +44193,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "sAN" = (
@@ -43975,12 +44214,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/library)
 "sAQ" = (
 /obj/machinery/camera{
 	c_tag = "Security - Cell 1";
-	dir = 2;
 	network = list("ss13","Security")
 	},
 /obj/machinery/computer/secure_data,
@@ -44002,6 +44243,8 @@
 	name = "Xenobiology APC";
 	pixel_x = 24
 	},
+/obj/structure/closet/l3closet/scientist,
+/obj/item/extinguisher,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "sBf" = (
@@ -44072,7 +44315,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
 	},
@@ -44145,9 +44387,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -44158,6 +44397,9 @@
 	dir = 10
 	},
 /obj/item/kirbyplants/random,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "sDC" = (
@@ -44223,9 +44465,7 @@
 /area/crew_quarters/kitchen)
 "sEq" = (
 /obj/structure/table,
-/obj/item/clothing/head/that{
-	throwforce = 1
-	},
+/obj/item/clothing/head/that,
 /obj/item/toy/figure/bartender,
 /obj/structure/sign/plaques/deempisi{
 	pixel_y = 24
@@ -44274,6 +44514,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/blobstart,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "sFX" = (
@@ -44308,7 +44549,6 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/engine/engineering";
-	dir = 2;
 	name = "Engine Room APC";
 	pixel_y = -23
 	},
@@ -44374,6 +44614,9 @@
 	pixel_y = -30
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -44450,23 +44693,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"sJz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "sJM" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -44554,9 +44783,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "sLx" = (
@@ -44567,6 +44793,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "sLL" = (
@@ -44586,9 +44813,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 23
-	},
+/obj/machinery/power/apc/auto_name/north,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "sMI" = (
@@ -44619,9 +44844,6 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
 "sNT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -44679,6 +44901,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/stripes/corner,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "sOL" = (
@@ -44689,12 +44912,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"sON" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
 "sOU" = (
 /obj/effect/turf_decal/bot_white/left,
 /obj/effect/turf_decal/siding/yellow{
@@ -44722,8 +44939,23 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"sPi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "sPW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -44734,6 +44966,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "sQo" = (
@@ -44748,6 +44981,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -44810,7 +45046,6 @@
 	dir = 4
 	},
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
@@ -44887,18 +45122,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"sSe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 13
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "sSj" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Pure to Ports"
@@ -44913,9 +45136,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4
 	},
+/obj/effect/mapping_helpers/mail_sorting/engineering/atmospherics,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "sSu" = (
@@ -44946,6 +45170,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"sSQ" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 9
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "sTl" = (
 /obj/machinery/vending/cart,
 /obj/machinery/airalarm{
@@ -44962,7 +45196,6 @@
 /obj/machinery/reagentgrinder,
 /obj/structure/table/wood,
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/wood,
@@ -44985,15 +45218,15 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -45146,8 +45379,17 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"sYg" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sYX" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -45178,15 +45420,16 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "sZG" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -45230,7 +45473,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/mail_sorting/supply/qm_office,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "taD" = (
@@ -45332,9 +45578,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -45350,9 +45593,6 @@
 	pixel_y = -28
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "teO" = (
@@ -45371,6 +45611,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -45394,6 +45637,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"tfK" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "tfW" = (
 /obj/machinery/power/tesla_coil,
 /turf/open/floor/plating/airless,
@@ -45422,6 +45672,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 10
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "tgQ" = (
@@ -45475,6 +45726,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/wood,
 /area/tcommsat/computer)
 "thg" = (
@@ -45497,6 +45751,7 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "thy" = (
@@ -45544,8 +45799,7 @@
 /area/tcommsat/server)
 "tiq" = (
 /obj/machinery/camera{
-	c_tag = "Hallway - Central Southeast 1";
-	dir = 2
+	c_tag = "Hallway - Central Southeast 1"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -45559,14 +45813,8 @@
 /area/construction/mining/aux_base)
 "tjp" = (
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 4;
 	id = "garbage"
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -45599,10 +45847,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"tkl" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "tkq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrogen_output{
 	dir = 1
@@ -45669,9 +45913,6 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "tmx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
@@ -45732,7 +45973,6 @@
 /turf/open/floor/carpet,
 /area/bridge)
 "tob" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
 	},
@@ -45750,6 +45990,7 @@
 /obj/vehicle/ridden/wheelchair{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "toe" = (
@@ -45839,12 +46080,19 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "tqb" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/wood,
 /area/tcommsat/computer)
 "tqd" = (
@@ -45944,6 +46192,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -46067,9 +46318,6 @@
 	network = list("ss13","Research")
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ttW" = (
@@ -46132,7 +46380,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
-/obj/structure/disposalpipe/junction/yjunction,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "tum" = (
@@ -46212,7 +46459,6 @@
 	dir = 8;
 	network = list("ss13","Security")
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
@@ -46282,8 +46528,7 @@
 /area/science/robotics/lab)
 "tyd" = (
 /obj/machinery/computer/robotics{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -46317,10 +46562,10 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "tyw" = (
@@ -46335,6 +46580,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "tyS" = (
@@ -46347,11 +46593,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -46387,6 +46633,7 @@
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "tzX" = (
@@ -46466,6 +46713,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "tBa" = (
@@ -46504,6 +46752,11 @@
 /obj/item/restraints/legcuffs/beartrap,
 /turf/open/floor/plasteel,
 /area/janitor)
+"tCb" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "tCS" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -46606,9 +46859,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "tGm" = (
@@ -46652,11 +46902,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -46666,6 +46912,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
@@ -46740,10 +46989,8 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "tHM" = (
@@ -46791,8 +47038,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/spawner/wire_splicing/thirty,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "tIZ" = (
@@ -46830,9 +47077,6 @@
 	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -46879,13 +47123,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/stairs/goon/stairs_middle{
@@ -46968,9 +47212,6 @@
 /area/quartermaster/warehouse)
 "tMp" = (
 /obj/structure/chair/stool,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /turf/open/floor/plasteel/chapel{
 	dir = 1
 	},
@@ -47000,6 +47241,9 @@
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -47041,9 +47285,6 @@
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "tNI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
@@ -47107,10 +47348,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -47160,6 +47401,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"tQN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "tQS" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing)
@@ -47210,7 +47460,6 @@
 /obj/structure/closet/l3closet,
 /obj/machinery/camera{
 	c_tag = "Medical - Virology Airlock";
-	dir = 2;
 	network = list("ss13","Medical")
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -47250,12 +47499,14 @@
 "tSn" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/research";
-	dir = 2;
 	name = "Science Main APC";
 	pixel_y = -23
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "tSp" = (
@@ -47458,7 +47709,6 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "tWo" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
@@ -47480,9 +47730,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
 	dir = 1
 	},
@@ -47497,24 +47744,17 @@
 /area/security/courtroom)
 "tWM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "tXl" = (
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Civilian - Garden Main 2";
-	dir = 1;
-	network = list("ss13")
+	dir = 1
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "tXW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -47539,9 +47779,6 @@
 /obj/machinery/door/window/eastleft{
 	name = "Bar Access";
 	req_access_txt = "25"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/bar)
@@ -47569,9 +47806,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "tZl" = (
@@ -47592,6 +47826,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"tZv" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "tZx" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
@@ -47661,21 +47899,20 @@
 "uaK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "ubf" = (
 /obj/machinery/computer/rdconsole/robotics{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -47701,8 +47938,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Disposals Office";
-	dir = 8;
-	network = list("ss13")
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -47759,6 +47995,9 @@
 "udy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -47842,14 +48081,6 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"ueu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "uew" = (
 /obj/item/wrench,
 /obj/effect/decal/cleanable/dirt,
@@ -47874,7 +48105,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "ueH" = (
@@ -47901,12 +48131,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"ueL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "ufa" = (
 /obj/structure/bodycontainer/crematorium{
 	dir = 8;
@@ -47921,8 +48145,7 @@
 /area/engine/engineering)
 "ufk" = (
 /obj/structure/particle_accelerator/particle_emitter/right{
-	dir = 1;
-	icon_state = "emitter_right"
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -48051,10 +48274,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -48118,6 +48343,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ukY" = (
@@ -48143,10 +48371,10 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/turnstile/brig{
 	dir = 4
 	},
-/obj/machinery/turnstile/brig{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -48195,7 +48423,7 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
-	dir = 1
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
@@ -48266,15 +48494,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"uok" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "uos" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -48282,6 +48501,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uou" = (
@@ -48302,6 +48522,7 @@
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "uoM" = (
@@ -48325,6 +48546,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 6
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "upt" = (
@@ -48380,7 +48605,6 @@
 /area/solar/starboard/fore)
 "uqn" = (
 /obj/machinery/airalarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/open/floor/carpet,
@@ -48453,9 +48677,7 @@
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/trimline/white/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220
-	},
+/obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "urW" = (
@@ -48468,7 +48690,6 @@
 /obj/item/clothing/head/wig/random,
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/theatre";
-	dir = 2;
 	name = "Theatre APC";
 	pixel_y = -23
 	},
@@ -48477,9 +48698,6 @@
 /area/crew_quarters/theatre)
 "ust" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -48628,6 +48846,7 @@
 /area/science/robotics/lab)
 "uvg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "uvi" = (
@@ -48715,6 +48934,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "uzo" = (
@@ -48752,6 +48974,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "uAM" = (
@@ -48785,7 +49008,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Engineering";
 	departmentType = 4;
 	name = "Engineering RC";
@@ -48800,7 +49022,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -48856,7 +49077,6 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "uCF" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
 	},
@@ -48867,6 +49087,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "uCR" = (
@@ -48879,13 +49100,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "uDW" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -48946,7 +49164,6 @@
 	icon_state = "1-8"
 	},
 /obj/item/radio/intercom{
-	dir = 2;
 	pixel_y = -28
 	},
 /obj/machinery/camera{
@@ -48970,6 +49187,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "uEH" = (
@@ -49047,6 +49265,9 @@
 /obj/effect/turf_decal/trimline/green/filled/line/lower,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -49172,11 +49393,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "uIp" = (
@@ -49199,6 +49420,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "uIU" = (
@@ -49207,8 +49431,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"uIX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "uIY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
@@ -49233,9 +49469,6 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "uJm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access";
 	req_access_txt = "47"
@@ -49282,9 +49515,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
@@ -49398,11 +49628,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -49411,6 +49637,12 @@
 /obj/item/paper/fluff/holodeck/disclaimer,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"uNh" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "uNC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49419,6 +49651,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -49452,9 +49687,8 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 2;
-	sortType = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -49472,6 +49706,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
@@ -49516,6 +49753,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"uPL" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "uPP" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -49526,8 +49770,7 @@
 /area/medical/psych)
 "uQm" = (
 /obj/machinery/computer/mecha{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -49541,7 +49784,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "uQH" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -49553,13 +49795,13 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "uQT" = (
@@ -49583,7 +49825,7 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 10
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -49615,6 +49857,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/library)
 "uRH" = (
@@ -49628,14 +49871,22 @@
 /area/medical/sleeper)
 "uRP" = (
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/janitor)
+"uSG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port)
 "uSS" = (
 /obj/effect/landmark/stationroom/maint/tenxten,
 /turf/template_noop,
@@ -49717,9 +49968,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
@@ -49751,8 +49999,7 @@
 /area/engine/atmos)
 "uUo" = (
 /obj/machinery/computer/message_monitor{
-	dir = 4;
-	icon_state = "computer"
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -49783,9 +50030,6 @@
 /area/crew_quarters/heads/hos)
 "uVn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
@@ -49903,6 +50147,18 @@
 	},
 /turf/open/floor/plating,
 /area/medical/virology)
+"uXy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "uXD" = (
 /obj/structure/chair{
 	dir = 1
@@ -50044,8 +50300,7 @@
 	dir = 1
 	},
 /obj/machinery/power/terminal{
-	dir = 8;
-	icon_state = "term"
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -50113,11 +50368,15 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/tcommsat/computer)
 "vch" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/stairs/goon/wood_stairs_middle,
 /area/library)
 "vcr" = (
@@ -50127,7 +50386,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
@@ -50236,13 +50494,14 @@
 "vdN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "vej" = (
@@ -50379,6 +50638,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "vgY" = (
@@ -50420,9 +50682,6 @@
 	departmentType = 2;
 	pixel_y = -30
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -50438,9 +50697,7 @@
 /obj/structure/sign/warning/deathsposal{
 	pixel_y = 32
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
 "vif" = (
@@ -50546,6 +50803,9 @@
 /obj/item/gun/energy/laser/practice,
 /obj/item/gun/energy/laser/practice,
 /obj/item/gun/energy/laser/practice,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "vlY" = (
@@ -50593,19 +50853,13 @@
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
 "vnh" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/window{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	layer = 3
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "vnj" = (
@@ -50626,12 +50880,27 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "vnK" = (
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"vor" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "voN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -50685,20 +50954,8 @@
 /area/security/execution/transfer)
 "vpS" = (
 /obj/effect/landmark/event_spawn,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"vqp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "vqt" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -50743,6 +51000,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "vrN" = (
@@ -50766,15 +51026,19 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
+"vsK" = (
+/obj/item/kirbyplants/random,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "vsO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -50785,17 +51049,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"vsV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "vtk" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/visible,
 /turf/closed/wall/r_wall,
@@ -50899,6 +51152,21 @@
 /obj/effect/landmark/stationroom/maint/threexfive,
 /turf/template_noop,
 /area/maintenance/port/aft)
+"vvL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "vvS" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -50931,6 +51199,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
+"vwE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/science/research)
 "vwN" = (
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 8
@@ -50955,6 +51229,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "vxU" = (
@@ -51036,9 +51311,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
@@ -51046,6 +51318,9 @@
 	name = "Security Office";
 	req_one_access_txt = "1;4";
 	security_level = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -51076,6 +51351,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "vyI" = (
@@ -51136,9 +51412,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "vAs" = (
@@ -51175,6 +51449,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "vBq" = (
@@ -51197,27 +51472,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"vBL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/science/mixing)
 "vBX" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"vCb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "vCj" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel,
@@ -51233,15 +51498,15 @@
 /obj/machinery/disposal/deliveryChute{
 	dir = 8
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/structure/window/reinforced{
 	dir = 4;
 	layer = 2.9
 	},
 /obj/structure/window/reinforced{
 	layer = 2.9
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
@@ -51294,6 +51559,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -51368,10 +51636,6 @@
 /area/engine/atmos)
 "vFF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 18
-	},
 /obj/effect/spawner/xmastree,
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
@@ -51386,14 +51650,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
-"vGc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 2
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "vGd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -51540,9 +51796,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "vJg" = (
-/obj/structure/disposaloutlet,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/conveyor{
+	id = "garbage";
+	name = " recycler conveyor belt";
+	dir = 6
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -51568,6 +51825,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "vJL" = (
@@ -51582,8 +51842,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Civilian - Commissary";
-	dir = 1;
-	network = list("ss13")
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
@@ -51612,8 +51871,16 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"vKm" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/plasticflaps/opaque,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "vKx" = (
 /obj/structure/window/reinforced,
 /obj/machinery/camera{
@@ -51625,7 +51892,6 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "vKV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
 "vKX" = (
@@ -51652,9 +51918,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -51663,6 +51926,9 @@
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
@@ -51679,6 +51945,17 @@
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
+"vLL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "vNc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -51729,6 +52006,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "vOk" = (
@@ -51826,7 +52104,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
 	},
@@ -51905,8 +52182,7 @@
 	pixel_y = 24
 	},
 /obj/machinery/camera{
-	c_tag = "Bridge - Breakroom";
-	dir = 2
+	c_tag = "Bridge - Breakroom"
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
 	dir = 1
@@ -51923,6 +52199,9 @@
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -51958,6 +52237,21 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/security/interrogation)
+"vRS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "vRT" = (
 /obj/machinery/light/small,
 /obj/machinery/advanced_airlock_controller{
@@ -51988,25 +52282,26 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"vSy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "vSJ" = (
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"vSL" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "vTr" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -52037,7 +52332,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -52056,6 +52351,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/tcommsat/computer)
@@ -52106,6 +52404,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
@@ -52168,9 +52469,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 4
 	},
@@ -52186,9 +52484,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52237,6 +52532,14 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"vYD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "vYJ" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -52293,16 +52596,23 @@
 /obj/machinery/light,
 /turf/open/floor/wood,
 /area/tcommsat/computer)
+"vZE" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/machinery/disposal/bin/tagger,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "vZL" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Disposals Maintenance";
 	req_access_txt = "31"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "vZY" = (
@@ -52391,9 +52701,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
 	},
@@ -52432,7 +52739,6 @@
 "wcK" = (
 /obj/structure/plasticflaps,
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "NTMSLoad2";
 	name = "on ramp"
 	},
@@ -52447,14 +52753,14 @@
 "wcR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
@@ -52489,9 +52795,8 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
 	dir = 1
 	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 4;
-	sortType = 6
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -52589,18 +52894,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"wgw" = (
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "wgO" = (
 /turf/closed/wall,
 /area/medical/paramedic)
@@ -52659,6 +52952,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"wiu" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "wiy" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/warden";
@@ -52697,19 +52994,18 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Security Maintenance";
-	req_access_txt = "63";
-	req_one_access_txt = "0"
+	req_access_txt = "63"
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "wjm" = (
 /obj/machinery/camera{
 	c_tag = "Research - Xenobiology Cell 2";
-	dir = 2;
 	network = list("ss13","Research","Xenobiology")
 	},
 /turf/open/floor/engine,
@@ -52745,6 +53041,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "wkC" = (
@@ -52760,6 +53059,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 10
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "wlh" = (
@@ -52785,6 +53085,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "wlY" = (
@@ -52807,6 +53108,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"wmd" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plating,
+/area/science/research)
 "wmD" = (
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
@@ -52851,7 +53159,6 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "wnO" = (
@@ -52877,7 +53184,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/camera{
 	c_tag = "Research - Xenobiology Northen Kill Chamber";
-	dir = 2;
 	network = list("ss13","Research","Xenobiology")
 	},
 /turf/open/floor/circuit/telecomms,
@@ -52902,6 +53208,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "woH" = (
@@ -52915,6 +53224,17 @@
 "woJ" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"woN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "woO" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
@@ -52922,7 +53242,6 @@
 "wpc" = (
 /obj/structure/table,
 /obj/machinery/button/massdriver{
-	dir = 2;
 	id = "toxinsdriver";
 	pixel_x = 5
 	},
@@ -52998,8 +53317,7 @@
 /area/bridge)
 "wqF" = (
 /obj/structure/particle_accelerator/end_cap{
-	dir = 1;
-	icon_state = "end_cap"
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -53046,8 +53364,7 @@
 /area/bridge)
 "wsx" = (
 /obj/machinery/computer/cargo{
-	dir = 8;
-	icon_state = "computer"
+	dir = 8
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 6
@@ -53067,6 +53384,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "wtb" = (
@@ -53114,11 +53434,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -53131,8 +53451,21 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/mail_sorting/science/experimentor_lab,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"wtD" = (
+/obj/structure/disposalpipe/broken{
+	dir = 1
+	},
+/obj/structure/disposalpipe/broken{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "wtE" = (
 /obj/machinery/computer/med_data{
 	dir = 8
@@ -53149,6 +53482,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"wuk" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "wuu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -53184,6 +53521,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"wuI" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/science/research)
+"wuS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "wvf" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
@@ -53213,12 +53563,12 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/tcommsat/computer)
 "wvA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
@@ -53237,11 +53587,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -53261,14 +53611,14 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -53336,8 +53686,7 @@
 "wwP" = (
 /obj/structure/frame/computer{
 	anchored = 1;
-	dir = 8;
-	icon_state = "0"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
@@ -53434,12 +53783,12 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "wyC" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "wzc" = (
@@ -53453,9 +53802,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -53620,10 +53966,10 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "wBL" = (
@@ -53670,6 +54016,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "wCA" = (
@@ -53708,7 +54057,6 @@
 /area/science/research)
 "wDU" = (
 /obj/machinery/button/door{
-	dir = 2;
 	id = "engsm";
 	name = "Radiation Shutters Control";
 	pixel_y = 24;
@@ -53775,6 +54123,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "wFe" = (
@@ -53789,7 +54138,7 @@
 	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -53838,6 +54187,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "wHd" = (
@@ -53963,6 +54313,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "wKa" = (
@@ -54001,10 +54354,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8;
-	sortType = 14
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "wKZ" = (
@@ -54045,6 +54395,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "wLx" = (
@@ -54056,9 +54409,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line/lower,
 /turf/open/floor/plasteel,
@@ -54080,6 +54430,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "wMR" = (
@@ -54116,7 +54467,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
@@ -54175,9 +54525,8 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "wPm" = (
-/obj/item/storage/secure/safe{
-	pixel_x = 4;
-	pixel_y = 24
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
@@ -54194,15 +54543,21 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"wPs" = (
+"wPy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "wQb" = (
@@ -54298,6 +54653,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "wRx" = (
@@ -54337,11 +54695,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -54381,14 +54739,7 @@
 	},
 /turf/open/floor/catwalk_floor/telecomms,
 /area/ai_monitored/turret_protected/ai)
-"wTh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "wTq" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
@@ -54429,7 +54780,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /obj/item/kirbyplants/random,
@@ -54442,6 +54792,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "wTT" = (
@@ -54474,9 +54825,10 @@
 "wUq" = (
 /obj/machinery/conveyor/inverted{
 	dir = 9;
-	id = "garbage"
+	id = "garbage";
+	name = "recycler conveyor belt"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "wUs" = (
@@ -54494,15 +54846,14 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
 	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	sortType = 21
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -54531,6 +54882,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "wVd" = (
@@ -54555,7 +54909,6 @@
 "wVz" = (
 /obj/machinery/camera{
 	c_tag = "Research - Xenobiology Cell 1";
-	dir = 2;
 	network = list("ss13","Research","Xenobiology")
 	},
 /turf/open/floor/engine,
@@ -54563,9 +54916,6 @@
 "wVB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
@@ -54605,6 +54955,9 @@
 	pixel_y = -28
 	},
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "wWq" = (
@@ -54626,14 +54979,7 @@
 	},
 /turf/open/floor/catwalk_floor/telecomms,
 /area/ai_monitored/turret_protected/ai)
-"wWJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/security/main)
 "wWP" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/chapel{
 	dir = 8
@@ -54649,9 +54995,6 @@
 /obj/machinery/door/window{
 	dir = 4;
 	name = "Theatre Stage"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
@@ -54710,8 +55053,7 @@
 	dir = 6
 	},
 /obj/machinery/camera{
-	c_tag = "Bridge - Captain's Private Quarters";
-	dir = 2
+	c_tag = "Bridge - Captain's Private Quarters"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -54731,6 +55073,12 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
+"wYT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "wZk" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
@@ -54739,7 +55087,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/effect/landmark/event_spawn,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -54781,6 +55128,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -54883,11 +55233,12 @@
 /area/maintenance/port/aft)
 "xcY" = (
 /obj/machinery/camera{
-	c_tag = "Civilian - Crematorium";
-	dir = 2;
-	network = list("ss13")
+	c_tag = "Civilian - Crematorium"
 	},
 /obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -54990,6 +55341,9 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "xfr" = (
@@ -55006,6 +55360,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "xfS" = (
@@ -55017,7 +55374,6 @@
 /area/storage/primary)
 "xgb" = (
 /obj/docking_port/stationary{
-	dir = 1;
 	dwidth = 3;
 	height = 5;
 	name = "mining shuttle bay";
@@ -55052,13 +55408,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
 "xgN" = (
@@ -55108,15 +55464,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"xiw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "xiI" = (
 /obj/machinery/disposal/bin,
 /obj/structure/window/reinforced{
@@ -55139,18 +55486,6 @@
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
-"xje" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "xjl" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 8
@@ -55163,9 +55498,6 @@
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
 	},
 /obj/machinery/light_switch{
 	pixel_y = 24
@@ -55277,7 +55609,7 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "xkD" = (
-/obj/machinery/disposal/bin,
+/obj/machinery/disposal/bin/tagger,
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -32
 	},
@@ -55325,21 +55657,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"xlp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "xlr" = (
 /obj/machinery/computer/holodeck{
 	dir = 8
@@ -55368,6 +55685,7 @@
 "xmc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/closet/emcloset,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "xmg" = (
@@ -55386,6 +55704,9 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -55431,6 +55752,11 @@
 /obj/item/hand_labeler,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"xmS" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/turf/open/floor/wood,
+/area/medical/psych)
 "xnb" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/plasteel/showroomfloor,
@@ -55449,9 +55775,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
@@ -55462,7 +55785,6 @@
 /area/security/detectives_office)
 "xno" = (
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Medbay";
 	departmentType = 1;
 	name = "Medbay RC";
@@ -55549,7 +55871,6 @@
 	},
 /obj/machinery/requests_console{
 	department = "Mining";
-	departmentType = 0;
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
@@ -55606,6 +55927,15 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"xpI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/junction/flip,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "xpM" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -55624,9 +55954,9 @@
 /area/maintenance/port/aft)
 "xqF" = (
 /obj/machinery/conveyor{
-	id = "garbage"
+	id = "garbage";
+	name = " recycler conveyor belt"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "xqM" = (
@@ -55638,7 +55968,6 @@
 "xrd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northleft{
-	dir = 1;
 	name = "Engineering Desk";
 	req_one_access_txt = "32;19"
 	},
@@ -55690,6 +56019,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "xrN" = (
@@ -55733,8 +56065,7 @@
 /area/security/brig)
 "xsb" = (
 /obj/machinery/camera{
-	c_tag = "Hallway - Central West 1";
-	dir = 2
+	c_tag = "Hallway - Central West 1"
 	},
 /obj/structure/sign/directions/medical{
 	dir = 8;
@@ -55746,7 +56077,6 @@
 	},
 /obj/structure/sign/directions/evac{
 	dir = 8;
-	icon_state = "direction_evac";
 	pixel_y = 42
 	},
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -55799,16 +56129,14 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower,
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"xui" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 4
+"xux" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "xuE" = (
 /obj/effect/landmark/start/janitor,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -55858,14 +56186,14 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -55881,6 +56209,9 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "xvB" = (
@@ -55893,6 +56224,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"xvP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "xwr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -55936,6 +56273,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/junction/yjunction{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -56053,7 +56393,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "xyo" = (
-/obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 8
 	},
@@ -56135,21 +56474,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
-"xAt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "xAD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -56258,6 +56582,18 @@
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
+"xDe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "xDl" = (
 /obj/machinery/status_display/ai{
 	pixel_x = 32
@@ -56287,14 +56623,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"xDV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/wood,
-/area/hallway/primary/central)
 "xEI" = (
 /obj/machinery/atmospherics/miner/toxins{
 	max_ext_kpa = 2500
@@ -56316,6 +56649,7 @@
 	name = "toxins launcher intersection";
 	req_access_txt = "12"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "xFb" = (
@@ -56343,6 +56677,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
+"xFQ" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "xFT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -56414,21 +56753,11 @@
 /obj/structure/closet/wardrobe/green,
 /obj/machinery/camera{
 	c_tag = "Civilian - Dorm Main 2";
-	dir = 4;
-	network = list("ss13")
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"xHQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "xId" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
 	},
@@ -56448,8 +56777,7 @@
 /area/security/brig)
 "xIF" = (
 /obj/structure/particle_accelerator/particle_emitter/left{
-	dir = 1;
-	icon_state = "emitter_left"
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -56481,6 +56809,7 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "xJk" = (
@@ -56536,6 +56865,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "xJU" = (
@@ -56556,7 +56888,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/disposalpipe/trunk,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "xKD" = (
@@ -56568,6 +56902,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
@@ -56595,9 +56932,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "xKX" = (
@@ -56660,6 +56994,9 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "xMj" = (
@@ -56763,12 +57100,10 @@
 /obj/structure/sign/warning/pods{
 	pixel_x = 32
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 5
 	},
+/obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "xNN" = (
@@ -56780,6 +57115,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "xOd" = (
@@ -56812,6 +57148,9 @@
 /area/space/nearstation)
 "xOt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -57005,6 +57344,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "xRN" = (
@@ -57058,6 +57400,7 @@
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "12"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/fore)
 "xSu" = (
@@ -57077,15 +57420,18 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "xSX" = (
 /obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
 	dir = 6
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -57098,7 +57444,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -57132,14 +57477,14 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "xVn" = (
 /obj/structure/disposaloutlet{
 	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -57170,9 +57515,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -57234,21 +57576,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"xXk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "xXt" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
@@ -57339,18 +57666,20 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security - Cell 2";
-	dir = 2;
 	network = list("ss13","Security")
 	},
 /obj/item/bedsheet/prisoner,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"xZI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
+"xZP" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
-/turf/open/floor/carpet/purple,
-/area/chapel/main)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "yan" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -57378,6 +57707,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
+"yaT" = (
+/obj/structure/window/reinforced{
+	layer = 2.9
+	},
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/quartermaster/sorting)
 "ybz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -57398,14 +57739,14 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
 	},
 /obj/machinery/turnstile/brig{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -57428,14 +57769,14 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Public Garden"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
@@ -57502,7 +57843,6 @@
 "ycE" = (
 /obj/machinery/camera{
 	c_tag = "Research - Toxins Main 2";
-	dir = 2;
 	network = list("ss13","Research")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -57529,7 +57869,6 @@
 "ycU" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/chemistry";
-	dir = 2;
 	name = "Chemistry APC";
 	pixel_y = -23
 	},
@@ -57538,9 +57877,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "ycZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -57549,6 +57885,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
@@ -57606,10 +57945,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
-"yeC" = (
-/obj/structure/disposalpipe/junction/flip,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "yeL" = (
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -57636,9 +57971,6 @@
 /area/hallway/primary/central)
 "yfr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 8
 	},
@@ -57655,7 +57987,6 @@
 "yfT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -57667,11 +57998,11 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -57728,7 +58059,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -57745,7 +58075,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/secred/warning/lower{
-	alpha = 220;
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -57810,9 +58139,6 @@
 /turf/open/space/basic,
 /area/solar/port/fore)
 "yjk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
@@ -57823,10 +58149,10 @@
 	dir = 4
 	},
 /obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/corner,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "yjm" = (
@@ -57886,6 +58212,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "ykl" = (
@@ -57901,6 +58230,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "ykt" = (
@@ -57912,9 +58244,7 @@
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ykw" = (
@@ -57943,13 +58273,10 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ykR" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "garbage"
-	},
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
 	},
+/obj/machinery/conveyor/inverted,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "ylp" = (
@@ -69380,7 +69707,7 @@ xSu
 nYv
 drC
 drC
-jWs
+drC
 drC
 hth
 xSu
@@ -73783,17 +74110,17 @@ xSu
 xSu
 jyB
 vgR
-vgR
-vgR
-vgR
-vgR
+xvP
+wiu
+wiu
+wiu
 cxl
-qij
+hmw
 xmc
-vgR
-vgR
-vgR
-vgR
+wiu
+wiu
+wiu
+lpu
 vgR
 jyB
 xSu
@@ -74040,7 +74367,7 @@ ylr
 xSu
 jyB
 pSD
-pSD
+fyE
 hIt
 hIt
 hIt
@@ -74050,7 +74377,7 @@ hIt
 hIt
 hIt
 hIt
-vgR
+csP
 vgR
 jyB
 ylr
@@ -74297,7 +74624,7 @@ ylr
 ylr
 jyB
 vgR
-vgR
+csP
 hIt
 uKh
 sGJ
@@ -74307,8 +74634,8 @@ sGJ
 sGJ
 sGJ
 hIt
-pSD
-pSD
+dmO
+mGJ
 jyB
 jyB
 jyB
@@ -74554,7 +74881,7 @@ ylr
 ylr
 jyB
 vgR
-qij
+qFM
 hIt
 sGJ
 sGJ
@@ -74565,7 +74892,7 @@ sGJ
 sGJ
 hIt
 vgR
-vgR
+csP
 vgR
 jyB
 fDZ
@@ -74811,7 +75138,7 @@ xSu
 ylr
 jyB
 vgR
-vgR
+csP
 hIt
 sGJ
 vPE
@@ -75068,7 +75395,7 @@ jyB
 jyB
 jyB
 vgR
-duu
+bIM
 hIt
 hIt
 eXf
@@ -75079,7 +75406,7 @@ eXf
 hIt
 hIt
 vgR
-vgR
+csP
 vgR
 jyB
 fDZ
@@ -75325,7 +75652,7 @@ kYn
 aqa
 iQK
 fNQ
-vgR
+csP
 hIt
 vYg
 hjm
@@ -75336,7 +75663,7 @@ hjm
 vYg
 hIt
 euM
-vgR
+csP
 vgR
 jyB
 jyB
@@ -75579,10 +75906,10 @@ ylr
 xSu
 jyB
 vgR
-vgR
-vgR
-vgR
-vgR
+xvP
+wiu
+wiu
+hMX
 hIt
 vOk
 dhn
@@ -75593,10 +75920,10 @@ eVD
 fnz
 hIt
 gEE
-vgR
-vgR
-vgR
-vgR
+iqG
+wiu
+wiu
+lpu
 vgR
 jsz
 jyB
@@ -75836,7 +76163,7 @@ hpU
 wSb
 jyB
 moN
-lJE
+dfs
 hIt
 hIt
 hIt
@@ -75853,7 +76180,7 @@ hIt
 hIt
 hIt
 vgR
-vgR
+csP
 vgR
 snr
 jyB
@@ -76093,7 +76420,7 @@ pMc
 joc
 xEO
 fyd
-lJE
+uSG
 hIt
 wod
 cku
@@ -76110,7 +76437,7 @@ cku
 rEf
 hIt
 vgR
-vgR
+csP
 jyB
 jyB
 jyB
@@ -76367,7 +76694,7 @@ hPd
 vya
 hIt
 euM
-vgR
+csP
 jyB
 vgR
 fyX
@@ -78403,8 +78730,8 @@ eVZ
 eVZ
 atc
 wld
-mgl
-kin
+vBL
+iEG
 wGR
 sOZ
 hIt
@@ -78430,7 +78757,7 @@ jiF
 ijG
 qvf
 uaK
-vGc
+baH
 ruE
 yfr
 jmG
@@ -78663,7 +78990,7 @@ bSc
 rdL
 uAw
 mEr
-uRq
+inp
 hIt
 hIt
 hIt
@@ -78920,7 +79247,7 @@ fTw
 mgl
 kin
 dRU
-uRq
+inp
 hIt
 sGJ
 fTe
@@ -79951,7 +80278,7 @@ dRU
 smy
 nUz
 tgP
-aVC
+tCb
 ojt
 pWs
 jfb
@@ -80209,7 +80536,7 @@ ggw
 ggw
 cvX
 ems
-sOL
+gVY
 sOL
 pyz
 xBX
@@ -80462,8 +80789,8 @@ qgC
 tEL
 rUI
 vEP
-dpM
-dpM
+nUO
+nUO
 cWu
 aVC
 pPE
@@ -80721,7 +81048,7 @@ grI
 bRa
 sEy
 iNa
-cWu
+qfy
 bDJ
 hIt
 hIt
@@ -80747,7 +81074,7 @@ mCF
 bQC
 cGa
 whA
-dYn
+xmS
 uOw
 tav
 dYn
@@ -81783,7 +82110,7 @@ quE
 fpe
 wgO
 wgO
-arm
+vor
 gIJ
 vDp
 gIJ
@@ -82040,7 +82367,7 @@ rfB
 hVl
 nKK
 wgO
-arm
+vor
 gIJ
 vDp
 gIJ
@@ -83028,14 +83355,14 @@ uyv
 vJb
 cLs
 xjI
-vSL
-bdh
+wDE
+wDE
 vyi
 wDE
 wDE
 nBg
-dRU
-dpM
+mkM
+lfB
 gVO
 pIW
 pev
@@ -83068,7 +83395,7 @@ rXq
 fFJ
 suK
 wgO
-arm
+vor
 gIJ
 vDp
 gIJ
@@ -83284,20 +83611,20 @@ wRR
 uyv
 qtI
 pmZ
-eAW
+kin
 asZ
-sSe
+eno
 ero
-oUU
+eno
 aYO
-oUU
+eno
 mHn
-dpM
+ewb
 muq
 syf
 bhc
 lyY
-xzK
+cNm
 dAp
 rOQ
 uhX
@@ -83561,7 +83888,7 @@ rRg
 xcn
 kgD
 pMJ
-pMJ
+eul
 xXV
 wHe
 ikA
@@ -83582,7 +83909,7 @@ pkJ
 lDH
 yjm
 hOu
-arm
+vor
 gIJ
 vDp
 gIJ
@@ -83798,7 +84125,7 @@ lhd
 wSH
 upf
 pmZ
-eAW
+kin
 pOM
 teK
 tEL
@@ -83839,7 +84166,7 @@ pkJ
 bsP
 gIJ
 hOu
-arm
+vor
 gIJ
 vDp
 gIJ
@@ -84057,7 +84384,7 @@ pmZ
 cLs
 bbk
 pOM
-inp
+uRq
 tEL
 seO
 tHH
@@ -84096,7 +84423,7 @@ pkJ
 vZq
 gIJ
 hOu
-arm
+vor
 gIJ
 vDp
 xkg
@@ -84314,7 +84641,7 @@ dIw
 wLx
 mIo
 pOM
-kih
+dpM
 tEL
 doT
 ibK
@@ -84353,7 +84680,7 @@ pkJ
 nkr
 gIJ
 hOu
-arm
+vor
 gIJ
 vDp
 vDp
@@ -84538,7 +84865,7 @@ tiJ
 nio
 fvD
 eyR
-wgw
+ttB
 vHZ
 idJ
 wPn
@@ -84571,11 +84898,11 @@ oiq
 vrb
 ocI
 qte
-inp
+jYe
 fus
-ibK
-ibK
-ibK
+wuI
+wuI
+vwE
 eUu
 ibK
 vxV
@@ -84610,7 +84937,7 @@ pkJ
 gIJ
 gIJ
 kkN
-arm
+vor
 gIJ
 vDp
 clM
@@ -84828,11 +85155,11 @@ vaA
 fkO
 mIo
 pOM
-inp
+uRq
 tEL
 qqt
 ibK
-ibK
+psI
 fXw
 ibK
 ibK
@@ -85085,11 +85412,11 @@ wLx
 wLx
 sjn
 pOM
-inp
+uRq
 tEL
 qes
 fvS
-ibK
+wmd
 tEL
 tEL
 tEL
@@ -85125,7 +85452,7 @@ gIJ
 jTD
 hOu
 gIJ
-jTD
+prL
 vDp
 clM
 clM
@@ -85309,7 +85636,7 @@ fNq
 fNq
 fNq
 nHw
-hjG
+fNq
 kPd
 idJ
 jTp
@@ -85362,7 +85689,7 @@ dNw
 eQm
 cCv
 eEu
-dlt
+nCP
 dlt
 eVA
 dlt
@@ -85382,7 +85709,7 @@ tzj
 dlR
 hOu
 gIJ
-jTD
+prL
 vDp
 vDp
 vDp
@@ -85556,7 +85883,7 @@ ylr
 lWR
 idJ
 ihh
-iof
+ppy
 fNq
 fNq
 fNq
@@ -85566,7 +85893,7 @@ kze
 fNq
 fNq
 nHw
-hjG
+fNq
 kPd
 idJ
 jTp
@@ -85597,9 +85924,9 @@ dIt
 uku
 kin
 dpM
-kih
+dpM
 jCJ
-inp
+uRq
 wTa
 uuZ
 jrL
@@ -85619,8 +85946,8 @@ xMZ
 qsm
 fME
 xId
-yeC
-gHn
+nCP
+dlt
 dlt
 dlt
 dlt
@@ -85639,7 +85966,7 @@ rml
 vDp
 vDp
 gIJ
-jTD
+prL
 hOu
 xcP
 heq
@@ -85823,7 +86150,7 @@ idJ
 idJ
 idJ
 idJ
-hjG
+fNq
 kPd
 idJ
 jTp
@@ -85854,7 +86181,7 @@ wnv
 wuB
 miF
 oUU
-lja
+oUU
 ifn
 wKK
 ucJ
@@ -85896,7 +86223,7 @@ clM
 lBV
 vDp
 asW
-jTD
+prL
 gIJ
 gIJ
 gIJ
@@ -86070,7 +86397,7 @@ ylr
 lWR
 lWR
 ihh
-iof
+ppy
 ezc
 wTI
 ttB
@@ -86080,7 +86407,7 @@ ptj
 mBx
 wTs
 ihh
-hjG
+fNq
 kPd
 idJ
 bMz
@@ -86106,13 +86433,13 @@ tSp
 inM
 wQP
 wQP
-lmI
+wQP
 xtV
 cCE
-ggf
-nUO
-mRz
-wGR
+iNa
+dpM
+dpM
+bsu
 xKR
 wTa
 loc
@@ -86139,8 +86466,8 @@ qfm
 bbg
 icl
 dsL
-jtH
-rQR
+dlt
+dlt
 wFe
 wNV
 jqr
@@ -86152,12 +86479,12 @@ clM
 clM
 clM
 xAq
-nSo
+lPe
 xwJ
 eIh
-gOO
-gOO
-gOO
+wuS
+wuS
+wuS
 wlF
 wCr
 gIJ
@@ -86327,7 +86654,7 @@ ylr
 ylr
 nnZ
 lWR
-iof
+ppy
 cTj
 loX
 shy
@@ -86337,7 +86664,7 @@ ptj
 jsX
 uts
 ihh
-hjG
+fNq
 gxo
 idJ
 xKP
@@ -86363,13 +86690,13 @@ tSp
 kdx
 nMU
 wQP
-dfg
+bOz
 qJD
 uku
 dot
 iNa
-kih
-vEP
+dpM
+qOZ
 blq
 bXE
 bYZ
@@ -86409,7 +86736,7 @@ clM
 clM
 clM
 vDp
-jTD
+prL
 gIJ
 jTD
 gIJ
@@ -86417,9 +86744,9 @@ xkg
 nnr
 tcj
 quY
-gOO
-gOO
-gOO
+wuS
+wuS
+wuS
 ukP
 gIJ
 gIJ
@@ -86584,7 +86911,7 @@ ylr
 ylr
 nnZ
 lWR
-iof
+ppy
 cTj
 aaQ
 shy
@@ -86594,7 +86921,7 @@ kNF
 hCR
 kNF
 avH
-ueu
+kNF
 mfe
 idJ
 pow
@@ -86648,7 +86975,7 @@ sCr
 llu
 sCr
 omM
-swz
+sCr
 ooJ
 bQK
 icl
@@ -86666,9 +86993,9 @@ vDp
 rml
 vDp
 vDp
-jTD
-gIJ
-jTD
+pUi
+wuk
+bAu
 gIJ
 fOG
 fOG
@@ -86698,7 +87025,7 @@ xSu
 xSu
 xSu
 fTO
-uES
+vZE
 xKD
 vCt
 cEj
@@ -86841,7 +87168,7 @@ ylr
 ylr
 nnZ
 lWR
-iof
+ppy
 cTj
 mTT
 shy
@@ -86851,7 +87178,7 @@ ptj
 pge
 uts
 ihh
-hjG
+fNq
 kPd
 idJ
 xKP
@@ -86877,7 +87204,7 @@ eYh
 xim
 koa
 erY
-dfg
+bOz
 gcF
 xHg
 pHG
@@ -86905,7 +87232,7 @@ ayj
 uBZ
 sQY
 iYN
-swz
+sCr
 ooJ
 vNj
 icl
@@ -86921,11 +87248,11 @@ arA
 jjD
 pEW
 rba
-gOO
-tzj
-dlR
+wuS
+lzc
+vRS
 gIJ
-jTD
+prL
 fOG
 fOG
 kwU
@@ -87098,7 +87425,7 @@ ylr
 lWR
 idJ
 ihh
-iof
+ppy
 axm
 dRH
 dUh
@@ -87365,7 +87692,7 @@ idJ
 idJ
 idJ
 idJ
-hjG
+fNq
 kPd
 idJ
 pCD
@@ -87391,14 +87718,14 @@ kAI
 bDo
 koa
 fre
-dfg
+bOz
 uau
 ttt
 cyk
 tSp
 tPf
 dpM
-ksq
+bEb
 bXE
 dkp
 eXZ
@@ -87417,9 +87744,9 @@ vmO
 fEe
 sCr
 sCr
-dHB
-swH
-pvV
+sCr
+sCr
+sCr
 dGO
 vNj
 icl
@@ -87612,7 +87939,7 @@ ylr
 lWR
 idJ
 ihh
-iof
+ppy
 fNq
 fNq
 fNq
@@ -87622,7 +87949,7 @@ fNq
 fNq
 fNq
 nHw
-hjG
+fNq
 kPd
 idJ
 dYW
@@ -87648,7 +87975,7 @@ jol
 jol
 koa
 hYh
-dfg
+bOz
 bOz
 bOz
 tZx
@@ -87700,7 +88027,7 @@ cyY
 fOG
 cYU
 lYH
-iLc
+eLP
 oaM
 dnx
 fOG
@@ -87879,7 +88206,7 @@ fNq
 fNq
 fNq
 nHw
-hjG
+fNq
 kPd
 idJ
 iuw
@@ -88136,7 +88463,7 @@ olZ
 nej
 qWG
 jDO
-wgw
+ttB
 kPd
 idJ
 eJT
@@ -88214,7 +88541,7 @@ gxy
 fOG
 mRa
 sxt
-egN
+uPG
 eDe
 jlD
 cmK
@@ -88420,30 +88747,30 @@ oRL
 osy
 jsG
 raj
-raj
-raj
-raj
-raj
+iey
+inC
+fuJ
+gxx
 syW
 fEz
-gkZ
-hUt
-eDH
-eDH
-eDH
-eDH
-eDH
-xTs
-eDH
-rZJ
-eDH
 bWN
-eDH
+hUt
+swM
+swM
+swM
+swM
+swM
+xTs
+swM
+rZJ
+swM
+bWN
+swM
 wZI
-eDH
+swM
 iOC
-eDH
-eDH
+swM
+swM
 xTs
 tXW
 jlK
@@ -88471,7 +88798,7 @@ xQJ
 fOG
 uqn
 uPG
-egN
+uPG
 uPG
 jRC
 aCJ
@@ -88662,7 +88989,7 @@ idT
 toP
 rOV
 hFw
-xHQ
+cTV
 jNk
 qcR
 puU
@@ -88676,10 +89003,10 @@ osy
 osy
 osy
 lTH
-cPC
-cPC
-vCb
-eDH
+foJ
+ran
+fEz
+swM
 eDH
 cPG
 xXK
@@ -88703,10 +89030,10 @@ bIW
 bIW
 bIW
 iAu
-xAt
-kYt
+bcM
+swM
 vcr
-nOr
+htP
 bSw
 vxr
 esC
@@ -88720,8 +89047,8 @@ ehB
 cod
 qTz
 ghI
-pOm
-pOm
+uRy
+uRy
 gtn
 gxy
 gxy
@@ -88919,9 +89246,9 @@ toP
 toP
 lqg
 qRF
-wTh
-cTV
-mye
+wVK
+wVK
+wSh
 rBt
 wVK
 oRL
@@ -88929,13 +89256,13 @@ okE
 okE
 okE
 osy
-sSu
+vsK
 rUM
 mPv
 gjP
-vCb
+fEz
 cmA
-auI
+jcb
 cPC
 rkl
 cAV
@@ -88963,9 +89290,9 @@ aJB
 bIW
 bIW
 tVO
-gkJ
-kYt
-kYt
+bcM
+swM
+swM
 hxU
 vxr
 kYf
@@ -88985,7 +89312,7 @@ ekJ
 ekJ
 hdL
 uPG
-egN
+uPG
 uPG
 qFq
 uPG
@@ -89183,14 +89510,14 @@ wVK
 wVK
 okE
 okE
-cPC
-cPC
-cPC
-cPC
-vCb
-eDH
+nZi
+foJ
+foJ
+ran
+fEz
+swM
 xTs
-auI
+jcb
 fYG
 bZP
 qAi
@@ -89223,8 +89550,8 @@ eOB
 bIW
 gQi
 roP
-gkJ
-kYt
+bcM
+swM
 qRD
 hxU
 uoT
@@ -89236,14 +89563,14 @@ gfj
 gfj
 pqb
 gfj
-pRu
+fGO
 gxy
 dZz
 dZz
 vcJ
 jZn
-nVh
-peT
+jZn
+jZn
 smj
 wXo
 akr
@@ -89443,7 +89770,7 @@ cPC
 fuA
 mVo
 mVo
-eDH
+swM
 nBj
 jjV
 jTN
@@ -89452,7 +89779,7 @@ qAi
 qAi
 qAi
 jqY
-gDs
+nMP
 wra
 sJa
 wtn
@@ -89483,17 +89810,17 @@ mnt
 eHk
 bIW
 roP
-gkJ
-kYt
+bcM
+swM
 eSO
 oJU
 pVF
 mGG
 uLk
 uLk
-hHk
-khg
-dUQ
+uLk
+uLk
+uLk
 mjk
 uLk
 uLk
@@ -89709,13 +90036,13 @@ qAi
 tQT
 xpH
 ewZ
-ewZ
+hNn
 ewZ
 sJa
 oLn
 pJl
 bXr
-ofy
+qeC
 ffF
 mwV
 skC
@@ -89742,16 +90069,16 @@ lGn
 jiY
 bIW
 roP
-xAt
-gXm
+gkJ
+sya
 xyo
-khg
-khg
-deM
-lzf
-ons
-aoW
-nwQ
+uLk
+uLk
+xpG
+dMI
+pYw
+uLk
+rjI
 dMI
 pYw
 vvk
@@ -89954,7 +90281,7 @@ wJB
 wJB
 osy
 cPC
-sJz
+dIl
 aXf
 aYf
 jFY
@@ -89972,7 +90299,7 @@ sJa
 kxF
 kxF
 bXr
-ofy
+qeC
 rAR
 sdB
 hlb
@@ -90000,7 +90327,7 @@ gyG
 gyG
 jiY
 roP
-bcM
+gkJ
 pHN
 jQg
 uLk
@@ -90008,12 +90335,12 @@ uLk
 uLk
 iQQ
 vFF
-nmk
+bsc
 bex
 nmk
 vNc
-eJG
 xnw
+kDr
 xnw
 xnw
 hEa
@@ -90210,8 +90537,8 @@ wUs
 xJA
 txm
 jgE
-vCb
-auI
+fEz
+jcb
 rdo
 jFY
 jFY
@@ -90223,7 +90550,7 @@ iTP
 ewZ
 ewZ
 ewZ
-ewZ
+hNn
 sJa
 sJa
 cNy
@@ -90258,19 +90585,19 @@ gyG
 gyG
 jiY
 roP
-bcM
+gkJ
 pHN
 jQg
 nwQ
 dMI
 pYw
-ivd
+uLk
 xpG
 dMI
 pYw
 uLk
 nwQ
-dMI
+lqI
 pYw
 uLk
 vvv
@@ -90478,15 +90805,15 @@ rpg
 rpg
 rpg
 rpg
-ewZ
-ewZ
-ewZ
+aQq
+aqY
+hNn
 sJa
 tYm
 pJl
 eGM
 xFT
-pJl
+rWK
 cNq
 pdc
 sJa
@@ -90495,7 +90822,7 @@ pZj
 sJa
 sJa
 sRu
-hlG
+ciO
 qAi
 uWp
 eBL
@@ -90516,18 +90843,18 @@ gyG
 gyG
 jiY
 roP
-xlp
-bQL
-khg
-khg
-khg
-dUQ
+iOl
+fWU
 uLk
 uLk
 uLk
 uLk
 uLk
 uLk
+uLk
+uLk
+uLk
+ivd
 uLk
 ykw
 lpn
@@ -90736,8 +91063,8 @@ ygl
 ygl
 rpg
 rpg
-ewZ
-ewZ
+hNn
+hNn
 sJa
 tYm
 pJl
@@ -90773,7 +91100,7 @@ hsS
 gyG
 gyG
 gFE
-dfT
+iOl
 fWU
 uLk
 dZz
@@ -90967,7 +91294,7 @@ kMy
 tHI
 nZt
 dIi
-xiw
+mGl
 mvu
 mGl
 qSI
@@ -90993,14 +91320,14 @@ jwl
 rIV
 ivY
 rpg
-ewZ
-ewZ
+hNn
+hNn
 sJa
 wRd
 pJl
 lyF
 pJl
-pJl
+rWK
 pJl
 qKF
 sJa
@@ -91226,7 +91553,7 @@ idJ
 eoC
 fNq
 tYy
-hjG
+fNq
 cIJ
 idJ
 jTp
@@ -91237,7 +91564,7 @@ mPK
 wJB
 wuw
 cPC
-dGG
+fEz
 tdD
 ijQ
 mqI
@@ -91250,8 +91577,8 @@ kmu
 ydM
 syB
 rpg
-hRP
-ewZ
+bSa
+hNn
 sJa
 wRd
 aLg
@@ -91265,8 +91592,8 @@ sJa
 sJa
 sJa
 sJa
-ewZ
-ewZ
+skI
+seK
 qAi
 iFJ
 oAH
@@ -91285,7 +91612,7 @@ bTJ
 bTJ
 bTJ
 byk
-gyG
+lZn
 uoK
 fLc
 ggg
@@ -91483,7 +91810,7 @@ lWR
 lBB
 fNq
 fNq
-hjG
+fNq
 wie
 idJ
 jTp
@@ -91493,8 +91820,8 @@ wJB
 wJB
 wJB
 sSu
-dGG
-ccu
+fEz
+bWJ
 rdo
 bTk
 bTk
@@ -91507,8 +91834,8 @@ pUf
 ydM
 bWH
 rpg
-ewZ
-hRP
+hNn
+bSa
 sJa
 sJa
 sJa
@@ -91544,7 +91871,7 @@ bhY
 cqe
 dVA
 iiI
-xAt
+gkJ
 sya
 cQq
 vam
@@ -91563,7 +91890,7 @@ kIz
 mvc
 xnb
 mew
-jTD
+prL
 fTd
 vDp
 ylr
@@ -91740,7 +92067,7 @@ lWR
 jiP
 fNq
 fNq
-hjG
+fNq
 jZW
 idJ
 jTp
@@ -91750,7 +92077,7 @@ dYW
 hQp
 iuw
 vvB
-iOl
+rvO
 cPC
 kPR
 bTk
@@ -91764,13 +92091,13 @@ iTa
 rIV
 cxT
 rpg
-ewZ
-ewZ
-ewZ
-ewZ
-ewZ
-ewZ
-jqY
+hNn
+wYT
+mSi
+mSi
+mSi
+mSi
+uPL
 gDs
 wra
 ewZ
@@ -91820,7 +92147,7 @@ hWo
 mvc
 fSn
 mew
-jTD
+prL
 bZz
 vDp
 vDp
@@ -92021,7 +92348,7 @@ ygl
 ygl
 rpg
 rpg
-ewZ
+hNn
 ewZ
 qAi
 qAi
@@ -92059,7 +92386,7 @@ cqe
 gyG
 gyG
 gFE
-dfT
+iOl
 jGz
 vam
 qud
@@ -92277,8 +92604,8 @@ rpg
 rpg
 rpg
 rpg
-ewZ
-ewZ
+pqM
+seK
 ewZ
 qEt
 ylr
@@ -92316,7 +92643,7 @@ jin
 vjs
 guO
 gFE
-dfT
+iOl
 jGz
 mew
 mew
@@ -92523,18 +92850,18 @@ cPC
 aen
 mQx
 pOs
-bIo
-yiG
-ptk
-ewZ
-csM
-ewZ
-ewZ
-ewZ
-njL
-ewZ
-ewZ
-ewZ
+jix
+bXc
+xFQ
+mSi
+nzh
+mSi
+mSi
+mSi
+foR
+mSi
+mSi
+seK
 ewZ
 qEt
 qEt
@@ -92573,7 +92900,7 @@ hwv
 uIU
 rIh
 gFE
-dfT
+iOl
 nWv
 jEs
 rSz
@@ -92591,7 +92918,7 @@ mew
 mew
 mew
 mew
-jTD
+prL
 gIJ
 gIJ
 fTd
@@ -92781,7 +93108,7 @@ dGG
 ccu
 nTT
 qAi
-wra
+xZP
 ewZ
 ewZ
 csM
@@ -92831,7 +93158,7 @@ jvn
 jvn
 dFK
 jKM
-jgd
+nOr
 lrB
 rkz
 eNe
@@ -92848,7 +93175,7 @@ nKe
 gIJ
 vDp
 dyp
-arm
+vor
 gIJ
 gIJ
 fTd
@@ -93038,7 +93365,7 @@ rTA
 yfd
 qAi
 qAi
-ewZ
+hNn
 ewZ
 qAi
 qAi
@@ -93105,7 +93432,7 @@ nKe
 gIJ
 vDp
 nfI
-arm
+vor
 gIJ
 gIJ
 vwN
@@ -93295,7 +93622,7 @@ iOl
 cPC
 qAi
 uTF
-ewZ
+hNn
 ewZ
 qAi
 ylr
@@ -93346,11 +93673,11 @@ jqS
 jvn
 khu
 dfT
-cPC
-aqy
+foJ
+sYg
 jSm
 hcg
-tGP
+eqm
 fgA
 oqE
 nAq
@@ -93363,22 +93690,22 @@ gIJ
 epV
 gIJ
 sXI
-gOO
-gOO
-gOO
-gOO
-gOO
-gOO
+wuS
+woN
+wuS
+wuS
+wuS
+wuS
 bsD
 bbd
-flF
-flF
-flF
+sPi
+sPi
+sPi
 dLW
-flF
+sPi
 ogw
-flF
-flF
+sPi
+sPi
 qSK
 gUe
 gUe
@@ -93541,18 +93868,18 @@ sqv
 vNC
 wvA
 gOp
-cmQ
+tQN
 dCw
 sLx
-cmQ
+tQN
 sbq
-swM
-swM
+kYt
+kYt
 yfZ
 cPC
 qAi
 wKZ
-ewZ
+hNn
 ewZ
 qAi
 xSu
@@ -93602,13 +93929,13 @@ fLD
 stM
 jvn
 xsb
-dfT
+iOl
 cPC
 aqy
 lmJ
 gKs
 tGP
-fgA
+xDe
 oqE
 isM
 rsm
@@ -93621,7 +93948,7 @@ vDp
 gIJ
 gIJ
 gIJ
-gIJ
+jCD
 gIJ
 gIJ
 gIJ
@@ -93642,7 +93969,7 @@ oLK
 oLK
 uix
 cwn
-flF
+sPi
 dGL
 flF
 flF
@@ -93798,18 +94125,18 @@ aet
 aet
 pyk
 lbA
-fjw
-fjw
-fjw
-fjw
-nKY
-foJ
-foJ
-xXk
+pZt
+pZt
+pZt
+pZt
+naV
+cPC
+cPC
+iOl
 gGr
 qAi
 iTP
-ewZ
+hNn
 ewZ
 qAi
 xSu
@@ -93859,7 +94186,7 @@ jqa
 wEp
 jvn
 khu
-dfT
+iOl
 cPC
 hCp
 xQe
@@ -93878,7 +94205,7 @@ vDp
 vDp
 qmO
 nGh
-gIJ
+iIo
 gIJ
 geT
 gIJ
@@ -94062,11 +94389,11 @@ tge
 yfL
 cPC
 cPC
-oZy
+sQt
 cPC
 qAi
-ewZ
-ewZ
+maD
+seK
 ewZ
 qAi
 qAi
@@ -94116,7 +94443,7 @@ kHX
 kHX
 jvn
 khu
-dfT
+iOl
 bcF
 hMK
 fiB
@@ -94319,7 +94646,7 @@ eZJ
 yfL
 cPC
 rgs
-dfT
+iOl
 nvt
 qAi
 hlG
@@ -94373,7 +94700,7 @@ pEz
 sHp
 dMR
 khu
-dfT
+iOl
 aqy
 uix
 dhx
@@ -94403,7 +94730,7 @@ uix
 eYz
 qKy
 ths
-kDP
+qpL
 wsV
 fYs
 vLb
@@ -94576,7 +94903,7 @@ pAL
 pAL
 pww
 eNt
-dfT
+iOl
 cPC
 tEq
 tEq
@@ -94619,7 +94946,7 @@ rvl
 rvl
 rvl
 eWC
-nvb
+pxl
 ctN
 xDP
 sjM
@@ -94630,7 +94957,7 @@ moM
 fvg
 dMR
 khu
-dfT
+iOl
 aqy
 uix
 oiD
@@ -94833,7 +95160,7 @@ iWA
 nUV
 gAv
 uTm
-oZy
+sQt
 yfd
 tEq
 hmN
@@ -94893,7 +95220,7 @@ uix
 aSi
 tGP
 tGP
-hJf
+xIQ
 xNB
 uix
 sRv
@@ -95144,7 +95471,7 @@ aQN
 wEq
 dMR
 hyJ
-dfT
+iOl
 aqy
 uix
 lJp
@@ -95338,7 +95665,7 @@ qJL
 aBt
 lwl
 awv
-gWw
+rNo
 igx
 cOe
 usN
@@ -95395,7 +95722,7 @@ bPr
 fho
 dMR
 sDs
-enu
+chD
 amE
 enu
 mqo
@@ -95603,7 +95930,7 @@ tHB
 uhl
 bwY
 uaC
-xje
+kYt
 pHP
 cPC
 lTu
@@ -95659,7 +95986,7 @@ hKh
 dMR
 hyJ
 rvO
-ogY
+aqy
 uix
 rGO
 xIQ
@@ -95908,7 +96235,7 @@ kFW
 iGX
 jcf
 bZW
-ccr
+qRg
 agh
 cqa
 agh
@@ -96117,7 +96444,7 @@ kzM
 gNx
 liD
 gAv
-iTk
+uTm
 iOl
 cPC
 tEq
@@ -96363,8 +96690,8 @@ uJQ
 mIc
 gNx
 bdW
-gNx
-gNx
+erz
+erz
 cAv
 vfV
 wsx
@@ -96374,7 +96701,7 @@ ueJ
 luv
 rmP
 gAv
-iTk
+uTm
 sQt
 vXF
 qAi
@@ -96618,9 +96945,9 @@ qhu
 tue
 mki
 bSU
-uhl
+vYD
 fiz
-uhl
+vYD
 wvM
 xLx
 lRa
@@ -96888,7 +97215,7 @@ sgT
 jHI
 bgM
 pVC
-iIL
+gFE
 iOl
 mAK
 qAi
@@ -97134,7 +97461,7 @@ pTe
 usN
 cRl
 cRl
-gNx
+nat
 beR
 ktX
 pww
@@ -97145,7 +97472,7 @@ sQo
 sQo
 xOt
 pVC
-iIL
+gFE
 sQt
 cPC
 qAi
@@ -97391,10 +97718,10 @@ wvC
 crc
 xwz
 vGG
-nat
+bsp
 cVx
-igx
-pww
+ePT
+nuh
 jUv
 agl
 nhS
@@ -97496,9 +97823,9 @@ xSu
 xSu
 xSu
 uix
-dGe
-dNe
-xkI
+fjA
+dZF
+vvL
 bpb
 xbB
 xbB
@@ -97648,18 +97975,18 @@ xor
 xor
 nuh
 bsp
-bsp
+yaT
 bFF
 mZT
 nuh
 tby
 hza
-xDV
-cya
-cya
-cya
+sQo
+sQo
+sQo
+sQo
 jeL
-foJ
+cPC
 qYP
 yfd
 qAi
@@ -97905,13 +98232,13 @@ yep
 wEP
 nuh
 meM
-wBw
+soG
 ffl
 pnR
 nuh
 iqS
 hza
-aVD
+sQo
 sQo
 sQo
 sQo
@@ -98005,12 +98332,12 @@ rQg
 imH
 xSu
 oLK
-dGe
-dNe
-dNe
-dNe
-dNe
-xkI
+fjA
+dZF
+dZF
+dZF
+dZF
+vvL
 uJr
 uJr
 uJr
@@ -98161,14 +98488,14 @@ vXv
 lHr
 gHZ
 nuh
-ohe
+hEb
 cfw
 hIy
 goo
 nuh
 caN
 ncf
-aVD
+sQo
 xAF
 lXw
 kOm
@@ -98418,14 +98745,14 @@ sOg
 ljJ
 mYp
 nuh
-hEb
-biO
+qSJ
+wBw
 cuq
 wqs
 xfr
 toe
 jdP
-rJO
+toe
 fpH
 fpH
 fpH
@@ -98676,13 +99003,13 @@ bOO
 sVV
 nuh
 qSJ
-wBw
+ezB
 sst
 ptF
 xfr
 oib
 lHe
-fYB
+jMb
 fpH
 uQT
 cbl
@@ -98997,7 +99324,7 @@ ylr
 xSu
 eBU
 cPC
-gRd
+dfE
 nHV
 nTT
 xbB
@@ -99032,8 +99359,8 @@ xSu
 xSu
 uix
 dGe
-dNe
-xkI
+vLL
+vvL
 kQk
 klP
 uJr
@@ -99204,7 +99531,7 @@ jkL
 fpH
 opr
 tqN
-ukp
+gZj
 fRv
 qAi
 hPb
@@ -99254,7 +99581,7 @@ xSu
 eBU
 eBU
 cPC
-dfT
+iOl
 qoB
 oXw
 xbB
@@ -99511,7 +99838,7 @@ ylr
 eBU
 cPC
 cPC
-dfT
+iOl
 ioM
 ijq
 ijq
@@ -99527,11 +99854,11 @@ ijq
 dDP
 uJr
 trq
-dNe
-dNe
-dNe
+dZF
+dZF
+dZF
 sPW
-nvS
+hLg
 nQq
 ouZ
 aPm
@@ -99546,7 +99873,7 @@ dNe
 dNe
 dNe
 xkI
-uJr
+knu
 xbB
 aGn
 aGn
@@ -99768,10 +100095,10 @@ xSu
 bDj
 tLB
 cPC
-dfT
+iOl
 ioM
 uAj
-muu
+eBH
 ulC
 ijq
 oqt
@@ -99803,7 +100130,7 @@ uJr
 uJr
 uJr
 uJr
-uJr
+knu
 bPu
 aGn
 aGn
@@ -99966,8 +100293,8 @@ jBL
 vXY
 wSN
 neO
-xZI
-ixn
+jMb
+hZJ
 fpH
 xDB
 oZu
@@ -100029,7 +100356,7 @@ bqR
 dwa
 gIx
 msR
-eBH
+rPK
 wTN
 ocw
 ocw
@@ -100039,7 +100366,7 @@ mFm
 mFm
 mFm
 gwb
-dNe
+dZF
 qYW
 nQq
 nQq
@@ -100060,7 +100387,7 @@ vDs
 vil
 uJr
 uJr
-uJr
+tfK
 xbB
 aGn
 aGn
@@ -100279,11 +100606,11 @@ xPK
 rSB
 kNq
 vdN
-eDH
-nrN
+kYt
+kYt
 diP
 auI
-qoB
+mas
 pAQ
 eBH
 eBH
@@ -100480,7 +100807,7 @@ jBL
 cwM
 csp
 eLj
-dOS
+iIn
 cII
 cjS
 jPZ
@@ -100491,7 +100818,7 @@ tho
 ksy
 iny
 eKG
-ukp
+gZj
 azs
 cQq
 fNl
@@ -100537,7 +100864,7 @@ cIr
 qrq
 pAH
 gRd
-lEf
+swM
 jVc
 gGv
 sAd
@@ -100554,7 +100881,7 @@ uTe
 sgr
 ijq
 uJr
-sAN
+htA
 nQq
 jHy
 jHy
@@ -100749,7 +101076,7 @@ ksy
 ksy
 ewp
 eKG
-sQt
+dIl
 nWv
 cQq
 fNl
@@ -100793,7 +101120,7 @@ ofi
 ofi
 tJo
 eaP
-dfT
+rvO
 cPC
 ioM
 iEQ
@@ -100811,7 +101138,7 @@ oxu
 oxu
 ijq
 uJr
-sAN
+htA
 nQq
 tmJ
 jHy
@@ -100994,7 +101321,7 @@ nTb
 xbS
 lDd
 tMp
-btw
+iIn
 hLQ
 jlB
 eZW
@@ -101007,7 +101334,7 @@ ksy
 ksy
 khu
 dqS
-kYt
+swM
 uKf
 cQq
 fNl
@@ -101050,7 +101377,7 @@ ofi
 tJo
 eaP
 gRd
-auI
+jcb
 qoB
 qWX
 iEQ
@@ -101068,7 +101395,7 @@ iSC
 nOQ
 ijq
 uJr
-sAN
+htA
 nQq
 tmJ
 jHy
@@ -101264,8 +101591,8 @@ ulA
 smr
 gDt
 xvm
-cPC
-iOl
+foJ
+gcD
 nWv
 sEb
 fnh
@@ -101305,8 +101632,8 @@ uNK
 uNK
 uNK
 hoL
-eDH
-auI
+swM
+jcb
 qoB
 sAd
 iEQ
@@ -101325,7 +101652,7 @@ jpX
 nOQ
 ijq
 rLc
-sAN
+htA
 nQq
 cxk
 jWb
@@ -101507,11 +101834,11 @@ jBL
 jBL
 xbS
 lDd
-jes
+tMp
 wWP
 bGw
 uQH
-mCs
+jFa
 ksy
 cre
 hmF
@@ -101561,7 +101888,7 @@ cPC
 gRd
 auh
 eLW
-auI
+jcb
 qoB
 gGv
 sAd
@@ -101750,8 +102077,8 @@ oPS
 oPS
 tjp
 hdN
-jyr
-bur
+uzK
+kdA
 oPS
 oPS
 eGX
@@ -101768,7 +102095,7 @@ xJU
 ivQ
 xfr
 qHI
-maz
+jFa
 brs
 brs
 brs
@@ -101815,7 +102142,7 @@ cPC
 cPC
 cPC
 gRd
-auI
+jcb
 qoB
 fOK
 gGv
@@ -102007,10 +102334,10 @@ oKL
 nZf
 bgx
 dYG
-lJF
+bur
 ruG
-oPS
-nbU
+vKm
+jcu
 fGZ
 jFa
 jBL
@@ -102025,7 +102352,7 @@ fPW
 iIn
 xfr
 jFa
-maz
+jFa
 pQN
 brs
 iqk
@@ -102043,14 +102370,14 @@ gRD
 gGv
 vYJ
 eIc
-suY
+kYt
 kYt
 ovy
-jgd
+nOr
 jgE
 dpq
 cPC
-fTF
+iOl
 cPC
 tWc
 asN
@@ -102068,9 +102395,9 @@ cPC
 dIl
 cPC
 gRd
-eDH
-eDH
-eDH
+swM
+swM
+swM
 kZY
 gGv
 sAd
@@ -102264,11 +102591,11 @@ oKL
 dlT
 pLU
 idl
-rOW
+bur
 qAF
 oPS
-rgv
-fGZ
+jFa
+kqW
 jFa
 jBL
 atr
@@ -102282,7 +102609,7 @@ xJU
 kZs
 xfr
 piy
-maz
+jFa
 wQS
 brs
 iqk
@@ -102291,7 +102618,7 @@ iqk
 iqk
 brs
 jFa
-bLl
+mka
 qkO
 hhB
 ioA
@@ -102300,27 +102627,27 @@ lvD
 lvD
 gRD
 lHd
-ksh
+gGv
 gGv
 vYJ
-erF
-eLW
-iOC
-eDH
+ukp
+uIX
+qHy
+kYt
 frG
-eDH
-eDH
-eDH
-bWN
+kYt
+kYt
+kYt
+nQx
 pDO
 xxb
-kYt
+hoD
 dsM
 kYt
 kYt
 aBs
 kYt
-vsV
+kYt
 uos
 jQN
 bxF
@@ -102519,13 +102846,13 @@ xSu
 xSu
 oKL
 vJg
-gdU
-kQx
+xqF
+xqF
 xqF
 wUq
-jHB
-nHI
-rny
+oPS
+nbU
+kqW
 jFa
 sth
 gUD
@@ -102539,7 +102866,7 @@ xfr
 xfr
 xfr
 jFa
-maz
+jFa
 fyF
 brs
 iqk
@@ -102548,12 +102875,12 @@ iqk
 iqk
 sJl
 jFa
-bLl
+mka
 ykQ
 hhB
 nZg
-mEX
-sON
+wjI
+wjI
 lvD
 hhB
 xne
@@ -102775,17 +103102,17 @@ pHO
 pHO
 pHO
 oKL
-nPK
+oKL
 jYA
 mZS
-nPK
+oPS
 ivq
 oPS
 lyQ
 xQM
 pZM
 pZM
-pZM
+orT
 agW
 jFa
 pOg
@@ -102796,7 +103123,7 @@ wUI
 alE
 nPH
 cnT
-maz
+jFa
 jFa
 brs
 iqk
@@ -102805,7 +103132,7 @@ iqk
 iqk
 brs
 sBp
-bLl
+mka
 lyQ
 hhB
 tGN
@@ -102852,7 +103179,7 @@ vra
 aBK
 dKd
 vra
-vBx
+sSQ
 tSq
 qhm
 aFL
@@ -102861,9 +103188,9 @@ dkN
 jzR
 vfk
 uJr
-dGe
-noR
-noR
+fjA
+pVT
+pVT
 wiS
 rsR
 faC
@@ -103053,7 +103380,7 @@ jFa
 jFa
 nPH
 jFa
-maz
+jFa
 jFa
 brs
 iqk
@@ -103062,7 +103389,7 @@ iqk
 iqk
 brs
 jFa
-bLl
+mka
 kWC
 hhB
 nQB
@@ -103109,7 +103436,7 @@ vra
 vBx
 mzt
 fsl
-kjA
+isB
 cVD
 qEj
 rvi
@@ -103310,7 +103637,7 @@ kfB
 jFa
 eit
 jFa
-maz
+jFa
 jFa
 brs
 brs
@@ -103319,9 +103646,9 @@ brs
 brs
 brs
 jFa
-bLl
-gYl
-hhB
+cew
+nHI
+iuY
 wPm
 gMZ
 gMZ
@@ -103342,13 +103669,13 @@ leC
 ouG
 gHm
 eRv
-olk
+mpR
 mfu
 prH
 iQb
 mCZ
 mfu
-eSU
+avf
 qEj
 enL
 hur
@@ -103366,7 +103693,7 @@ fkv
 kjA
 cVD
 uLb
-qEj
+pFO
 pST
 qEj
 rdK
@@ -103567,17 +103894,17 @@ pZM
 pZM
 gPH
 pZM
-szl
-ueL
-ueL
+pZM
+pZM
+pZM
 ire
 bxr
-oaI
+xpI
 dEz
 oaI
 oaI
 wJL
-jFa
+gYl
 hhB
 dwG
 kXP
@@ -103599,7 +103926,7 @@ dBR
 ouG
 kPn
 tPX
-olk
+mpR
 mfu
 vRh
 iQb
@@ -103613,7 +103940,7 @@ vra
 vBx
 ghg
 qhm
-qhm
+lnV
 qhm
 mzt
 uBS
@@ -103630,9 +103957,9 @@ dbb
 qHt
 oua
 tAX
-dNe
-dNe
-xkI
+dZF
+dZF
+vvL
 uJr
 uJr
 eJH
@@ -103829,7 +104156,7 @@ jgH
 jgH
 jgH
 bLl
-jFa
+maz
 ehx
 jFa
 qka
@@ -103870,13 +104197,13 @@ vra
 avf
 kTF
 qEj
-qEj
+pFO
 qEj
 cVD
 qEj
 qEj
 kNh
-evb
+wPy
 gYk
 fWj
 fWj
@@ -104113,7 +104440,7 @@ sIn
 ouG
 tyS
 eRv
-uKl
+cwv
 otq
 fED
 iQb
@@ -104125,12 +104452,12 @@ qhm
 qiP
 jYf
 qjo
-plu
-pxd
-pxd
-pxd
+kTF
+qEj
+pFO
+qEj
 bOr
-fcD
+tym
 hGL
 uQP
 fWj
@@ -104370,7 +104697,7 @@ mTZ
 cde
 niS
 iqN
-iqN
+vSy
 iqN
 iqN
 ccv
@@ -104384,10 +104711,10 @@ noV
 iWv
 kiM
 noV
-noV
+aIF
 noV
 rBR
-jIe
+gYk
 fWj
 tAE
 fWj
@@ -104396,7 +104723,7 @@ fUl
 fWj
 qls
 sQp
-opf
+vKV
 vKV
 ceS
 oMD
@@ -104408,7 +104735,7 @@ uJr
 uJr
 rEi
 uJr
-uJr
+wtD
 uJr
 nQq
 jHy
@@ -104600,7 +104927,7 @@ kSm
 smZ
 jgH
 gNd
-fTU
+uXy
 nPH
 twP
 egt
@@ -104627,19 +104954,19 @@ ouG
 ouG
 gKD
 eRv
-uaF
+bcs
 xJk
 xJk
 xJk
 xVC
 mfu
 ngA
-xui
-xui
-xui
-xui
+dPp
+dPp
+dPp
+dPp
 mIn
-xui
+dPp
 moA
 twb
 kEO
@@ -104652,8 +104979,8 @@ tqC
 tqC
 eMV
 bsI
-dAJ
-qVx
+wmc
+qeu
 kEi
 kEi
 kEi
@@ -104665,7 +104992,7 @@ rsK
 rsK
 rsK
 rsK
-uJr
+ePy
 uJr
 nQq
 nQq
@@ -104857,7 +105184,7 @@ gxC
 mVH
 jgH
 brs
-fTU
+uXy
 nPH
 owH
 jFa
@@ -104875,12 +105202,12 @@ mfu
 mfu
 tlj
 bOf
-uok
+uKl
 hXi
 fZV
 cLC
 qfd
-lQZ
+otq
 hXi
 tWp
 eRv
@@ -104905,8 +105232,8 @@ fWj
 jlg
 gCm
 tqC
-wWJ
-tkl
+tqC
+tqC
 lEQ
 eGa
 uOq
@@ -104922,7 +105249,7 @@ rFh
 cwh
 qod
 rsK
-uJr
+knu
 uJr
 xbB
 ylr
@@ -105114,7 +105441,7 @@ gxC
 uua
 ksJ
 ufM
-fTU
+uXy
 eit
 jFa
 tUg
@@ -105139,7 +105466,7 @@ fug
 cFn
 cFn
 cFn
-maL
+bOf
 eRv
 wVZ
 jEc
@@ -105370,8 +105697,8 @@ ylr
 gxC
 qXg
 ksJ
-jFa
-fTU
+hrC
+hJA
 eit
 pOg
 jFa
@@ -105416,10 +105743,10 @@ qvj
 ykt
 jnd
 wnG
-tkl
-eDG
-tkl
-jOP
+tqC
+aGC
+tqC
+tqC
 siA
 fWj
 xFb
@@ -105670,8 +105997,8 @@ bwX
 dAf
 dEj
 sVE
-wPs
-asF
+avf
+xfz
 eMV
 rEd
 vHz
@@ -105927,7 +106254,7 @@ bwX
 lWG
 cDi
 icQ
-vqp
+avf
 ghq
 fWj
 xTi
@@ -105950,7 +106277,7 @@ ixN
 kvm
 yda
 rsK
-uJr
+knu
 uJr
 mMC
 ylr
@@ -106207,7 +106534,7 @@ rsK
 rsK
 rsK
 rsK
-sAg
+jQd
 sAg
 xbB
 ylr
@@ -106441,7 +106768,7 @@ nFF
 ccs
 rjl
 dQt
-vqp
+avf
 xfz
 fWj
 avO
@@ -106460,11 +106787,11 @@ epS
 cJk
 aHr
 cJk
-uJr
-uJr
-uJr
-uJr
-uJr
+xux
+tZv
+tZv
+tZv
+sjj
 uJr
 xbB
 ylr
@@ -106698,7 +107025,7 @@ bbW
 wnY
 qmE
 rGq
-vqp
+avf
 rPg
 fWj
 dZx
@@ -106717,7 +107044,7 @@ sQr
 mjO
 xGX
 cJk
-uJr
+uNh
 uJr
 uJr
 uJr
@@ -106955,7 +107282,7 @@ xdh
 sur
 xMI
 cDD
-vqp
+avf
 xfz
 fWj
 fWj
@@ -107212,7 +107539,7 @@ nEV
 nEV
 ueH
 dQt
-vqp
+avf
 pFT
 aTg
 sfw
@@ -107983,7 +108310,7 @@ dvb
 tWh
 rfr
 glV
-vqp
+avf
 pFT
 uVE
 fJm

--- a/_maps/map_files/DonutStation/DonutStation.dmm
+++ b/_maps/map_files/DonutStation/DonutStation.dmm
@@ -353,6 +353,16 @@
 "ahA" = (
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
+"ahG" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/mail_sorting/science/research,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ahK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastleft{
@@ -371,6 +381,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"aib" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "aiI" = (
 /obj/machinery/pipedispenser,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -790,12 +808,6 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"aqY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "arm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1119,6 +1131,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"awo" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "awv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1269,6 +1293,18 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"azS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "aBa" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1482,6 +1518,12 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/nuke_storage)
+"aFB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "aFL" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
@@ -1512,6 +1554,17 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/bridge)
+"aGg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aGn" = (
 /turf/template_noop,
 /area/maintenance/aft)
@@ -1591,6 +1644,21 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
+"aHG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "aHH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -1614,15 +1682,6 @@
 /obj/item/soap/nanotrasen,
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
-"aIF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/junction,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aII" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/ale,
@@ -1973,11 +2032,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"aQq" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "aQs" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Foyer";
@@ -2011,6 +2065,15 @@
 	icon_state = "damaged3"
 	},
 /area/space/nearstation)
+"aQB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "aQK" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey{
@@ -2449,6 +2512,13 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/fore)
+"bay" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/obj/machinery/disposal/bin/tagger,
+/turf/open/floor/plasteel/dark,
+/area/tcommsat/computer)
 "baH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -2554,13 +2624,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
-"bcs" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "bcF" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip,
@@ -2623,6 +2686,21 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"bdU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "bdW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -3079,6 +3157,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"blu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
+"blN" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "blO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -3342,13 +3433,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bsc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/kitchen)
 "bsf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -3388,18 +3472,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"bsu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "bsw" = (
 /obj/machinery/bluespace_beacon,
 /obj/effect/turf_decal/stripes/line,
@@ -3447,6 +3519,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"bsZ" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "btE" = (
 /obj/structure/sign/departments/custodian{
 	pixel_y = -32
@@ -3558,6 +3640,15 @@
 /obj/machinery/pool_filter,
 /turf/open/indestructible/sound/pool/end,
 /area/crew_quarters/fitness/recreation)
+"bvr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "bvJ" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Surgery Observation"
@@ -3810,21 +3901,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
-"bAu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "bBh" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -4046,6 +4122,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/turf_decal/trimline/brown/warning/lower{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bFM" = (
@@ -4187,13 +4266,6 @@
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
 /area/space)
-"bIM" = (
-/obj/effect/landmark/blobstart,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "bIW" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 4
@@ -4690,14 +4762,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bSa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/central)
 "bSc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -4897,18 +4961,6 @@
 /obj/structure/closet/crate/rcd,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"bWJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bWM" = (
 /obj/structure/rack,
 /obj/item/aicard,
@@ -4930,15 +4982,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bXc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "bXq" = (
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
@@ -5011,6 +5054,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"bYP" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 9
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel,
+/area/security/brig)
+"bYW" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "bYZ" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/machinery/button/door{
@@ -5378,22 +5435,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/dark,
 /area/security/interrogation)
-"cew" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/mail_sorting/security/detectives_office,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "ceN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -5437,11 +5478,11 @@
 	},
 /area/maintenance/port/fore)
 "cfw" = (
-/obj/effect/turf_decal/trimline/brown/warning/lower{
-	dir = 1
-	},
 /obj/structure/disposalpipe/sorting/wrap/flip{
 	dir = 1
+	},
+/obj/effect/turf_decal/trimline/brown/warning/lower{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -5520,19 +5561,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/processing)
-"chD" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 1;
-	pixel_y = -1
-	},
-/obj/effect/mapping_helpers/mail_sorting/engineering/general,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "chE" = (
 /obj/item/stack/cable_coil/cut/red,
 /turf/open/floor/plasteel/airless{
@@ -5624,14 +5652,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/janitor)
-"ciO" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "ciX" = (
 /obj/machinery/light/small,
 /obj/machinery/camera/motion{
@@ -5760,6 +5780,21 @@
 "clM" = (
 /turf/template_noop,
 /area/maintenance/port/aft)
+"clR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cmA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -6114,6 +6149,15 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
+"cuj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "cuq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -6250,15 +6294,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"cwv" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "cww" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -6501,6 +6536,13 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/engine/atmos)
+"cAh" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/landmark/start/cargo_technician,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "cAl" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -7173,13 +7215,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"cNm" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "cNq" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/wood,
@@ -7376,12 +7411,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"cQU" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/plasticflaps/opaque,
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "cQX" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cRl" = (
 /obj/effect/landmark/start/cargo_technician,
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "cSd" = (
@@ -7527,6 +7568,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -8024,14 +8068,6 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"dfs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/port)
 "dfE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -8323,18 +8359,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"dmO" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "dmS" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenocontainment";
@@ -8379,6 +8403,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"dnC" = (
+/obj/structure/chair,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/kitchen)
+"dnK" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/kitchen)
 "dnV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -8685,6 +8729,10 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"duF" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "dvb" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -8895,6 +8943,15 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"dzT" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "dAf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -9872,6 +9929,21 @@
 /obj/item/toy/cards/deck,
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
+"dUa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "dUh" = (
 /obj/effect/turf_decal/trimline/white/filled/corner/lower{
 	dir = 1
@@ -10096,15 +10168,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"dZF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "dZN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -10711,15 +10774,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/bar)
-"eno" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "enu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10814,10 +10868,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"eqm" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "eqM" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -10854,10 +10904,6 @@
 /obj/effect/mapping_helpers/mail_sorting/science/rd_office,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"erz" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "erJ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -11040,15 +11086,15 @@
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"eul" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "eun" = (
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
+"euu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "euM" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -11093,14 +11139,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"ewb" = (
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/mail_sorting/science/toxins,
-/obj/effect/mapping_helpers/mail_sorting/science/xenobiology,
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "ewp" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 5
@@ -11240,15 +11278,6 @@
 /obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"ezB" = (
-/obj/effect/turf_decal/trimline/brown/warning/lower{
-	dir = 1
-	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "packageSort2"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
 "ezI" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -11531,6 +11560,18 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"eFK" = (
+/obj/structure/window/reinforced{
+	layer = 2.9
+	},
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/quartermaster/sorting)
 "eGa" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
@@ -11540,6 +11581,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"eGe" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "eGr" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/machinery/door/firedoor/border_only{
@@ -12002,15 +12052,6 @@
 /obj/item/stack/cable_coil/cut/red,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"ePy" = (
-/obj/structure/disposalpipe/broken{
-	dir = 4
-	},
-/obj/structure/disposalpipe/broken{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "ePE" = (
 /obj/machinery/computer/cloning{
 	dir = 8
@@ -12021,20 +12062,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics/cloning)
-"ePT" = (
-/obj/effect/turf_decal/trimline/brown/filled/line/lower,
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Office";
-	req_access_txt = "50"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
 "ePY" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -12211,6 +12238,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"eTu" = (
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/mail_sorting/science/toxins,
+/obj/effect/mapping_helpers/mail_sorting/science/xenobiology,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "eTx" = (
 /obj/structure/sign/departments/security{
 	pixel_x = 32
@@ -12757,11 +12792,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/brown/warning/lower{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/warning/lower{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -12806,6 +12841,22 @@
 "ffF" = (
 /turf/open/floor/plasteel/stairs/goon/wood_stairs_middle,
 /area/library)
+"ffL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/mail_sorting/service/theater,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "ffW" = (
 /obj/machinery/airalarm/tcomms{
 	dir = 4;
@@ -12937,6 +12988,12 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"fhD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "fhP" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/solars/solar_96,
@@ -13019,21 +13076,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"fjA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "fjF" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -13220,12 +13262,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"foR" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/central)
 "fpe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -13260,6 +13296,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"fpP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "fpS" = (
 /obj/machinery/air_sensor/atmos/carbon_tank,
 /turf/open/floor/engine/co2{
@@ -13576,13 +13624,13 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/fore)
-"fuJ" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 8
+"fuK" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/turf/open/floor/wood,
+/area/library)
 "fva" = (
 /obj/structure/girder,
 /obj/effect/turf_decal/stripes/corner{
@@ -13867,18 +13915,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"fyE" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "fyF" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
@@ -14921,6 +14957,18 @@
 "fWj" = (
 /turf/closed/wall,
 /area/security/main)
+"fWu" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "fWP" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 4
@@ -15158,6 +15206,14 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
+"gcc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "gcp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -15191,21 +15247,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"gcD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "gcF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -16111,16 +16152,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"gxx" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/mail_sorting/service/library,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "gxy" = (
 /turf/closed/wall,
 /area/crew_quarters/bar)
@@ -16291,6 +16322,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"gCx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "gDs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -16490,6 +16527,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"gII" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "gIJ" = (
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -16695,6 +16745,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"gOb" = (
+/obj/item/kirbyplants/random,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "gOc" = (
 /obj/machinery/power/smes/engineering{
 	charge = 5e+006;
@@ -17083,17 +17140,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
-"gVY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
 "gWd" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -17227,18 +17273,6 @@
 	dir = 4
 	},
 /area/crew_quarters/dorms)
-"gZj" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "gZz" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 8
@@ -17279,6 +17313,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"hay" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/science/research)
 "haC" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/shaker,
@@ -17308,6 +17348,13 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
+"hbp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/kitchen)
 "hcg" = (
 /obj/structure/chair{
 	dir = 1
@@ -17610,6 +17657,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
+"hko" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "hkC" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -17697,11 +17755,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/fitness)
-"hmw" = (
-/obj/structure/grille,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "hmE" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
@@ -17859,15 +17912,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"hoD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/junction/flip,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "hoL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -18021,11 +18065,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"hrC" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "hrW" = (
 /obj/structure/sign/departments/science{
 	pixel_y = 32
@@ -18042,6 +18081,9 @@
 	},
 /obj/machinery/disposal/bin{
 	name = "sample disposal unit"
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -18068,6 +18110,11 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel,
+/area/hydroponics)
+"hsZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
 /area/hydroponics)
 "htb" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower,
@@ -18104,33 +18151,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/fore)
-"htA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
-"htP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "hub" = (
 /turf/closed/wall/r_wall,
 /area/security/prison)
@@ -18265,6 +18285,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"hwG" = (
+/obj/structure/grille/broken,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "hwH" = (
 /obj/effect/turf_decal/pool{
 	dir = 4
@@ -18310,6 +18335,11 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"hxo" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "hxt" = (
 /obj/machinery/gulag_processor,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -18419,6 +18449,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"hzB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "hAd" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -18546,6 +18591,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"hBX" = (
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "hCk" = (
 /obj/effect/turf_decal/stripes{
 	dir = 1
@@ -18828,6 +18884,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/storage)
+"hIq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hIt" = (
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
@@ -18844,6 +18912,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/effect/turf_decal/trimline/brown/warning/lower/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -18919,18 +18990,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"hJA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "hJD" = (
 /obj/machinery/vending/clothing,
 /turf/open/floor/plasteel,
@@ -18968,6 +19027,24 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"hKe" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner{
+	dir = 8
+	},
+/obj/structure/window/reinforced/spawner{
+	dir = 1
+	},
+/obj/machinery/door/window{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "hKh" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Engineering - Entrance";
@@ -18993,14 +19070,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"hLg" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "hLr" = (
 /obj/structure/table/wood,
 /obj/effect/landmark/event_spawn,
@@ -19059,12 +19128,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/virology)
-"hMX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "hNi" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=RIGHTTOP";
@@ -19094,12 +19157,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"hNn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "hNs" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -19402,6 +19459,15 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"hVU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "hWo" = (
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/plasteel/showroomfloor,
@@ -19787,15 +19853,6 @@
 "iei" = (
 /turf/closed/wall,
 /area/storage/tools)
-"iey" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "ifi" = (
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
@@ -20140,22 +20197,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"inC" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/mail_sorting/science/research,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "inM" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
+"iol" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "iop" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -20274,12 +20326,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"iqG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "iqL" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -20326,15 +20372,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
-"isB" = (
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "isK" = (
 /obj/item/circuitboard/machine/generator,
 /obj/structure/frame/machine,
@@ -20373,6 +20410,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
+"itQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "iuk" = (
 /obj/machinery/food_cart,
 /obj/machinery/firealarm{
@@ -20401,13 +20450,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"iuY" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "6;12;50"
-	},
-/turf/open/floor/plating,
-/area/security/detectives_office)
 "ivd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20794,13 +20836,6 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/storage/art)
-"iEG" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "iEQ" = (
 /turf/closed/wall/r_wall,
 /area/security/interrogation)
@@ -20885,13 +20920,6 @@
 	dir = 8
 	},
 /area/chapel/main)
-"iIo" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "iIy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -21464,6 +21492,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"iUr" = (
+/obj/structure/grille,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "iUz" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/effect/turf_decal/tile/green/opposingcorners{
@@ -21811,18 +21846,6 @@
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"jcb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "jcf" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /obj/structure/cable/orange{
@@ -21834,11 +21857,6 @@
 /obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"jcu" = (
-/obj/effect/spawner/lootdrop/organ_spawner,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "jcZ" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
@@ -22059,6 +22077,13 @@
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/bar)
+"jgY" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plating,
+/area/science/research)
 "jhk" = (
 /obj/structure/table,
 /obj/item/hand_tele,
@@ -22119,17 +22144,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"jix" = (
-/obj/machinery/door/airlock/maintenance{
-	req_one_access_txt = "12"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "jiF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -22249,6 +22263,24 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
+"jkr" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/filled/corner/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "jkC" = (
 /obj/machinery/microwave{
 	pixel_y = 4
@@ -22710,6 +22742,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"jtU" = (
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "jtW" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/condiment/peppermill{
@@ -23092,6 +23133,18 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"jBY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "jBZ" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -23139,12 +23192,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/science/server)
-"jCD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "jCJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -23403,6 +23450,13 @@
 /obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"jHg" = (
+/obj/effect/landmark/blobstart,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "jHy" = (
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
@@ -23531,6 +23585,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"jKn" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/junction/flip,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "jKB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -23578,6 +23641,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"jKQ" = (
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/courtroom)
 "jLn" = (
 /obj/machinery/atmospherics/miner/oxygen{
 	max_ext_kpa = 2500
@@ -23845,18 +23914,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"jQd" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "jQg" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/turf_decal/siding/wood{
@@ -24203,15 +24260,23 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"jXU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 1;
+	pixel_y = -1
+	},
+/obj/effect/mapping_helpers/mail_sorting/engineering/general,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jYb" = (
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"jYe" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "jYf" = (
 /obj/machinery/light{
 	dir = 8
@@ -24524,24 +24589,6 @@
 /obj/machinery/nanite_program_hub,
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
-"kdA" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 8
-	},
-/obj/structure/window/reinforced/spawner{
-	dir = 1
-	},
-/obj/machinery/door/window{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "kes" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -25011,12 +25058,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"knu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+"knq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/junction/flip,
+/turf/open/floor/wood,
+/area/crew_quarters/kitchen)
 "knF" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
@@ -25061,6 +25108,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"kpT" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "kqm" = (
 /obj/structure/table,
 /obj/machinery/light/small{
@@ -25165,6 +25216,11 @@
 "ksy" = (
 /turf/closed/wall,
 /area/storage/tech)
+"ksB" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/turf/open/floor/wood,
+/area/medical/psych)
 "ksC" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -25285,6 +25341,12 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"kwN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "kwT" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
@@ -25482,12 +25544,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"kDr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/junction/flip,
-/turf/open/floor/wood,
-/area/crew_quarters/kitchen)
 "kDP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
@@ -26043,6 +26099,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"kRf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "kRs" = (
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
@@ -26091,6 +26156,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"kSt" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "kSy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -26163,6 +26234,19 @@
 	},
 /turf/open/floor/catwalk_floor/telecomms,
 /area/ai_monitored/secondarydatacore)
+"kUa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "kUg" = (
 /obj/machinery/power/apc{
 	areastring = "/area/escapepodbay";
@@ -26405,6 +26489,12 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
+"kZh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "kZs" = (
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
@@ -26454,6 +26544,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"lat" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "lav" = (
 /obj/structure/table,
 /turf/open/floor/plasteel,
@@ -26490,6 +26589,11 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"lbr" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/bin,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "lbA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -26683,12 +26787,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"lfB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "lfL" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -26700,6 +26798,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"lfS" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "lgl" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/camera{
@@ -26954,6 +27059,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"lmg" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/sorting/mail,
+/obj/effect/mapping_helpers/mail_sorting/service/chapel,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "lmq" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -27009,16 +27122,6 @@
 /obj/item/folder/red,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"lnV" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "lnZ" = (
 /obj/structure/closet/secure_closet/bar{
 	req_access_txt = "25"
@@ -27053,6 +27156,15 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"lor" = (
+/obj/effect/turf_decal/trimline/brown/warning/lower{
+	dir = 1
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "packageSort2"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "lot" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -27079,12 +27191,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
-"lpu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "lpx" = (
 /obj/machinery/door/window/eastright{
 	name = "Test Chamber";
@@ -27182,19 +27288,6 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
-"lqI" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/condiment/peppermill{
-	pixel_x = 3
-	},
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/kitchen)
 "lrh" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -27449,6 +27542,13 @@
 /obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/plasteel,
 /area/clerk)
+"lwE" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "lxy" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -27485,15 +27585,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"lzc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "lzm" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -27745,6 +27836,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"lEc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "lEi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -28268,21 +28365,6 @@
 "lOT" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
-"lPe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "lPi" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -28345,6 +28427,7 @@
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 6
 	},
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "lRo" = (
@@ -28716,11 +28799,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"lZn" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/hydroponics)
 "lZq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -28776,13 +28854,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"mas" = (
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "maw" = (
 /obj/machinery/light,
 /obj/machinery/light_switch{
@@ -28796,11 +28867,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"maD" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "maH" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -29199,21 +29265,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
-"mka" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "mki" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
@@ -29254,21 +29305,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"mkM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "mln" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/light{
@@ -29481,13 +29517,6 @@
 	},
 /turf/open/floor/grass,
 /area/medical/genetics)
-"mpR" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "mqb" = (
 /obj/structure/bed/dogbed/ian,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -29638,6 +29667,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"msx" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/sorting/mail/flip{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/mail_sorting/security/detectives_office,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "msP" = (
 /obj/effect/turf_decal/trimline/yellow/arrow_cw{
 	dir = 10
@@ -29758,6 +29803,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"muG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "muH" = (
 /obj/machinery/light/small,
 /turf/open/floor/engine/n2o{
@@ -29824,6 +29875,13 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
+"mvU" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "mwB" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -30172,6 +30230,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"mEz" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/science/research)
 "mFd" = (
 /obj/machinery/vending/sustenance,
 /obj/effect/decal/cleanable/dirt,
@@ -30223,18 +30285,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
-"mGJ" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "mGP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -30427,6 +30477,14 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"mJF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/central)
 "mJL" = (
 /obj/item/reagent_containers/spray/plantbgone{
 	pixel_y = 3
@@ -30499,6 +30557,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"mLT" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mLX" = (
 /obj/machinery/computer/cargo/request{
 	dir = 8
@@ -30820,10 +30887,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
-"mSi" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "mSs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -31246,13 +31309,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"nat" = (
-/obj/machinery/vending/wardrobe/cargo_wardrobe,
-/obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "nax" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/light{
@@ -32020,6 +32076,17 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
+"noo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "noC" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -32350,11 +32417,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"nzh" = (
-/obj/structure/grille/broken,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "nzq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -32415,6 +32477,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"nBi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "nBj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -32522,12 +32590,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"nCP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "nCU" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 4
@@ -32694,6 +32756,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"nFX" = (
+/obj/structure/grille,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "nGg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -32720,6 +32787,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
+"nGw" = (
+/obj/structure/disposalpipe/broken{
+	dir = 4
+	},
+/obj/structure/disposalpipe/broken{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "nGL" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
@@ -32958,6 +33034,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/effect/turf_decal/trimline/brown/warning/lower{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "nJG" = (
@@ -33009,6 +33088,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
+"nKF" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "nKK" = (
 /obj/machinery/suit_storage_unit/standard_unit{
 	suit_type = /obj/item/clothing/suit/space/paramedic
@@ -33178,15 +33269,6 @@
 /obj/machinery/light,
 /turf/open/floor/catwalk_floor/telecomms,
 /area/ai_monitored/secondarydatacore)
-"nMP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "nMR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -33297,17 +33379,6 @@
 "nQq" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
-"nQx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "nQy" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -33727,12 +33798,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"nZi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "nZt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -34287,6 +34352,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"oko" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "okw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -34549,14 +34629,6 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"orT" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/sorting/mail,
-/obj/effect/mapping_helpers/mail_sorting/service/chapel,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "osb" = (
 /obj/structure/table,
 /obj/item/plant_analyzer,
@@ -34783,6 +34855,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ovO" = (
+/obj/machinery/mineral/stacking_unit_console{
+	machinedir = 1
+	},
+/turf/closed/wall,
+/area/maintenance/disposal)
 "ovV" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -35006,6 +35084,14 @@
 /obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"oCO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port)
 "oCS" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -35660,6 +35746,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"oRA" = (
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "oRF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -36535,12 +36628,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"pqM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "pqQ" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -36617,21 +36704,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"prL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "prO" = (
 /obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large{
@@ -36724,12 +36796,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
-"psI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/science/research)
 "psN" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -36878,6 +36944,10 @@
 	icon_state = "damaged5"
 	},
 /area/space/nearstation)
+"pvJ" = (
+/obj/structure/disposalpipe/broken,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "pww" = (
 /turf/closed/wall,
 /area/quartermaster/office)
@@ -37299,6 +37369,14 @@
 /obj/effect/mapping_helpers/mail_sorting/service/bar,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"pFj" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "pFo" = (
 /obj/structure/cable/orange{
 	icon_state = "4-8"
@@ -37325,12 +37403,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"pFO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "pFT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -37483,6 +37555,12 @@
 /obj/machinery/light,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"pJW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/science/research)
 "pKm" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/effect/turf_decal/tile/green/opposingcorners{
@@ -38071,22 +38149,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"pUi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/mail_sorting/service/theater,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "pUv" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable/yellow,
@@ -38117,15 +38179,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"pVT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "pWb" = (
 /turf/closed/wall/r_wall,
 /area/chapel/main)
@@ -38371,6 +38424,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"qaV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "qbc" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -28
@@ -38538,13 +38603,6 @@
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
-"qeC" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
 "qeI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -38601,22 +38659,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
-"qfy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line/lower,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "qfT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -38719,6 +38761,12 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"qiz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
 "qiM" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 10
@@ -38920,6 +38968,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"qml" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qmC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -38948,6 +39003,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/turf_decal/trimline/brown/warning/lower/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -39115,19 +39173,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"qpL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "qqe" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/beakers{
@@ -39316,6 +39361,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"qtt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "qtI" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
@@ -39829,13 +39880,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/morgue)
-"qFM" = (
-/obj/structure/grille,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "qGg" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -39920,19 +39964,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
-"qHy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "qHI" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -39956,6 +39987,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
+"qIw" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
 "qIz" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/assistant,
@@ -40199,18 +40237,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"qOZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "qPm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -40291,16 +40317,18 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
-"qRg" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
+"qRq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
 	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "qRr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -40483,6 +40511,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"qUP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
+"qVc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qVf" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 6
@@ -40512,6 +40561,12 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"qWi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "qWl" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
@@ -40797,12 +40852,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ran" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "raC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -40814,6 +40863,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"raT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "rba" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -40846,6 +40911,12 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"rcv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "rcJ" = (
 /obj/structure/particle_accelerator/particle_emitter/center{
 	dir = 1
@@ -41029,6 +41100,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"rgv" = (
+/obj/effect/spawner/lootdrop/organ_spawner,
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "rhm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -41148,13 +41223,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"rjI" = (
-/obj/structure/chair,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/kitchen)
 "rjK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -41351,6 +41419,16 @@
 "rpg" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/eva)
+"rps" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rpt" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41764,6 +41842,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
+"ryp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "ryw" = (
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -42149,6 +42233,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"rFX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "rGc" = (
 /obj/structure/noticeboard,
 /turf/closed/wall/r_wall,
@@ -42492,15 +42581,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"rNo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "rNq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -42608,6 +42688,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"rPa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "rPb" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Two"
@@ -42655,12 +42744,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"rPK" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/courtroom)
 "rPO" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 4
@@ -42684,6 +42767,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"rQv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "rQN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -42745,6 +42834,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"rSW" = (
+/obj/structure/disposalpipe/broken{
+	dir = 1
+	},
+/obj/structure/disposalpipe/broken{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "rTz" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -42771,6 +42869,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"rUq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "rUI" = (
 /obj/structure/sign/warning/pods{
 	pixel_y = 32
@@ -42855,12 +42968,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"rWK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
 "rXd" = (
 /obj/machinery/airalarm/all_access{
 	pixel_y = 24
@@ -43101,12 +43208,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
-"seK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "seM" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -43138,6 +43239,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"sfF" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "sfV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -43374,12 +43481,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"sjj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "sjn" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
@@ -43450,10 +43551,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"skI" = (
-/obj/structure/disposalpipe/broken,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "slw" = (
 /obj/structure/chair/office/light,
 /obj/effect/turf_decal/trimline/secred/warning/lower,
@@ -43640,17 +43737,6 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/plating,
 /area/medical/sleeper)
-"soG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 4;
-	layer = 2.9
-	},
-/obj/machinery/door/window/brigdoor,
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
 "spx" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -43712,6 +43798,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
+"sqQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "srj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -43887,6 +43988,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"svr" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plating,
+/area/maintenance/central)
+"svy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "svz" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access_txt = "47"
@@ -44944,18 +45056,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"sPi" = (
+"sPt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/trimline/yellow/arrow_cw{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sPW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -44969,6 +45080,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"sQd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "sQo" = (
 /turf/open/floor/wood,
 /area/hallway/primary/central)
@@ -45170,16 +45290,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"sSQ" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 9
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "sTl" = (
 /obj/machinery/vending/cart,
 /obj/machinery/airalarm{
@@ -45384,12 +45494,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"sYg" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "sYX" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -45606,6 +45710,12 @@
 "teY" = (
 /turf/closed/wall/r_wall,
 /area/janitor)
+"tfa" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "tfk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -45637,13 +45747,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"tfK" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "tfW" = (
 /obj/machinery/power/tesla_coil,
 /turf/open/floor/plating/airless,
@@ -45890,6 +45993,12 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
+"tlB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "tlY" = (
 /obj/machinery/atmospherics/components/binary/pump/on/layer2{
 	dir = 4;
@@ -46752,11 +46861,6 @@
 /obj/item/restraints/legcuffs/beartrap,
 /turf/open/floor/plasteel,
 /area/janitor)
-"tCb" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/science/xenobiology)
 "tCS" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -47401,15 +47505,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"tQN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "tQS" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing)
@@ -47754,6 +47849,14 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"tXt" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = null;
+	req_access_txt = "4;12"
+	},
+/turf/open/floor/plating,
+/area/security/detectives_office)
 "tXW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -47826,10 +47929,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"tZv" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "tZx" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
@@ -48510,6 +48609,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"uox" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/science/xenobiology)
 "uoK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -49043,6 +49153,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"uBy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "uBE" = (
 /obj/structure/closet/crate,
 /obj/item/clothing/head/wig/random,
@@ -49431,17 +49556,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"uIX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "uIY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -49637,12 +49751,6 @@
 /obj/item/paper/fluff/holodeck/disclaimer,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"uNh" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "uNC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49734,6 +49842,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"uPu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "uPv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/structure/cable{
@@ -49753,13 +49873,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"uPL" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "uPP" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -49879,14 +49992,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"uSG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/port)
 "uSS" = (
 /obj/effect/landmark/stationroom/maint/tenxten,
 /turf/template_noop,
@@ -50147,18 +50252,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/virology)
-"uXy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "uXD" = (
 /obj/structure/chair{
 	dir = 1
@@ -50238,6 +50331,17 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet)
+"vad" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 4;
+	layer = 2.9
+	},
+/obj/machinery/door/window/brigdoor,
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "vae" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -50786,6 +50890,14 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"vkR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "vlp" = (
 /obj/structure/filingcabinet{
 	pixel_x = 3
@@ -50886,21 +50998,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"vor" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "voN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -51026,13 +51123,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
-"vsK" = (
-/obj/item/kirbyplants/random,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "vsO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -51152,21 +51242,6 @@
 /obj/effect/landmark/stationroom/maint/threexfive,
 /turf/template_noop,
 /area/maintenance/port/aft)
-"vvL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "vvS" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -51199,12 +51274,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"vwE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/science/research)
 "vwN" = (
 /obj/effect/turf_decal/trimline/yellow/corner{
 	dir = 8
@@ -51398,6 +51467,20 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"vzS" = (
+/obj/effect/turf_decal/trimline/brown/filled/line/lower,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Office";
+	req_access_txt = "50"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "vAa" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
@@ -51438,6 +51521,13 @@
 /obj/machinery/rnd/server/master,
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
+"vAV" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "vBd" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -51846,6 +51936,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"vJS" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "vJX" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -51876,11 +51973,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"vKm" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/plasticflaps/opaque,
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "vKx" = (
 /obj/structure/window/reinforced,
 /obj/machinery/camera{
@@ -51945,17 +52037,6 @@
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
-"vLL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "vNc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -52057,6 +52138,11 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"vPh" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/white,
+/area/science/research)
 "vPD" = (
 /obj/structure/table/glass,
 /obj/machinery/photocopier/faxmachine{
@@ -52237,21 +52323,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/security/interrogation)
-"vRS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "vRT" = (
 /obj/machinery/light/small,
 /obj/machinery/advanced_airlock_controller{
@@ -52290,14 +52361,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"vSy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge)
 "vSJ" = (
 /obj/structure/closet,
 /turf/open/floor/plating,
@@ -52532,14 +52595,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"vYD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "vYJ" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -52595,13 +52650,6 @@
 /obj/item/kirbyplants/random,
 /obj/machinery/light,
 /turf/open/floor/wood,
-/area/tcommsat/computer)
-"vZE" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/obj/machinery/disposal/bin/tagger,
-/turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "vZL" = (
 /obj/machinery/door/airlock/maintenance{
@@ -52709,6 +52757,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"wcA" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "wcC" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
@@ -52952,10 +53012,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"wiu" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/port)
 "wiy" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/warden";
@@ -53075,6 +53131,14 @@
 /obj/effect/turf_decal/trimline/green,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"wlz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/port)
 "wlF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -53108,13 +53172,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"wmd" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plating,
-/area/science/research)
 "wmD" = (
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
@@ -53224,17 +53281,6 @@
 "woJ" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"woN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "woO" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
@@ -53457,15 +53503,6 @@
 /obj/effect/mapping_helpers/mail_sorting/science/experimentor_lab,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"wtD" = (
-/obj/structure/disposalpipe/broken{
-	dir = 1
-	},
-/obj/structure/disposalpipe/broken{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "wtE" = (
 /obj/machinery/computer/med_data{
 	dir = 8
@@ -53482,10 +53519,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"wuk" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "wuu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -53521,19 +53554,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"wuI" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/science/research)
-"wuS" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "wvf" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
@@ -53824,6 +53844,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"wzE" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "wzH" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 1
@@ -54238,6 +54262,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/solars/port/fore)
+"wHN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/maintenance/central)
 "wHY" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -54403,6 +54433,18 @@
 "wLx" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/science)
+"wLE" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "wLL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -54425,6 +54467,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"wLY" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/maintenance/central)
 "wMk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
@@ -54548,18 +54596,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"wPy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/security/brig)
 "wQb" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -55073,12 +55109,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"wYT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/central)
 "wZk" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
@@ -55722,6 +55752,18 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"xmB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/yellow/arrow_cw{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "xmJ" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -55752,11 +55794,6 @@
 /obj/item/hand_labeler,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"xmS" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/turf/open/floor/wood,
-/area/medical/psych)
 "xnb" = (
 /obj/structure/kitchenspike,
 /turf/open/floor/plasteel/showroomfloor,
@@ -55927,15 +55964,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"xpI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/junction/flip,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "xpM" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -55946,6 +55974,15 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
+"xqa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction/flip,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xqf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -56131,12 +56168,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/science/lab)
-"xux" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
 "xuE" = (
 /obj/effect/landmark/start/janitor,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -56224,12 +56255,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"xvP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "xwr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -56257,7 +56282,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
-	dir = 4
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -56399,6 +56424,21 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"xyI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "xyV" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -56517,6 +56557,12 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
+"xBn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xBX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -56581,18 +56627,6 @@
 	dir = 1
 	},
 /turf/open/space/basic,
-/area/engine/atmos)
-"xDe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "xDl" = (
 /obj/machinery/status_display/ai{
@@ -56677,11 +56711,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
-"xFQ" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "xFT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -57413,6 +57442,16 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"xSP" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/mail_sorting/service/library,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xSQ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -57485,6 +57524,9 @@
 "xVn" = (
 /obj/structure/disposaloutlet{
 	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -57642,6 +57684,13 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"xYl" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "xYx" = (
 /obj/structure/table/wood,
 /obj/effect/landmark/event_spawn,
@@ -57671,15 +57720,10 @@
 /obj/item/bedsheet/prisoner,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"xZP" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+"yae" = (
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/port)
 "yan" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -57707,18 +57751,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
-"yaT" = (
-/obj/structure/window/reinforced{
-	layer = 2.9
-	},
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/quartermaster/sorting)
 "ybz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -57939,12 +57971,33 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"yeb" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "yep" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
+"yev" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "yeL" = (
 /obj/machinery/telecomms/server/presets/supply,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -74110,17 +74163,17 @@ xSu
 xSu
 jyB
 vgR
-xvP
-wiu
-wiu
-wiu
+ryp
+yae
+yae
+yae
 cxl
-hmw
+nFX
 xmc
-wiu
-wiu
-wiu
-lpu
+yae
+yae
+yae
+kwN
 vgR
 jyB
 xSu
@@ -74367,7 +74420,7 @@ ylr
 xSu
 jyB
 pSD
-fyE
+fWu
 hIt
 hIt
 hIt
@@ -74634,8 +74687,8 @@ sGJ
 sGJ
 sGJ
 hIt
-dmO
-mGJ
+awo
+wcA
 jyB
 jyB
 jyB
@@ -74881,7 +74934,7 @@ ylr
 ylr
 jyB
 vgR
-qFM
+iUr
 hIt
 sGJ
 sGJ
@@ -75395,7 +75448,7 @@ jyB
 jyB
 jyB
 vgR
-bIM
+jHg
 hIt
 hIt
 eXf
@@ -75906,10 +75959,10 @@ ylr
 xSu
 jyB
 vgR
-xvP
-wiu
-wiu
-hMX
+ryp
+yae
+yae
+fhD
 hIt
 vOk
 dhn
@@ -75920,10 +75973,10 @@ eVD
 fnz
 hIt
 gEE
-iqG
-wiu
-wiu
-lpu
+aFB
+yae
+yae
+kwN
 vgR
 jsz
 jyB
@@ -76163,7 +76216,7 @@ hpU
 wSb
 jyB
 moN
-dfs
+wlz
 hIt
 hIt
 hIt
@@ -76420,7 +76473,7 @@ pMc
 joc
 xEO
 fyd
-uSG
+oCO
 hIt
 wod
 cku
@@ -78731,7 +78784,7 @@ eVZ
 atc
 wld
 vBL
-iEG
+lfS
 wGR
 sOZ
 hIt
@@ -80278,7 +80331,7 @@ dRU
 smy
 nUz
 tgP
-tCb
+rFX
 ojt
 pWs
 jfb
@@ -80536,7 +80589,7 @@ ggw
 ggw
 cvX
 ems
-gVY
+uox
 sOL
 pyz
 xBX
@@ -81048,7 +81101,7 @@ grI
 bRa
 sEy
 iNa
-qfy
+raT
 bDJ
 hIt
 hIt
@@ -81074,7 +81127,7 @@ mCF
 bQC
 cGa
 whA
-xmS
+ksB
 uOw
 tav
 dYn
@@ -82110,7 +82163,7 @@ quE
 fpe
 wgO
 wgO
-vor
+aHG
 gIJ
 vDp
 gIJ
@@ -82367,7 +82420,7 @@ rfB
 hVl
 nKK
 wgO
-vor
+aHG
 gIJ
 vDp
 gIJ
@@ -83361,8 +83414,8 @@ vyi
 wDE
 wDE
 nBg
-mkM
-lfB
+sqQ
+qWi
 gVO
 pIW
 pev
@@ -83395,7 +83448,7 @@ rXq
 fFJ
 suK
 wgO
-vor
+aHG
 gIJ
 vDp
 gIJ
@@ -83613,18 +83666,18 @@ qtI
 pmZ
 kin
 asZ
-eno
+sQd
 ero
-eno
+sQd
 aYO
-eno
+sQd
 mHn
-ewb
+eTu
 muq
 syf
 bhc
 lyY
-cNm
+qIw
 dAp
 rOQ
 uhX
@@ -83888,7 +83941,7 @@ rRg
 xcn
 kgD
 pMJ
-eul
+svy
 xXV
 wHe
 ikA
@@ -83909,7 +83962,7 @@ pkJ
 lDH
 yjm
 hOu
-vor
+aHG
 gIJ
 vDp
 gIJ
@@ -84166,7 +84219,7 @@ pkJ
 bsP
 gIJ
 hOu
-vor
+aHG
 gIJ
 vDp
 gIJ
@@ -84423,7 +84476,7 @@ pkJ
 vZq
 gIJ
 hOu
-vor
+aHG
 gIJ
 vDp
 xkg
@@ -84680,7 +84733,7 @@ pkJ
 nkr
 gIJ
 hOu
-vor
+aHG
 gIJ
 vDp
 vDp
@@ -84898,11 +84951,11 @@ oiq
 vrb
 ocI
 qte
-jYe
+vPh
 fus
-wuI
-wuI
-vwE
+mEz
+mEz
+hay
 eUu
 ibK
 vxV
@@ -84937,7 +84990,7 @@ pkJ
 gIJ
 gIJ
 kkN
-vor
+aHG
 gIJ
 vDp
 clM
@@ -85159,7 +85212,7 @@ uRq
 tEL
 qqt
 ibK
-psI
+pJW
 fXw
 ibK
 ibK
@@ -85416,7 +85469,7 @@ uRq
 tEL
 qes
 fvS
-wmd
+jgY
 tEL
 tEL
 tEL
@@ -85452,7 +85505,7 @@ gIJ
 jTD
 hOu
 gIJ
-prL
+hzB
 vDp
 clM
 clM
@@ -85689,7 +85742,7 @@ dNw
 eQm
 cCv
 eEu
-nCP
+gCx
 dlt
 eVA
 dlt
@@ -85709,7 +85762,7 @@ tzj
 dlR
 hOu
 gIJ
-prL
+hzB
 vDp
 vDp
 vDp
@@ -85946,7 +85999,7 @@ xMZ
 qsm
 fME
 xId
-nCP
+gCx
 dlt
 dlt
 dlt
@@ -85966,7 +86019,7 @@ rml
 vDp
 vDp
 gIJ
-prL
+hzB
 hOu
 xcP
 heq
@@ -86223,7 +86276,7 @@ clM
 lBV
 vDp
 asW
-prL
+hzB
 gIJ
 gIJ
 gIJ
@@ -86439,7 +86492,7 @@ cCE
 iNa
 dpM
 dpM
-bsu
+uPu
 xKR
 wTa
 loc
@@ -86479,12 +86532,12 @@ clM
 clM
 clM
 xAq
-lPe
+rUq
 xwJ
 eIh
-wuS
-wuS
-wuS
+hVU
+hVU
+hVU
 wlF
 wCr
 gIJ
@@ -86696,7 +86749,7 @@ uku
 dot
 iNa
 dpM
-qOZ
+fpP
 blq
 bXE
 bYZ
@@ -86736,7 +86789,7 @@ clM
 clM
 clM
 vDp
-prL
+hzB
 gIJ
 jTD
 gIJ
@@ -86744,9 +86797,9 @@ xkg
 nnr
 tcj
 quY
-wuS
-wuS
-wuS
+hVU
+hVU
+hVU
 ukP
 gIJ
 gIJ
@@ -86993,9 +87046,9 @@ vDp
 rml
 vDp
 vDp
-pUi
-wuk
-bAu
+ffL
+duF
+uBy
 gIJ
 fOG
 fOG
@@ -87025,7 +87078,7 @@ xSu
 xSu
 xSu
 fTO
-vZE
+bay
 xKD
 vCt
 cEj
@@ -87248,11 +87301,11 @@ arA
 jjD
 pEW
 rba
-wuS
-lzc
-vRS
+hVU
+rPa
+bdU
 gIJ
-prL
+hzB
 fOG
 fOG
 kwU
@@ -88747,10 +88800,10 @@ oRL
 osy
 jsG
 raj
-iey
-inC
-fuJ
-gxx
+mLT
+ahG
+qml
+xSP
 syW
 fEz
 bWN
@@ -89004,7 +89057,7 @@ osy
 osy
 lTH
 foJ
-ran
+xBn
 fEz
 swM
 eDH
@@ -89033,7 +89086,7 @@ iAu
 bcM
 swM
 vcr
-htP
+hIq
 bSw
 vxr
 esC
@@ -89256,13 +89309,13 @@ okE
 okE
 okE
 osy
-vsK
+gOb
 rUM
 mPv
 gjP
 fEz
 cmA
-jcb
+jBY
 cPC
 rkl
 cAV
@@ -89510,14 +89563,14 @@ wVK
 wVK
 okE
 okE
-nZi
+muG
 foJ
 foJ
-ran
+xBn
 fEz
 swM
 xTs
-jcb
+jBY
 fYG
 bZP
 qAi
@@ -89779,7 +89832,7 @@ qAi
 qAi
 qAi
 jqY
-nMP
+blu
 wra
 sJa
 wtn
@@ -90036,13 +90089,13 @@ qAi
 tQT
 xpH
 ewZ
-hNn
+qtt
 ewZ
 sJa
 oLn
 pJl
 bXr
-qeC
+fuK
 ffF
 mwV
 skC
@@ -90078,7 +90131,7 @@ xpG
 dMI
 pYw
 uLk
-rjI
+dnC
 dMI
 pYw
 vvk
@@ -90299,7 +90352,7 @@ sJa
 kxF
 kxF
 bXr
-qeC
+fuK
 rAR
 sdB
 hlb
@@ -90335,12 +90388,12 @@ uLk
 uLk
 iQQ
 vFF
-bsc
+hbp
 bex
 nmk
 vNc
 xnw
-kDr
+knq
 xnw
 xnw
 hEa
@@ -90538,7 +90591,7 @@ xJA
 txm
 jgE
 fEz
-jcb
+jBY
 rdo
 jFY
 jFY
@@ -90550,7 +90603,7 @@ iTP
 ewZ
 ewZ
 ewZ
-hNn
+qtt
 sJa
 sJa
 cNy
@@ -90597,7 +90650,7 @@ dMI
 pYw
 uLk
 nwQ
-lqI
+dnK
 pYw
 uLk
 vvv
@@ -90805,15 +90858,15 @@ rpg
 rpg
 rpg
 rpg
-aQq
-aqY
-hNn
+iol
+rQv
+qtt
 sJa
 tYm
 pJl
 eGM
 xFT
-rWK
+qiz
 cNq
 pdc
 sJa
@@ -90822,7 +90875,7 @@ pZj
 sJa
 sJa
 sRu
-ciO
+aib
 qAi
 uWp
 eBL
@@ -91063,8 +91116,8 @@ ygl
 ygl
 rpg
 rpg
-hNn
-hNn
+qtt
+qtt
 sJa
 tYm
 pJl
@@ -91320,14 +91373,14 @@ jwl
 rIV
 ivY
 rpg
-hNn
-hNn
+qtt
+qtt
 sJa
 wRd
 pJl
 lyF
 pJl
-rWK
+qiz
 pJl
 qKF
 sJa
@@ -91577,8 +91630,8 @@ kmu
 ydM
 syB
 rpg
-bSa
-hNn
+mJF
+qtt
 sJa
 wRd
 aLg
@@ -91592,8 +91645,8 @@ sJa
 sJa
 sJa
 sJa
-skI
-seK
+pvJ
+lEc
 qAi
 iFJ
 oAH
@@ -91612,7 +91665,7 @@ bTJ
 bTJ
 bTJ
 byk
-lZn
+hsZ
 uoK
 fLc
 ggg
@@ -91821,7 +91874,7 @@ wJB
 wJB
 sSu
 fEz
-bWJ
+qVc
 rdo
 bTk
 bTk
@@ -91834,8 +91887,8 @@ pUf
 ydM
 bWH
 rpg
-hNn
-bSa
+qtt
+mJF
 sJa
 sJa
 sJa
@@ -91890,7 +91943,7 @@ kIz
 mvc
 xnb
 mew
-prL
+hzB
 fTd
 vDp
 ylr
@@ -92091,13 +92144,13 @@ iTa
 rIV
 cxT
 rpg
-hNn
-wYT
-mSi
-mSi
-mSi
-mSi
-uPL
+qtt
+rcv
+kpT
+kpT
+kpT
+kpT
+mvU
 gDs
 wra
 ewZ
@@ -92147,7 +92200,7 @@ hWo
 mvc
 fSn
 mew
-prL
+hzB
 bZz
 vDp
 vDp
@@ -92348,7 +92401,7 @@ ygl
 ygl
 rpg
 rpg
-hNn
+qtt
 ewZ
 qAi
 qAi
@@ -92604,8 +92657,8 @@ rpg
 rpg
 rpg
 rpg
-pqM
-seK
+wHN
+lEc
 ewZ
 qEt
 ylr
@@ -92850,18 +92903,18 @@ cPC
 aen
 mQx
 pOs
-jix
-bXc
-xFQ
-mSi
-nzh
-mSi
-mSi
-mSi
-foR
-mSi
-mSi
-seK
+hBX
+aQB
+hxo
+kpT
+hwG
+kpT
+kpT
+kpT
+wLY
+kpT
+kpT
+lEc
 ewZ
 qEt
 qEt
@@ -92918,7 +92971,7 @@ mew
 mew
 mew
 mew
-prL
+hzB
 gIJ
 gIJ
 fTd
@@ -93108,7 +93161,7 @@ dGG
 ccu
 nTT
 qAi
-xZP
+dzT
 ewZ
 ewZ
 csM
@@ -93175,7 +93228,7 @@ nKe
 gIJ
 vDp
 dyp
-vor
+aHG
 gIJ
 gIJ
 fTd
@@ -93365,7 +93418,7 @@ rTA
 yfd
 qAi
 qAi
-hNn
+qtt
 ewZ
 qAi
 qAi
@@ -93432,7 +93485,7 @@ nKe
 gIJ
 vDp
 nfI
-vor
+aHG
 gIJ
 gIJ
 vwN
@@ -93622,7 +93675,7 @@ iOl
 cPC
 qAi
 uTF
-hNn
+qtt
 ewZ
 qAi
 ylr
@@ -93674,10 +93727,10 @@ jvn
 khu
 dfT
 foJ
-sYg
+kSt
 jSm
 hcg
-eqm
+blN
 fgA
 oqE
 nAq
@@ -93690,22 +93743,22 @@ gIJ
 epV
 gIJ
 sXI
-wuS
-woN
-wuS
-wuS
-wuS
-wuS
+hVU
+hko
+hVU
+hVU
+hVU
+hVU
 bsD
 bbd
-sPi
-sPi
-sPi
+xmB
+xmB
+xmB
 dLW
-sPi
+xmB
 ogw
-sPi
-sPi
+xmB
+xmB
 qSK
 gUe
 gUe
@@ -93868,10 +93921,10 @@ sqv
 vNC
 wvA
 gOp
-tQN
+lat
 dCw
 sLx
-tQN
+lat
 sbq
 kYt
 kYt
@@ -93879,7 +93932,7 @@ yfZ
 cPC
 qAi
 wKZ
-hNn
+qtt
 ewZ
 qAi
 xSu
@@ -93935,7 +93988,7 @@ aqy
 lmJ
 gKs
 tGP
-xDe
+azS
 oqE
 isM
 rsm
@@ -93948,7 +94001,7 @@ vDp
 gIJ
 gIJ
 gIJ
-jCD
+yev
 gIJ
 gIJ
 gIJ
@@ -93969,7 +94022,7 @@ oLK
 oLK
 uix
 cwn
-sPi
+xmB
 dGL
 flF
 flF
@@ -94136,7 +94189,7 @@ iOl
 gGr
 qAi
 iTP
-hNn
+qtt
 ewZ
 qAi
 xSu
@@ -94205,7 +94258,7 @@ vDp
 vDp
 qmO
 nGh
-iIo
+vAV
 gIJ
 geT
 gIJ
@@ -94392,8 +94445,8 @@ cPC
 sQt
 cPC
 qAi
-maD
-seK
+svr
+lEc
 ewZ
 qAi
 qAi
@@ -94730,7 +94783,7 @@ uix
 eYz
 qKy
 ths
-qpL
+gII
 wsV
 fYs
 vLb
@@ -95665,7 +95718,7 @@ qJL
 aBt
 lwl
 awv
-rNo
+qUP
 igx
 cOe
 usN
@@ -95722,7 +95775,7 @@ bPr
 fho
 dMR
 sDs
-chD
+jXU
 amE
 enu
 mqo
@@ -96235,7 +96288,7 @@ kFW
 iGX
 jcf
 bZW
-qRg
+rps
 agh
 cqa
 agh
@@ -96690,8 +96743,8 @@ uJQ
 mIc
 gNx
 bdW
-erz
-erz
+bYW
+bYW
 cAv
 vfV
 wsx
@@ -96945,9 +96998,9 @@ qhu
 tue
 mki
 bSU
-vYD
+gcc
 fiz
-vYD
+gcc
 wvM
 xLx
 lRa
@@ -97458,11 +97511,11 @@ qhu
 dcG
 eXu
 pTe
-usN
+cAh
 cRl
-cRl
-nat
-beR
+vGG
+tfa
+jkr
 ktX
 pww
 lSz
@@ -97717,10 +97770,10 @@ nGW
 wvC
 crc
 xwz
-vGG
+pww
 bsp
 cVx
-ePT
+vzS
 nuh
 jUv
 agl
@@ -97823,9 +97876,9 @@ xSu
 xSu
 xSu
 uix
-fjA
-dZF
-vvL
+dUa
+kRf
+xyI
 bpb
 xbB
 xbB
@@ -97974,8 +98027,8 @@ fFs
 xor
 xor
 nuh
-bsp
-yaT
+nuh
+eFK
 bFF
 mZT
 nuh
@@ -98232,7 +98285,7 @@ yep
 wEP
 nuh
 meM
-soG
+vad
 ffl
 pnR
 nuh
@@ -98332,12 +98385,12 @@ rQg
 imH
 xSu
 oLK
-fjA
-dZF
-dZF
-dZF
-dZF
-vvL
+dUa
+kRf
+kRf
+kRf
+kRf
+xyI
 uJr
 uJr
 uJr
@@ -99003,7 +99056,7 @@ bOO
 sVV
 nuh
 qSJ
-ezB
+lor
 sst
 ptF
 xfr
@@ -99359,8 +99412,8 @@ xSu
 xSu
 uix
 dGe
-vLL
-vvL
+noo
+xyI
 kQk
 klP
 uJr
@@ -99531,7 +99584,7 @@ jkL
 fpH
 opr
 tqN
-gZj
+nKF
 fRv
 qAi
 hPb
@@ -99854,11 +99907,11 @@ ijq
 dDP
 uJr
 trq
-dZF
-dZF
-dZF
+kRf
+kRf
+kRf
 sPW
-hLg
+pFj
 nQq
 ouZ
 aPm
@@ -99873,7 +99926,7 @@ dNe
 dNe
 dNe
 xkI
-knu
+euu
 xbB
 aGn
 aGn
@@ -100130,7 +100183,7 @@ uJr
 uJr
 uJr
 uJr
-knu
+euu
 bPu
 aGn
 aGn
@@ -100356,7 +100409,7 @@ bqR
 dwa
 gIx
 msR
-rPK
+jKQ
 wTN
 ocw
 ocw
@@ -100366,7 +100419,7 @@ mFm
 mFm
 mFm
 gwb
-dZF
+kRf
 qYW
 nQq
 nQq
@@ -100387,7 +100440,7 @@ vDs
 vil
 uJr
 uJr
-tfK
+vJS
 xbB
 aGn
 aGn
@@ -100610,7 +100663,7 @@ kYt
 kYt
 diP
 auI
-mas
+oRA
 pAQ
 eBH
 eBH
@@ -100818,7 +100871,7 @@ tho
 ksy
 iny
 eKG
-gZj
+nKF
 azs
 cQq
 fNl
@@ -100881,7 +100934,7 @@ uTe
 sgr
 ijq
 uJr
-htA
+yeb
 nQq
 jHy
 jHy
@@ -101138,7 +101191,7 @@ oxu
 oxu
 ijq
 uJr
-htA
+yeb
 nQq
 tmJ
 jHy
@@ -101377,7 +101430,7 @@ ofi
 tJo
 eaP
 gRd
-jcb
+jBY
 qoB
 qWX
 iEQ
@@ -101395,7 +101448,7 @@ iSC
 nOQ
 ijq
 uJr
-htA
+yeb
 nQq
 tmJ
 jHy
@@ -101566,7 +101619,7 @@ fwZ
 cOt
 bur
 uzK
-oPS
+ovO
 kqW
 jFa
 jBL
@@ -101592,7 +101645,7 @@ smr
 gDt
 xvm
 foJ
-gcD
+clR
 nWv
 sEb
 fnh
@@ -101633,7 +101686,7 @@ uNK
 uNK
 hoL
 swM
-jcb
+jBY
 qoB
 sAd
 iEQ
@@ -101652,7 +101705,7 @@ jpX
 nOQ
 ijq
 rLc
-htA
+yeb
 nQq
 cxk
 jWb
@@ -101888,7 +101941,7 @@ cPC
 gRd
 auh
 eLW
-jcb
+jBY
 qoB
 gGv
 sAd
@@ -102078,7 +102131,7 @@ oPS
 tjp
 hdN
 uzK
-kdA
+hKe
 oPS
 oPS
 eGX
@@ -102142,7 +102195,7 @@ cPC
 cPC
 cPC
 gRd
-jcb
+jBY
 qoB
 fOK
 gGv
@@ -102336,8 +102389,8 @@ bgx
 dYG
 bur
 ruG
-vKm
-jcu
+cQU
+nHI
 fGZ
 jFa
 jBL
@@ -102594,7 +102647,7 @@ idl
 bur
 qAF
 oPS
-jFa
+rgv
 kqW
 jFa
 jBL
@@ -102618,7 +102671,7 @@ iqk
 iqk
 brs
 jFa
-mka
+oko
 qkO
 hhB
 ioA
@@ -102631,17 +102684,17 @@ gGv
 gGv
 vYJ
 ukp
-uIX
-qHy
+aGg
+kUa
 kYt
 frG
 kYt
 kYt
 kYt
-nQx
+sPt
 pDO
 xxb
-hoD
+xqa
 dsM
 kYt
 kYt
@@ -102875,7 +102928,7 @@ iqk
 iqk
 sJl
 jFa
-mka
+oko
 ykQ
 hhB
 nZg
@@ -103112,7 +103165,7 @@ lyQ
 xQM
 pZM
 pZM
-orT
+lmg
 agW
 jFa
 pOg
@@ -103132,7 +103185,7 @@ iqk
 iqk
 brs
 sBp
-mka
+oko
 lyQ
 hhB
 tGN
@@ -103179,7 +103232,7 @@ vra
 aBK
 dKd
 vra
-sSQ
+bYP
 tSq
 qhm
 aFL
@@ -103188,9 +103241,9 @@ dkN
 jzR
 vfk
 uJr
-fjA
-pVT
-pVT
+dUa
+bvr
+bvr
 wiS
 rsR
 faC
@@ -103389,7 +103442,7 @@ iqk
 iqk
 brs
 jFa
-mka
+oko
 kWC
 hhB
 nQB
@@ -103436,7 +103489,7 @@ vra
 vBx
 mzt
 fsl
-isB
+jtU
 cVD
 qEj
 rvi
@@ -103646,9 +103699,9 @@ brs
 brs
 brs
 jFa
-cew
+msx
 nHI
-iuY
+tXt
 wPm
 gMZ
 gMZ
@@ -103669,7 +103722,7 @@ leC
 ouG
 gHm
 eRv
-mpR
+lwE
 mfu
 prH
 iQb
@@ -103693,7 +103746,7 @@ fkv
 kjA
 cVD
 uLb
-pFO
+nBi
 pST
 qEj
 rdK
@@ -103899,7 +103952,7 @@ pZM
 pZM
 ire
 bxr
-xpI
+jKn
 dEz
 oaI
 oaI
@@ -103926,7 +103979,7 @@ dBR
 ouG
 kPn
 tPX
-mpR
+lwE
 mfu
 vRh
 iQb
@@ -103940,7 +103993,7 @@ vra
 vBx
 ghg
 qhm
-lnV
+bsZ
 qhm
 mzt
 uBS
@@ -103957,9 +104010,9 @@ dbb
 qHt
 oua
 tAX
-dZF
-dZF
-vvL
+kRf
+kRf
+xyI
 uJr
 uJr
 eJH
@@ -104197,13 +104250,13 @@ vra
 avf
 kTF
 qEj
-pFO
+nBi
 qEj
 cVD
 qEj
 qEj
 kNh
-wPy
+itQ
 gYk
 fWj
 fWj
@@ -104440,7 +104493,7 @@ sIn
 ouG
 tyS
 eRv
-cwv
+eGe
 otq
 fED
 iQb
@@ -104454,7 +104507,7 @@ jYf
 qjo
 kTF
 qEj
-pFO
+nBi
 qEj
 bOr
 tym
@@ -104697,7 +104750,7 @@ mTZ
 cde
 niS
 iqN
-vSy
+vkR
 iqN
 iqN
 ccv
@@ -104711,7 +104764,7 @@ noV
 iWv
 kiM
 noV
-aIF
+cuj
 noV
 rBR
 gYk
@@ -104735,7 +104788,7 @@ uJr
 uJr
 rEi
 uJr
-wtD
+rSW
 uJr
 nQq
 jHy
@@ -104927,7 +104980,7 @@ kSm
 smZ
 jgH
 gNd
-uXy
+qaV
 nPH
 twP
 egt
@@ -104954,7 +105007,7 @@ ouG
 ouG
 gKD
 eRv
-bcs
+xYl
 xJk
 xJk
 xJk
@@ -104992,7 +105045,7 @@ rsK
 rsK
 rsK
 rsK
-ePy
+nGw
 uJr
 nQq
 nQq
@@ -105184,7 +105237,7 @@ gxC
 mVH
 jgH
 brs
-uXy
+qaV
 nPH
 owH
 jFa
@@ -105249,7 +105302,7 @@ rFh
 cwh
 qod
 rsK
-knu
+euu
 uJr
 xbB
 ylr
@@ -105441,7 +105494,7 @@ gxC
 uua
 ksJ
 ufM
-uXy
+qaV
 eit
 jFa
 tUg
@@ -105697,8 +105750,8 @@ ylr
 gxC
 qXg
 ksJ
-hrC
-hJA
+lbr
+qRq
 eit
 pOg
 jFa
@@ -106277,7 +106330,7 @@ ixN
 kvm
 yda
 rsK
-knu
+euu
 uJr
 mMC
 ylr
@@ -106534,7 +106587,7 @@ rsK
 rsK
 rsK
 rsK
-jQd
+wLE
 sAg
 xbB
 ylr
@@ -106787,11 +106840,11 @@ epS
 cJk
 aHr
 cJk
-xux
-tZv
-tZv
-tZv
-sjj
+kZh
+wzE
+wzE
+wzE
+tlB
 uJr
 xbB
 ylr
@@ -107044,7 +107097,7 @@ sQr
 mjO
 xGX
 cJk
-uNh
+sfF
 uJr
 uJr
 uJr


### PR DESCRIPTION

# Document the changes in your pull request

i just redid all of disposals. new mapping helpers in and out of maints. and there is 80 percent more disposal bins in the station becuase of how big and empty the maints are

shifts delivery room over to have room for a wrap pipe

redone recycling room so it functions

detective has a maint door in their office 

# Why is this good for the game?
i dont know anymore.
was originally redoing all sort pipes to use helper but forgot how disgusting donut is
gives more ways to get across station in the vast nothing 
some more hiding spots


# Testing
<!-- Describe what testing you did with this PR. Try to be thorough, especially if this is a larger project. -->

# Changelog

:cl:  

mapping: updates recycling room to function
mapping: overhauls disposals on donut, considerably more disposal bins in station with helpers
mapping: adds a maint door to det's office
mapping: delivery room is a bit bigger for a wrap pipe sort

/:cl:
