### PR TITLE
Updates space vine event parameters

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -2,8 +2,8 @@
 	name = "Spacevine"
 	typepath = /datum/round_event/spacevine
 	weight = 15
-	max_occurrences = 3
-	min_players = 10
+	max_occurrences = 1
+	min_players = 25
 
 /datum/round_event/spacevine
 	fakeable = FALSE


### PR DESCRIPTION
# Document the changes in your pull request

Adjusts min pop from 10 to 25
Reduces occurrences from 3 to 1

# Why is this good for the game?

lowpop vines suck

# Testing

yes

# Changelog

:cl:  

tweak: adjusts spacevines event


/:cl:
