### PR TITLE
Fixes not being able to tell if a cat is dead or alive

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -177,8 +177,9 @@
 /mob/living/simple_animal/pet/cat/update_icon_state()
 	. = ..()
 	if(stat == DEAD)
-		return
-	if(resting)
+		icon_state = "[icon_living]_dead"
+		collar_type = "[initial(collar_type)]_dead"
+	else if(resting)
 		if(sitting)
 			icon_state = "[icon_living]_sit"
 			collar_type = "[initial(collar_type)]_sit"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1d1dfc85-749f-4297-b7c2-02bb87bd1414)

:cl:  
bugfix: Fixed cats not updating their sprite properly when dying
/:cl:
