### PR TITLE
Reduces jungleland ore spawns + plasmacutter interactions + bluespace bugfix

### DIFF
--- a/code/__DEFINES/{yogs_defines}/jungle.dm
+++ b/code/__DEFINES/{yogs_defines}/jungle.dm
@@ -24,7 +24,7 @@ GLOBAL_LIST_INIT(jungle_ores, list( \
 		ORE_DIAMOND = new /datum/ore_patch/diamond(), 
 		ORE_TITANIUM = new /datum/ore_patch/titanium(), 
 		ORE_URANIUM = new /datum/ore_patch/uranium(),
-		ORE_BLUESAPCE = new /datum/ore_patch/bluespace(),
+		ORE_BLUESPACE = new /datum/ore_patch/bluespace(),
 		ORE_DILITHIUM = new /datum/ore_patch/dilithium()
 ))
 

--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -35,6 +35,11 @@
 	if(istype(newloc,/turf/open/floor/plating/dirt/jungleland))
 		var/turf/open/floor/plating/dirt/jungleland/JG = newloc
 		JG.spawn_rock()
+		if(explosive) //so the plasmacutter ore upgrade spawns double
+			JG.spawn_ores()
+		if(mine_range > 0)
+			mine_range -= 2 //mine_range is less effective on lavaland
+			range++
 
 //yogs end
 /obj/projectile/plasma/on_hit(atom/target)

--- a/yogstation/code/datums/mapgen/JungleGen.dm
+++ b/yogstation/code/datums/mapgen/JungleGen.dm
@@ -51,6 +51,11 @@
 		)
 
 	var/list/ore_preferences = list(
+		ORE_EMPTY = list(
+			WORLEY_REG_SIZE = 10,
+			WORLEY_THRESHOLD = 3,
+			WORLEY_NODE_PER_REG = 50),
+
 		ORE_IRON = list(
 			WORLEY_REG_SIZE = 10,
 			WORLEY_THRESHOLD = 3,
@@ -99,6 +104,12 @@
 //creates a 2d map of every single ore vein on the map
 /datum/map_generator/jungleland/proc/generate_ores(list/turfs)
 	var/list/ore_strings = list(
+		ORE_EMPTY  = rustg_worley_generate("[ore_preferences[ORE_EMPTY][WORLEY_REG_SIZE]]",
+										"[ore_preferences[ORE_EMPTY][WORLEY_THRESHOLD]]",
+										"[ore_preferences[ORE_EMPTY][WORLEY_NODE_PER_REG]]",
+										"[world.maxx]",
+										"1",
+										"2"),
 		ORE_BLUESPACE  = rustg_worley_generate("[ore_preferences[ORE_BLUESPACE][WORLEY_REG_SIZE]]",
 										"[ore_preferences[ORE_BLUESPACE][WORLEY_THRESHOLD]]",
 										"[ore_preferences[ORE_BLUESPACE][WORLEY_NODE_PER_REG]]",
@@ -156,6 +167,7 @@
 										"2"))
 	//order of generation, ordered from rarest to most common
 	var/list/generation_queue = list(
+		ORE_EMPTY,
 		ORE_IRON,
 		ORE_SILVER,
 		ORE_TITANIUM,

--- a/yogstation/code/modules/jungleland/jungle_turfs.dm
+++ b/yogstation/code/modules/jungleland/jungle_turfs.dm
@@ -86,6 +86,9 @@ Temperature: 126.85 °C (400 K)
 	can_spawn_ore = FALSE
 	if(spawn_overlay)
 		add_overlay(image(icon='yogstation/icons/obj/jungle.dmi',icon_state="dug_spot",layer=BELOW_OBJ_LAYER))
+	spawn_ores()
+
+/turf/open/floor/plating/dirt/jungleland/proc/spawn_ores()
 	var/datum/ore_patch/ore = GLOB.jungle_ores[ ore_present ]
 	if(ore)
 		ore.spawn_at(src)
@@ -116,6 +119,7 @@ Temperature: 126.85 °C (400 K)
 /turf/open/floor/plating/dirt/jungleland/ex_act(severity, target)
 	if(can_spawn_ore && prob( (severity/3)*100  ))
 		spawn_rock()
+		
 /turf/open/floor/plating/dirt/jungleland/barren_rocks
 	name = "rocky surface"
 	desc = "Surface covered by rocks, pebbles and stones."


### PR DESCRIPTION
With how ore spawns, it was easier to add a new "ore type" that's just the lack of ore

plasmacutters have a mechanic where if they're mining an ore, they'll travel extra tiles based on plasmacutter type
plasmacutters will now benefit from half that extra tile bonus if they're being used on jungleland

# Why is this good for the game?
jungleland has issues, this seeks to solve some of those issues

# Testing
probably need to reduce it more, but see how it's not a solid square
![image](https://github.com/yogstation13/Yogstation/assets/108117184/fa4b29e7-bf36-451c-ba13-1392ffb0b0d5)


:cl:  
tweak: plasmacutters now go slightly further when mining on jungleland
tweak: reduced jungleland ore spawns
bugfix: fixed a typo that prevented bluespace from spawning on jungleland
bugfix: fixed the plasmacutter ore upgrade not working on jungleland
/:cl:
