### PR TITLE
Prevents being able to bag of holding bomb from a range

### DIFF
--- a/code/datums/components/storage/concrete/bag_of_holding.dm
+++ b/code/datums/components/storage/concrete/bag_of_holding.dm
@@ -11,10 +11,16 @@
 
 /datum/component/storage/concrete/bluespace/bag_of_holding/proc/recursive_insertion(obj/item/W, mob/living/user)
 	var/atom/A = parent
+	var/client/asked = user.client //store the client that is responding to the prompt
 	var/safety = tgui_alert(user, "Doing this will have extremely dire consequences for the station and its crew. Be sure you know what you're doing.", "Put in [A.name]?", list("Proceed", "Abort"))
-	if(safety != "Proceed" || QDELETED(A) || QDELETED(W) || QDELETED(user) || !user.canUseTopic(A, BE_CLOSE, iscarbon(user)) || !user.canUseTopic(W, BE_CLOSE, iscarbon(user)))
+	if(safety != "Proceed")
 		return
-	if(get_dist(W, user) > 1)
+	//get the mob of the client that responded to the prompt
+	var/mob/living/responder = asked.mob 
+	//this ensures that if someone can swap mob bodies while the prompt is open, they can't use that prompt to remotely detonate the BoH bomb that's on that other body
+	if(QDELETED(A) || QDELETED(W) || QDELETED(responder))
+		return
+	if(!responder.canUseTopic(A, BE_CLOSE, iscarbon(responder)) || !responder.canUseTopic(W, BE_CLOSE, iscarbon(user)))
 		return
 	var/turf/loccheck = get_turf(A)
 	if(is_reebe(loccheck.z))

--- a/code/datums/components/storage/concrete/bag_of_holding.dm
+++ b/code/datums/components/storage/concrete/bag_of_holding.dm
@@ -14,6 +14,8 @@
 	var/safety = tgui_alert(user, "Doing this will have extremely dire consequences for the station and its crew. Be sure you know what you're doing.", "Put in [A.name]?", list("Proceed", "Abort"))
 	if(safety != "Proceed" || QDELETED(A) || QDELETED(W) || QDELETED(user) || !user.canUseTopic(A, BE_CLOSE, iscarbon(user)) || !user.canUseTopic(W, BE_CLOSE, iscarbon(user)))
 		return
+	if(get_dist(W, user) > 1)
+		return
 	var/turf/loccheck = get_turf(A)
 	if(is_reebe(loccheck.z))
 		user.visible_message(span_warning("An unseen force knocks [user] to the ground!"), "[span_big_brass("\"I think not!\"")]")


### PR DESCRIPTION
if you just left the popup open and swapped bodies, you could click yes whenever you felt like it

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/3d2911cb-0bbe-410e-a527-60731112b69f)
![image](https://github.com/yogstation13/Yogstation/assets/108117184/f2fcbc07-2a04-457f-bd7d-3ef8c32be76a)


:cl:  
bugfix: Prevents being able to bag of holding bomb from a range using other bodies
/:cl:
