### PR TITLE
Adds missing "quality = POSITIVE" to acid_spit.dm

### DIFF
--- a/code/datums/mutations/acid_spit.dm
+++ b/code/datums/mutations/acid_spit.dm
@@ -1,6 +1,7 @@
 /datum/mutation/human/acidspit // polysmorph inert mutation
 	name = "Acid Spit"
 	desc = "An ancient mutation from xenomorphs that changes the salivary glands to produce acid."
+	quality = POSITIVE
 	instability = 50
 	difficulty = 12
 	locked = TRUE


### PR DESCRIPTION
# Document the changes in your pull request

Adds a missing "quality = POSITIVE" to acid spit so it appears green on the gene console, instead of white.

# Why is this good for the game?
Makes it like the rest of the genes.

# Testing
👍 
# Changelog

:cl:  
rscadd: Adds missing quality to acid spit
/:cl:
