### PR TITLE
Created servants now more closely follow their creator's antag status

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -417,6 +417,9 @@
 		N.nukeop_outfit = null
 		add_antag_datum(N,converter.nuke_team)
 
+	else if(is_team_darkspawn(creator))
+		add_antag_datum(/datum/antagonist/psyche)
+
 
 	enslaved_to = WEAKREF(creator)
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -209,6 +209,8 @@
 /datum/mind/proc/add_antag_datum(datum_type_or_instance, team)
 	if(!datum_type_or_instance)
 		return
+	if(has_antag_datum(datum_type_or_instance)) //if they already have it, don't give it again
+		return
 	var/datum/antagonist/A
 	if(!ispath(datum_type_or_instance))
 		A = datum_type_or_instance
@@ -396,10 +398,18 @@
 		return I
 
 
+//Register a signal to the creator such that if they gain an antagonist datum, they also get it
+/datum/mind/proc/add_creator_antag(mob/living/creator, datum/antagonist/antag)
+	add_antag_datum(antag)
+
+/datum/mind/proc/remove_creator_antag(mob/living/creator, datum/antagonist/antag)
+	remove_antag_datum(antag)
 
 //Link a new mobs mind to the creator of said mob. They will join any team they are currently on, and will only switch teams when their creator does.
-
 /datum/mind/proc/enslave_mind_to_creator(mob/living/creator)
+	RegisterSignal(creator, COMSIG_ANTAGONIST_GAINED, PROC_REF(add_creator_antag), creator) //re-enslave to the new antag
+	RegisterSignal(creator, COMSIG_ANTAGONIST_REMOVED, PROC_REF(remove_creator_antag), creator) //remove enslavement to the antag
+
 	if(iscultist(creator))
 		SSticker.mode.add_cultist(src)
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -399,7 +399,7 @@
 
 
 //Register a signal to the creator such that if they gain an antagonist datum, they also get it
-/datum/mind/proc/add_creator_antag(mob/living/creator, datum/antagonist/antag)
+/datum/mind/proc/add_creator_antag(datum/mind/creator, datum/antagonist/antag)
 	var/antag_type = antag.type
 
 	//don't give them a full antag status if there's a suitable servant antag datum
@@ -412,7 +412,7 @@
 
 	add_antag_datum(antag_type)
 
-/datum/mind/proc/remove_creator_antag(mob/living/creator, datum/antagonist/antag)
+/datum/mind/proc/remove_creator_antag(datum/mind/creator, datum/antagonist/antag)
 	var/antag_type = antag.type
 
 	//make sure to do it here too so the proper tag is removed
@@ -427,8 +427,8 @@
 
 //Link a new mobs mind to the creator of said mob. They will join any team they are currently on, and will only switch teams when their creator does.
 /datum/mind/proc/enslave_mind_to_creator(mob/living/creator)
-	RegisterSignal(creator, COMSIG_ANTAGONIST_GAINED, PROC_REF(add_creator_antag), creator) //re-enslave to the new antag
-	RegisterSignal(creator, COMSIG_ANTAGONIST_REMOVED, PROC_REF(remove_creator_antag), creator) //remove enslavement to the antag
+	RegisterSignal(creator.mind, COMSIG_ANTAGONIST_GAINED, PROC_REF(add_creator_antag)) //re-enslave to the new antag
+	RegisterSignal(creator.mind, COMSIG_ANTAGONIST_REMOVED, PROC_REF(remove_creator_antag)) //remove enslavement to the antag
 
 	if(iscultist(creator))
 		SSticker.mode.add_cultist(src)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -400,10 +400,30 @@
 
 //Register a signal to the creator such that if they gain an antagonist datum, they also get it
 /datum/mind/proc/add_creator_antag(mob/living/creator, datum/antagonist/antag)
-	add_antag_datum(antag)
+	var/antag_type = antag.type
+
+	//don't give them a full antag status if there's a suitable servant antag datum
+	var/list/antag_downgrade = list(
+		/datum/antagonist/darkspawn = /datum/antagonist/psyche,
+		/datum/antagonist/thrall = /datum/antagonist/psyche
+	)
+	if(antag_type in antag_downgrade)
+		antag_type = antag_downgrade[antag_type]
+
+	add_antag_datum(antag_type)
 
 /datum/mind/proc/remove_creator_antag(mob/living/creator, datum/antagonist/antag)
-	remove_antag_datum(antag)
+	var/antag_type = antag.type
+
+	//make sure to do it here too so the proper tag is removed
+	var/list/antag_downgrade = list(
+		/datum/antagonist/darkspawn = /datum/antagonist/psyche,
+		/datum/antagonist/thrall = /datum/antagonist/psyche
+	)
+	if(antag_type in antag_downgrade)
+		antag_type = antag_downgrade[antag_type]
+
+	remove_antag_datum(antag_type)
 
 //Link a new mobs mind to the creator of said mob. They will join any team they are currently on, and will only switch teams when their creator does.
 /datum/mind/proc/enslave_mind_to_creator(mob/living/creator)


### PR DESCRIPTION
# Why is this good for the game?
prevents golems being drainable by darkspawns because as a ghost role it allows for infinite lucidity
adds depth as it allows golems to be buffed by darkspawn abilities

# Testing
![image](https://github.com/user-attachments/assets/7c144539-26e9-470a-957f-7a11d0854887)
![image](https://github.com/user-attachments/assets/e07d1507-5bd0-4bef-a56c-78c8f666bdf0)
made the creator a clown op for this one
![image](https://github.com/user-attachments/assets/9a24c112-ed80-4fe9-926e-af4410ca71cc)
![image](https://github.com/user-attachments/assets/5f2e091a-2ada-4994-8f1d-a9aba74603b2)


:cl:  
tweak: Created servants now more closely follow their creator's antag status
/:cl:
