### PR TITLE
Tweaks the kinetic javelin

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -163,6 +163,8 @@
 
 #define STATUS_EFFECT_TAUNT /datum/status_effect/taunt //forced movement towards the person applying
 
+#define STATUS_EFFECT_HOLY_FIRE /datum/status_effect/holy_fire //not actually fire, more of a short duration damage over time
+
 /////////////
 // NEUTRAL //
 /////////////

--- a/code/datums/status_effects/buffs/buffs.dm
+++ b/code/datums/status_effects/buffs/buffs.dm
@@ -44,7 +44,7 @@
 /datum/status_effect/vanguard_shield
 	id = "vanguard"
 	duration = 200
-	tick_interval = 0 //tick as fast as possible
+	tick_interval = 1 //tick as fast as possible
 	status_type = STATUS_EFFECT_REPLACE
 	alert_type = /atom/movable/screen/alert/status_effect/vanguard
 	var/datum/progressbar/progbar
@@ -268,7 +268,6 @@
 /datum/status_effect/blooddrunk
 	id = "blooddrunk"
 	duration = 10
-	tick_interval = 0
 	alert_type = /atom/movable/screen/alert/status_effect/blooddrunk
 
 /atom/movable/screen/alert/status_effect/blooddrunk
@@ -553,7 +552,6 @@
 /datum/status_effect/doubledown
 	id = "doubledown"
 	duration = 20
-	tick_interval = 0
 	status_type = STATUS_EFFECT_REFRESH
 	alert_type = /atom/movable/screen/alert/status_effect/doubledown
 	var/obj/effect/temp_visual/decoy/tensecond/s_such_strength //surely a combo wont go on for more than 10 seconds
@@ -625,7 +623,6 @@
 /datum/status_effect/diamondskin
 	id = "diamondskin"
 	duration = 20 SECONDS
-	tick_interval = 0
 	status_type = STATUS_EFFECT_REFRESH
 	alert_type = /atom/movable/screen/alert/status_effect/diamondskin
 

--- a/code/datums/status_effects/debuffs/debuffs.dm
+++ b/code/datums/status_effects/debuffs/debuffs.dm
@@ -1,7 +1,7 @@
 //Largely negative status effects go here, even if they have small benificial effects
 //STUN EFFECTS
 /datum/status_effect/incapacitating
-	tick_interval = 0
+	tick_interval = 1
 	status_type = STATUS_EFFECT_REPLACE
 	alert_type = null
 	remove_on_fullheal = TRUE
@@ -355,7 +355,7 @@
 /datum/status_effect/belligerent
 	id = "belligerent"
 	duration = 70
-	tick_interval = 0 //tick as fast as possible
+	tick_interval = 1 //tick as fast as possible
 	status_type = STATUS_EFFECT_REPLACE
 	alert_type = /atom/movable/screen/alert/status_effect/belligerent
 	var/leg_damage_on_toggle = 2 //damage on initial application and when the owner tries to toggle to run

--- a/code/datums/status_effects/debuffs/holy_fire.dm
+++ b/code/datums/status_effects/debuffs/holy_fire.dm
@@ -1,0 +1,22 @@
+/datum/status_effect/holy_fire
+	id = "doubledown"
+	duration = 4 SECONDS
+	tick_interval = 1 //10 times per second
+	status_type = STATUS_EFFECT_REFRESH
+	var/total_damage = 180
+	var/damage_per_tick = 1
+
+/datum/status_effect/holy_fire/on_apply()
+	. = ..()
+	if(.)
+		damage_per_tick = total_damage / (duration / tick_interval) //we do it this way for easier balancing
+		owner.add_emitter(/obj/emitter/fire/holy, "holy_fire")
+		owner.add_emitter(/obj/emitter/sparks/fire, "holy_sparks")
+
+/datum/status_effect/holy_fire/tick(delta_time, times_fired)
+	. = ..()
+	owner.apply_damage(damage_per_tick, BURN)
+
+/datum/status_effect/holy_fire/on_remove()
+	owner.remove_emitter("holy_fire")
+	owner.remove_emitter("holy_sparks")

--- a/code/datums/status_effects/debuffs/holy_fire.dm
+++ b/code/datums/status_effects/debuffs/holy_fire.dm
@@ -1,9 +1,9 @@
 /datum/status_effect/holy_fire
 	id = "doubledown"
-	duration = 4 SECONDS
+	duration = 5 SECONDS
 	tick_interval = 1 //10 times per second
 	status_type = STATUS_EFFECT_REFRESH
-	var/total_damage = 150
+	var/total_damage = 180
 	var/damage_per_tick = 1
 
 /datum/status_effect/holy_fire/on_apply()
@@ -12,7 +12,7 @@
 		damage_per_tick = total_damage / (duration / tick_interval) //we do it this way for easier balancing
 		owner.add_emitter(/obj/emitter/fire/holy, "holy_fire")
 		owner.add_emitter(/obj/emitter/sparks/fire, "holy_sparks")
-		owner.apply_damage(damage_per_tick, BURN)
+		owner.apply_damage(damage_per_tick, BURN) //apply damage here too so it actually does the full total expected damage rather than 1 less tick of damage
 
 /datum/status_effect/holy_fire/tick(delta_time, times_fired)
 	. = ..()

--- a/code/datums/status_effects/debuffs/holy_fire.dm
+++ b/code/datums/status_effects/debuffs/holy_fire.dm
@@ -1,6 +1,6 @@
 /datum/status_effect/holy_fire
 	id = "doubledown"
-	duration = 5 SECONDS
+	duration = 6 SECONDS
 	tick_interval = 1 //10 times per second
 	status_type = STATUS_EFFECT_REFRESH
 	var/total_damage = 180

--- a/code/datums/status_effects/debuffs/holy_fire.dm
+++ b/code/datums/status_effects/debuffs/holy_fire.dm
@@ -3,7 +3,7 @@
 	duration = 4 SECONDS
 	tick_interval = 1 //10 times per second
 	status_type = STATUS_EFFECT_REFRESH
-	var/total_damage = 180
+	var/total_damage = 150
 	var/damage_per_tick = 1
 
 /datum/status_effect/holy_fire/on_apply()
@@ -12,6 +12,7 @@
 		damage_per_tick = total_damage / (duration / tick_interval) //we do it this way for easier balancing
 		owner.add_emitter(/obj/emitter/fire/holy, "holy_fire")
 		owner.add_emitter(/obj/emitter/sparks/fire, "holy_sparks")
+		owner.apply_damage(damage_per_tick, BURN)
 
 /datum/status_effect/holy_fire/tick(delta_time, times_fired)
 	. = ..()

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -93,7 +93,7 @@
 	if(QDELETED(owner))
 		qdel(src)
 		return
-	if(tick_interval < world.time)
+	if(tick_interval <= world.time)
 		tick(delta_time, times_fired)
 		tick_interval = world.time + initial(tick_interval)
 	if(duration != -1 && duration < world.time)

--- a/code/modules/particles/byond_particles/emitter/fire.dm
+++ b/code/modules/particles/byond_particles/emitter/fire.dm
@@ -1,9 +1,13 @@
 /obj/emitter/fire
 	alpha = 225
 	particles = new/particles/fire
+	var/fire_colour = "#FF3300"
 
 //I hate this, i loath everything about having to create an Init because the byond level filters doesn't allow multiple filters to be set at once if this ever gets fixed please ping me -Borbop
 /obj/emitter/fire/Initialize(mapload)
 	. = ..()
-	add_filter(name ="outline", priority = 1, params = list(type = "outline", size = 3,  color = "#FF3300"))
+	add_filter(name ="outline", priority = 1, params = list(type = "outline", size = 3,  color = fire_colour))
 	add_filter(name = "bloom", priority = 2 , params = list(type = "bloom", threshold = rgb(255,128,255), size = 6, offset = 4, alpha = 255))
+
+/obj/emitter/fire/holy
+	fire_colour = "#fff700"

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -892,6 +892,7 @@
 #include "code\datums\status_effects\debuffs\drunk.dm"
 #include "code\datums\status_effects\debuffs\fire_stacks.dm"
 #include "code\datums\status_effects\debuffs\hallucination.dm"
+#include "code\datums\status_effects\debuffs\holy_fire.dm"
 #include "code\datums\status_effects\debuffs\jitteriness.dm"
 #include "code\datums\status_effects\debuffs\knuckleroot.dm"
 #include "code\datums\status_effects\debuffs\red_eye.dm"

--- a/yogstation/code/modules/jungleland/kinetic_javelin.dm
+++ b/yogstation/code/modules/jungleland/kinetic_javelin.dm
@@ -39,7 +39,7 @@
 	var/exotic_damage_multiplier = 2
 	var/obj/item/kinetic_javelin_core/core 	
 	var/charges = 0
-	var/max_charges = 3
+	var/max_charges = 2
 	var/charged = FALSE
 	var/always_recall = FALSE
 	///The mob to return the spear to if thrown
@@ -140,9 +140,9 @@
 		if(isliving(hit_atom))
 			if(!always_recall)
 				user.put_in_active_hand(src)
-			charge_up()
 			if(charged)
 				core.charged_effect(hit_atom,src,user)
+			charge_up()
 		else 
 			remove_charge()
 	else
@@ -217,11 +217,20 @@
 	javelin_icon_state = "yellow"
 	javelin_item_state = "kinetic_javelin_yellow"
 
+/obj/item/kinetic_javelin_core/yellow/on_insert(obj/item/kinetic_javelin/javelin)
+	javelin.max_charges = 1
+	javelin.exotic_damage_multiplier = 0
+	
+/obj/item/kinetic_javelin_core/yellow/on_remove(obj/item/kinetic_javelin/javelin)
+	javelin.max_charges = initial(javelin.max_charges)
+	javelin.exotic_damage_multiplier = initial(javelin.exotic_damage_multiplier)
+
 /obj/item/kinetic_javelin_core/yellow/get_effect_description()
-	return "Striking an enemy while charged slows that enemy to a standstill for 3 seconds." 
+	return "Striking an enemy while charged discharges the javelin into the enemy, igniting them with brilliant fire. Does no damage with the spear itself." 
 
 /obj/item/kinetic_javelin_core/yellow/charged_effect(mob/living/simple_animal/hostile/victim, obj/item/kinetic_javelin/javelin,mob/user)
-	victim.Immobilize(3 SECONDS)
+	victim.apply_status_effect(STATUS_EFFECT_HOLY_FIRE)
+	javelin.remove_charge()
 
 /obj/item/kinetic_javelin_core/purple
 	name = "Loyal Kinetic Javelin Core"

--- a/yogstation/code/modules/jungleland/kinetic_javelin.dm
+++ b/yogstation/code/modules/jungleland/kinetic_javelin.dm
@@ -180,7 +180,7 @@
 
 /obj/item/kinetic_javelin_core/blue/charged_effect(mob/living/simple_animal/hostile/victim, obj/item/kinetic_javelin/javelin,mob/user)
 	for(var/mob/living/simple_animal/hostile/H in range(4, victim) - victim)
-		victim.Beam(H,"lightning[rand(1,12)]", time = 15)
+		victim.Beam(H,"lightning[rand(1,12)]", beam_color = charged_glow_color, time = 15)
 		H.adjustFireLoss(15)
 
 /obj/item/kinetic_javelin_core/red 

--- a/yogstation/code/modules/jungleland/kinetic_javelin.dm
+++ b/yogstation/code/modules/jungleland/kinetic_javelin.dm
@@ -202,7 +202,7 @@
 	charged_glow_color = "#00b61b"
 	javelin_icon_state = "green"
 	javelin_item_state = "kinetic_javelin_green"
-	var/heal_amount = 10
+	var/heal_amount = 20
 
 /obj/item/kinetic_javelin_core/green/get_effect_description()
 	return "Striking an enemy while charged heals [heal_amount] damage distributed across all types." 

--- a/yogstation/code/modules/jungleland/kinetic_javelin.dm
+++ b/yogstation/code/modules/jungleland/kinetic_javelin.dm
@@ -142,7 +142,8 @@
 				user.put_in_active_hand(src)
 			if(charged)
 				core.charged_effect(hit_atom,src,user)
-			charge_up()
+			else
+				charge_up()
 		else 
 			remove_charge()
 	else
@@ -155,7 +156,7 @@
 	if(!core)
 		return
 	charges += 1 
-	if(charges == 3)
+	if(charges >= max_charges)
 		if(!charged)
 			add_filter("charge_glow", 2, list("type" = "outline", "color" = core.charged_glow_color, "size" = 2))
 		core.on_charged(src)


### PR DESCRIPTION
# Why is this good for the game?
The javelin is overall just a bit too good
i've shifted power from the base javelin into the cores
i've buffed every core except the lightning one because the lightning one is actually really good since it has aoe

Also, the radiant core was boring, so i reworked it

# Testing
![image](https://github.com/yogstation13/Yogstation/assets/108117184/435d1b5b-b6d1-4d03-b780-b3c0df632cc4)

:cl:  
bugfix: fixes a bug where the loyalty core kinetic javelin sometimes wouldn't return
tweak: Kinetic javelin now does 30 damage on fauna hit rather than 45
tweak: Enraged javelin core now gives a 50% damage boost rather than 25%
tweak: Merciful kinetic javelin core now heals 20 health distributed smartly rather than 5 to every damage type
tweak: Loyalty Javelin core no longer throws slower or does less damage
tweak: Radiant javelin core now applies a short duration burn but does no impact damage
bugfix: fixes a bug where most status effects were 1 decisecond slower with their effects than intended
/:cl:
