### PR TITLE
Reduces maximum uptime of reactive stealth armor from 80% to 27%

### DIFF
--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -185,6 +185,7 @@
 	desc = "An experimental suit of armor that renders the wearer invisible on detection of imminent harm, and creates a decoy that runs away from the owner. You can't fight what you can't see."
 	cooldown_message = span_danger("The reactive stealth system activates, but is not charged enough to fully cloak!")
 	emp_message = span_warning("The reactive stealth armor's threat assessment system crashes...")
+	reactivearmor_cooldown_duration = 15 SECONDS
 	///when triggering while on cooldown will only flicker the alpha slightly. this is how much it removes.
 	var/cooldown_alpha_removal = 50
 	///cooldown alpha flicker- how long it takes to return to the original alpha


### PR DESCRIPTION
It had a 5 second cooldown but you were invisible for 4 seconds with a 2 second fade in, meaning you were about half visible 20% of the time and completely invisible 80% of the time. Good luck hitting someone that is completely invisible though.

This increases the cooldown to 15 seconds to reflect the fact that its 4 seconds of not being attacked (and blocking that first attack too lol) with almost no tell on when you become invisible.


# Why is this good for the game?
Stealth armor kinda impossible to fight when you cant see them for 80% of the time and barely see them for the remaining 20%

# Testing

Variable change, not needed

# Wiki Documentation

15 second cooldown for stealth armor

# Changelog


:cl:  

tweak: Increased cooldown of reactive stealth armor from 5 to 15 seconds

/:cl:
