### PR TITLE
Adds three new arm toolset implants

### DIFF
--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -349,6 +349,39 @@
 	build_path = /obj/item/organ/cyberimp/arm/toolset
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+	
+/datum/design/cyberimp_botanyset
+	name = "Botanical Arm Implant"
+	desc = "A set of botanical tools hidden behind a concealed panel on the user's arm."
+	id = "ci-botanyset"
+	build_type = MECHFAB
+	materials = list (/datum/material/iron = 2500, /datum/material/glass = 1000, /datum/material/silver = 500, /datum/material/plastic = 500)
+	construction_time = 200
+	build_path = /obj/item/organ/cyberimp/arm/toolset
+	category = list("Implants", "Medical Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+
+/datum/design/cyberimp_janitorset
+	name = "Janitorial Arm Implant"
+	desc = "A set of janitorial tools hidden behind a concealed panel on the user's arm."
+	id = "ci-janitorset"
+	build_type = MECHFAB
+	materials = list (/datum/material/iron = 2500, /datum/material/glass = 1000, /datum/material/silver = 500, /datum/material/plastic = 500)
+	construction_time = 200
+	build_path = /obj/item/organ/cyberimp/arm/toolset
+	category = list("Implants", "Medical Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
+
+/datum/design/cyberimp_clownset
+	name = "Comedy Arm Implant"
+	desc = "A set of comedy tools hidden behind a concealed panel on the user's arm."
+	id = "ci-clownset"
+	build_type = MECHFAB
+	materials = list (/datum/material/iron = 2500, /datum/material/glass = 1500, /datum/material/bananium = 3000) //costs more bananium than any other individual item, but the utility is unmatched
+	construction_time = 200
+	build_path = /obj/item/organ/cyberimp/arm/toolset
+	category = list("Implants", "Medical Designs")
+	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
 /datum/design/cyberimp_medical_hud
 	name = "Medical HUD Implant"

--- a/code/modules/research/designs/medical_designs.dm
+++ b/code/modules/research/designs/medical_designs.dm
@@ -357,7 +357,7 @@
 	build_type = MECHFAB
 	materials = list (/datum/material/iron = 2500, /datum/material/glass = 1000, /datum/material/silver = 500, /datum/material/plastic = 500)
 	construction_time = 200
-	build_path = /obj/item/organ/cyberimp/arm/toolset
+	build_path = /obj/item/organ/cyberimp/arm/toolset/botany
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
@@ -368,7 +368,7 @@
 	build_type = MECHFAB
 	materials = list (/datum/material/iron = 2500, /datum/material/glass = 1000, /datum/material/silver = 500, /datum/material/plastic = 500)
 	construction_time = 200
-	build_path = /obj/item/organ/cyberimp/arm/toolset
+	build_path = /obj/item/organ/cyberimp/arm/toolset/janitor
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 
@@ -379,7 +379,7 @@
 	build_type = MECHFAB
 	materials = list (/datum/material/iron = 2500, /datum/material/glass = 1500, /datum/material/bananium = 3000) //costs more bananium than any other individual item, but the utility is unmatched
 	construction_time = 200
-	build_path = /obj/item/organ/cyberimp/arm/toolset
+	build_path = /obj/item/organ/cyberimp/arm/toolset/clown
 	category = list("Implants", "Medical Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_MEDICAL
 

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -433,7 +433,7 @@
 	display_name = "Clown Technology"
 	description = "Honk?!"
 	prereq_ids = list("base")
-	design_ids = list("air_horn", "honker_main", "honker_peri", "honker_targ", "honk_chassis", "honk_head", "honk_torso", "honk_left_arm", "honk_right_arm",
+	design_ids = list("ci-clownset", "air_horn", "honker_main", "honker_peri", "honker_targ", "honk_chassis", "honk_head", "honk_torso", "honk_left_arm", "honk_right_arm",
 	"honk_left_leg", "honk_right_leg", "mech_banana_mortar", "mech_mousetrap_mortar", "mech_honker", "mech_punching_face", "implant_trombone", "borg_transform_clown", "clown_mine", "clownshot", "clownshoesimplant",
 	"holosignclown")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
@@ -575,7 +575,7 @@ datum/techweb_node/cyber_organs/New()
 	display_name = "Advanced Cybernetic Implants"
 	description = "Upgraded and more powerful cybernetic implants."
 	prereq_ids = list("neural_programming", "cyber_implants","integrated_HUDs")
-	design_ids = list("ci-toolset", "ci-surgery", "ci-reviver", "ci-nutrimentplus", "ci-magboots")
+	design_ids = list("ci-toolset", "ci-surgery", "ci-janitorset", "ci-botanyset", "ci-reviver", "ci-nutrimentplus", "ci-magboots")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /datum/techweb_node/adv_cyber_implants/New()

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -251,6 +251,21 @@
 	desc = "A set of surgical tools hidden behind a concealed panel on the user's arm."
 	items_list = list(/obj/item/retractor/augment, /obj/item/hemostat/augment, /obj/item/cautery/augment, /obj/item/surgicaldrill/augment, /obj/item/scalpel/augment, /obj/item/circular_saw/augment)
 
+/obj/item/organ/cyberimp/arm/toolset/botany
+	name = "botanical toolset implant"
+	desc = "A set of botanical tools hidden behind a concealed panel on the user's arm."
+	items_list = list(/obj/item/hatchet, /obj/item/cultivator, /obj/item/plant_analyzer, /obj/item/reagent_containers/glass/bucket, /obj/item/reagent_containers/dropper)
+
+/obj/item/organ/cyberimp/arm/toolset/janitor
+	name = "janitorial toolset implant"
+	desc = "A set of janitorial tools hidden behind a concealed panel on the user's arm."
+	items_list = list(/obj/item/mop/advanced, /obj/item/broom, /obj/item/reagent_containers/spray/cleaner, /obj/item/holosign_creator/janibarrier, /obj/item/lightreplacer)
+
+/obj/item/organ/cyberimp/arm/toolset/clown
+	name = "comedy toolset implant"
+	desc = "A set of comedy tools hidden behind a concealed panel on the user's arm."
+	items_list = list(/obj/item/holosign_creator/clown, /obj/item/reagent_containers/spray/waterflower/lube, /obj/item/gun/water/full, /obj/item/bikehorn/airhorn)
+
 /obj/item/organ/cyberimp/arm/esword
 	name = "arm-mounted energy blade"
 	desc = "An illegal and highly dangerous cybernetic implant that can project a deadly blade of concentrated energy."


### PR DESCRIPTION
botanical and janitorial are from advanced implants
comedy is from clown research

Botanical toolset implant
- Hatchet
- Cultivator
- Plant analyzer
- Bucket
- Dropper

Janitorial toolset implant
- Advanced mop
- broom
- spray cleaner (full)
- holosign janibarrier
- light replacer

Comedy toolset implant (costs bananium)
- Holobanana
- Lube waterflower (full)
- Watergun (full of water)
- Airhorn

I decided the spray cleaner and lube water flower coming with stuff in them is fine since
- welding tools in the engineering toolset come prefilled
- no one's gonna go to the effort of printing more toolsets and do the surgery when they could just do some basic chemistry to refill it
- the clown one costs a bunch of bananium

# Why is this good for the game?
implants are cool and are best when they're mostly just utility and convenience

# Testing
gotta

:cl:  
rscadd: Adds three new arm toolsets, botanical, janitorial, and comedy
/:cl:
