### PR TITLE
morphine mood boost is no longer permanent

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -753,6 +753,7 @@
 /datum/reagent/medicine/morphine/on_mob_end_metabolize(mob/living/L)
 	L.unignore_slowdown(type)
 	REMOVE_TRAIT(L, TRAIT_SURGERY_PREPARED, type)
+	SEND_SIGNAL(L, COMSIG_CLEAR_MOOD_EVENT, "[type]_high")
 	..()
 
 /datum/reagent/medicine/morphine/on_mob_life(mob/living/carbon/M)


### PR DESCRIPTION
# Document the changes in your pull request
Fixes #22379 
Morphine mood boost clears when morphine is out of your system.

# Testing
Tested, works.

:cl: ktlwjec
bugfix: Morphine mood boost is not permanent.
/:cl: