### PR TITLE
Disables voting for asteroid

### DIFF
--- a/config/maps.txt
+++ b/config/maps.txt
@@ -32,7 +32,6 @@ endmap
 
 map asteroidstation
 	minplayers 40
-	votable
 endmap
 
 map donutstation


### PR DESCRIPTION
i want to remove it outright, but i'll wait on biome for permission on that

# Why is this good for the game?
asteroid just needs so much work and we don't have the mapping team for it
it's also far too large a map for our current pop
it also pre-dates multi-z maps, a map of this size would be significantly better as multiple z levels instead of one

# Testing
no need

:cl:  
rscdel: Disables voting for asteroid
/:cl:
