### PR TITLE
Fixes ethereals getting permanently stuck at max charge

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1031,7 +1031,7 @@
 			nutrition = 0
 			dna?.species.get_hunger_alert(src)
 			return FALSE
-		if(nutrition >= NUTRITION_LEVEL_FAT)
+		if(nutrition >= NUTRITION_LEVEL_FAT && change > 0)
 			return FALSE
 		change = min(change, NUTRITION_LEVEL_FAT - nutrition) // no getting fat
 	..()


### PR DESCRIPTION
If ethereals reach 600 charge they get permanently stuck in a loop of discharging their energy forever.

:cl:  
bugfix: Fixed ethereals getting permanently stuck at max charge
/:cl:
