### PR TITLE
Fixes jungleland mobs dying to toxic water + deep toxic not being stronger

### DIFF
--- a/_maps/RandomRuins/JungleRuins/jungleland_swamp_syndicatestation.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungleland_swamp_syndicatestation.dmm
@@ -3359,7 +3359,7 @@
 /turf/open/floor/engine/plasma,
 /area/ruin/powered/syndicate_lava_base/engineering)
 "Fi" = (
-/turf/open/water/toxic_pit/deep_toxic_pit,
+/turf/open/water/toxic_pit/deep,
 /area/jungleland/toxic_pit)
 "Fl" = (
 /obj/effect/turf_decal/siding/brown,
@@ -5631,7 +5631,7 @@
 /area/ruin/powered/syndicate_lava_base/cargo)
 "ZW" = (
 /obj/structure/flora/ausbushes/stalkybush,
-/turf/open/water/toxic_pit/deep_toxic_pit,
+/turf/open/water/toxic_pit/deep,
 /area/jungleland/toxic_pit)
 "ZX" = (
 /obj/effect/turf_decal/siding/blue{

--- a/_maps/RandomRuins/JungleRuins/jungleland_swamp_syndicatestation.dmm
+++ b/_maps/RandomRuins/JungleRuins/jungleland_swamp_syndicatestation.dmm
@@ -3359,7 +3359,7 @@
 /turf/open/floor/engine/plasma,
 /area/ruin/powered/syndicate_lava_base/engineering)
 "Fi" = (
-/turf/open/water/deep_toxic_pit,
+/turf/open/water/toxic_pit/deep_toxic_pit,
 /area/jungleland/toxic_pit)
 "Fl" = (
 /obj/effect/turf_decal/siding/brown,
@@ -5631,7 +5631,7 @@
 /area/ruin/powered/syndicate_lava_base/cargo)
 "ZW" = (
 /obj/structure/flora/ausbushes/stalkybush,
-/turf/open/water/deep_toxic_pit,
+/turf/open/water/toxic_pit/deep_toxic_pit,
 /area/jungleland/toxic_pit)
 "ZX" = (
 /obj/effect/turf_decal/siding/blue{

--- a/_maps/map_files/mining/Jungleland.dmm
+++ b/_maps/map_files/mining/Jungleland.dmm
@@ -233,7 +233,7 @@
 /turf/closed/wall,
 /area/mine/laborcamp)
 "gg" = (
-/turf/open/water/deep_toxic_pit,
+/turf/open/water/toxic_pit/deep_toxic_pit,
 /area/jungleland/explored)
 "gh" = (
 /obj/machinery/door/airlock/security/glass{
@@ -1162,7 +1162,7 @@
 /turf/open/floor/plating/dirt/jungleland/dry_swamp,
 /area/jungleland/explored)
 "LE" = (
-/turf/open/water/deep_toxic_pit,
+/turf/open/water/toxic_pit/deep_toxic_pit,
 /area/jungleland/ocean)
 "LM" = (
 /obj/structure/ore_box,

--- a/_maps/map_files/mining/Jungleland.dmm
+++ b/_maps/map_files/mining/Jungleland.dmm
@@ -233,7 +233,7 @@
 /turf/closed/wall,
 /area/mine/laborcamp)
 "gg" = (
-/turf/open/water/toxic_pit/deep_toxic_pit,
+/turf/open/water/toxic_pit/deep,
 /area/jungleland/explored)
 "gh" = (
 /obj/machinery/door/airlock/security/glass{
@@ -1162,7 +1162,7 @@
 /turf/open/floor/plating/dirt/jungleland/dry_swamp,
 /area/jungleland/explored)
 "LE" = (
-/turf/open/water/toxic_pit/deep_toxic_pit,
+/turf/open/water/toxic_pit/deep,
 /area/jungleland/ocean)
 "LM" = (
 /obj/structure/ore_box,

--- a/code/modules/mining/aux_base.dm
+++ b/code/modules/mining/aux_base.dm
@@ -229,7 +229,7 @@
 			/turf/open/lava,
 			/turf/open/indestructible,
 			/turf/open/water/toxic_pit,
-			/turf/open/water/deep_toxic_pit,
+			/turf/open/water/toxic_pit/deep_toxic_pit,
 			/turf/open/water/tar_basin,
 			)) - typecacheof(list(
 			/turf/closed/mineral,

--- a/code/modules/mining/aux_base.dm
+++ b/code/modules/mining/aux_base.dm
@@ -229,7 +229,7 @@
 			/turf/open/lava,
 			/turf/open/indestructible,
 			/turf/open/water/toxic_pit,
-			/turf/open/water/toxic_pit/deep_toxic_pit,
+			/turf/open/water/toxic_pit/deep,
 			/turf/open/water/tar_basin,
 			)) - typecacheof(list(
 			/turf/closed/mineral,

--- a/code/modules/mining/shelters.dm
+++ b/code/modules/mining/shelters.dm
@@ -8,7 +8,7 @@
 
 /datum/map_template/shelter/New()
 	. = ..()
-	blacklisted_turfs = typecacheof(/turf/closed, /turf/open/lava/smooth/lava_land_surface/no_shelter,/turf/open/water/deep_toxic_pit)
+	blacklisted_turfs = typecacheof(/turf/closed, /turf/open/lava/smooth/lava_land_surface/no_shelter,/turf/open/water/toxic_pit/deep_toxic_pit)
 	whitelisted_turfs = list()
 	banned_areas = typecacheof(/area/shuttle)
 	banned_objects = list()

--- a/code/modules/mining/shelters.dm
+++ b/code/modules/mining/shelters.dm
@@ -8,7 +8,7 @@
 
 /datum/map_template/shelter/New()
 	. = ..()
-	blacklisted_turfs = typecacheof(/turf/closed, /turf/open/lava/smooth/lava_land_surface/no_shelter,/turf/open/water/toxic_pit/deep_toxic_pit)
+	blacklisted_turfs = typecacheof(/turf/closed, /turf/open/lava/smooth/lava_land_surface/no_shelter,/turf/open/water/toxic_pit/deep)
 	whitelisted_turfs = list()
 	banned_areas = typecacheof(/area/shuttle)
 	banned_objects = list()

--- a/yogstation/code/modules/jungleland/jungle_turfs.dm
+++ b/yogstation/code/modules/jungleland/jungle_turfs.dm
@@ -202,7 +202,14 @@ Temperature: 126.85 °C (400 K)
 	AddComponent(/datum/component/lingering, CALLBACK(src, PROC_REF(toxic_stuff)), GLOB.lavasafeties)
 
 /turf/open/water/toxic_pit/proc/toxic_stuff(thing, delta_time)
-	if (isliving(thing)) //objects are unaffected for now
+	if(isobj(thing))
+		var/obj/O = thing
+		if((O.resistance_flags & (UNACIDABLE|INDESTRUCTIBLE)) || O.throwing)
+			return
+		. = TRUE
+		O.acid_act(5 * acid_strength, 7.5 * acid_strength)
+
+	else if (isliving(thing))
 		. = TRUE
 		var/mob/living/L = thing
 		if(WEATHER_ACID in L.weather_immunities) //if they're immune to acid weather

--- a/yogstation/code/modules/jungleland/jungle_turfs.dm
+++ b/yogstation/code/modules/jungleland/jungle_turfs.dm
@@ -266,14 +266,14 @@ Temperature: 126.85 °C (400 K)
 /turf/open/water/safe/jungle
 	initial_gas_mix = JUNGLELAND_DEFAULT_ATMOS
 
-/turf/open/water/deep_toxic_pit
+/turf/open/water/toxic_pit/deep_toxic_pit
 	name = "deep sulphuric pit"
 	desc = "Extraordinarily toxic."
 	color = "#004700"
 	slowdown = 4
 	initial_gas_mix = JUNGLELAND_DEFAULT_ATMOS
 	planetary_atmos = TRUE
-	baseturfs = /turf/open/water/deep_toxic_pit
+	baseturfs = /turf/open/water/toxic_pit/deep_toxic_pit
 	acid_strength = 2
 
 /turf/open/floor/wood/jungle

--- a/yogstation/code/modules/jungleland/jungle_turfs.dm
+++ b/yogstation/code/modules/jungleland/jungle_turfs.dm
@@ -271,8 +271,6 @@ Temperature: 126.85 °C (400 K)
 	desc = "Extraordinarily toxic."
 	color = "#004700"
 	slowdown = 4
-	initial_gas_mix = JUNGLELAND_DEFAULT_ATMOS
-	planetary_atmos = TRUE
 	baseturfs = /turf/open/water/toxic_pit/deep_toxic_pit
 	acid_strength = 2
 

--- a/yogstation/code/modules/jungleland/jungle_turfs.dm
+++ b/yogstation/code/modules/jungleland/jungle_turfs.dm
@@ -266,12 +266,12 @@ Temperature: 126.85 °C (400 K)
 /turf/open/water/safe/jungle
 	initial_gas_mix = JUNGLELAND_DEFAULT_ATMOS
 
-/turf/open/water/toxic_pit/deep_toxic_pit
+/turf/open/water/toxic_pit/deep
 	name = "deep sulphuric pit"
 	desc = "Extraordinarily toxic."
 	color = "#004700"
 	slowdown = 4
-	baseturfs = /turf/open/water/toxic_pit/deep_toxic_pit
+	baseturfs = /turf/open/water/toxic_pit/deep
 	acid_strength = 2
 
 /turf/open/floor/wood/jungle


### PR DESCRIPTION
I just copied from old code, apparently it never checked for WEATHER_ACID immunity
but it also never checked anything other than a human
so they were immune, not because of their immunity, but because they weren't even being looked at in the first place

this also meant that if a human got acid weather immunity, they'd still be affected anyway

also, i removed an unintentional part of deep toxic water being significantly more dangerous

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/956dcb57-4f69-491f-b11e-1470303d1c4a)

:cl:  
bugfix: Fixes jungleland mobs not being immune to toxic water
bugfix: Fixes deep toxic water not being more dangerous
bugfix: Fixes jungleland plant people not being immune to toxic water like intended
bugfix: Fixes objects being unaffected by the toxic water acid (cardboard boxes)
/:cl:
