### PR TITLE
just cleans some code for marine medical text

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -372,7 +372,7 @@
 	mob_trait = TRAIT_MARINE
 	gain_text = span_notice("You've graduated top of your class and have over 300 confirmed kills.")
 	lose_text = span_danger("You've lost the fierceless spirit of a Marine, alongside your appetite for crayons.")
-	medical_record_text = ("Patient's stomach is unusually proficient at digesting wax.")
+	medical_record_text = "Patient's stomach is unusually proficient at digesting wax."
 
 /datum/quirk/multilingual
 	name = "Multilingual"


### PR DESCRIPTION
# Document the changes in your pull request
![image](https://github.com/user-attachments/assets/19edd212-5110-426e-af10-397e569c9712)
It didn't break anything, just annoyed me since none of the other quirks do it like that. Tested just in case, works.