### PR TITLE
Kudzu now mutates from magnus purpura and lavaland cactus instead of weeds

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -403,7 +403,7 @@
 		if(myseed)
 			qdel(myseed)
 			myseed = null
-		var/newWeed = pick(/obj/item/seeds/liberty, /obj/item/seeds/angel, /obj/item/seeds/nettle/death, /obj/item/seeds/kudzu)
+		var/newWeed = pick(/obj/item/seeds/liberty, /obj/item/seeds/angel, /obj/item/seeds/nettle/death)
 		myseed = new newWeed
 		dead = 0
 		hardmutate()

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -222,6 +222,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/ash_flora/cactus_fruit
 	genes = list(/datum/plant_gene/trait/fire_resistance)
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
+	mutatelist = list(/obj/item/seeds/kudzu) //get the fuck outta here kudzu
 	growthstages = 2
 	reagents_add = list(/datum/reagent/consumable/nutriment = 0.02, /datum/reagent/consumable/vitfro = 0.08, /datum/reagent/consumable/ashresin = 0.02)
 
@@ -233,7 +234,6 @@
 	plantname = "Polypore Mushrooms"
 	product = /obj/item/reagent_containers/food/snacks/grown/ash_flora/shavings
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/fire_resistance)
-	mutatelist = list(/obj/item/seeds/kudzu) //get the fuck outta here kudzu
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	reagents_add = list(/datum/reagent/consumable/sugar = 0.06, /datum/reagent/consumable/ethanol = 0.04, /datum/reagent/stabilizing_agent = 0.06, /datum/reagent/consumable/mintextract = 0.02, /datum/reagent/consumable/ashresin = 0.08,	/datum/reagent/consumable/nutriment = 0.1)
 

--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -233,6 +233,7 @@
 	plantname = "Polypore Mushrooms"
 	product = /obj/item/reagent_containers/food/snacks/grown/ash_flora/shavings
 	genes = list(/datum/plant_gene/trait/plant_type/fungal_metabolism, /datum/plant_gene/trait/fire_resistance)
+	mutatelist = list(/obj/item/seeds/kudzu) //get the fuck outta here kudzu
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	reagents_add = list(/datum/reagent/consumable/sugar = 0.06, /datum/reagent/consumable/ethanol = 0.04, /datum/reagent/stabilizing_agent = 0.06, /datum/reagent/consumable/mintextract = 0.02, /datum/reagent/consumable/ashresin = 0.08,	/datum/reagent/consumable/nutriment = 0.1)
 

--- a/yogstation/code/modules/jungleland/jungle_items.dm
+++ b/yogstation/code/modules/jungleland/jungle_items.dm
@@ -175,6 +175,7 @@
 	product = /obj/item/reagent_containers/food/snacks/grown/jungle/magnus_purpura
 	growing_icon = 'icons/obj/hydroponics/growing_flowers.dmi'
 	growthstages = 3
+	mutatelist = list(/obj/item/seeds/kudzu) //get the fuck outta here kudzu
 	reagents_add = list(/datum/reagent/magnus_purpura_enzyme = 0.25)
 
 /obj/item/reagent_containers/food/snacks/grown/jungle/magnus_purpura


### PR DESCRIPTION
# Why is this good for the game?
kudzu is too impactful for how easy it is to get
adds interaction between mining and botany (i guess? why would mining provide kudzu for botany)
removing the mutation outright is too boring as it'll effectively remove kudzu interactions with botany, putting it behind an obscure mutation means if someone wants it, they can focus it and just need to either get supplied by mining or go planetside themselves

# Testing
gotta (but realistically, this is just tweaking lists, so unless there's a typo there shouldn't be any bugs

:cl:  
tweak: Kudzu now mutates from magnus purpura and lavaland cactus instead of weeds
/:cl:
