### PR TITLE
Tweaks lightning flow

### DIFF
--- a/code/datums/martial/lightning_flow.dm
+++ b/code/datums/martial/lightning_flow.dm
@@ -36,7 +36,7 @@
 	var/final_armour = (electric_armour + melee_armour) / 2
 	target.apply_damage(amount, BURN, zone, final_armour)
 	if(ishuman(target))
-		var/mob/living/carbon/human/flicker
+		var/mob/living/carbon/human/flicker = target
 		flicker.electrocution_animation(4 SECONDS)
 
 /datum/martial_art/lightning_flow/proc/on_click(mob/living/carbon/human/H, atom/target, params)

--- a/code/datums/martial/lightning_flow.dm
+++ b/code/datums/martial/lightning_flow.dm
@@ -27,11 +27,11 @@
 /datum/martial_art/lightning_flow/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(dashing)
 		return TRUE
-	damage(D, A, 5, zone=A.zone_selected)
+	damage(D, A, 5, A.zone_selected)
 	return FALSE
 
-/datum/martial_art/lightning_flow/proc/damage(mob/living/target, mob/living/carbon/human/user, amount = 5, stun = FALSE, zone = null)
-	target.electrocute_act(amount, user, stun = stun, zone = zone)
+/datum/martial_art/lightning_flow/proc/damage(mob/living/target, mob/living/carbon/human/user, amount = 5, zone = null)
+	target.electrocute_act(amount, user, zone = zone, stun = FALSE)
 
 /datum/martial_art/lightning_flow/proc/on_click(mob/living/carbon/human/H, atom/target, params)
 	var/list/modifiers = params2list(params)
@@ -91,7 +91,6 @@
 		var/mob/living/carbon/human/victim = target
 		if(victim.check_shields(src, 0, "[H]", attack_type = LEAP_ATTACK))
 			return FALSE
-		H.SetKnockdown(0) //remove the self knockdown from the dropkick
 		dropkick(target, H, throwingdatum)
 	else if(action_modifiers[CTRL_CLICK])
 		target.grabbedby(H)
@@ -105,13 +104,17 @@
 /////////////////////////////////////////////////////////////////
 /datum/martial_art/lightning_flow/proc/dropkick(mob/living/target, mob/living/carbon/human/H, datum/thrownthing/throwingdatum)
 	target.visible_message(span_danger("[H] dropkicks [target]!"), span_userdanger("[H] dropkicks you!"))
+	do_sparks(4, FALSE, target)
+
 	target.Knockdown(5 SECONDS)
-	damage(target, H, 15, TRUE, BODY_ZONE_CHEST)
+	H.SetKnockdown(0) //remove the self knockdown from the dropkick
+	H.set_resting(FALSE)
+	damage(target, H, 15, BODY_ZONE_CHEST)
+
 	var/destination = throwingdatum.target
 	if(get_dist(target, destination) < 5)
 		destination = get_ranged_target_turf(get_turf(H), throwingdatum.init_dir, 5)
 	target.throw_at(destination, 5, 3, H)
-	do_sparks(4, FALSE, target)
 
 /////////////////////////////////////////////////////////////////
 //-----------------training related section--------------------//
@@ -138,7 +141,7 @@
 		var/mob/living/carbon/human/user = H
 		user.physiology.punchdamagelow_bonus += 5
 		user.physiology.punchdamagehigh_bonus += 5
-		user.physiology.punchstunthreshold_bonus += 5
+		user.physiology.punchstunthreshold_bonus += 6 //no knockdowns
 
 /datum/martial_art/lightning_flow/on_remove(mob/living/carbon/human/H)
 	UnregisterSignal(H, COMSIG_MOB_CLICKON)
@@ -146,7 +149,7 @@
 		var/mob/living/carbon/human/user = H
 		user.physiology.punchdamagelow_bonus -= 5
 		user.physiology.punchdamagehigh_bonus -= 5
-		user.physiology.punchstunthreshold_bonus -= 5
+		user.physiology.punchstunthreshold_bonus -= 6
 	return ..()
 
 #undef ACTION_DELAY

--- a/code/datums/martial/lightning_flow.dm
+++ b/code/datums/martial/lightning_flow.dm
@@ -31,7 +31,13 @@
 	return FALSE
 
 /datum/martial_art/lightning_flow/proc/damage(mob/living/target, mob/living/carbon/human/user, amount = 5, zone = null)
-	target.electrocute_act(amount, user, zone = zone, stun = FALSE)
+	var/electric_armour = target.run_armor_check(zone, ELECTRIC)
+	var/melee_armour = target.run_armor_check(zone, MELEE)
+	var/final_armour = (electric_armour + melee_armour) / 2
+	target.apply_damage(amount, BURN, zone, final_armour)
+	if(ishuman(target))
+		var/mob/living/carbon/human/flicker
+		flicker.electrocution_animation(4 SECONDS)
 
 /datum/martial_art/lightning_flow/proc/on_click(mob/living/carbon/human/H, atom/target, params)
 	var/list/modifiers = params2list(params)


### PR DESCRIPTION
Removes the stun from lightning flow dropkick (still has the knockdown)

Also now checks for melee and electric armour and applies damage like a regular attack
instead of relying on electrocute_act which is negated completely by certain things

# Why is this good for the game?
it's meant to be zipping about being annoying, not stun locking people

# Testing
i did, but forgot the screenshot, i can provide one if needed

:cl:  
tweak: Lightning flow no longer stuns on landing a dropkick
tweak: Lightning flow is no longer hard countered by shock immunity
/:cl:
