### PR TITLE
Fixes a runtime when swapping from a synth in the character menu

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/wy_synths.dm
+++ b/code/modules/mob/living/carbon/human/species_types/wy_synths.dm
@@ -99,8 +99,7 @@
 	. = ..()
 	C.remove_language(/datum/language/machine, source = LANGUAGE_SYNTH)
 	os_button.Remove(C)
-	inbuilt_cpu.forceMove(get_turf(C))
-	inbuilt_cpu = null
+	QDEL_NULL(inbuilt_cpu)
 	C.physiology.force_multiplier /= 1.25
 
 /datum/species/wy_synth/proc/handle_speech(datum/source, list/speech_args)


### PR DESCRIPTION
nowhere for it to drop the cpu so it runtimed

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/9d042786-93ea-4589-8ad2-ede6762b744e)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/a6e6005c-990f-4a37-a581-02bf18396e0f)



nothing player facing
:cl:  
/:cl:
