### PR TITLE
Extended shocktouch doesn't force the target to drop items anymore

### DIFF
--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -31,8 +31,6 @@
 		var/mob/living/carbon/carbon_victim = victim
 		var returned_damage = carbon_victim.electrocute_act(15, caster, 1, zone = caster.zone_selected, stun = FALSE) // Does not stun. Never let this stun.
 		if(returned_damage != FALSE && returned_damage > 0)
-			carbon_victim.dropItemToGround(carbon_victim.get_active_held_item())
-			carbon_victim.dropItemToGround(carbon_victim.get_inactive_held_item())
 			// Confusion is more or less expected to happen due to the rarity of electric armor and the ability to select zones.
 			// Expected defense items: hardsuit (all @ 100), insulated gloves (arms @ 100), any engineering shoes (legs @ 100), hardsuit (head @ 100), hazard vest / engineering coat (chest @ 20).
 			var/shock_multiplier = returned_damage / 15 // Accounts for armor, siemens_coeff, and future changes.

--- a/code/datums/mutations/touch.dm
+++ b/code/datums/mutations/touch.dm
@@ -24,13 +24,15 @@
 	button_icon = 'icons/mob/actions/humble/actions_humble.dmi'
 	draw_message = span_notice("You channel electricity into your hand.")
 	drop_message = span_notice("You let the electricity from your hand dissipate.")
-
+	var/drop_items = TRUE
 
 /datum/action/cooldown/spell/touch/shock/cast_on_hand_hit(obj/item/melee/touch_attack/hand, atom/victim, mob/living/carbon/caster)
 	if(iscarbon(victim))
 		var/mob/living/carbon/carbon_victim = victim
 		var returned_damage = carbon_victim.electrocute_act(15, caster, 1, zone = caster.zone_selected, stun = FALSE) // Does not stun. Never let this stun.
 		if(returned_damage != FALSE && returned_damage > 0)
+			if(drop_items)
+				carbon_victim.drop_all_held_items()
 			// Confusion is more or less expected to happen due to the rarity of electric armor and the ability to select zones.
 			// Expected defense items: hardsuit (all @ 100), insulated gloves (arms @ 100), any engineering shoes (legs @ 100), hardsuit (head @ 100), hazard vest / engineering coat (chest @ 20).
 			var/shock_multiplier = returned_damage / 15 // Accounts for armor, siemens_coeff, and future changes.

--- a/code/datums/mutations/touchfar.dm
+++ b/code/datums/mutations/touchfar.dm
@@ -16,9 +16,10 @@
 	caster.Beam(victim, icon_state="red_lightning", time = 1.5 SECONDS)
 
 /obj/item/melee/touch_attack/shock/far
+	var/range = 5
 
 /obj/item/melee/touch_attack/shock/far/afterattack(atom/target, mob/living/carbon/user, proximity, click_parameters)
-	if(!can_see(user, target, 5) || get_dist(target, user) > 5)
+	if(!can_see(user, target, range) || get_dist(target, user) > range)
 		user.visible_message(span_notice("[user]'s hand reaches out but nothing happens."))
 		return
 	. = ..(target, user, TRUE, click_parameters) //call the parent, forcing proximity = TRUE so even distant things are considered nearby

--- a/code/datums/mutations/touchfar.dm
+++ b/code/datums/mutations/touchfar.dm
@@ -9,6 +9,7 @@
 /datum/action/cooldown/spell/touch/shock/far
 	name = "Extended Shock Touch"
 	hand_path = /obj/item/melee/touch_attack/shock/far
+	drop_items = FALSE
 
 /datum/action/cooldown/spell/touch/shock/far/cast_on_hand_hit(obj/item/melee/touch_attack/hand, atom/victim, mob/living/carbon/caster)
 	. = ..()


### PR DESCRIPTION
# Why is this good for the game?
extended shock touch just instantly disarming a target with a single click is kinda silly powerful for a civilian tool
better hope you aren't relying on an item as an antag

# Testing
shouldn't need to, but i can

:cl:  
tweak: Extended shocktouch doesn't force the target to drop items anymore
/:cl:
