### PR TITLE
Fixes a bug where ethereal eyes didn't remove the zoom effect upon removal

### DIFF
--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -525,7 +525,7 @@
 
 /obj/item/organ/eyes/ethereal/Remove(mob/living/carbon/M, special)
 	. = ..()
-	M?.client?.dude?.view_size?.zoomIn()
+	M?.client?.view_size?.zoomIn()
 
 /obj/item/organ/eyes/ethereal/Initialize(mapload)
 	. = ..()

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -523,6 +523,10 @@
 	var/ethereal_color = "#9c3030"
 	var/active = FALSE
 
+/obj/item/organ/eyes/ethereal/Remove(mob/living/carbon/M, special)
+	. = ..()
+	M?.client?.dude?.view_size?.zoomIn()
+
 /obj/item/organ/eyes/ethereal/Initialize(mapload)
 	. = ..()
 	add_atom_colour(ethereal_color, FIXED_COLOUR_PRIORITY)


### PR DESCRIPTION
look at title
also, it affected people swapping from ethereals as a species

# Testing
gotta

:cl:  
bugfix: Fixes a bug where ethereal eyes didn't remove the zoom effect upon removal
/:cl:
