### PR TITLE
fixes some issues with cooking chicken meat

### DIFF
--- a/code/modules/food_and_drinks/food/snacks/meat.dm
+++ b/code/modules/food_and_drinks/food/snacks/meat.dm
@@ -343,7 +343,7 @@
 	filling_color = "#B22222"
 	tastes = list("chicken" = 1, "antibiotics" = 1)
 
-/obj/item/reagent_containers/food/snacks/meat/slab/penguin/MakeGrillable()
+/obj/item/reagent_containers/food/snacks/meat/slab/chicken/MakeGrillable()
 	AddComponent(/datum/component/grillable, /obj/item/reagent_containers/food/snacks/meat/steak/chicken, rand(30 SECONDS, 90 SECONDS), TRUE, TRUE) //Add medium rare later maybe?
 
 /obj/item/reagent_containers/food/snacks/meat/slab/blessed
@@ -556,7 +556,7 @@
 	name = "raw chicken cutlet"
 	tastes = list("chicken" = 1, "antibiotics" = 1)
 
-/obj/item/reagent_containers/food/snacks/meat/raw_cutlet/penguin/MakeGrillable()
+/obj/item/reagent_containers/food/snacks/meat/raw_cutlet/chicken/MakeGrillable()
 	AddComponent(/datum/component/grillable, /obj/item/reagent_containers/food/snacks/meat/cutlet/chicken, rand(35 SECONDS, 50 SECONDS), TRUE, TRUE)
 
 /obj/item/reagent_containers/food/snacks/meat/raw_cutlet/axolotl

--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -57,6 +57,16 @@
 	output = /obj/item/reagent_containers/food/snacks/raw_meatball/bear
 	blacklist = null
 
+/datum/food_processor_process/chicken
+	input = /obj/item/reagent_containers/food/snacks/meat/slab/chicken
+	output = /obj/item/reagent_containers/food/snacks/raw_meatball/chicken
+	blacklist = null
+
+/datum/food_processor_process/cutlet/chicken
+	input = /obj/item/reagent_containers/food/snacks/meat/cutlet/chicken
+	output = /obj/item/reagent_containers/food/snacks/raw_meatball/chicken
+	blacklist = null
+
 /datum/food_processor_process/bacon
 	input = /obj/item/reagent_containers/food/snacks/meat/raw_cutlet
 	output = /obj/item/reagent_containers/food/snacks/meat/rawbacon


### PR DESCRIPTION
# Document the changes in your pull request

Fixes some issues with chicken meat not producing chicken variants of meats. Copy paste moment for steak and cutlets, and chicken was never added to the processor recipes.

![image](https://github.com/user-attachments/assets/5e565c41-3fd0-4fa9-b0df-d4633ba3a8d6)
here is a friendly chef testing it works

:cl: ktlwjec
bugfix: Chicken meat will grill into chicken steak/cutlets, and process chicken meatballs.
/:cl: