### PR TITLE
Fixes a few issues with worldbreaker

### DIFF
--- a/code/datums/martial/worldbreaker.dm
+++ b/code/datums/martial/worldbreaker.dm
@@ -269,14 +269,14 @@
 	var/jumpspeed = 4 - user.cached_multiplicative_slowdown
 	jumpspeed = clamp(jumpspeed, 0.75, 4)
 
-	user.throw_at(target, 15, jumpspeed, user, FALSE, TRUE, callback = CALLBACK(src, PROC_REF(leap_end), user))
-	user.Immobilize(1 SECONDS, ignore_canstun = TRUE) //to prevent cancelling the leap
-
 	var/obj/effect/temp_visual/decoy/D = new /obj/effect/temp_visual/decoy(user.loc,user)
 	animate(D, alpha = 0, color = "#000000", transform = matrix()*2, time = 0.3 SECONDS)
 	animate(user, time = (heavy ? 0.4 : 0.2)SECONDS, pixel_y = 20)//we up in the air
 	playsound(user, 'sound/effects/gravhit.ogg', 15)
 	playsound(user, 'sound/effects/dodge.ogg', 15, TRUE)
+
+	user.Immobilize(1 SECONDS, ignore_canstun = TRUE) //to prevent cancelling the leap
+	user.throw_at(target, 15, jumpspeed, user, FALSE, TRUE, callback = CALLBACK(src, PROC_REF(leap_end), user))
 	return COMSIG_MOB_CANCEL_CLICKON
 
 /datum/martial_art/worldbreaker/proc/leap_end(mob/living/carbon/human/user)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/power_suck.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/power_suck.dm
@@ -31,7 +31,7 @@
 		draining = FALSE
 		return
 
-	var/blocked = H.getarmor(H.held_index_to_hand(H.active_hand_index), ELECTRIC)
+	var/blocked = H.gloves?.armor?.getRating(ELECTRIC)
 	siemens_coefficient *= (100 - blocked) / 100
 	if(blocked >= 100)
 		to_chat(H, span_info("NOTICE: [H.gloves] prevent electrical contact - CONSUME protocol aborted."))


### PR DESCRIPTION
The temporary self-immobilization meant to be canceled after the leap end was applied after it starts, so if it ends instantly you get the leap end effects first and then the leap start effects, leaving you immobilized for a second.

Also because recharging was blocked by electrical armor, and worldbreaker's damage resistance provides electrical armor, this meant users couldn't recharge.

![image](https://github.com/user-attachments/assets/71d06db0-c27d-4a52-8822-f52f41fa66db)

:cl:  
bugfix: Fixed worldbreaker users getting stuck immobilized sometimes
bugfix: Fixed worldbreaker users being unable to recharge
/:cl:
