### PR TITLE
Removes the ability to lifesteal off yourself

### DIFF
--- a/code/datums/components/lifesteal.dm
+++ b/code/datums/components/lifesteal.dm
@@ -31,6 +31,8 @@
 	do_lifesteal(firer, target)
 
 /datum/component/lifesteal/proc/do_lifesteal(atom/heal_target, atom/damage_target)
+	if(heal_target == damage_target)
+		return
 	if(isliving(heal_target) && isliving(damage_target))
 		var/mob/living/healing = heal_target
 		var/mob/living/damaging = damage_target


### PR DESCRIPTION
it at no point checked if the target being healed was also the target being hurt
this meant something with more lifesteal than damage could infinitely heal

# Testing
gotta

:cl:  
bugfix: Removes the ability to lifesteal off yourself
/:cl:
