### PR TITLE
[PORT] Corrected the bio emergency crate

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -90,10 +90,10 @@
 	name = "Biological Emergency Crate"
 	desc = "This crate holds 2 full bio suits which will protect you from viruses."
 	cost = 2000
-	contains = list(/obj/item/clothing/head/bio_hood,
-					/obj/item/clothing/head/bio_hood,
-					/obj/item/clothing/suit/bio_suit,
-					/obj/item/clothing/suit/bio_suit,
+	contains = list(/obj/item/clothing/head/bio_hood/general,
+					/obj/item/clothing/head/bio_hood/general,
+					/obj/item/clothing/suit/bio_suit/general,
+					/obj/item/clothing/suit/bio_suit/general,
 					/obj/item/storage/bag/bio,
 					/obj/item/reagent_containers/syringe/antiviral,
 					/obj/item/reagent_containers/syringe/antiviral,


### PR DESCRIPTION
# Document the changes in your pull request
There is no difference, visible or stat-wise, changed by doing this.

From the original PR https://github.com/tgstation/tgstation/pull/84547 :
Corrected the bioemergency crate to bring general instead of generic bio suits, thus allowing for a source of general biosuits to exist.

# Why is this good for the game?
From the original PR:
Keeps the equipment consistent by making it so we get a general type of the object instead of the generic which shouldn't exist.

# Testing
![image](https://github.com/user-attachments/assets/32835640-7169-4f71-8397-973460df9ac9)

:cl:  OrbisAnima
bugfix: Corrected the bio emergency crate
/:cl: