### PR TITLE
Reduces Crafty trait cost by 1 (to 1)

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -286,7 +286,7 @@
 	name = "Crafty"
 	desc = "You're very good at making stuff, and can craft faster than others."
 	icon = "wrench"
-	value = 2
+	value = 1
 	mob_trait = TRAIT_CRAFTY
 	gain_text = span_notice("You feel like crafting some stuff.")
 	lose_text = span_danger("You lose the itch to craft.")


### PR DESCRIPTION
# Document the changes in your pull request

title

# Why is this good for the game?
This trait is on par with the other 1 point traits. It's very, very situationally useful and has no reason to be in the same catergory as a permanent large mood buff/extra language/better night vision as it is nowhere near as useful as those

# Changelog

:cl:  cark  
tweak: crafty trait now costs 1 point instead of 2 
/:cl:
