### PR TITLE
Rotates the massdrivers to not hit the shipbreaking area (real edition)

### DIFF
--- a/_maps/RandomRuins/StationRuins/BoxStation/chapel1.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/chapel1.dmm
@@ -52,15 +52,13 @@
 	name = "Mass Driver";
 	req_access_txt = "22"
 	},
-/obj/machinery/mass_driver{
-	dir = 4;
-	id = "chapelgun";
-	name = "Holy Driver"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "du" = (
 /obj/structure/table/wood,
@@ -280,12 +278,10 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
 "nS" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/mass_driver{
+	dir = 1;
+	id = "chapelgun";
+	name = "Holy Driver"
 	},
 /turf/open/floor/plating,
 /area/chapel/main)
@@ -448,6 +444,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
+/area/chapel/main)
+"Cb" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "chapelgun";
+	name = "Chapel Launcher Door"
+	},
+/turf/open/floor/plating,
 /area/chapel/main)
 "Ck" = (
 /turf/closed/wall,
@@ -717,6 +721,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"SU" = (
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/chapel/main)
 "SX" = (
 /obj/structure/bodycontainer/crematorium{
 	id = "crematoriumChapel"
@@ -781,12 +792,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "XX" = (
-/obj/machinery/door/poddoor{
-	id = "chapelgun";
-	name = "Chapel Launcher Door"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/space/nearstation)
 "Yh" = (
 /obj/structure/cable{
@@ -1199,8 +1205,8 @@ ZG
 Ck
 "}
 (16,1,1) = {"
-Ck
-Ck
+Cb
+SU
 nS
 Ck
 Fi

--- a/_maps/RandomRuins/StationRuins/BoxStation/chapel1.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/chapel1.dmm
@@ -445,14 +445,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"Cb" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/poddoor{
-	id = "chapelgun";
-	name = "Chapel Launcher Door"
-	},
-/turf/open/floor/plating,
-/area/chapel/main)
 "Ck" = (
 /turf/closed/wall,
 /area/chapel/main)
@@ -620,6 +612,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
+"OS" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "chapelgun";
+	name = "Chapel Launcher Door"
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
 "PM" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -721,13 +721,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"SU" = (
-/obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/chapel/main)
 "SX" = (
 /obj/structure/bodycontainer/crematorium{
 	id = "crematoriumChapel"
@@ -792,8 +785,12 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "XX" = (
-/turf/closed/wall,
-/area/space/nearstation)
+/obj/effect/landmark/event_spawn,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/chapel/main)
 "Yh" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -1205,8 +1202,8 @@ ZG
 Ck
 "}
 (16,1,1) = {"
-Cb
-SU
+OS
+XX
 nS
 Ck
 Fi
@@ -1229,7 +1226,7 @@ II
 (17,1,1) = {"
 Ck
 Ck
-XX
+Ck
 II
 II
 II

--- a/_maps/RandomRuins/StationRuins/BoxStation/chapel2.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/chapel2.dmm
@@ -1,7 +1,11 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "an" = (
-/obj/machinery/vending/wardrobe/chap_wardrobe,
-/turf/open/floor/carpet/red,
+/obj/machinery/door/poddoor{
+	id = "chapelgun";
+	name = "Chapel Launcher Door"
+	},
+/obj/structure/fans/tiny,
+/turf/open/space/basic,
 /area/chapel/office)
 "as" = (
 /obj/effect/turf_decal/ramp_middle,
@@ -66,6 +70,7 @@
 	dir = 8;
 	pixel_x = 26
 	},
+/obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/carpet/red,
 /area/chapel/office)
 "dd" = (
@@ -234,16 +239,13 @@
 	name = "Mass Driver";
 	req_access_txt = "22"
 	},
-/obj/machinery/mass_driver{
-	dir = 4;
-	id = "chapelgun";
-	name = "Holy Driver"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/item/reagent_containers/food/snacks/grown/poppy,
-/turf/open/floor/plating,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "kU" = (
 /obj/effect/turf_decal/ramp_middle,
@@ -538,9 +540,6 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "DX" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_y = 32
-	},
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -606,12 +605,7 @@
 /turf/open/floor/carpet/black,
 /area/chapel/main)
 "FN" = (
-/obj/machinery/door/poddoor{
-	id = "chapelgun";
-	name = "Chapel Launcher Door"
-	},
-/obj/structure/fans/tiny,
-/turf/open/floor/plating,
+/turf/closed/wall,
 /area/space/nearstation)
 "Gn" = (
 /obj/item/nullrod,
@@ -678,6 +672,15 @@
 "IL" = (
 /turf/open/floor/carpet/red,
 /area/chapel/main)
+"IN" = (
+/obj/machinery/mass_driver{
+	dir = 1;
+	id = "chapelgun";
+	name = "Holy Driver"
+	},
+/obj/item/reagent_containers/food/snacks/grown/poppy,
+/turf/open/floor/plating,
+/area/chapel/office)
 "IS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -1442,10 +1445,10 @@ Cq
 xL
 "}
 (16,1,1) = {"
-zg
-DX
-zg
 an
+DX
+IN
+zg
 cC
 Kz
 XU

--- a/_maps/RandomRuins/StationRuins/BoxStation/chapel2.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/chapel2.dmm
@@ -1,11 +1,12 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "an" = (
-/obj/machinery/door/poddoor{
+/obj/machinery/mass_driver{
+	dir = 1;
 	id = "chapelgun";
-	name = "Chapel Launcher Door"
+	name = "Holy Driver"
 	},
-/obj/structure/fans/tiny,
-/turf/open/space/basic,
+/obj/item/reagent_containers/food/snacks/grown/poppy,
+/turf/open/floor/plating,
 /area/chapel/office)
 "as" = (
 /obj/effect/turf_decal/ramp_middle,
@@ -605,7 +606,12 @@
 /turf/open/floor/carpet/black,
 /area/chapel/main)
 "FN" = (
-/turf/closed/wall,
+/obj/machinery/door/poddoor{
+	id = "chapelgun";
+	name = "Chapel Launcher Door"
+	},
+/obj/structure/fans/tiny,
+/turf/open/space/basic,
 /area/space/nearstation)
 "Gn" = (
 /obj/item/nullrod,
@@ -672,15 +678,6 @@
 "IL" = (
 /turf/open/floor/carpet/red,
 /area/chapel/main)
-"IN" = (
-/obj/machinery/mass_driver{
-	dir = 1;
-	id = "chapelgun";
-	name = "Holy Driver"
-	},
-/obj/item/reagent_containers/food/snacks/grown/poppy,
-/turf/open/floor/plating,
-/area/chapel/office)
 "IS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -1445,9 +1442,9 @@ Cq
 xL
 "}
 (16,1,1) = {"
-an
+FN
 DX
-IN
+an
 zg
 cC
 Kz
@@ -1468,7 +1465,7 @@ wA
 "}
 (17,1,1) = {"
 zg
-FN
+zg
 zg
 wA
 wA

--- a/_maps/RandomRuins/StationRuins/BoxStation/chapel2.dmm
+++ b/_maps/RandomRuins/StationRuins/BoxStation/chapel2.dmm
@@ -611,7 +611,7 @@
 	name = "Chapel Launcher Door"
 	},
 /obj/structure/fans/tiny,
-/turf/open/space/basic,
+/turf/open/floor/plating,
 /area/space/nearstation)
 "Gn" = (
 /obj/item/nullrod,


### PR DESCRIPTION
I forgot to redo this since I accidentally moved the lazy load templates we dont use last time (thanks chubby)

# Document the changes in your pull request

rotato potato

# Testing

![image](https://github.com/user-attachments/assets/1a4b2f7f-1e66-43f4-8133-a57272344472)

![image](https://github.com/user-attachments/assets/1ddf62f5-ad8a-407f-9e10-29963da4cdef)


# Changelog

:cl:  

bugfix: technically a fix since there's a bug report
mapping: fixes the massdrivers hitting shit they shouldn't

/:cl:
