### PR TITLE
[s] Caps material reclamation at 100%

### DIFF
--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -18,7 +18,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 	var/T = 0
 	for(var/obj/item/stock_parts/S in component_parts)
 		T += S.rating
-	decon_mod = T
+	decon_mod = min(T, 100)
 
 
 /obj/machinery/rnd/destructive_analyzer/proc/ConvertReqString2List(list/source_list)


### PR DESCRIPTION
# Document the changes in your pull request

fixes https://github.com/yogstation13/Yogstation/issues/22281

if you have T4 stuff you can get 120%, infinite resource glitch

# Why is this good for the game?
it's actually bad for the game cause i cant abuse this bug

# Changelog

:cl:  
bugfix: material reclamation is capped at 100% now
/:cl:
