### PR TITLE
adds back ice cream cones to some recipes

### DIFF
--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_frozen.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_frozen.dm
@@ -15,6 +15,7 @@
 /datum/crafting_recipe/food/spacefreezy
 	name ="Space freezy"
 	reqs = list(
+		/obj/item/reagent_containers/food/snacks/icecream = 1,
 		/datum/reagent/consumable/bluecherryjelly = 5,
 		/datum/reagent/consumable/spacemountainwind = 15,
 		/obj/item/reagent_containers/food/snacks/ice_cream_scoop/vanilla = 1
@@ -25,6 +26,7 @@
 /datum/crafting_recipe/food/sundae
 	name ="Sundae"
 	reqs = list(
+		/obj/item/reagent_containers/food/snacks/icecream = 1,
 		/obj/item/reagent_containers/food/snacks/grown/cherries = 1,
 		/obj/item/reagent_containers/food/snacks/grown/banana = 1,
 		/obj/item/reagent_containers/food/snacks/ice_cream_scoop/vanilla = 1
@@ -35,6 +37,7 @@
 /datum/crafting_recipe/food/honkdae
 	name ="Honkdae"
 	reqs = list(
+		/obj/item/reagent_containers/food/snacks/icecream = 1,
 		/obj/item/clothing/mask/gas/clown_hat = 1,
 		/obj/item/reagent_containers/food/snacks/grown/cherries = 1,
 		/obj/item/reagent_containers/food/snacks/grown/banana = 2,


### PR DESCRIPTION
# Document the changes in your pull request

Just the empty cone, adds it to space freezy, honkdae and sundae.

# Why is this good for the game?
Sprites have cones on, yet no cones are used in the recipes. Oversight I'd assume with adding ice cream scoops and replacing full ice creams in recipes there.

# Testing
![image](https://github.com/user-attachments/assets/03ec2181-3f9d-4e8d-98cf-747159cd9a00)

:cl:  ktlwjec
rscadd: Space freezy, honkdae and sundae need ice cream cones to craft.
/:cl: