### PR TITLE
Slight nerfs to fire breath

### DIFF
--- a/code/datums/mutations/fire_breath.dm
+++ b/code/datums/mutations/fire_breath.dm
@@ -20,8 +20,9 @@
 	if(GET_MUTATION_POWER(src) <= 1) // we only care about power from here on
 		return
 
-	to_modify.cone_levels += 2  // Cone fwooshes further, and...
-	to_modify.self_throw_range += 1 // the breath throws the user back more
+	to_modify.cone_levels += 2  // Cone fwooshes further,
+	to_modify.self_throw_range += 1 // the breath throws the user back more,
+	to_modify.max_damage = 40	// and the burn is burnier
 
 /datum/action/cooldown/spell/cone/staggered/fire_breath
 	name = "Fire Breath"
@@ -39,6 +40,8 @@
 	respect_density = TRUE
 	/// The range our user is thrown backwards after casting the spell
 	var/self_throw_range = 1
+	/// The max point-blank damage dealt by the cone
+	var/max_damage = 25
 
 /datum/action/cooldown/spell/cone/staggered/fire_breath/before_cast(atom/cast_on)
 	. = ..()
@@ -71,6 +74,14 @@
 	)
 	// Try to set us to our original direction after, so we don't end up backwards.
 	living_cast_on.setDir(original_dir)
+	//If we have the empowered version it'll also knock us down, assuming we cant use our hands to remain balanced
+	//Using the throw range to check for empowering because it's easier
+	if(iscarbon(cast_on) && (self_throw_range > 1))
+		var/mob/living/carbon/lizard_projectile = cast_on
+		if(lizard_projectile.restrained())
+			lizard_projectile.Knockdown(2 SECONDS)
+			to_chat(lizard_projectile, span_warning("You can't keep your balance with your hands restrained!"))
+
 
 /datum/action/cooldown/spell/cone/staggered/fire_breath/calculate_cone_shape(current_level)
 	// This makes the cone shoot out into a 3 wide column of flames.
@@ -86,7 +97,7 @@
 /datum/action/cooldown/spell/cone/staggered/fire_breath/do_mob_cone_effect(mob/living/target_mob, atom/caster, level)
 	// Further out targets take less immediate burn damage and get less fire stacks.
 	// The actual burn damage application is not blocked by fireproofing, like space dragons.
-	target_mob.apply_damage(max(10, 40 - (5 * level)), BURN)
+	target_mob.apply_damage(max(10, max_damage - (5 * level)), BURN, wound_bonus = -30, bare_wound_bonus = 30)
 	target_mob.adjust_fire_stacks(max(2, 5 - level))
 	target_mob.ignite_mob()
 

--- a/code/datums/mutations/fire_breath.dm
+++ b/code/datums/mutations/fire_breath.dm
@@ -97,7 +97,7 @@
 /datum/action/cooldown/spell/cone/staggered/fire_breath/do_mob_cone_effect(mob/living/target_mob, atom/caster, level)
 	// Further out targets take less immediate burn damage and get less fire stacks.
 	// The actual burn damage application is not blocked by fireproofing, like space dragons.
-	target_mob.apply_damage(max(10, max_damage - (5 * level)), BURN, wound_bonus = -30, bare_wound_bonus = 30)
+	target_mob.apply_damage(max(10, max_damage - (5 * level)), BURN, wound_bonus = -50, bare_wound_bonus = 40)
 	target_mob.adjust_fire_stacks(max(2, 5 - level))
 	target_mob.ignite_mob()
 


### PR DESCRIPTION
It's deceptively powerful if someone has you handcuffed.

# Document the changes in your pull request

Changes fire breath so that power also gives it increased base damage (by reducing the unempowered base damage to a max of 25 at point blank and leaving empowered as current damage). Additionally, it now has a -50 wound bonus so it shouldn't immediately dunk on you with a t2 burn wound when it hits you unless you're naked (BWB of 40). With the amount of damage it deals, it's really necessary. Finally, the most important one that I actually made this pr for in the first place, if you're handcuffed and you used empowered fire breath you get knocked down for 2 seconds because you aren't able to keep your balance with your hands tied behind your back or whatever. No more free escapes please thank you.

# Why is this good for the game?
People (cough Daniel cough) with fire breath can no longer both nuke their captors for 40 (!!!) damage AND escape in one click without repercussions. Also gives a reason to use other chromosomes with it if you specifically want to use it to escape.

# Testing
Half of this is just number changes, the rest is:

![image](https://github.com/yogstation13/Yogstation/assets/43766432/ecc8f76b-c54b-4e38-a82c-23a2182948fc)

And no, it doesn't knockdown without handcuffs.


# Wiki Documentation

Empowered fire breath actually has extra oomph rather than just increasing range.

# Changelog

:cl:  

tweak: Power chromosome increases fire breath damage
tweak: Fire breath gene base damage reduced and is less likely to wound
tweak: Empowered fire breath knocks you down if you're restrained

/:cl:
