### PR TITLE
Fixes dying in VR breaking certain items

### DIFF
--- a/code/modules/VR/vr_human.dm
+++ b/code/modules/VR/vr_human.dm
@@ -19,7 +19,7 @@
 
 /mob/living/carbon/human/virtual_reality/Destroy()
 	revert_to_reality()
-	for(var/obj/item/I in get_all_contents())
+	for(var/obj/item/I in contents)
 		if(I.item_flags & ABSTRACT)
 			continue
 		dropItemToGround(I, TRUE, TRUE)

--- a/code/modules/VR/vr_human.dm
+++ b/code/modules/VR/vr_human.dm
@@ -19,10 +19,7 @@
 
 /mob/living/carbon/human/virtual_reality/Destroy()
 	revert_to_reality()
-	for(var/obj/item/I in contents)
-		if(I.item_flags & ABSTRACT)
-			continue
-		dropItemToGround(I, TRUE, TRUE)
+	unequip_everything(TRUE)
 	return ..()
 
 /mob/living/carbon/human/virtual_reality/Life(seconds_per_tick = SSMOBS_DT, times_fired)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -266,10 +266,10 @@
 	I.dropped(src)
 	return FALSE
 
-/mob/proc/drop_all_held_items()
+/mob/proc/drop_all_held_items(force = FALSE)
 	. = FALSE
 	for(var/obj/item/I in held_items)
-		. |= dropItemToGround(I)
+		. |= dropItemToGround(I, force)
 
 //Here lie drop_from_inventory and before_item_take, already forgotten and not missed.
 
@@ -398,12 +398,12 @@
 			items += s_store
 	return items
 
-/mob/living/proc/unequip_everything()
+/mob/living/proc/unequip_everything(force = FALSE)
 	var/list/items = list()
 	items |= get_equipped_items(TRUE)
 	for(var/I in items)
-		dropItemToGround(I)
-	drop_all_held_items()
+		dropItemToGround(I, force)
+	drop_all_held_items(force)
 
 
 /mob/living/carbon/proc/check_obscured_slots(transparent_protection)


### PR DESCRIPTION
Dying dropped contents of contents which meant anything inside another item would be removed and dropped onto the floor, breaking certain things like guns.

:cl:  
bugfix: Fixed dying in VR breaking certain items
/:cl:
