### PR TITLE
Shipbreaking: Fixes the invisible bananium table, and makes the stealth cutter no longer super stealthy

### DIFF
--- a/_maps/templates/shipbreaker/old_banana.dmm
+++ b/_maps/templates/shipbreaker/old_banana.dmm
@@ -17,12 +17,6 @@
 "q" = (
 /turf/open/floor/mineral/bananium/airless,
 /area/template_noop)
-"r" = (
-/obj/structure/chair/bananium{
-	dir = 8
-	},
-/turf/open/floor/mineral/bananium/airless,
-/area/template_noop)
 "u" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -69,9 +63,8 @@
 /turf/open/floor/mineral/bananium/airless,
 /area/template_noop)
 "T" = (
-/obj/structure/table/bananium,
-/obj/item/reagent_containers/food/snacks/burger/clown,
 /obj/item/bikehorn,
+/obj/item/reagent_containers/food/snacks/burger/clown,
 /turf/open/floor/mineral/bananium/airless,
 /area/template_noop)
 "Y" = (
@@ -125,7 +118,7 @@ Y
 Y
 Y
 u
-r
+q
 q
 M
 Y

--- a/_maps/templates/shipbreaker/old_stealth_cutter.dmm
+++ b/_maps/templates/shipbreaker/old_stealth_cutter.dmm
@@ -1,42 +1,42 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/open/floor/mineral/plastitanium/airless/broken,
-/area/space)
+/area/template_noop)
 "b" = (
 /turf/closed/wall/mineral/plastitanium,
-/area/space)
+/area/template_noop)
 "f" = (
 /turf/template_noop,
-/area/space)
+/area/template_noop)
 "h" = (
 /obj/machinery/modular_computer,
 /turf/open/floor/mineral/plastitanium/airless/broken,
-/area/space)
+/area/template_noop)
 "m" = (
 /obj/effect/spawner/structure/window/plastitanium,
 /turf/open/floor/plating,
-/area/space)
+/area/template_noop)
 "n" = (
 /obj/item/cardboard_cutout/adaptive,
 /turf/open/floor/mineral/plastitanium/airless/broken,
-/area/space)
+/area/template_noop)
 "o" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium/airless/broken,
-/area/space)
+/area/template_noop)
 "r" = (
 /turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/space)
+/area/template_noop)
 "w" = (
 /obj/machinery/door/poddoor/shutters,
 /turf/open/floor/mineral/plastitanium/airless/broken,
-/area/space)
+/area/template_noop)
 "x" = (
 /obj/item/clothing/glasses/eyepatch,
 /turf/open/floor/mineral/plastitanium/airless/broken,
-/area/space)
+/area/template_noop)
 "z" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 1
@@ -45,36 +45,36 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/template_noop)
 "F" = (
 /obj/effect/mine/stun,
 /turf/open/floor/mineral/plastitanium/airless/broken,
-/area/space)
+/area/template_noop)
 "H" = (
 /obj/item/clothing/under/syndicate/tacticool,
 /turf/open/floor/mineral/plastitanium/airless/broken,
-/area/space)
+/area/template_noop)
 "L" = (
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/mineral/plastitanium/airless/broken,
-/area/space)
+/area/template_noop)
 "P" = (
 /obj/machinery/shuttle/engine{
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/space)
+/area/template_noop)
 "S" = (
 /obj/structure/closet/cardboard/metal,
 /turf/open/floor/mineral/plastitanium/airless/broken,
-/area/space)
+/area/template_noop)
 "Z" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
 /obj/item/clothing/glasses/night,
 /turf/open/floor/mineral/plastitanium/airless/broken,
-/area/space)
+/area/template_noop)
 
 (1,1,1) = {"
 f

--- a/yogstation/code/modules/shipbreaker/shipbreaker.dm
+++ b/yogstation/code/modules/shipbreaker/shipbreaker.dm
@@ -7,13 +7,11 @@
 	var/description
 	var/datum/parsed_map/lastparsed
 
-
 /datum/map_template/shipbreaker/syndicate_old
 	name = "Old Syndicate Ship"
 	template_id = "old_syndicate"
 	description = "mapshaker_syndicate"
 	mappath = "_maps/templates/shipbreaker/old_syndicate.dmm"
-
 
 /datum/map_template/shipbreaker/nt_old
 	name = "Old NT Medical Ship"
@@ -51,11 +49,11 @@
 	description = "mapshaker_old_bathroom"
 	mappath = "_maps/templates/shipbreaker/old_bathroom.dmm"
 
-/datum/map_template/shipbreaker/stealthcutter_old
-	name = "Old Stealth Cutter Ship"
-	template_id = "old_Stealth_Cutter"
-	description = "mapshaker_old_stealth_cutter"
-	mappath = "_maps/templates/shipbreaker/old_stealth_cutter.dmm"
+// /datum/map_template/shipbreaker/stealthcutter_old -- dont reenable until I fix this -- cowbot/2024
+// 	name = "Old Stealth Cutter Ship"
+// 	template_id = "old_Stealth_Cutter"
+// 	description = "mapshaker_old_stealth_cutter"
+// 	mappath = "_maps/templates/shipbreaker/old_stealth_cutter.dmm"
 
 /datum/map_template/shipbreaker/altar_old
 	name = "Old Ashwalker Altar Ship"


### PR DESCRIPTION
# Document the changes in your pull request

Removes the bananium table until someone who likes smoothing fixes it

Fixes the stealth cutter being so stealthy that you could call additional ships on top of it, making an infinite loot spawner

# Testing

I would literally not make this if I didnt test it

# Changelog

:cl:  

bugfix: fixed shipbreaking stuff

/:cl:
