### PR TITLE
Fix the mapping blacklists directory being broken and also set the indestructible wall type to hopefully use the right icon file

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -602,10 +602,10 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 
 /datum/controller/subsystem/mapping/proc/preloadRuinTemplates()
 	// Still supporting bans by filename
-	var/list/banned = generateMapList("[global.config.directory]/lavaruinblacklist.txt")
-	banned += generateMapList("[global.config.directory]/spaceruinblacklist.txt")
-	banned += generateMapList("[global.config.directory]/iceruinblacklist.txt")
-	banned += generateMapList("[global.config.directory]/jungleruinblacklist.txt")
+	var/list/banned = generateMapList("lavaruinblacklist.txt")
+	banned += generateMapList("spaceruinblacklist.txt")
+	banned += generateMapList("iceruinblacklist.txt")
+	banned += generateMapList("jungleruinblacklist.txt")
 
 	for(var/item in sortList(subtypesof(/datum/map_template/ruin), /proc/cmp_ruincost_priority))
 		var/datum/map_template/ruin/ruin_type = item

--- a/code/game/turfs/closed/indestructible.dm
+++ b/code/game/turfs/closed/indestructible.dm
@@ -1,8 +1,7 @@
 /turf/closed/indestructible
 	name = "wall"
 	desc = "Effectively impervious to conventional methods of destruction."
-	icon = 'icons/turf/walls/wall.dmi'
-	icon_state = "wall-0"
+	icon = 'icons/turf/walls.dmi'
 	explosion_block = 50
 	turf_flags = NOJAUNT | NO_RUST
 


### PR DESCRIPTION
# Document the changes in your pull request

fixes #22391 by setting the icon correctly but more importantly fixing the blacklist

# Why is this good for the game?
Bugfix

# Testing

The blacklisted ruins didn't show up in the preloaded templates list and the proc that creates the blacklist accurately returned what it should be
![image](https://github.com/user-attachments/assets/e939d167-6c35-48cd-b3e9-6ac605a14ae1)


# Changelog

:cl:  
bugfix: mapping blacklist for ruins fixed
bugfix: base icon file for indestructible walls changed to walls.dmi instead of the metal walls
/:cl:
