### PR TITLE
Partially reverts #21730

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -13,7 +13,10 @@
 
 /datum/quirk/no_taste/check_quirk(datum/preferences/prefs)
 	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
-	var/disallowed_trait = (NOMOUTH in initial(species_type.species_traits)) // Cant drink
+	species_type = new species_type()
+	var/disallowed_trait = (NOMOUTH in species_type.species_traits) // Cant eat
+	qdel(species_type)
+	
 	if(disallowed_trait)
 		return "You don't have the ability to eat!"
 	return FALSE
@@ -30,7 +33,9 @@
 
 /datum/quirk/alcohol_tolerance/check_quirk(datum/preferences/prefs)
 	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
-	var/disallowed_trait = (NOMOUTH in initial(species_type.species_traits)) // Cant drink
+	species_type = new species_type()
+	var/disallowed_trait = (NOMOUTH in species_type.species_traits) // Cant eat
+	qdel(species_type)
 
 	if(disallowed_trait)
 		return "You don't have the ability to drink!"
@@ -67,7 +72,9 @@
 
 /datum/quirk/drunkhealing/check_quirk(datum/preferences/prefs)
 	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
-	var/disallowed_trait = (NOMOUTH in initial(species_type.species_traits)) // Cant drink
+	species_type = new species_type()
+	var/disallowed_trait = (NOMOUTH in species_type.species_traits) // Cant eat
+	qdel(species_type)
 
 	if(disallowed_trait) // Cant drink
 		return "You don't have the ability to drink!"
@@ -231,7 +238,9 @@
 
 /datum/quirk/toxic_tastes/check_quirk(datum/preferences/prefs)
 	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
-	var/disallowed_trait = (NOMOUTH in initial(species_type.species_traits)) // Cant drink
+	species_type = new species_type()
+	var/disallowed_trait = (NOMOUTH in species_type.species_traits) // Cant eat
+	qdel(species_type)
 
 	if(disallowed_trait) // Cant eat
 		return "You don't have the ability to eat!"
@@ -266,7 +275,9 @@
 
 /datum/quirk/voracious/check_quirk(datum/preferences/prefs)
 	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
-	var/disallowed_trait = (NOMOUTH in initial(species_type.species_traits)) // Cant drink
+	species_type = new species_type()
+	var/disallowed_trait = (NOMOUTH in species_type.species_traits) // Cant eat
+	qdel(species_type)
 
 	if(disallowed_trait) // Cant eat
 		return "You don't have the ability to eat!"
@@ -356,8 +367,10 @@
 
 /datum/quirk/telomeres_long/check_quirk(datum/preferences/prefs)
 	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
-	var/no_dna = (NO_DNA_COPY in initial(species_type.species_traits)) //Can't pick if you have no DNA bruv.
-	var/no_clone = (TRAIT_NOCLONE in initial(species_type.inherent_traits))
+	species_type = new species_type()
+	var/no_dna = (NO_DNA_COPY in species_type.species_traits) //Can't pick if you have no DNA bruv.
+	var/no_clone = (TRAIT_NOCLONE in species_type.inherent_traits)
+	qdel(species_type)
 	if(no_dna)
 		return "You have no DNA!"
 	else if(no_clone)

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -28,7 +28,9 @@
 
 /datum/quirk/blooddeficiency/check_quirk(datum/preferences/prefs)
 	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
-	var/disallowed_trait = (NOBLOOD in initial(species_type.species_traits)) //can't lose blood if your species doesn't have any
+	species_type = new species_type()
+	var/disallowed_trait = (NOBLOOD in species_type.species_traits) // Cant lose blood if your species doesn't have any
+	qdel(species_type)
 
 	if(disallowed_trait)
 		return "You don't have blood!"
@@ -154,8 +156,9 @@
 
 /datum/quirk/light_drinker/check_quirk(datum/preferences/prefs)
 	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
-	var/disallowed_trait = (NOMOUTH in initial(species_type.species_traits)) || !(initial(species_type.inherent_biotypes) & MOB_ORGANIC)// Cant drink or process alcohol
-
+	species_type = new species_type()
+	var/disallowed_trait = (NOMOUTH in species_type.species_traits) || !(initial(species_type.inherent_biotypes) & MOB_ORGANIC)// Cant drink or process alcohol
+	qdel(species_type)
 	if(disallowed_trait)
 		return "You don't have the ability to consume alcohol!"
 	return FALSE
@@ -683,7 +686,9 @@
 
 /datum/quirk/allergic/check_quirk(datum/preferences/prefs)
 	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
-	var/disallowed_trait = !(TRAIT_MEDICALIGNORE in initial(species_type.inherent_traits))
+	species_type = new species_type()
+	var/disallowed_trait = (TRAIT_MEDICALIGNORE in species_type.inherent_traits)
+	qdel(species_type)
 
 	if(disallowed_trait)
 		return "You don't benefit from the use of medicine."
@@ -765,7 +770,9 @@
 
 /datum/quirk/hemophilia/check_quirk(datum/preferences/prefs)
 	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
-	var/disallowed_trait = (NOBLOOD in initial(species_type.species_traits))
+	species_type = new species_type()
+	var/disallowed_trait = (NOBLOOD in species_type.species_traits)
+	qdel(species_type)
 
 	if(disallowed_trait)
 		return "You can't bleed."
@@ -826,8 +833,10 @@
 
 /datum/quirk/telomeres_short/check_quirk(datum/preferences/prefs)
 	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
-	var/no_dna = (NO_DNA_COPY in initial(species_type.species_traits)) //Can't pick if you have no DNA bruv.
-	var/no_clone = (TRAIT_NOCLONE in initial(species_type.inherent_traits))
+	species_type = new species_type()
+	var/no_dna = (NO_DNA_COPY in  species_type.species_traits) //Can't pick if you have no DNA bruv.
+	var/no_clone = (TRAIT_NOCLONE in species_type.inherent_traits)
+	qdel(species_type)
 	if(no_dna)
 		return "You have no DNA!"
 	else if(no_clone)

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -27,10 +27,9 @@
 
 /datum/quirk/vegetarian/check_quirk(datum/preferences/prefs)
 	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
-	var/datum/species/species = new species_type
-
-	var/disallowed_trait = (NOMOUTH in initial(species_type.species_traits)) // Cant eat
-	qdel(species)
+	species_type = new species_type()
+	var/disallowed_trait = (NOMOUTH in species_type.species_traits) // Cant eat
+	qdel(species_type)
 
 	if(disallowed_trait)
 		return "You don't have the ability to eat!"
@@ -58,7 +57,9 @@
 
 /datum/quirk/pineapple_liker/check_quirk(datum/preferences/prefs)
 	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
-	var/disallowed_trait = (NOMOUTH in initial(species_type.species_traits)) // Cant eat
+	species_type = new species_type()
+	var/disallowed_trait = (NOMOUTH in species_type.species_traits) // Cant eat
+	qdel(species_type)
 
 	if(disallowed_trait)
 		return "You don't have the ability to eat!"
@@ -86,7 +87,9 @@
 
 /datum/quirk/pineapple_hater/check_quirk(datum/preferences/prefs)
 	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
-	var/disallowed_trait = (NOMOUTH in initial(species_type.species_traits)) // Cant eat
+	species_type = new species_type()
+	var/disallowed_trait = (NOMOUTH in species_type.species_traits) // Cant eat
+	qdel(species_type)
 
 	if(disallowed_trait)
 		return "You don't have the ability to eat!"
@@ -117,7 +120,9 @@
 
 /datum/quirk/deviant_tastes/check_quirk(datum/preferences/prefs)
 	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
-	var/disallowed_trait = (NOMOUTH in initial(species_type.species_traits)) // Cant eat
+	species_type = new species_type()
+	var/disallowed_trait = (NOMOUTH in species_type.species_traits) // Cant eat
+	qdel(species_type)
 
 	if(disallowed_trait)
 		return "You don't have the ability to eat!"
@@ -174,7 +179,9 @@
 
 /datum/quirk/colorist/check_quirk(datum/preferences/prefs)
 	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
-	var/disallowed_trait = (HAIR in initial(species_type.species_traits)) || ("vox_quills" in initial(species_type.mutant_bodyparts)) // No Hair
+	species_type = new species_type()
+	var/disallowed_trait = (HAIR in species_type.species_traits) || ("vox_quills" in species_type.mutant_bodyparts) //no hair
+	qdel(species_type)
 
 	if(!disallowed_trait)
 		return "You don't have hair!"


### PR DESCRIPTION
partially reverts #21730

code cleanup in theory is good, the only issue is that you can't call initial() on a list
the examples shown in the pr notably don't rely on checking a list so they work as intended

# Testing
![image](https://github.com/user-attachments/assets/61ecec7a-8e8a-4f9d-a801-782d2a88ef98)
![image](https://github.com/user-attachments/assets/bce35ec9-26a1-4c7c-b2d0-0733aa1c8616)
![image](https://github.com/user-attachments/assets/fefee436-140d-4545-bac3-48243bdfc484)

:cl:  
bugfix: Fixes species being able to pick incompatible quirks
/:cl:
