### PR TITLE
Regenerative bluespace core now teleports to within a 7x7 area

### DIFF
--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -144,7 +144,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/bluespace
 	colour = "bluespace"
-	effect_desc = "Partially heals the target and teleports them to where this core was created."
+	effect_desc = "Partially heals the target and teleports them to nearby where this core was created."
 	var/turf/open/T
 
 /obj/item/slimecross/regenerative/bluespace/core_effect(mob/living/target, mob/user)

--- a/code/modules/research/xenobiology/crossbreeding/regenerative.dm
+++ b/code/modules/research/xenobiology/crossbreeding/regenerative.dm
@@ -155,7 +155,7 @@ Regenerative extracts:
 
 /obj/item/slimecross/regenerative/bluespace/Initialize(mapload)
 	. = ..()
-	T = get_turf(src)
+	T = pick(range(3, get_turf(src))) //picks a random tile in the area
 
 /obj/item/slimecross/regenerative/sepia
 	colour = "sepia"


### PR DESCRIPTION
instead of teleporting to the exact tile
it now teleports to a tile within a 7x7 area
adds some rng to it

# Why is this good for the game?
Makes 1 shotting people too easy when it's 100% reliable
spend some time setting up a death box with conveyors or something, that's way cooler

# Testing
gotta

:cl:  
tweak: Regenerative bluespace core now teleports to within a 7x7 area
/:cl:
