### PR TITLE
Disables butchering while cleaving

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -136,16 +136,15 @@
 	user.weapon_slow(I)
 	if(user.combat_mode && stat == DEAD && (butcher_results || guaranteed_butcher_results)) //can we butcher it?
 		var/datum/component/butchering/butchering = I.GetComponent(/datum/component/butchering)
-		if(butchering && butchering.butchering_enabled)
+		if(I.is_sharp() && !butchering)
+			I.AddComponent(/datum/component/butchering, 80 * I.toolspeed) //give sharp objects butchering functionality, for consistency
+			butchering = I.GetComponent(/datum/component/butchering)
+		if(butchering && butchering.butchering_enabled && !HAS_TRAIT(I, TRAIT_CLEAVING))
 			to_chat(user, span_notice("You begin to butcher [src]..."))
 			playsound(loc, butchering.butcher_sound, 50, TRUE, -1)
 			if(do_after(user, butchering.speed, src) && Adjacent(I))
 				butchering.Butcher(user, src)
 			return TRUE
-		else if(I.is_sharp() && !butchering) //give sharp objects butchering functionality, for consistency
-			I.AddComponent(/datum/component/butchering, 80 * I.toolspeed)
-			attackby(I, user, params) //call the attackby again to refresh and do the butchering check again
-			return
 	return I.attack(src, user, params)
 
 /mob/living/attackby_secondary(obj/item/weapon, mob/living/user, params)


### PR DESCRIPTION
no clue why it was left this long, it's just annoying when you go to attack something, but you happen to be near a corpse and so it tries to butcher the corpse instead of hitting the target

(yes, i did get annoyed by this while testing my jungleland pr with a dualsaber)

# Testing
![image](https://github.com/user-attachments/assets/b5e2214a-0df4-4c07-a86f-a9af302958ca)

:cl:  
bugfix: Cleaving no longer gets interrupted by butchering
/:cl:
