### PR TITLE
medical records show the chemical you are allergic to

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -621,11 +621,10 @@
 			return
 		SEND_SIGNAL(quirk_holder, COMSIG_ADD_MOOD_EVENT, "wrong_cigs", /datum/mood_event/wrong_brand)
 
-
 /datum/quirk/junkie/drunkard
 	name = "Drunkard"
 	desc = "In space there's no such thing as day drinking."
-	icon = "beer" 
+	icon = "beer"
 	value = -2
 	mood_quirk = TRUE
 	gain_text = span_danger("You could really go for a stiff drink right about now.")
@@ -633,14 +632,14 @@
 	medical_record_text = "Patient is known to be dependent on alcohol."
 	reagent_type = /datum/reagent/consumable/ethanol
 	junkie_warning = "You suddenly feel like you need another drink..."
-	
+
 /datum/quirk/junkie/drunkard/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	H.reagents.add_reagent(/datum/reagent/consumable/ethanol, 20)
 	drug_container_type = pick(/obj/item/reagent_containers/food/drinks/beer/light/plastic)
 	. = ..()
 
-	
+
 /datum/quirk/junkie/drunkard/check_quirk(datum/preferences/prefs)
 	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
 	var/disallowed_trait = !(initial(species_type.inherent_biotypes) & MOB_ORGANIC) //if you can't process organic chems you couldn't get addicted in the first place
@@ -668,7 +667,6 @@
 	mob_trait = TRAIT_ALLERGIC
 	gain_text = span_danger("You remember your allergic reaction to a common medicine.")
 	lose_text = span_notice("You no longer are allergic to medicine.")
-	medical_record_text = "Patient has a severe allergic reaction to a common medicine."
 	var/allergy_chem_list = list(	/datum/reagent/medicine/inacusiate,
 									/datum/reagent/medicine/silver_sulfadiazine,
 									/datum/reagent/medicine/styptic_powder,
@@ -696,6 +694,7 @@
 	var/datum/reagent/allergy = GLOB.chemical_reagents_list[reagent_id]
 	to_chat(quirk_holder, span_danger("You remember you are allergic to [allergy.name]."))
 	quirk_holder.allergies += allergy
+	medical_record_text = "Patient has a severe allergic reaction to [allergy.name]."
 
 /datum/quirk/allergic/on_process()
 	var/mob/living/carbon/H = quirk_holder
@@ -847,7 +846,7 @@
 	var/datum/dna/holder = quirk_holder?.has_dna()
 	if(holder)
 		holder.features -= TRAIT_SHORT_TELOMERES
-	
+
 /datum/quirk/telomeres_short/transfer_mob(mob/living/to_mob)
 	. = ..()
 	var/datum/dna/holder = quirk_holder?.has_dna()


### PR DESCRIPTION
# Document the changes in your pull request
Medical records currently show this:
![image](https://github.com/user-attachments/assets/51bc3c05-d8af-47f8-ba12-13f0a180d56e)
This PR changes "a common medicine" to the name of the chemical.

# Why is this good for the game?
Nice qol thing.

# Testing
![image](https://github.com/user-attachments/assets/40736e57-6fd0-48bc-ab5d-473ad7ae9be9)
![image](https://github.com/user-attachments/assets/d8cfe87a-1993-41ee-9ffd-37c34b706834)
Tested as a single quirk and with others, no issues found.

:cl:  ktlwjec
tweak: Medical records show the name of the chemical a patient is allergic to.
/:cl: