### PR TITLE
cooked cutlets do not process into raw meatballs

### DIFF
--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -14,21 +14,8 @@
 		/obj/item/reagent_containers/food/snacks/meat/slab/bear,
 		/obj/item/reagent_containers/food/snacks/meat/slab/chicken)
 
-/datum/food_processor_process/cutlet
-	input = /obj/item/reagent_containers/food/snacks/meat/cutlet/plain
-	output = /obj/item/reagent_containers/food/snacks/raw_meatball
-	blacklist = list(/obj/item/reagent_containers/food/snacks/meat/cutlet/plain/human,
-		/obj/item/reagent_containers/food/snacks/meat/cutlet/xeno,
-		/obj/item/reagent_containers/food/snacks/meat/cutlet/bear,
-		/obj/item/reagent_containers/food/snacks/meat/cutlet/chicken)
-
 /datum/food_processor_process/human
 	input = /obj/item/reagent_containers/food/snacks/meat/slab/human
-	output = /obj/item/reagent_containers/food/snacks/raw_meatball/human
-	blacklist = null
-
-/datum/food_processor_process/cutlet/human
-	input = /obj/item/reagent_containers/food/snacks/meat/cutlet/plain/human
 	output = /obj/item/reagent_containers/food/snacks/raw_meatball/human
 	blacklist = null
 
@@ -42,28 +29,13 @@
 	output = /obj/item/reagent_containers/food/snacks/raw_meatball/xeno
 	blacklist = null
 
-/datum/food_processor_process/cutlet/xeno
-	input = /obj/item/reagent_containers/food/snacks/meat/cutlet/xeno
-	output = /obj/item/reagent_containers/food/snacks/raw_meatball/xeno
-	blacklist = null
-
 /datum/food_processor_process/meat/bear
 	input = /obj/item/reagent_containers/food/snacks/meat/slab/bear
 	output = /obj/item/reagent_containers/food/snacks/raw_meatball/bear
 	blacklist = null
 
-/datum/food_processor_process/cutlet/bear
-	input = /obj/item/reagent_containers/food/snacks/meat/cutlet/bear
-	output = /obj/item/reagent_containers/food/snacks/raw_meatball/bear
-	blacklist = null
-
 /datum/food_processor_process/chicken
 	input = /obj/item/reagent_containers/food/snacks/meat/slab/chicken
-	output = /obj/item/reagent_containers/food/snacks/raw_meatball/chicken
-	blacklist = null
-
-/datum/food_processor_process/cutlet/chicken
-	input = /obj/item/reagent_containers/food/snacks/meat/cutlet/chicken
 	output = /obj/item/reagent_containers/food/snacks/raw_meatball/chicken
 	blacklist = null
 


### PR DESCRIPTION
# Document the changes in your pull request
Removes cooked cutlets producing raw meatballs in the processor. You can still make meatballs the usual way - processing meat slabs.

# Why is this good for the game?
This was added when we added griddles, and honestly I thought it was a bug the first time I saw it. I don't get why cooked food suddenly turns raw by doing this. It also doesn't make sense why (unupgraded processor) you get a single meatball from one meat slab yet you can get three from the same piece just by cutting it, but the end result is the exact same size meatball.

# Testing
![image](https://github.com/user-attachments/assets/7ba5ee4e-4192-4553-9524-3c35cddfddff)
![image](https://github.com/user-attachments/assets/2ced3aee-0971-4ec0-91fa-1965635a2efb)

:cl: ktlwjec
rscdel: Cooked cutlets producing raw meatballs.
/:cl: