### PR TITLE
Slimes can no longer paralyze for up to 26 seconds with a single click

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -318,24 +318,19 @@
 
 
 /mob/living/carbon/attack_slime(mob/living/simple_animal/slime/M)
-	if(..()) //successful slime attack
+	. = ..()
+	if(.) //successful slime attack
 		if(M.powerlevel > 0)
-			var/stunprob = M.powerlevel * 7 + 10  // 17 at level 1, 80 at level 10
-			if(prob(stunprob))
-				M.powerlevel -= 3
-				if(M.powerlevel < 0)
-					M.powerlevel = 0
+			var/dazeprob = M.powerlevel * 10  // 10 at level 1, 100 at level 10
+			if(!prob(dazeprob))
+				return
 
-				visible_message(span_danger("The [M.name] has shocked [src]!"), \
-				span_userdanger("The [M.name] has shocked [src]!"))
+			visible_message(span_danger("The [M.name] has dazed [src]!"), span_userdanger("The [M.name] has dazed [src]!"))
 
-				do_sparks(5, TRUE, src)
-				var/power = M.powerlevel + rand(0,3)
-				set_stutter_if_lower(power * 2 SECONDS)
-				if (prob(stunprob) && M.powerlevel >= 8)
-					adjustFireLoss(M.powerlevel * rand(6,10))
-					updatehealth()
-		return TRUE
+			var/power = M.powerlevel + rand(0,3)
+			set_stutter_if_lower(power SECONDS)
+			Daze(power SECONDS)
+		return
 
 /mob/living/carbon/proc/dismembering_strike(mob/living/attacker, dam_zone)
 	if(!attacker.limb_destroyer)

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -331,7 +331,6 @@
 
 				do_sparks(5, TRUE, src)
 				var/power = M.powerlevel + rand(0,3)
-				Paralyze(power*20)
 				set_stutter_if_lower(power * 2 SECONDS)
 				if (prob(stunprob) && M.powerlevel >= 8)
 					adjustFireLoss(M.powerlevel * rand(6,10))


### PR DESCRIPTION
# Why is this good for the game?
slimes shouldn't be able to game-end someone with a single click if they're fed enough

# Testing
don't need to

:cl:  
tweak: Slimes can no longer paralyze for up to 26 seconds with a single click
tweak: Slimes now have a chance to daze targets when glomping them
/:cl:
