### PR TITLE
Tweaks the BFG mech weapon

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -222,6 +222,15 @@
 	projectile = /obj/projectile/energy/electrode
 	fire_sound = 'sound/weapons/taser.ogg'
 
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/bfg
+	name = "\improper BFG-90 \"Graze\" Radioactive Cannon"
+	desc = "A weapon for combat exosuits. Shoots an incredibly hot beam surrounded by a field of plasma."
+	icon_state = "mecha_laser"
+	energy_drain = 500
+	equip_cooldown = 2 SECONDS
+	projectile = /obj/projectile/beam/bfg
+	harmful = TRUE
+	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 
 /obj/item/mecha_parts/mecha_equipment/weapon/honker
 	name = "\improper HoNkER BlAsT 5000"
@@ -390,19 +399,6 @@
 	projectile_delay = 2
 	harmful = TRUE
 	ammo_type = "lmg"
-
-/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/bfg
-	name = "\improper BFG-90 \"Graze\" Radioactive Cannon"
-	desc = "A weapon for combat exosuits. Shoots an incredibly hot beam surrounded by a field of plasma."
-	icon_state = "mecha_laser"
-	equip_cooldown = 2 SECONDS
-	projectile = /obj/projectile/beam/bfg
-	projectiles = 5
-	projectiles_cache = 0
-	projectiles_cache_max = 10
-	harmful = TRUE
-	ammo_type = "bfg"
-	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/venom
 	name = "\improper K0-B3 \"Snakebite\" Carbine"

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -228,7 +228,7 @@
 	icon_state = "mecha_laser"
 	energy_drain = 500
 	equip_cooldown = 2 SECONDS
-	projectile = /obj/projectile/beam/bfg
+	projectile = /obj/projectile/beam/laser/bfg
 	harmful = TRUE
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -274,13 +274,14 @@
 	wound_bonus = -5
 
 /// BFG
-/obj/projectile/beam/bfg
+/obj/projectile/beam/laser/bfg
 	name = "searing rod"
 	icon_state = "lava"
 	damage = 35
 	light_power = 2
 	light_color = "#ffff00"
 	speed = 1
+	fire_hazard = TRUE
 	///used to keep track of people to prevent grazing the same target multiple times
 	var/list/grazed = list()
 	///damage done during the graze

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -287,7 +287,7 @@
 	///damage done during the graze
 	var/graze_damage = 10
 
-/obj/projectile/beam/bfg/Range()
+/obj/projectile/beam/laser/bfg/Range()
 	. = ..()
 	for(var/atom/movable/passed in range(1, src))
 		if(passed == src || (passed in grazed))

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -281,15 +281,21 @@
 	light_power = 2
 	light_color = "#ffff00"
 	speed = 1
+	///used to keep track of people to prevent grazing the same target multiple times
+	var/list/grazed = list()
 
 /obj/projectile/beam/bfg/Range()
 	. = ..()
 	for(var/atom/movable/passed in range(1, src))
-		if(passed == src)
+		if(passed == src || (passed in grazed))
 			continue
 		if(isliving(passed))
 			var/mob/living/m_passed = passed
-			m_passed.apply_damage(HEAT_DAMAGE_LEVEL_3, BURN)
+			var/blocked = m_passed.run_armor_check(null, BURN)
+			m_passed.apply_damage(10, BURN, blocked = blocked)
+			m_passed.playsound_local(m_passed, hitsound, 30, TRUE)
+			to_chat(m_passed, "[src] sears you as it flies nearby.")
 			new /obj/effect/temp_visual/ratvar/ocular_warden(get_turf(m_passed))
 		else
 			passed.fire_act(460, 100)
+		grazed |= passed

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -281,6 +281,8 @@
 	light_power = 2
 	light_color = "#ffff00"
 	speed = 1
+	wound_bonus = -20
+	bare_wound_bonus = 10
 	fire_hazard = TRUE
 	///used to keep track of people to prevent grazing the same target multiple times
 	var/list/grazed = list()

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -283,6 +283,8 @@
 	speed = 1
 	///used to keep track of people to prevent grazing the same target multiple times
 	var/list/grazed = list()
+	///damage done during the graze
+	var/graze_damage = 10
 
 /obj/projectile/beam/bfg/Range()
 	. = ..()
@@ -291,8 +293,8 @@
 			continue
 		if(isliving(passed))
 			var/mob/living/m_passed = passed
-			var/blocked = m_passed.run_armor_check(null, BURN)
-			m_passed.apply_damage(10, BURN, blocked = blocked)
+			var/blocked = m_passed.run_armor_check(null, armor)
+			m_passed.apply_damage(graze_damage, BURN, blocked = blocked)
 			m_passed.playsound_local(m_passed, hitsound, 30, TRUE)
 			to_chat(m_passed, "[src] sears you as it flies nearby.")
 			new /obj/effect/temp_visual/ratvar/ocular_warden(get_turf(m_passed))

--- a/code/modules/research/designs/mecha_designs.dm
+++ b/code/modules/research/designs/mecha_designs.dm
@@ -228,22 +228,10 @@
 	desc = "Allows for the construction of the BFG-90 \"Graze\" Radioactive Cannon."
 	id = "mech_bfg"
 	build_type = MECHFAB
-	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/bfg
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/bfg
 	materials = list(/datum/material/iron=12000,/datum/material/uranium=6000,/datum/material/diamond=2000)
 	construction_time = 10 SECONDS
 	category = list("Exosuit Equipment")
-	combat_design = TRUE
-
-/datum/design/mech_bfg_ammo
-	name = "BFG-90 Radioactive Cannon Ammunition"
-	desc = "Ammunition for the BFG-90 \"Graze\" Radioactive Cannon."
-	id = "mech_bfg_ammo"
-	build_type = PROTOLATHE | MECHFAB
-	build_path = /obj/item/mecha_ammo/bfg
-	materials = list(/datum/material/iron=6000,/datum/material/uranium=6000,/datum/material/diamond=2000)
-	construction_time = 20
-	category = list("Exosuit Ammunition", "Ammo")
-	departmental_flags = DEPARTMENTAL_FLAG_ARMORY
 	combat_design = TRUE
 
 /datum/design/mech_ion

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -943,7 +943,7 @@ datum/techweb_node/cyber_organs/New()
 	display_name = "Exosuit Weapon (BFG-90 \"Graze\" Radioactive Cannon)"
 	description = "An advanced piece of mech weaponry"
 	prereq_ids = list("adv_beam_weapons")
-	design_ids = list("mech_bfg", "mech_bfg_ammo")
+	design_ids = list("mech_bfg")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 
 /datum/techweb_node/mech_laser


### PR DESCRIPTION
# Why is this good for the game?
for a BFG, it doesn't really fell good to use or play against
having only 5 ammo means it needs to be constantly refilled, making it feel tedious and unfun to use
it's grazing being able to hit multiple times means it's super inconsistent with how much damage it can do, meaning it can range between doing nothing, and one-shotting, entirely depending on how you're walking
it also provides no visual or audio feedback as to what's happening, adding confusion to the situation

# Testing
gotta

:cl:  
rscdel: Removed BFG mech weapon ammo
bugfix: BFG graze damage no longer ignores armour
tweak: BFG does slightly more graze damage
tweak: BFG can't graze the same target multiple times
tweak: BFG is now an energy weapon rather than ballistic
tweak: BFG graze now has a sound effect
tweak: BFG projectile is now a fire hazard
/:cl:
