### PR TITLE
bodycams now shown when worn

### DIFF
--- a/code/modules/clothing/neck/bodycamera.dm
+++ b/code/modules/clothing/neck/bodycamera.dm
@@ -9,6 +9,7 @@
 	desc = "A wearable camera, capable of streaming a live feed."
 	icon_state = "sec_bodycam_off"
 	item_state = "sec_bodycam"
+	worn_icon_state = "sec_bodycam"
 	var/prefix = "sec"//used for sprites, miner etc
 	strip_delay = 1 SECONDS //takes one second to strip, so a downed officer can be un-cammed quickly
 	actions_types = list(/datum/action/item_action/toggle_bodycam)
@@ -141,6 +142,7 @@
 	prefix = "miner"
 	icon_state = "miner_bodycam_off"
 	item_state = "miner_bodycam"
+	worn_icon_state = "miner_bodycam"
 	setup = TRUE
 	preset = TRUE
 	resistance_flags = FIRE_PROOF //For showing off to your friends about how you can kill an ashdrake, or some shit


### PR DESCRIPTION
# Document the changes in your pull request
We had sprites for miner and sec bodycams when worn, but they didn't work. This fixes that.

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/122807629/56ce448d-3b09-4a6c-80db-00455933fd90)
![image](https://github.com/yogstation13/Yogstation/assets/122807629/c5dfda4e-edc8-4572-beee-ae4981e8aff0)
No new sprites.

:cl:  ktlwjec
imageadd: Bodycams show on-person, no need to examine to see if someone is wearing one.
/:cl: