### PR TITLE
Fixes water rocks looking like ERR̴̪̅OR̴͇͝

### DIFF
--- a/code/game/turfs/open/floor/plating/misc_plating.dm
+++ b/code/game/turfs/open/floor/plating/misc_plating.dm
@@ -93,6 +93,7 @@
 /turf/open/floor/plating/ashplanet/wateryrock
 	gender = PLURAL
 	name = "wet rocky ground"
+	icon = 'icons/turf/mining.dmi'
 	icon_state = "wateryrock"
 	base_icon_state = null
 	smoothing_flags = NONE

--- a/code/game/turfs/open/floor/plating/misc_plating.dm
+++ b/code/game/turfs/open/floor/plating/misc_plating.dm
@@ -93,8 +93,8 @@
 /turf/open/floor/plating/ashplanet/wateryrock
 	gender = PLURAL
 	name = "wet rocky ground"
-	icon_state = "watery_rock"
-	base_icon_state = "watery_rock"
+	icon_state = "wateryrock"
+	base_icon_state = null
 	smoothing_flags = NONE
 	slowdown = 2
 	footstep = FOOTSTEP_FLOOR
@@ -103,7 +103,7 @@
 	heavyfootstep = FOOTSTEP_GENERIC_HEAVY
 
 /turf/open/floor/plating/ashplanet/wateryrock/Initialize(mapload)
-	icon_state = "[base_icon_state][rand(1, 9)]"
+	icon_state = "[icon_state][rand(1, 9)]"
 	return ..()
 
 /turf/open/floor/plating/beach


### PR DESCRIPTION
# Document the changes in your pull request

![image](https://github.com/yogstation13/Yogstation/assets/143908044/3238a4a3-306c-4bbf-baee-08f12ed39928)

Broke on the icon smoothing PR
Our icons for this don't smooth (but the parent /type does, so `base_icon_state = null`)
also `icon_state` and `icon` were wrong

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/143908044/9de661c1-3e7b-46cc-bb48-ac8a386a795f)


# Changelog
:cl:
bugfix: Fixed watery rocks looking like the all-consuming void
/:cl:
