### PR TITLE
Tweaks preternis ore eating + bugfix

### DIFF
--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -66,7 +66,7 @@
 			qdel(src)
 
 /obj/item/stack/ore/attack(mob/living/M, mob/living/user)
-	if(!user.combat_mode || M != user || !ishuman(user))
+	if(user.combat_mode || M != user || !ishuman(user))
 		return ..()
 
 	var/mob/living/carbon/human/H = user
@@ -265,6 +265,11 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	points = 50
 	materials = list(/datum/material/titanium=MINERAL_MATERIAL_AMOUNT)
 	refined_type = /obj/item/stack/sheet/mineral/titanium
+	eaten_text = "The titanium shards lacerate your insides as you eat it."
+
+/obj/item/stack/ore/titanium/eaten(mob/living/carbon/human/H)
+	H.vomit(0, TRUE, FALSE) // vomit blood, no stun
+	return TRUE
 
 /obj/item/stack/ore/slag
 	name = "slag"

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/organs.dm
@@ -142,6 +142,6 @@
 		owner.reagents.remove_reagent(/datum/reagent/consumable/nutriment, 1) //worse for actually eating (not that it matters for preterni)
 
 /obj/item/organ/stomach/cell/preternis/emp_act(severity)
-	owner.vomit(stun=FALSE) // fuck that
+	owner.vomit(0, TRUE, FALSE) // vomit blood, no stun
 	owner.adjust_disgust(2*severity)
-	to_chat(owner, "<span class='warning'>You feel violently ill as the EMP causes your stomach to kick into high gear.</span>")
+	to_chat(owner, span_warning("You feel violently ill as the EMP causes your stomach to kick into high gear."))


### PR DESCRIPTION
# Why is this good for the game?
titanium didn't have a special eating interaction
also, preterni have an interesting blood colour, but because mech wounds don't exist yet, it's not seen unless they're gibbed
this helps to remedy that

# Testing
gotta

:cl:  
rscadd: Adds titanium ore eat effect
bugfix: eating ores as pretenis now requires combat mode off instead of on
tweak: preternis stomach emp effect now makes the host vomit blood
/:cl:
