### PR TITLE
Tweaks toolset implants drop and menu opening keys

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_carbon.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_carbon.dm
@@ -123,3 +123,8 @@
 
 /// from  base of mob/living/carbon/set_species(): (new_race)
 #define COMSIG_CARBON_SPECIESCHANGE "mob_carbon_specieschange"
+
+/// from base of mob/living/carbon/toggle_throw_mode()
+#define COMSIG_CARBON_TOGGLE_THROW "toggle_throwmode"
+	// Prevents the toggle
+	#define COMSIG_CARBON_BLOCK_TOGGLE_THROW (1 << 0)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -128,6 +128,8 @@
 /mob/living/carbon/proc/toggle_throw_mode()
 	if(stat)
 		return
+	if(SEND_SIGNAL(src, COMSIG_CARBON_TOGGLE_THROW) & COMSIG_CARBON_BLOCK_TOGGLE_THROW)
+		return
 	if(ismecha(loc))
 		var/obj/mecha/M = loc
 		if(M.occupant == src)

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -82,7 +82,7 @@
 		return FALSE
 
 	UnregisterSignal(holder, COMSIG_ITEM_PREDROPPED)
-	UnregisterSignal(holder, COMSIG_ITEM_PRE_ATTACK_SECONDARY)
+	UnregisterSignal(owner, COMSIG_CARBON_TOGGLE_THROW)
 	UnregisterSignal(owner, COMSIG_CARBON_REMOVE_LIMB)
 
 	if(!syndicate_implant)
@@ -104,7 +104,7 @@
 /obj/item/organ/cyberimp/arm/proc/on_drop(datum/source, mob/user)
 	Retract()
 
-/obj/item/organ/cyberimp/arm/proc/secondary_attack()
+/obj/item/organ/cyberimp/arm/proc/throw_mode()
 
 /obj/item/organ/cyberimp/arm/proc/Extend(obj/item/item)
 	if(!(item in src))
@@ -113,7 +113,7 @@
 
 	holder = item
 	RegisterSignal(holder, COMSIG_ITEM_PREDROPPED, PROC_REF(on_drop))
-	RegisterSignal(holder, COMSIG_ITEM_PRE_ATTACK_SECONDARY, PROC_REF(secondary_attack))
+	RegisterSignal(owner, COMSIG_CARBON_TOGGLE_THROW, PROC_REF(throw_mode))
 	RegisterSignal(owner, COMSIG_CARBON_REMOVE_LIMB, PROC_REF(Retract))
 	ADD_TRAIT(holder, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
 
@@ -223,9 +223,9 @@
 /obj/item/organ/cyberimp/arm/toolset/l
 	zone = BODY_ZONE_L_ARM
 
-/obj/item/organ/cyberimp/arm/toolset/secondary_attack() //right click to swap weapons
+/obj/item/organ/cyberimp/arm/toolset/throw_mode() //press r to toggle items instead of prepping a throw
 	ui_action_click()
-	return COMPONENT_SECONDARY_CANCEL_ATTACK_CHAIN
+	return COMSIG_CARBON_BLOCK_TOGGLE_THROW
 
 /obj/item/organ/cyberimp/arm/toolset/emag_act(mob/user, obj/item/card/emag/emag_card)
 	if(!(locate(/obj/item/kitchen/knife/combat/cyborg) in items_list))

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -82,6 +82,7 @@
 		return FALSE
 
 	UnregisterSignal(holder, COMSIG_ITEM_PREDROPPED)
+	UnregisterSignal(holder, COMSIG_ITEM_PRE_ATTACK_SECONDARY)
 	UnregisterSignal(owner, COMSIG_CARBON_REMOVE_LIMB)
 
 	if(!syndicate_implant)
@@ -103,6 +104,8 @@
 /obj/item/organ/cyberimp/arm/proc/on_drop(datum/source, mob/user)
 	Retract()
 
+/obj/item/organ/cyberimp/arm/proc/secondary_attack()
+
 /obj/item/organ/cyberimp/arm/proc/Extend(obj/item/item)
 	if(!(item in src))
 		stack_trace("[item.type] is not in [type] and cannot be extended!")
@@ -110,6 +113,7 @@
 
 	holder = item
 	RegisterSignal(holder, COMSIG_ITEM_PREDROPPED, PROC_REF(on_drop))
+	RegisterSignal(holder, COMSIG_ITEM_PRE_ATTACK_SECONDARY, PROC_REF(secondary_attack))
 	RegisterSignal(owner, COMSIG_CARBON_REMOVE_LIMB, PROC_REF(Retract))
 	ADD_TRAIT(holder, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
 
@@ -219,8 +223,9 @@
 /obj/item/organ/cyberimp/arm/toolset/l
 	zone = BODY_ZONE_L_ARM
 
-/obj/item/organ/cyberimp/arm/toolset/on_drop(datum/source, mob/user)
+/obj/item/organ/cyberimp/arm/toolset/secondary_attack() //right click to swap weapons
 	ui_action_click()
+	return COMPONENT_SECONDARY_CANCEL_ATTACK_CHAIN
 
 /obj/item/organ/cyberimp/arm/toolset/emag_act(mob/user, obj/item/card/emag/emag_card)
 	if(!(locate(/obj/item/kitchen/knife/combat/cyborg) in items_list))


### PR DESCRIPTION
Dropping a toolset item now retracts it rather than bringing up the menu to swap
Attempting to activate throw mode with a toolset item now brings up the menu to swap

# Why is this good for the game?
drop is drop, drop should always be drop
in-hand use can't open the menu because of welding tool
right click can't be used because a number of construction items need to right click on an object to do things
the throw mode button is ideal because you can't actually throw toolset items

# Testing


:cl:  
tweak: Dropping a toolset item now retracts it rather than bringing up the menu to swap
tweak: Attempting to activate throw mode with a toolset item now brings up the menu to swap
/:cl:
