### PR TITLE
I refactored autosurgeons for some reason

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -811,7 +811,7 @@ GLOBAL_LIST_INIT(maintenance_loot_moderate,list(
 	/obj/item/aicard/aitater = W_RARE,
 	/obj/item/ammo_box/foambox/riot = W_RARE,
 	/obj/item/assembly/flash = W_UNCOMMON,
-	/obj/item/autosurgeon/limb/head/robot = W_MYTHICAL,
+	/obj/item/autosurgeon/head/robot = W_MYTHICAL,
 	/obj/item/bikehorn/sad = W_MYTHICAL,
 	/obj/item/bikehorn/golden = W_MYTHICAL,
 	/obj/item/bombcore/training = W_MYTHICAL,

--- a/code/game/objects/items/storage/briefcase.dm
+++ b/code/game/objects/items/storage/briefcase.dm
@@ -53,4 +53,4 @@
 /obj/item/storage/briefcase/nt_mantis/PopulateContents()
 	..()
 	new /obj/item/autosurgeon/nt_mantis(src)
-	new /obj/item/autosurgeon/nt_mantis/left(src)
+	new /obj/item/autosurgeon/nt_mantis(src)

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -272,10 +272,10 @@
 			new /obj/item/slimecross/stabilized/green(src) //secret identity
 
 		if("solo") //14 + 6x3 + 1 = 3 tc = 31 tc. it was, in fact, busted
-			new /obj/item/autosurgeon/syndicate/spinalspeed(src) //12 tc
+			new /obj/item/autosurgeon/suspicious/spinalspeed(src) //12 tc
 			new /obj/item/clothing/suit/toggle/cyberpunk/solo(src) //dont know what this costs, vague guesstimate says 6tc
-			new /obj/item/autosurgeon/arm/syndicate/syndie_mantis(src) //6 tc
-			new /obj/item/autosurgeon/arm/syndicate/syndie_mantis(src) //6 tc
+			new /obj/item/autosurgeon/suspicious/syndie_mantis(src) //6 tc
+			new /obj/item/autosurgeon/suspicious/syndie_mantis(src) //6 tc
 			new /obj/item/autosurgeon/upgraded_cyberlungs(src) //this is to remain true to the source material ok
 			new /obj/item/storage/pill_bottle/synaptizine(src) //take your drugs david, this and the lungs make up 1 tc
 			
@@ -876,12 +876,12 @@
 	real_name = "augmentation kit"
 
 /obj/item/storage/box/syndie_kit/augmentation/PopulateContents()
-	new /obj/item/autosurgeon/limb/head/robot(src)
-	new /obj/item/autosurgeon/limb/chest/robot(src)
-	new /obj/item/autosurgeon/limb/l_arm/robot(src)
-	new /obj/item/autosurgeon/limb/r_arm/robot(src)
-	new /obj/item/autosurgeon/limb/l_leg/robot(src)
-	new /obj/item/autosurgeon/limb/r_leg/robot(src)
+	new /obj/item/autosurgeon/head/robot(src)
+	new /obj/item/autosurgeon/chest/robot(src)
+	new /obj/item/autosurgeon/l_arm/robot(src)
+	new /obj/item/autosurgeon/r_arm/robot(src)
+	new /obj/item/autosurgeon/l_leg/robot(src)
+	new /obj/item/autosurgeon/r_leg/robot(src)
 
 /obj/item/storage/box/syndie_kit/augmentation/superior
 	real_name = "superior augmentation kit"

--- a/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -29,7 +29,7 @@
 	new /obj/item/storage/backpack/duffelbag/clothing/ce(src)
 	new /obj/item/storage/lockbox/medal/eng(src)
 	new /obj/item/barrier_taperoll/engineering(src)
-	new /obj/item/multisurgeon/magboots(src)
+	new /obj/item/autosurgeon/magboots(src)
 
 /obj/structure/closet/secure_closet/engineering_electrical
 	name = "electrical supplies locker"

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -195,9 +195,9 @@
 	icon_state = "cyber_implants"
 	var/list/boxed = list(
 		/obj/item/autosurgeon/thermal_eyes,
-		/obj/item/autosurgeon/xray_eyes,
-		/obj/item/autosurgeon/anti_stun,
-		/obj/item/autosurgeon/reviver)
+		/obj/item/autosurgeon/suspicious/xray_eyes,
+		/obj/item/autosurgeon/suspicious/anti_stun,
+		/obj/item/autosurgeon/suspicious/reviver)
 	var/amount = 5
 
 /obj/item/storage/box/cyber_implants/PopulateContents()

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -127,6 +127,7 @@
 		return
 	for(var/i in storedorgans)
 		handle_surgery(i, user)
+	storedorgans = list()
 	user.visible_message(span_notice("[user] presses a button on [src], and you hear a short mechanical noise."), span_notice("You feel a sharp sting as [src] plunges into your body."))
 	playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, 1)
 	name = initial(name)
@@ -150,7 +151,7 @@
 			AM.forceMove(drop_loc)
 			to_chat(user, span_notice("You remove the [J] from [src]."))
 			storedorgans -= J
-
+		
 		I.play_tool_sound(src)
 		if(!refills)
 			name = "dulled [initial(name)]"

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -5,355 +5,259 @@
 	icon_state = "autoimplanter"
 	item_state = "nothing"
 	w_class = WEIGHT_CLASS_SMALL
-	var/obj/item/organ/storedorgan
-	var/organ_type = /obj/item/organ
-	var/uses = INFINITE
-	var/starting_organ
+	var/list/storedorgans = list()
+	var/list/starting_organs = list()
+	/// How many organs can be inserted into this beyond the initial ones (make sure this is a larger number than the number of starting organs)
+	var/refills = 0
+
+	var/static/list/organ_types = typecacheof(list(
+		/obj/item/organ,
+		/obj/item/bodypart
+	))
 	var/static/list/blacklisted_organs = typecacheof(list(
 		/obj/item/organ/regenerative_core // Full heal with revive on demand.
 	))
+	
+	///The arm that is prioritized first when inserting arm implants (swaps after implanting an arm implant)
+	var/target_arm = BODY_ZONE_L_ARM
 
+////////////////////////////////////////////////////////////////////////////////////
+//---------------------------------Basic stuff------------------------------------//
+////////////////////////////////////////////////////////////////////////////////////
 /obj/item/autosurgeon/Initialize(mapload)
 	. = ..()
-	if(starting_organ)
-		insert_organ(new starting_organ(src))
+	for(var/i in starting_organs)
+		insert_organ(i, null, TRUE)
 
-/obj/item/autosurgeon/proc/insert_organ(obj/item/I)
-	storedorgan = I
-	I.forceMove(src)
-	name = "[initial(name)] ([storedorgan.name])"
+/obj/item/autosurgeon/examine(mob/user)
+	. = ..()
+	if(length(storedorgans))	
+		. += span_notice("it contains.")
+		for(var/i in storedorgans)
+			. += span_notice("- [i]")
+	if(locate(/obj/item/organ/cyberimp/arm) in storedorgans)
+		. += span_notice("It will implant any arm implants in the [target_arm == BODY_ZONE_L_ARM ? "left" : "right"] arm first.")
+		. += span_notice("This can be switched with ALT + CLICK.")
 
-/obj/item/autosurgeon/attack_self(mob/user)//when the object it used...
-	if(!uses)
-		to_chat(user, span_warning("[src] has already been used. The tools are dull and won't reactivate."))
-		return
-	else if(!storedorgan)
-		to_chat(user, span_notice("[src] currently has no implant stored."))
-		return
-	if(istype(storedorgan, /obj/item/organ/cyberimp/arm)) //these cunts have two limbs to select from, we'll want to check both because players are too lazy to do that themselves
-		var/obj/item/organ/cyberimp/arm/bastard = storedorgan
-		if(user.getorganslot(bastard.slot)) //FUCK IT WE BALL
-			var/original_zone = storedorgan.zone
-			if(bastard.zone == BODY_ZONE_R_ARM) // i do not like them sam i am  i do not like if else and ham
-				bastard.zone = BODY_ZONE_L_ARM
-			else
-				bastard.zone = BODY_ZONE_R_ARM
+////////////////////////////////////////////////////////////////////////////////////
+//---------------------------------Adding organs----------------------------------//
+////////////////////////////////////////////////////////////////////////////////////
+/obj/item/autosurgeon/attackby(obj/item/I, mob/user, params) //putting new things in
+	if(!insert_organ(I, user))
+		return ..()
+		
+/obj/item/autosurgeon/proc/insert_organ(obj/inserted, mob/user, bypass_refills)
+	if(is_type_in_typecache(inserted, blacklisted_organs) || !is_type_in_typecache(inserted, organ_types))
+		if(user)
+			to_chat(user, span_notice("[inserted] does not fit in \the [src]."))
+		return FALSE
+	if(!refills && !bypass_refills)
+		if(user)
+			to_chat(user, span_notice("[src] has already been used up."))
+		return FALSE
+	if(ispath(inserted))
+		inserted = new inserted()
+	storedorgans += inserted
+	inserted.forceMove(src)
+	name = "primed [initial(name)]"
+
+	if(refills != INFINITE && !bypass_refills)
+		refills--
+
+	if(user)
+		to_chat(user, span_notice("You insert the [inserted] into [src]."))
+	return TRUE
+
+////////////////////////////////////////////////////////////////////////////////////
+//--------------------------------Arm Swapping------------------------------------//
+////////////////////////////////////////////////////////////////////////////////////
+/obj/item/autosurgeon/AltClick(mob/user) //changes the prioritized arm
+	if(locate(/obj/item/organ/cyberimp/arm) in storedorgans)
+		swap_arm()
+		to_chat(user, span_notice("You change the autosurgeon to target the [target_arm == BODY_ZONE_L_ARM ? "left" : "right"] arm."))
+
+/obj/item/autosurgeon/proc/swap_arm()
+	if(target_arm == BODY_ZONE_L_ARM)
+		target_arm = BODY_ZONE_R_ARM
+	else if(target_arm == BODY_ZONE_R_ARM)
+		target_arm = BODY_ZONE_L_ARM
+
+////////////////////////////////////////////////////////////////////////////////////
+//--------------------------Attempts to implant a single item---------------------//
+////////////////////////////////////////////////////////////////////////////////////
+/obj/item/autosurgeon/proc/handle_surgery(obj/item, mob/living/carbon/human/user)
+	if(istype(item, /obj/item/organ/cyberimp/arm)) //these cunts have two limbs to select from, we'll want to check both because players are too lazy to do that themselves
+		var/obj/item/organ/cyberimp/arm/bastard = item
+		bastard.zone = target_arm //try the preferred limb
+		bastard.SetSlotFromZone()
+		swap_arm()
+		if(user.getorganslot(bastard.zone)) //preferred limb is full
+			bastard.zone = target_arm
 			bastard.SetSlotFromZone()
-			if(user.getorganslot(bastard.slot)) //NEVERMIND WE ARE NOT BALLING
-				bastard.zone = original_zone //MISSION ABORT
+			swap_arm()
+			if(user.getorganslot(bastard.zone)) //other limb is full, revert to the first selection and just FUCKING DO IT
+				bastard.zone = target_arm
 				bastard.SetSlotFromZone()
-			bastard.update_appearance(UPDATE_ICON)
-	storedorgan.Insert(user)//insert stored organ into the user
+				swap_arm()
+		bastard.update_appearance(UPDATE_ICON)
+		bastard.Insert(user)
+
+	else if(istype(item, /obj/item/organ)) //if it's just a regular organ
+		var/obj/item/organ/thing = item
+		thing.Insert(user)
+
+	else if(istype(item, /obj/item/bodypart)) //if it's a limb
+		var/obj/item/bodypart/thing = item
+		thing.replace_limb(user, TRUE)
+	else
+		stack_trace("[src] attempted to implant [item] in [user]")
+
+////////////////////////////////////////////////////////////////////////////////////
+//----------------------Use the item to implant every stored item-----------------//
+////////////////////////////////////////////////////////////////////////////////////
+/obj/item/autosurgeon/attack_self(mob/user)//when the object it used...
+	if(!length(storedorgans))
+		if(refills)
+			to_chat(user, span_notice("[src] currently has no implant stored."))
+		else
+			to_chat(user, span_warning("[src] has already been used. The tools are dull and won't reactivate."))
+		return
+	if(!ishuman(user))
+		to_chat(user, span_warning("You don't know how to use this."))
+		return
+	for(var/i in storedorgans)
+		handle_surgery(i, user)
 	user.visible_message(span_notice("[user] presses a button on [src], and you hear a short mechanical noise."), span_notice("You feel a sharp sting as [src] plunges into your body."))
 	playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, 1)
-	storedorgan = null
 	name = initial(name)
-	if(uses != INFINITE)
-		uses--
-	if(!uses)
+	if(!refills)
+		name = "dulled [initial(name)]"
 		desc = "[initial(desc)] Looks like it's been used up."
 
 /obj/item/autosurgeon/attack_self_tk(mob/user)
 	return //stops TK fuckery
 
-/obj/item/autosurgeon/attackby(obj/item/I, mob/user, params)
-	if(istype(I, organ_type))
-		if(storedorgan)
-			to_chat(user, span_notice("[src] already has an implant stored."))
-			return
-		else if(!uses)
-			to_chat(user, span_notice("[src] has already been used up."))
-			return
-		if(is_type_in_typecache(I, blacklisted_organs))
-			to_chat(user, span_notice("[I] does not fit in \the [src]."))
-			return
-		if(!user.transferItemToLoc(I, src))
-			return
-		storedorgan = I
-		to_chat(user, span_notice("You insert the [I] into [src]."))
-	else
-		return ..()
-
+////////////////////////////////////////////////////////////////////////////////////
+//--------------------------------Removing items----------------------------------//
+////////////////////////////////////////////////////////////////////////////////////
 /obj/item/autosurgeon/screwdriver_act(mob/living/user, obj/item/I)
 	if(..())
 		return TRUE
-	if(!storedorgan)
-		to_chat(user, span_notice("There's no implant in [src] for you to remove."))
-	else
+	if(length(storedorgans))
 		var/atom/drop_loc = user.drop_location()
-		for(var/J in src)
+		for(var/J in storedorgans)
 			var/atom/movable/AM = J
 			AM.forceMove(drop_loc)
+			to_chat(user, span_notice("You remove the [J] from [src]."))
+			storedorgans -= J
 
-		to_chat(user, span_notice("You remove the [storedorgan] from [src]."))
 		I.play_tool_sound(src)
-		storedorgan = null
-		if(uses != INFINITE)
-			uses--
-		if(!uses)
+		if(!refills)
+			name = "dulled [initial(name)]"
 			desc = "[initial(desc)] Looks like it's been used up."
+	else
+		to_chat(user, span_notice("There's no implant in [src] for you to remove."))
 	return TRUE
-
+	
+////////////////////////////////////////////////////////////////////////////////////
+//--------------------------Head of staff Autosurgeons----------------------------//
+////////////////////////////////////////////////////////////////////////////////////
 /obj/item/autosurgeon/cmo
 	desc = "A single-use autosurgeon that contains a medical heads-up display augment. A screwdriver can be used to remove it, but implants can't be placed back in."
-	uses = 1
-	starting_organ = /obj/item/organ/cyberimp/eyes/hud/medical
+	starting_organs = list(/obj/item/organ/cyberimp/eyes/hud/medical)
 
+/obj/item/autosurgeon/magboots //for ce
+	desc = "A single-use autosurgeon that contains magboot implants for each leg. A screwdriver can be used to remove them, but implants can't be placed back in."
+	starting_organs = list(/obj/item/organ/cyberimp/leg/magboot, /obj/item/organ/cyberimp/leg/magboot/l)
+
+////////////////////////////////////////////////////////////////////////////////////
+//-----------------------------Antag Autosurgeons---------------------------------//
+////////////////////////////////////////////////////////////////////////////////////
 /obj/item/autosurgeon/upgraded_cyberheart
-	uses = 1
-	starting_organ = /obj/item/organ/heart/cybernetic/upgraded
+	starting_organs = list(/obj/item/organ/heart/cybernetic/upgraded)
 
 /obj/item/autosurgeon/upgraded_cyberliver
-	uses = 1
-	starting_organ = /obj/item/organ/liver/cybernetic/upgraded
+	starting_organs = list(/obj/item/organ/liver/cybernetic/upgraded)
 
 /obj/item/autosurgeon/upgraded_cyberlungs
-	uses = 1
-	starting_organ = /obj/item/organ/lungs/cybernetic/upgraded
+	starting_organs = list(/obj/item/organ/lungs/cybernetic/upgraded)
 
 /obj/item/autosurgeon/upgraded_cyberstomach
-	uses = 1
-	starting_organ = /obj/item/organ/stomach/cybernetic/upgraded
+	starting_organs = list(/obj/item/organ/stomach/cybernetic/upgraded)
 
 /obj/item/autosurgeon/thermal_eyes
-	starting_organ = /obj/item/organ/eyes/robotic/thermals
-
-/obj/item/autosurgeon/xray_eyes
-	starting_organ = /obj/item/organ/eyes/robotic/xray/syndicate
-
-/obj/item/autosurgeon/anti_stun
-	starting_organ = /obj/item/organ/cyberimp/brain/anti_stun/syndicate
-
-/obj/item/autosurgeon/reviver
-	starting_organ = /obj/item/organ/cyberimp/chest/reviver
-
-/obj/item/autosurgeon/reviver/syndicate
-	starting_organ = /obj/item/organ/cyberimp/chest/reviver/syndicate
+	starting_organs = list(/obj/item/organ/eyes/robotic/thermals)
 
 /obj/item/autosurgeon/medibeam
-	uses = 1
-	starting_organ = /obj/item/organ/cyberimp/arm/medibeam
+	starting_organs = list(/obj/item/organ/cyberimp/arm/medibeam)
 
-/obj/item/autosurgeon/arm
-	organ_type = /obj/item/organ/cyberimp/arm //Technically means they can be meta'd by trying to put a normal organ in them and having it return no special text
+/obj/item/autosurgeon/plasmavessel
+	starting_organs = list(/obj/item/organ/alien/plasmavessel)
 
-/obj/item/autosurgeon/arm/examine(mob/user)
-	. = ..()
-	if(storedorgan) //So the extra text that distinguishes it from a normal autosurgeon doesn't appear if it's used up
-		. += "This autosurgeon can switch which arm it will install the implant into with ALT + CLICK."
+/obj/item/autosurgeon/head/robot
+	starting_organs = list(/obj/item/bodypart/head/robot)
 
-/obj/item/autosurgeon/arm/AltClick(mob/user) //Basically runs screwdriver_act on the implant inside
-	if(storedorgan)
-		var/obj/item/organ/cyberimp/arm/implant = storedorgan
-		if(implant.zone == BODY_ZONE_R_ARM)
-			implant.zone = BODY_ZONE_L_ARM
-			to_chat(user, span_notice("You change the autosurgeon to target the left arm."))
-		else
-			implant.zone = BODY_ZONE_R_ARM
-			to_chat(user, span_notice("You change the autosurgeon to target the right arm."))
-		implant.SetSlotFromZone()
-		implant.update_appearance(UPDATE_ICON) //If for whatever reason, the implant is removed from the autosurgeon after it's switched
+/obj/item/autosurgeon/chest/robot
+	starting_organs = list(/obj/item/bodypart/chest/robot)
 
-/obj/item/autosurgeon/arm/syndicate/syndie_mantis
-	uses = 1
-	starting_organ = /obj/item/organ/cyberimp/arm/syndie_mantis
+/obj/item/autosurgeon/l_arm/robot
+	starting_organs = list(/obj/item/bodypart/l_arm/robot)
 
-/obj/item/autosurgeon/arm/syndicate/syndie_hammer
-	uses = 1
-	starting_organ = /obj/item/organ/cyberimp/arm/syndie_hammer
+/obj/item/autosurgeon/r_arm/robot
+	starting_organs = list(/obj/item/bodypart/r_arm/robot)
 
-/obj/item/autosurgeon/arm/syndicate/syndie_hammer/attack_self(mob/user) //Preternis-only implant (if you don't manually remove the implant)
-	if(!ispreternis(user))
-		to_chat(user, span_warning("The autosurgeon rejects your body!"))
-		return
-	..()
+/obj/item/autosurgeon/l_leg/robot
+	starting_organs = list(/obj/item/bodypart/l_leg/robot)
 
-/obj/item/autosurgeon/arm/syndicate/stechkin_implant
-	uses = 1
-	starting_organ = /obj/item/organ/cyberimp/arm/stechkin_implant
+/obj/item/autosurgeon/r_leg/robot
+	starting_organs = list(/obj/item/bodypart/r_leg/robot)
 
-/obj/item/autosurgeon/nt_mantis
-	uses = 1
-	starting_organ = /obj/item/organ/cyberimp/arm/nt_mantis
-
-/obj/item/autosurgeon/nt_mantis/left
-	uses = 1
-	starting_organ = /obj/item/organ/cyberimp/arm/nt_mantis/left
-
-/obj/item/autosurgeon/plasmavessel //Yogs Start: Just an autosurgeon with a plasma vessel in it, used in /obj/item/storage/box/syndie_kit/xeno_organ_kit
-	uses = 3
-	starting_organ = /obj/item/organ/alien/plasmavessel //Yogs End
-
-/obj/item/autosurgeon/syndicate/spinalspeed
-	uses = 1
-	starting_organ = /obj/item/organ/cyberimp/chest/spinalspeed
-
+//------------------------Antag Autosurgeons without metashield-------------------
 /obj/item/autosurgeon/suspicious
 	name = "syndicate autosurgeon"
 	icon_state = "autoimplanter_red"
 
-//Limb autosurgeons
+/obj/item/autosurgeon/suspicious/reusable
+	refills = INFINITE
 
-/obj/item/autosurgeon/limb
-	name = "limb autosurgeon"
-	desc = "A experimental device that can automatically augment or replace a pre-existing limb with one stored in the autosurgeon. It has a slot to insert limbs and a screwdriver slot for removing accidentally added items."
-	organ_type = /obj/item/bodypart //Not an organ but guh
+/obj/item/autosurgeon/suspicious/airshoes
+	starting_organs = list(/obj/item/organ/cyberimp/leg/airshoes, /obj/item/organ/cyberimp/leg/airshoes/l)
 
-/obj/item/autosurgeon/limb/attack_self(mob/living/carbon/human/user)
-	if(!istype(user))
-		return
-	if(!uses)
-		to_chat(user, span_warning("[src] has already been used. The tools are dull and won't reactivate."))
-		return
-	else if(!storedorgan)
-		to_chat(user, span_notice("[src] currently has no limb stored."))
-		return
-	var/obj/item/bodypart/augmentor = storedorgan
-	augmentor.replace_limb(user, TRUE)
-	user.visible_message(span_danger("[user] presses a button on [src], and you watch as the device replaces one of their limbs!"), span_danger("A flash of agony washes over you as [src] replaces one of your limbs."))
-	playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, 1)
-	storedorgan = null
-	name = initial(name)
-	if(uses != INFINITE)
-		uses--
-	if(!uses)
-		desc = "[initial(desc)] Looks like it's been used up."
+/obj/item/autosurgeon/suspicious/noslipall
+	starting_organs = list(/obj/item/organ/cyberimp/leg/noslip, /obj/item/organ/cyberimp/leg/noslip/l)
 
-/obj/item/autosurgeon/limb/attackby(obj/item/I, mob/user, params)
-	if(istype(I, organ_type))
-		if(storedorgan)
-			to_chat(user, span_notice("[src] already has a limb stored."))
-			return
-		else if(!uses)
-			to_chat(user, span_notice("[src] has already been used up."))
-			return
-		if(!user.transferItemToLoc(I, src))
-			return
-		storedorgan = I
-		to_chat(user, span_notice("You insert the [I] into [src]."))
-	else
-		return ..()
+/obj/item/autosurgeon/suspicious/spinalspeed
+	starting_organs = list(/obj/item/organ/cyberimp/chest/spinalspeed)
 
-/obj/item/autosurgeon/limb/screwdriver_act(mob/living/user, obj/item/I)
-	if(..())
-		return TRUE
-	if(!storedorgan)
-		to_chat(user, span_notice("There's no limb in [src] for you to remove."))
-	else
-		var/atom/drop_loc = user.drop_location()
-		for(var/J in src)
-			var/atom/movable/AM = J
-			AM.forceMove(drop_loc)
+/obj/item/autosurgeon/suspicious/syndie_mantis
+	starting_organs = list(/obj/item/organ/cyberimp/arm/syndie_mantis)
 
-		to_chat(user, span_notice("You remove the [storedorgan] from [src]."))
-		I.play_tool_sound(src)
-		storedorgan = null
-		if(uses != INFINITE)
-			uses--
-		if(!uses)
-			desc = "[initial(desc)] Looks like it's been used up."
-	return TRUE
+/obj/item/autosurgeon/suspicious/stechkin_implant
+	starting_organs = list(/obj/item/organ/cyberimp/arm/stechkin_implant)
 
-/obj/item/autosurgeon/limb/head/robot
-	uses = 1
-	starting_organ = /obj/item/bodypart/head/robot
+/obj/item/autosurgeon/suspicious/anti_stun
+	starting_organs = list(/obj/item/organ/cyberimp/brain/anti_stun/syndicate)
 
-/obj/item/autosurgeon/limb/chest/robot
-	uses = 1
-	starting_organ = /obj/item/bodypart/chest/robot
+/obj/item/autosurgeon/suspicious/reviver
+	starting_organs = list(/obj/item/organ/cyberimp/chest/reviver/syndicate)
 
-/obj/item/autosurgeon/limb/l_arm/robot
-	uses = 1
-	starting_organ = /obj/item/bodypart/l_arm/robot
+/obj/item/autosurgeon/suspicious/xray_eyes
+	starting_organs = list(/obj/item/organ/eyes/robotic/xray/syndicate)
 
-/obj/item/autosurgeon/limb/r_arm/robot
-	uses = 1
-	starting_organ = /obj/item/bodypart/r_arm/robot
+/obj/item/autosurgeon/suspicious/syndie_hammer
+	starting_organs = list(/obj/item/organ/cyberimp/arm/syndie_hammer)
 
-/obj/item/autosurgeon/limb/l_leg/robot
-	uses = 1
-	starting_organ = /obj/item/bodypart/l_leg/robot
+////////////////////////////////////////////////////////////////////////////////////
+//--------------------------------NT Autosurgeons---------------------------------//
+////////////////////////////////////////////////////////////////////////////////////
+/obj/item/autosurgeon/nt_mantis
+	starting_organs = list(/obj/item/organ/cyberimp/arm/nt_mantis)
 
-/obj/item/autosurgeon/limb/r_leg/robot
-	uses = 1
-	starting_organ = /obj/item/bodypart/r_leg/robot
+////////////////////////////////////////////////////////////////////////////////////
+//-----------------------------Admeme Autosurgeons--------------------------------//
+////////////////////////////////////////////////////////////////////////////////////
+/obj/item/autosurgeon/jumpboots //for admins
+	starting_organs = list(/obj/item/organ/cyberimp/leg/jumpboots, /obj/item/organ/cyberimp/leg/jumpboots/l)
 
-//implants all the organs back to back, only single use
-//not a derivative of autosurgeons because things get fucky
-//someone is more than welcome to combine the two if they want, just make sure it actually works
-/obj/item/multisurgeon
-	name = "multisurgeon"
-	desc = "A device that automatically inserts an implant or organ into the user without the hassle of extensive surgery. It has a slot to insert implants/organs and a screwdriver slot for removing accidentally added items."
-	icon = 'icons/obj/device.dmi'
-	icon_state = "autoimplanter"
-	item_state = "nothing"
-	w_class = WEIGHT_CLASS_SMALL
-	var/list/obj/item/organ/storedorgan = list()
-	var/organ_type = /obj/item/organ
-	var/uses = 1
-	var/list/starting_organ
-
-/obj/item/multisurgeon/Initialize(mapload)
-	. = ..()
-	for(var/organ in starting_organ)
-		insert_organ(new organ(src))
-
-/obj/item/multisurgeon/proc/insert_organ(obj/item/I)
-	storedorgan |= I
-	I.forceMove(src)
-	name = "[initial(name)] ([I.name])"
-
-/obj/item/multisurgeon/examine(mob/user)
-	. = ..()
-	if(storedorgan)
-		. += span_info("Inside this multisurgeon is:")
-		for(var/obj/item/organ/implants in storedorgan)
-			. += span_info("-[implants] [implants.zone]")
-
-/obj/item/multisurgeon/attack_self(mob/user)//when the object it used...
-	if(!uses)
-		to_chat(user, span_warning("[src] has already been used. The tools are dull and won't reactivate."))
-		return
-	else if(!storedorgan)
-		to_chat(user, span_notice("[src] currently has no implant stored."))
-		return
-	for(var/obj/item/organ/toimplant in storedorgan)
-		if(istype(toimplant, /obj/item/organ/cyberimp/arm)) //these cunts have two limbs to select from, we'll want to check both because players are too lazy to do that themselves
-			var/obj/item/organ/cyberimp/arm/bastard = toimplant
-			if(user.getorganslot(bastard.slot)) //FUCK IT WE BALL
-				var/original_zone = toimplant.zone
-				if(bastard.zone == BODY_ZONE_R_ARM) // i do not like them sam i am  i do not like if else and ham
-					bastard.zone = BODY_ZONE_L_ARM
-				else
-					bastard.zone = BODY_ZONE_R_ARM
-				bastard.SetSlotFromZone()
-				if(user.getorganslot(bastard.slot)) //NEVERMIND WE ARE NOT BALLING
-					bastard.zone = original_zone //MISSION ABORT
-					bastard.SetSlotFromZone()
-				bastard.update_appearance(UPDATE_ICON)
-		toimplant.Insert(user)//insert stored organ into the user
-	user.visible_message(span_notice("[user] presses a button on [src], and you hear a short mechanical noise."), span_notice("You feel a sharp sting as [src] plunges into your body."))
-	playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, 1)
-	storedorgan = null
-	name = initial(name)
-	if(uses != INFINITE)
-		uses--
-	if(!uses)
-		desc = "[initial(desc)] Looks like it's been used up."
-
-/obj/item/multisurgeon/airshoes //for traitors
-	starting_organ = list(/obj/item/organ/cyberimp/leg/airshoes, /obj/item/organ/cyberimp/leg/airshoes/l)
-
-/obj/item/multisurgeon/noslipall //for traitors
-	starting_organ = list(/obj/item/organ/cyberimp/leg/noslip, /obj/item/organ/cyberimp/leg/noslip/l)
-
-/obj/item/multisurgeon/jumpboots //for admins
-	starting_organ = list(/obj/item/organ/cyberimp/leg/jumpboots, /obj/item/organ/cyberimp/leg/jumpboots/l)
-
-/obj/item/multisurgeon/wheelies //for admins
-	starting_organ = list(/obj/item/organ/cyberimp/leg/wheelies, /obj/item/organ/cyberimp/leg/wheelies/l)
-
-/obj/item/multisurgeon/magboots //for ce
-	desc = "A single-use multisurgeon that contains magboot implants for each leg."
-	starting_organ = list(/obj/item/organ/cyberimp/leg/magboot, /obj/item/organ/cyberimp/leg/magboot/l)
-
+/obj/item/autosurgeon/wheelies //for admins
+	starting_organs = list(/obj/item/organ/cyberimp/leg/wheelies, /obj/item/organ/cyberimp/leg/wheelies/l)

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -38,6 +38,8 @@
 	if(locate(/obj/item/organ/cyberimp/arm) in storedorgans)
 		. += span_notice("It will implant any arm implants in the [target_arm == BODY_ZONE_L_ARM ? "left" : "right"] arm first.")
 		. += span_notice("This can be switched with ALT + CLICK.")
+	if(refills > 0)
+		. += span_notice("Can accept [refills] more implants before it ceases to function.")
 
 ////////////////////////////////////////////////////////////////////////////////////
 //---------------------------------Adding organs----------------------------------//

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2126,7 +2126,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/implants/reusable
 	name = "Reusable Autosurgeon"
 	desc = "An empty autosurgeon, but unlike others can be used multiple times. More suspicious than others."
-	item = /obj/item/autosurgeon/suspicious
+	item = /obj/item/autosurgeon/suspicious/reusable
 	manufacturer = /datum/corporation/traitor/vahlen
 	cost = 5
 	// Nukies have no use for this and their autosurgeons are already multi-use
@@ -2146,7 +2146,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "This implant will stimulate muscle movements to help you get back up on your feet faster after being stunned. \
 			This version is modified to help reduce exhaustion during combat. \
 			Comes with an autosurgeon."
-	item = /obj/item/autosurgeon/anti_stun
+	item = /obj/item/autosurgeon/suspicious/anti_stun
 	manufacturer = /datum/corporation/traitor/vahlen
 	cost = 8
 	surplus = 0
@@ -2189,7 +2189,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/implants/reviver
 	name = "Syndicate Reviver Implant"
 	desc = "A more powerful and experimental version of the one utilized by Nanotrasen, this implant will attempt to revive and heal you if you are critically injured. Comes with an autosurgeon."
-	item = /obj/item/autosurgeon/reviver/syndicate
+	item = /obj/item/autosurgeon/suspicious/reviver
 	manufacturer = /datum/corporation/traitor/vahlen
 	cost = 8
 	surplus = 0
@@ -2242,7 +2242,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/implants/xray
 	name = "X-ray Vision Implant"
 	desc = "These cybernetic eyes will give you X-ray vision. Comes with an autosurgeon."
-	item = /obj/item/autosurgeon/xray_eyes
+	item = /obj/item/autosurgeon/suspicious/xray_eyes
 	cost = 10
 	surplus = 0
 	include_modes = list(/datum/game_mode/nuclear)
@@ -2250,7 +2250,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/implants/mantis
 	name = "G.O.R.L.E.X. Mantis Blade"
 	desc = "One G.O.R.L.E.X Mantis blade implant able to be retracted inside your body at will for easy storage and concealing. Two blades can be used at once."
-	item = /obj/item/autosurgeon/arm/syndicate/syndie_mantis
+	item = /obj/item/autosurgeon/suspicious/syndie_mantis
 	cost = 6
 	surplus = 0
 	exclude_modes = list(/datum/game_mode/infiltration) // yogs: infiltration
@@ -2258,26 +2258,26 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/implants/stechkin_implant
 	name = "Stechkin arm implant"
 	desc = "A modified version of the Stechkin pistol placed inside of the forearm to allow for easy concealment."
-	item = /obj/item/autosurgeon/arm/syndicate/stechkin_implant
+	item = /obj/item/autosurgeon/suspicious/stechkin_implant
 	cost = 9
 
 /datum/uplink_item/implants/noslipall
 	name = "Slip Prevention Implant"
 	desc = "An implant that uses advanced sensors to detect when you are slipping and utilize motors in order to prevent it."
-	item = /obj/item/multisurgeon/noslipall
+	item = /obj/item/autosurgeon/suspicious/noslipall
 	cost = 6	//tax for them being nigh impossible to steal or lose
 
 /datum/uplink_item/implants/airshoes
 	name = "Air Shoes Implant"
 	desc = "As a result of extreme popularity of the Air Shoes an implant version was developed. Just like the boots there are jets allowing the users to reach high speeds for prolonged durations and short bursts."
-	item = /obj/item/multisurgeon/airshoes
+	item = /obj/item/autosurgeon/suspicious/airshoes
 	cost = 6	//2 tc tax for them being nigh impossible to steal or lose
 	manufacturer = /datum/corporation/traitor/cybersun
 
 /datum/uplink_item/implants/spinal
 	name = "Neural Overclocker Implant"
 	desc = "Stimulates your central nervous system in order to enable you to perform muscle movements faster. Careful not to overuse it."
-	item = /obj/item/autosurgeon/syndicate/spinalspeed
+	item = /obj/item/autosurgeon/suspicious/spinalspeed
 	manufacturer = /datum/corporation/traitor/vahlen
 	cost = 12
 	exclude_modes = list(/datum/game_mode/infiltration, /datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
@@ -2381,7 +2381,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			It can be charged by the user's concentration, which permits a single blow that will decimate construction, \
 			fling bodies, and heavily damage mechs. Vir'ln krx'tai, lost one."
 	cost = 10
-	item = /obj/item/autosurgeon/arm/syndicate/syndie_hammer
+	item = /obj/item/autosurgeon/suspicious/syndie_hammer
 	restricted_species = list("preternis")
 
 /datum/uplink_item/race_restricted/hammerimplant/New()

--- a/yogstation/code/game/gamemodes/battle_royale/loot.dm
+++ b/yogstation/code/game/gamemodes/battle_royale/loot.dm
@@ -229,7 +229,7 @@ GLOBAL_LIST_INIT(battleroyale_weapon, list(
 		/obj/item/singularityhammer = -2,
 		
 		/obj/item/vibro_weapon = -3, //Strong melee weapon, but not enough to be -5
-		/obj/item/autosurgeon/arm/syndicate/syndie_mantis = -3,
+		/obj/item/autosurgeon/suspicious/syndie_mantis = -3,
 		/obj/item/melee/chainsaw/demon = -3,
 
 		/obj/item/melee/dualsaber = -4,
@@ -333,8 +333,8 @@ GLOBAL_LIST_INIT(battleroyale_utility, list(//bombs, explosives, anything that's
 		/obj/item/grenade/plastic/c4 = 3,
 
 		/obj/item/book/granter/action/spell/smoke/lesser = 2,
-		/obj/item/multisurgeon/jumpboots = 2,
-		/obj/item/autosurgeon/reviver = 2,
+		/obj/item/autosurgeon/jumpboots = 2,
+		/obj/item/autosurgeon/suspicious/reviver = 2,
 		/obj/item/grenade/plastic/c4 = 2,
 		/obj/effect/spawner/lootdrop/weakgene = 2,
 
@@ -347,20 +347,20 @@ GLOBAL_LIST_INIT(battleroyale_utility, list(//bombs, explosives, anything that's
 		/obj/effect/spawner/lootdrop/ammobox = 0,
 		/obj/item/warp_whistle = 0,
 		/obj/item/gun/magic/staff/animate = 0, //no clue why you'd want this, but why not
-		/obj/item/multisurgeon/wheelies = 0,
+		/obj/item/autosurgeon/wheelies = 0,
 		/obj/item/grenade/plastic/c4 = 0, //it's c4 all the way down buddy
 
 		/obj/item/autosurgeon/thermal_eyes = -1,
-		/obj/item/autosurgeon/xray_eyes = -1,
+		/obj/item/autosurgeon/suspicious/xray_eyes = -1,
 		/obj/item/gun/magic/wand/door = -1,
 		/obj/item/gun/magic/staff/door = -1,
 		/obj/item/storage/backpack/duffelbag/syndie = -1,
 		/obj/item/slimecross/stabilized/red = -1,
-		/obj/item/autosurgeon/reviver = -1,
+		/obj/item/autosurgeon/suspicious/reviver = -1,
 		/obj/effect/spawner/lootdrop/ammobox = -1,
 		/obj/item/slime_sling = -1,
 
-		/obj/item/multisurgeon/airshoes = -2,
+		/obj/item/autosurgeon/suspicious/airshoes = -2,
 		/obj/item/grenade/syndieminibomb = -2,
 		/obj/item/dragons_blood = -2,
 		/obj/item/dragons_blood/refined = -2,
@@ -407,7 +407,7 @@ GLOBAL_LIST_INIT(battleroyale_utility, list(//bombs, explosives, anything that's
 		/obj/item/bodypart/l_arm/robot/buster = -5,
 		/obj/item/demon_core = -5,
 
-		/obj/item/autosurgeon/syndicate/spinalspeed = -6, // No opportunity cost speed boost
+		/obj/item/autosurgeon/suspicious/spinalspeed = -6, // No opportunity cost speed boost
 
 		/obj/item/storage/belt/wands/full = -7, //not quite spellbook, but some of these wands are FUCKED
 		/obj/item/spellbook = -7, //literally auto-win IF you have the time to use it (a lot of spells are robe locked too)


### PR DESCRIPTION
We had three kinds
- Regular
- Arm specific
- Multisurgeon (my fault)

I was too dumb to follow through with what i attempted to do with multisurgeons when initially implemented them
so i'm rectifying that

i might have unintentionally removed metashielding from certain traitor autosurgeons
please let me know if this is an issue

# Why is this good for the game?
code quality and maintainability

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/fb03329c-358f-4e06-b3fd-f110600190fe)

:cl:  
tweak: reusable autosurgeons can now implant both organs and limbs
experimental: Refactored autosurgeons please report any inconsistencies
/:cl:
