### PR TITLE
Removes removed OD lint

### DIFF
--- a/tools/ci/od_lints.dm
+++ b/tools/ci/od_lints.dm
@@ -12,7 +12,6 @@
 #pragma SoftReservedKeyword error
 #pragma DuplicateVariable error
 #pragma DuplicateProcDefinition error
-#pragma TooManyArguments error
 #pragma PointlessParentCall error
 #pragma PointlessBuiltinCall error
 #pragma SuspiciousMatrixCall error


### PR DESCRIPTION
# Document the changes in your pull request

Ports https://github.com/tgstation/tgstation/pull/84069
PR in question says it was removed, so there's no reason to keep it around. I originally added it thinking it was something still being implemented, not something that no longer exists.