### PR TITLE
Fix a code oopsie regarding lockers that I made 5 years ago

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -666,7 +666,7 @@ GLOBAL_LIST_EMPTY(lockers)
 		air_contents = null
 
 /obj/structure/closet/return_air()
-	if(welded)
+	if(air_contents)
 		return air_contents
 	return ..()
 


### PR DESCRIPTION
# Document the changes in your pull request

5 years ago, I did a https://github.com/yogstation13/Yogstation/pull/7234 to make lockers airtight when welded. Well, today I was looking at the code for funsies and I realized that I made an oopsie. This oopsie has no effect right now, but if someone were to make a locker that doesnt become airtight when welded or becomes airtight when closed (there are vars in the locker I added for that) it would break in unexpected ways (aka probably throwing runtimes or just not doing what is expected), so this should fix that.

# Why is this good for the game?

# Testing

# Wiki Documentation

# Changelog

This PR doesn't have any player-facing changes.