### PR TITLE
removes unnamed sheep from kitchen animals

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -773,7 +773,6 @@
 	lootcount = 1
 	loot = list(/mob/living/simple_animal/hostile/retaliate/goat/pete = 1,
 			/mob/living/simple_animal/cow/betsy = 1,
-			/mob/living/simple_animal/sheep = 1,
 			/mob/living/simple_animal/sheep/shawn = 1)
 
 /obj/effect/spawner/lootdrop/mob/marrow_weaver


### PR DESCRIPTION
# Document the changes in your pull request
Removes unnamed sheep from kitchen animals spawner (cow/sheep/goat spawner).

# Why is this good for the game?
I think it is nice to have all of the kitchen "pet" animals be named. When it was originally added, it should've really replaced the original sheep. This should also make it evenly split between which animal you get, since I guess it's weighted towards sheep currently.

# Testing
Doesn't really need it but I can do if wanted.

:cl: ktlwjec
rscdel: Unnamed sheep from kitchen animals.
/:cl: