### PR TITLE
Prevents xenobio creating infinite powercrepes

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1084,7 +1084,8 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		D.vars[var_name] = var_value
 
 /proc/get_random_food()
-	var/list/blocked = list(/obj/item/reagent_containers/food/snacks/store/bread,
+	var/list/blocked = list(
+		/obj/item/reagent_containers/food/snacks/store/bread,
 		/obj/item/reagent_containers/food/snacks/breadslice,
 		/obj/item/reagent_containers/food/snacks/store/cake,
 		/obj/item/reagent_containers/food/snacks/cakeslice,
@@ -1104,7 +1105,8 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		/obj/item/reagent_containers/food/snacks/grown/shell, //base types
 		/obj/item/reagent_containers/food/snacks/store/bread,
 		/obj/item/reagent_containers/food/snacks/grown/nettle,
-		/obj/item/reagent_containers/food/snacks/fish // debug fish
+		/obj/item/reagent_containers/food/snacks/fish, // debug fish
+		/obj/item/reagent_containers/food/snacks/powercrepe //obscenely strong for a food item and shouldn't just be randomly spawned
 		)
 	blocked |= typesof(/obj/item/reagent_containers/food/snacks/customizable)
 


### PR DESCRIPTION
# Why is this good for the game?
the powercrepe is genuinely incredibly strong for a civilian item
there's a reason it requires the captain's rapier to make normally
xenobio is already the powergame job, no point letting them print 20 force 75ap weapons that can block

# Testing
gotta

:cl:  
tweak: Prevents xenobio creating infinite powercrepes
/:cl:
