### PR TITLE
Fixes a typo with the untrimmed hop skillcape

### DIFF
--- a/code/modules/clothing/neck/skillcapes/skillcape_datums.dm
+++ b/code/modules/clothing/neck/skillcapes/skillcape_datums.dm
@@ -33,7 +33,7 @@
 	id = "cap_trimmed"
 
 /datum/skillcape/hop
-	name = "cape of the head of personel"
+	name = "cape of the head of personnel"
 	job = "Head of Personnel"
 	path = /obj/item/clothing/neck/skillcape/hop
 	id = "hop"


### PR DESCRIPTION
personnel not personel

# Testing
no need

:cl:  
spellcheck: Fixes a typo with the untrimmed hop skillcape
/:cl:
