### PR TITLE
Material reclamation showed the wrong values

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -646,7 +646,7 @@ Nothing else in the console has ID requirements.
 			var/list/materials = linked_destroy.loaded_item.materials
 			l += "<div class='statusDisplay'><A href='?src=[REF(src)];deconstruct=[RESEARCH_MATERIAL_RECLAMATION_ID]'>[materials.len? "Material Reclamation" : "Destroy Item"]</A>"
 			for (var/M in materials)
-				l += "* [CallMaterialName(M)] x [materials[M]]"
+				l += "* [CallMaterialName(M)] x [materials[M] * (linked_destroy.decon_mod/10)]"
 			l += "</div>[RDSCREEN_NOBREAK]"
 			anything = TRUE
 


### PR DESCRIPTION
# Document the changes in your pull request

It would always show that it gives 100% back, which is not true.

# Why is this good for the game?
More truthful = more better
# Changelog

:cl:  
bugfix: Material reclamation with the R&D Console shows the correct values now
/:cl:
