### PR TITLE
Fixes some more bugs with the SELF insurgent ipc

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -489,7 +489,7 @@
 	// What examine_tgui.dm uses to determine if flavor text appears as "Obscured".
 	var/face_obscured = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
 
-	if(HAS_TRAIT(src, TRAIT_HUSK)) //can't identify hulk
+	if(HAS_TRAIT(src, TRAIT_HUSK)) //can't identify husk
 		flavor_text_link = span_notice("This person has been husked, and is unrecognizable!")
 	else if (HAS_TRAIT(src, TRAIT_DISFIGURED)) //can't identify disfigured
 		flavor_text_link = span_notice("This person has been horribly disfigured, and is unrecognizable!")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -13,7 +13,7 @@
 	var/t_is = p_are()
 	var/obscure_name
 	var/robotic = FALSE //robotic mobs look different under certain circumstances
-	if(mob_biotypes & MOB_ROBOTIC)//please someone tell me this is stupid and i can do it all in one line
+	if(mob_biotypes & MOB_ROBOTIC && !HAS_TRAIT(src, TRAIT_DISGUISED)) //if someone's trying to disguise, always use the default text, it's less obvious because people are used to it
 		robotic = TRUE
 
 	if(isliving(user))
@@ -489,14 +489,14 @@
 	// What examine_tgui.dm uses to determine if flavor text appears as "Obscured".
 	var/face_obscured = (wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE))
 
-	if(HAS_TRAIT(src, TRAIT_HUSK))
+	if(HAS_TRAIT(src, TRAIT_HUSK)) //can't identify hulk
 		flavor_text_link = span_notice("This person has been husked, and is unrecognizable!")
-	else if ((HAS_TRAIT(src, TRAIT_DISFIGURED)))
+	else if (HAS_TRAIT(src, TRAIT_DISFIGURED)) //can't identify disfigured
 		flavor_text_link = span_notice("This person has been horribly disfigured, and is unrecognizable!")
-	else if (!(face_obscured))
-		flavor_text_link = span_notice("[preview_text]... <a href='?src=[REF(src)];lookup_info=open_examine_panel'>\[Look closer?\]</a>")
-	else
+	else if (face_obscured || HAS_TRAIT(src, TRAIT_DISGUISED)) //won't print flavour text of hidden
 		flavor_text_link = span_notice("<a href='?src=[REF(src)];lookup_info=open_examine_panel'>\[Examine closely...\]</a>")
+	else //do it normally
+		flavor_text_link = span_notice("[preview_text]... <a href='?src=[REF(src)];lookup_info=open_examine_panel'>\[Look closer?\]</a>")
 	if (flavor_text_link)
 		. += flavor_text_link
 

--- a/code/modules/mob/living/carbon/human/examine_tgui.dm
+++ b/code/modules/mob/living/carbon/human/examine_tgui.dm
@@ -55,7 +55,7 @@
 
 	if(ishuman(holder))
 		var/mob/living/carbon/human/holder_human = holder
-		obscured = (holder_human.wear_mask && (holder_human.wear_mask.flags_inv & HIDEFACE)) || (holder_human.head && (holder_human.head.flags_inv & HIDEFACE))
+		obscured = (holder_human.wear_mask && (holder_human.wear_mask.flags_inv & HIDEFACE)) || (holder_human.head && (holder_human.head.flags_inv & HIDEFACE)) || HAS_TRAIT(holder_human, TRAIT_DISGUISED)
 		flavor_text = obscured ? "Obscured" :  holder_human.dna.features["flavor_text"]
 		if(!obscured)
 			headshot += holder_human.dna.features["headshot"]

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -17,7 +17,7 @@
 	mutantstomach = /obj/item/organ/stomach/cell
 	mutantears = /obj/item/organ/ears/robot
 	mutantlungs = /obj/item/organ/lungs/ipc
-	mutant_organs = list(/obj/item/organ/cyberimp/arm/power_cord)
+	mutant_organs = list(/obj/item/organ/cyberimp/arm/power_cord, /obj/item/organ/cyberimp/chest/cooling_intake)
 	mutant_bodyparts = list("ipc_screen", "ipc_antenna", "ipc_chassis")
 	default_features = list("mcolor" = "#7D7D7D", "ipc_screen" = "Static", "ipc_antenna" = "None", "ipc_chassis" = "Morpheus Cyberkinetics(Greyscale)")
 	meat = /obj/item/stack/sheet/plasteel{amount = 5}
@@ -415,6 +415,7 @@ ipc martial arts stuff
 	punchdamagelow = 5
 	punchdamagehigh = 12
 	punchstunthreshold = 12
+	mutant_organs = list()
 	inherent_traits = list(
 		TRAIT_RESISTCOLD,
 		TRAIT_RADIMMUNE,
@@ -429,7 +430,7 @@ ipc martial arts stuff
 		TRAIT_TOXIMMUNE,
 		TRAIT_EASILY_WOUNDED,
 		TRAIT_NODEFIB,
-		TRAIT_POWERHUNGRY,
+		TRAIT_NOHUNGER, //nuclear powered or some shit, idk
 		TRAIT_DISGUISED
 		)
 
@@ -500,6 +501,8 @@ ipc martial arts stuff
 	special_step_sounds = null
 	special_walk_sounds = null
 	species_traits |= fake_species.species_traits
+	if(!(MUTCOLORS in fake_species.species_traits)) //some species don't have mutcolors
+		species_traits -= MUTCOLORS
 	inherent_traits |= fake_species.inherent_traits
 	if(!(NO_UNDERWEAR in fake_species.species_traits))
 		species_traits -= NO_UNDERWEAR
@@ -509,8 +512,9 @@ ipc martial arts stuff
 	attack_sound = fake_species.attack_sound
 	miss_sound = fake_species.miss_sound
 	nojumpsuit = fake_species.nojumpsuit
-	limbs_id = fake_species.limbs_id
+	limbs_id = fake_species.limbs_id || fake_species.id
 	limb_icon_file = fake_species.limb_icon_file
+	is_dimorphic = fake_species.is_dimorphic
 	use_skintones = fake_species.use_skintones
 	fixed_mut_color = fake_species.fixed_mut_color
 	H.bubble_icon = fake_species.bubble_icon
@@ -544,6 +548,7 @@ ipc martial arts stuff
 	miss_sound = initial(miss_sound)
 	nojumpsuit = initial(nojumpsuit)
 	limbs_id = initial(limbs_id)
+	is_dimorphic = initial(is_dimorphic)
 	limb_icon_file = initial(limb_icon_file)
 	use_skintones = initial(use_skintones)
 	H.bubble_icon = initial(bubble_icon)

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -430,8 +430,7 @@ ipc martial arts stuff
 		TRAIT_TOXIMMUNE,
 		TRAIT_EASILY_WOUNDED,
 		TRAIT_NODEFIB,
-		TRAIT_NOHUNGER, //nuclear powered or some shit, idk
-		TRAIT_DISGUISED
+		TRAIT_NOHUNGER //nuclear powered or some shit, idk
 		)
 
 //infiltrators
@@ -519,11 +518,11 @@ ipc martial arts stuff
 	fixed_mut_color = fake_species.fixed_mut_color
 	H.bubble_icon = fake_species.bubble_icon
 	yogs_draw_robot_hair = TRUE
-
 	var/robotic = (fake_species.inherent_biotypes & MOB_ROBOTIC)
 	for(var/obj/item/bodypart/O in H.bodyparts)
 		O.render_like_organic = robotic //make sure to copy limbs as normal
 
+	ADD_TRAIT(H, TRAIT_DISGUISED, type)
 	H.update_body_parts()
 	H.regenerate_icons() //to update limb icon cache with the new damage overlays
 
@@ -557,6 +556,7 @@ ipc martial arts stuff
 	for(var/obj/item/bodypart/O in H.bodyparts)
 		O.render_like_organic = TRUE // Makes limbs render like organic limbs instead of augmented limbs, check bodyparts.dm
 		
+	REMOVE_TRAIT(H, TRAIT_DISGUISED, type)
 	H.update_body_parts()
 	H.regenerate_icons()
 

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -17,7 +17,7 @@
 	mutantstomach = /obj/item/organ/stomach/cell
 	mutantears = /obj/item/organ/ears/robot
 	mutantlungs = /obj/item/organ/lungs/ipc
-	mutant_organs = list(/obj/item/organ/cyberimp/arm/power_cord, /obj/item/organ/cyberimp/chest/cooling_intake)
+	mutant_organs = list(/obj/item/organ/cyberimp/arm/power_cord)
 	mutant_bodyparts = list("ipc_screen", "ipc_antenna", "ipc_chassis")
 	default_features = list("mcolor" = "#7D7D7D", "ipc_screen" = "Static", "ipc_antenna" = "None", "ipc_chassis" = "Morpheus Cyberkinetics(Greyscale)")
 	meat = /obj/item/stack/sheet/plasteel{amount = 5}
@@ -415,7 +415,23 @@ ipc martial arts stuff
 	punchdamagelow = 5
 	punchdamagehigh = 12
 	punchstunthreshold = 12
-	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_RADIMMUNE,TRAIT_NOBREATH,TRAIT_LIMBATTACHMENT,TRAIT_NODISMEMBER,TRAIT_NOLIMBDISABLE,TRAIT_NOCRITDAMAGE,TRAIT_GENELESS,TRAIT_MEDICALIGNORE,TRAIT_NOCLONE,TRAIT_TOXIMMUNE,TRAIT_EASILY_WOUNDED,TRAIT_NODEFIB,TRAIT_POWERHUNGRY)
+	inherent_traits = list(
+		TRAIT_RESISTCOLD,
+		TRAIT_RADIMMUNE,
+		TRAIT_NOBREATH,
+		TRAIT_LIMBATTACHMENT,
+		TRAIT_NODISMEMBER,
+		TRAIT_NOLIMBDISABLE,
+		TRAIT_NOCRITDAMAGE,
+		TRAIT_GENELESS,
+		TRAIT_MEDICALIGNORE,
+		TRAIT_NOCLONE,
+		TRAIT_TOXIMMUNE,
+		TRAIT_EASILY_WOUNDED,
+		TRAIT_NODEFIB,
+		TRAIT_POWERHUNGRY,
+		TRAIT_DISGUISED
+		)
 
 //infiltrators
 /datum/species/ipc/self/insurgent
@@ -428,7 +444,12 @@ ipc martial arts stuff
 	var/list/initial_step_sounds
 	var/list/initial_walk_sounds
 	var/list/initial_genders
-	var/list/blacklisted_species = list(/datum/species/ethereal, /datum/species/moth, /datum/species/gorilla)//species that really don't work with this system (lizards aren't quite right either, but whatever)
+	var/list/blacklisted_species = list(
+		/datum/species/ethereal, 
+		/datum/species/moth,
+		/datum/species/gorilla,
+		/datum/species/vox
+		)//species that really don't work with this system (lizards aren't quite right either, but whatever)
 	var/list/old_features
 	var/old_gender
 	var/ipc_color
@@ -456,8 +477,6 @@ ipc martial arts stuff
 	else
 		old_features["mcolor"] = skintone2hex(random_skin_tone())
 	..()
-	for(var/obj/item/bodypart/O in H.bodyparts)
-		O.render_like_organic = TRUE // Makes limbs render like organic limbs instead of augmented limbs, check bodyparts.dm
 	assume_disguise(H)
 	
 /datum/species/ipc/self/insurgent/spec_fully_heal(mob/living/carbon/human/H)
@@ -491,11 +510,17 @@ ipc martial arts stuff
 	miss_sound = fake_species.miss_sound
 	nojumpsuit = fake_species.nojumpsuit
 	limbs_id = fake_species.limbs_id
+	limb_icon_file = fake_species.limb_icon_file
 	use_skintones = fake_species.use_skintones
 	fixed_mut_color = fake_species.fixed_mut_color
-	bubble_icon = fake_species.bubble_icon
+	H.bubble_icon = fake_species.bubble_icon
 	yogs_draw_robot_hair = TRUE
 
+	var/robotic = (fake_species.inherent_biotypes & MOB_ROBOTIC)
+	for(var/obj/item/bodypart/O in H.bodyparts)
+		O.render_like_organic = robotic //make sure to copy limbs as normal
+
+	H.update_body_parts()
 	H.regenerate_icons() //to update limb icon cache with the new damage overlays
 
 /datum/species/ipc/self/insurgent/proc/break_disguise(mob/living/carbon/human/H)
@@ -519,12 +544,15 @@ ipc martial arts stuff
 	miss_sound = initial(miss_sound)
 	nojumpsuit = initial(nojumpsuit)
 	limbs_id = initial(limbs_id)
+	limb_icon_file = initial(limb_icon_file)
 	use_skintones = initial(use_skintones)
-	bubble_icon = initial(bubble_icon)
+	H.bubble_icon = initial(bubble_icon)
 	yogs_draw_robot_hair = FALSE
 
 	for(var/obj/item/bodypart/O in H.bodyparts)
 		O.render_like_organic = TRUE // Makes limbs render like organic limbs instead of augmented limbs, check bodyparts.dm
+		
+	H.update_body_parts()
 	H.regenerate_icons()
 
 /datum/species/ipc/self/insurgent/get_scream_sound(mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -445,10 +445,11 @@ ipc martial arts stuff
 	var/list/initial_walk_sounds
 	var/list/initial_genders
 	var/list/blacklisted_species = list(
-		/datum/species/ethereal, 
-		/datum/species/moth,
-		/datum/species/gorilla,
-		/datum/species/vox
+		/datum/species/ethereal, //glow 
+		/datum/species/moth, //wings
+		/datum/species/gorilla, //breaks human shapes
+		/datum/species/vox, //has weird clothing
+		/datum/species/abductor //not exactly sneaky
 		)//species that really don't work with this system (lizards aren't quite right either, but whatever)
 	var/list/old_features
 	var/old_gender


### PR DESCRIPTION
# Testing
![image](https://github.com/user-attachments/assets/bd237631-13cb-48d1-a315-9efd91138b72)
![image](https://github.com/user-attachments/assets/ad175881-31ab-495b-9763-ee5fe880d036)


:cl:  
tweak: IPC insurgents no longer have implants that give them away
tweak: IPC insurgents no longer need to recharge
bugfix: IPC insurgents no longer have flavour text that can give them away 
bugfix: Fixes IPC insurgents not properly disguising as species that don't have mutant colors
bugfix: Fixes IPC insurgents no longer use robotic damage terms while disguised
bugfix: Fixes IPC insurgents having an incorrect chat bubble while disguised
/:cl:
