### PR TITLE
plasma magmite now gives you a hint on mining it if you accidentally destroy it

### DIFF
--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -987,6 +987,7 @@
 /turf/closed/mineral/magmite/gets_drilled(mob/user, triggered_by_explosion = FALSE)
 	if(!triggered_by_explosion)
 		mineralAmt = 0
+		to_chat(user, span_danger("The structure of the plasma magmite crumbles to dust from the vibration! Maybe it could withstand an explosion..?"))
 	..(user,triggered_by_explosion,TRUE)
 
 /turf/closed/mineral/magmite/volcanic


### PR DESCRIPTION
# Document the changes in your pull request

it will tell you to use an explosion (still wont know that the first time)

# Why is this good for the game?
lessens confusion

# Changelog

:cl:  
tweak: plasma magmite now gives you a hint on mining it if you accidentally destroy it
/:cl:
