### PR TITLE
[PORT] Green Beer has an overdose effect now

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -138,10 +138,12 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	name = "Green Beer"
 	description = "An alcoholic beverage brewed since ancient times on Old Earth. This variety is dyed a festive green."
 	color = "#A8E61D"
+	overdose_threshold = 55 //More than a glass
 	taste_description = "green piss water"
 	glass_icon_state = "greenbeerglass"
 	glass_name = "glass of green beer"
 	glass_desc = "A freezing pint of green beer. Festive."
+	var/saved_color
 
 /datum/reagent/consumable/ethanol/beer/green/on_mob_life(mob/living/carbon/M)
 	if(M.color != color)
@@ -150,6 +152,19 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/beer/green/on_mob_end_metabolize(mob/living/M)
 	M.remove_atom_colour(TEMPORARY_COLOUR_PRIORITY, color)
+
+/datum/reagent/consumable/ethanol/beer/green/overdose_process(mob/living/M)
+	metabolization_rate = 1 * REAGENTS_METABOLISM
+
+	if(ishuman(M))
+		var/mob/living/carbon/human/N = M
+		if(N.dna.species.use_skintones)
+			saved_color = N.skin_tone
+			N.skin_tone = "green"
+		else if(MUTCOLORS in N.dna.species.species_traits)
+			saved_color = N.dna.features["mcolor"]
+			N.dna.features["mcolor"] = "#A8E61D"
+		N.regenerate_icons()
 
 /datum/reagent/consumable/ethanol/kahlua
 	name = "Kahlua"

--- a/code/modules/surgery/bodyparts/helpers.dm
+++ b/code/modules/surgery/bodyparts/helpers.dm
@@ -277,6 +277,8 @@
 			. = "#fff4e6"
 		if("orange")
 			. = "#ffc905"
+		if("green")
+			. = "#a8e61d"
 
 /mob/living/carbon/proc/Digitigrade_Leg_Swap(swap_back)
 	var/body_plan_changed = FALSE


### PR DESCRIPTION
# Document the changes in your pull request
https://github.com/tgstation/tgstation/pull/79537 : Green beer now has an overdose effect, stolen from spraytan.
Green beer will turn your skin green on overdose, overdose is 55u.

# Why is this good for the game?
Hulk roleplay.

I don't know, I think the spray tan overdose is funny, this already tints you green until it clears your system. Just a fun little extra if you want to consume that much.

# Testing
![image](https://github.com/user-attachments/assets/81ccd3b8-c492-4ec1-9a0a-234ab832d49c)
I can't find any issues with it breaking anything or not working.

:cl: Likteer, ktlwjec
rscadd: Green Beer has an overdose effect (55 units) that will turn your skin green.
/:cl: