### PR TITLE
Perfect parries no longer damage your shield

### DIFF
--- a/code/datums/components/blocking.dm
+++ b/code/datums/components/blocking.dm
@@ -202,7 +202,7 @@
 	if(attack_type & (UNARMED_ATTACK|THROWN_PROJECTILE_ATTACK|LEAP_ATTACK))
 		playsound(defender, 'sound/weapons/smash.ogg', 50, TRUE)
 
-	if(block_flags & DAMAGE_ON_BLOCK)
+	if((block_flags & DAMAGE_ON_BLOCK) && !is_parrying)
 		used_item.take_damage(damage, damage_type)
 
 	return SHIELD_BLOCK


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Shields capable of parrying no longer take damage when doing so. This does not include normal blocking.

# Why is this good for the game?
Incentivizes trying to parry, which is a lot more fun than just holding right click the whole time.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
tweak: Shields capable of parrying no longer take damage when doing so.
/:cl:
