### PR TITLE
[ICEMETA] [GAX] Changes stairs (the ones that actually let you travel z-levels) render plane, fixes some mapping bugs

### DIFF
--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -1232,6 +1232,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "aEO" = (
@@ -1842,6 +1843,7 @@
 	pixel_x = 11;
 	pixel_y = 8
 	},
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "aTR" = (
@@ -2899,6 +2901,9 @@
 /obj/effect/turf_decal/siding/wideplating/corner{
 	dir = 4
 	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 4
+	},
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
 "buE" = (
@@ -3090,6 +3095,9 @@
 	dir = 4
 	},
 /obj/machinery/seed_extractor,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 8
+	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "bBo" = (
@@ -8434,6 +8442,7 @@
 	dir = 8
 	},
 /obj/machinery/washing_machine,
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/toilet/auxiliary)
 "ebI" = (
@@ -12467,6 +12476,9 @@
 	dir = 4
 	},
 /obj/machinery/biogenerator,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 8
+	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "fOd" = (
@@ -14168,6 +14180,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "gGa" = (
@@ -17539,6 +17552,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "imX" = (
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
 /turf/open/floor/plasteel/stairs/goon/stairs2_wide{
 	dir = 1
 	},
@@ -22733,6 +22749,9 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "kVA" = (
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
 /turf/open/floor/plasteel/stairs/goon/stairs_wide{
 	dir = 1
 	},
@@ -26419,6 +26438,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "mIS" = (
@@ -34551,6 +34571,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
 /turf/open/floor/plasteel/stairs/goon/stairs_middle,
 /area/hydroponics/garden)
 "qQC" = (
@@ -35487,6 +35510,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/indestructible/grass/sand,
 /area/hydroponics/garden)
 "rmC" = (
@@ -37607,6 +37631,7 @@
 	dir = 1
 	},
 /obj/machinery/washing_machine,
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/toilet/auxiliary)
 "snD" = (
@@ -38759,6 +38784,9 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science/central)
 "sQs" = (
+/obj/effect/turf_decal/ramp_corner{
+	dir = 8
+	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/toilet/auxiliary)
 "sQy" = (
@@ -39874,7 +39902,12 @@
 "trI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/stairs/goon/stairs_wide,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs_wide{
+	dir = 1
+	},
 /area/hydroponics/garden)
 "tsz" = (
 /turf/open/floor/plasteel/dark,
@@ -41868,6 +41901,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/structure/railing/corner,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
 "uwi" = (
@@ -44960,7 +44994,12 @@
 	persistence_id = "public";
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/stairs/goon/stairs2_wide,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs2_wide{
+	dir = 1
+	},
 /area/hydroponics/garden)
 "vTP" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -45831,6 +45870,10 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 1
+	},
+/obj/structure/railing/corner,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "woR" = (
@@ -46686,6 +46729,9 @@
 	dir = 4
 	},
 /obj/machinery/vending/hydroseeds/weak,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 8
+	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "wKL" = (
@@ -46990,6 +47036,9 @@
 	dir = 4
 	},
 /obj/machinery/vending/hydronutrients,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 8
+	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "wTB" = (
@@ -49638,7 +49687,7 @@
 /obj/machinery/door/window/eastleft{
 	dir = 8;
 	name = "Hydroponics Window";
-	req_one_access_txt = "30;35"
+	req_one_access_txt = "35"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)

--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -499,6 +499,7 @@
 /obj/structure/railing/corner{
 	dir = 1
 	},
+/obj/effect/turf_decal/ramp_corner,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "agN" = (
@@ -2214,6 +2215,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"aHc" = (
+/obj/structure/stairs/goon/wide/right{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/mine/living_quarters)
 "aHd" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/hidden,
 /obj/structure/cable{
@@ -13095,8 +13105,13 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "dRf" = (
-/obj/structure/stairs/north,
-/turf/open/floor/plasteel/dark,
+/obj/structure/stairs/goon/wide/left{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/mine/living_quarters)
 "dRl" = (
 /obj/structure/sign/map/right{
@@ -13653,6 +13668,9 @@
 	},
 /obj/structure/railing{
 	dir = 8
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
@@ -17372,6 +17390,7 @@
 /obj/structure/fans/tiny{
 	resistance_flags = 115
 	},
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/plating,
 /area/mine/abandoned)
 "fiU" = (
@@ -21239,6 +21258,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "glv" = (
@@ -27724,6 +27744,7 @@
 /obj/structure/fans/tiny{
 	resistance_flags = 115
 	},
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/plating/snowed/colder,
 /area/mine/abandoned)
 "ihb" = (
@@ -32420,6 +32441,15 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/storage/art)
+"jvC" = (
+/obj/structure/stairs/goon/wide/right{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/mine/abandoned)
 "jvE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable/yellow{
@@ -35631,6 +35661,9 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "kqF" = (
@@ -37287,6 +37320,9 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/structure/railing/corner,
+/obj/effect/turf_decal/ramp_corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "kNr" = (
@@ -45571,7 +45607,12 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/mine/break_room)
 "ncA" = (
-/obj/structure/stairs/north,
+/obj/structure/stairs/goon/wide/left{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/mine/abandoned)
 "ncH" = (
@@ -53654,6 +53695,9 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/railing,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "ptR" = (
@@ -55796,6 +55840,9 @@
 	},
 /obj/structure/railing{
 	dir = 4
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
@@ -65881,6 +65928,7 @@
 /obj/structure/fans/tiny{
 	resistance_flags = 115
 	},
+/obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/plating,
 /area/mine/abandoned)
 "sVf" = (
@@ -69539,6 +69587,9 @@
 "tVb" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
+	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
@@ -78178,6 +78229,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/foyer)
+"wop" = (
+/obj/structure/stairs/goon/wide,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/mine/living_quarters)
 "wot" = (
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
@@ -79477,6 +79535,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"wHy" = (
+/obj/structure/stairs/goon/wide,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/mine/abandoned)
 "wHH" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -101877,7 +101942,7 @@ lbu
 lbu
 lbu
 iwT
-ncA
+wHy
 fiM
 iJS
 xXW
@@ -102134,7 +102199,7 @@ lbu
 lbu
 lbu
 iwT
-ncA
+jvC
 igO
 xXW
 kss
@@ -167409,7 +167474,7 @@ ibA
 eQD
 ptD
 lTL
-dRf
+wop
 glq
 hbq
 vhD
@@ -167666,7 +167731,7 @@ hcL
 fNF
 ptD
 lTL
-dRf
+aHc
 glq
 hbq
 shd

--- a/code/game/objects/structures/stairs.dm
+++ b/code/game/objects/structures/stairs.dm
@@ -10,7 +10,7 @@
 	name = "stairs"
 	icon = 'icons/obj/stairs.dmi'
 	icon_state = "stairs"
-	layer = BELOW_OPEN_DOOR_LAYER
+	layer = EMISSIVE_FLOOR_LAYER
 	anchored = TRUE
 	move_resist = INFINITY
 
@@ -156,3 +156,25 @@
 		if(S.dir == dir)
 			return FALSE
 	return TRUE
+
+// For the sake of keeping the same sprite as /turf/open/floor/plasteel/stairs/goon/stairs
+// One-tile stairs
+/obj/structure/stairs/goon
+	icon = 'goon/icons/turfs/floors.dmi'
+	icon_state = "stairs_alone"
+	base_icon_state = "stairs_alone"
+
+// Middle
+/obj/structure/stairs/goon/wide
+	icon_state = "stairs_middle"
+	base_icon_state = "stairs_middle"
+
+// Left side
+/obj/structure/stairs/goon/wide/left
+	icon_state = "stairs_wide"
+	base_icon_state = "stairs_wide"
+
+// Right side
+/obj/structure/stairs/goon/wide/right
+	icon_state = "stairs2_wide"
+	base_icon_state = "stairs2_wide"


### PR DESCRIPTION
# Document the changes in your pull request
- I'm tired of not being able to put ramp shadows on these things since they're structures, so I've moved them down to the floor plane (layer 2).

- And because we often use stairs (actually tiles, but they make people think they're stairs) that look like this:
![image](https://github.com/yogstation13/Yogstation/assets/143908044/03bfd277-284f-48e7-b43b-5814d9995429)

and not this: (ugly) (how structure stairs look (not floor tile))
![image](https://github.com/yogstation13/Yogstation/assets/143908044/926711c3-1e4b-4a6d-a2d3-a4b7acf8bf60)

we now have stairs (structure) that look like the above!

And tiny map fixes because
- IceMeta stairs in mining now use above ^ better looking stairs
- Added some ramp shadows to Gax stairs
- Fixed an access-related bug I noticed while doing the maptainer test a few months ago lol

# Why is this good for the game?
Lets me do my job better and map faster!!!

# Testing
Will do

# Changelog
:cl:
experimental: Actual stairs (currently only exist on IceMeta) are now visually rendered lower than some objects, you make report if see any issue yes?
mapping: The stairs found in mining on IceMeta now look a bit nicer
mapping: The stairs in the garden on NVS Gax now have some nice shading
mapping: The botanist's windoor between hydroponics and the kitchen on NVS Gax can no longer be opened with RD access (lol, lmao even)
/:cl: