### PR TITLE
fixes invisible rolling paper box

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -526,7 +526,7 @@ GLOBAL_LIST_INIT(maintenance_loot_makeshift,list(
 	/obj/item/storage/belt/military/snack = W_RARE,
 	/obj/item/storage/belt/utility/makeshift = W_UNCOMMON,
 	/obj/item/storage/book/bible/booze = W_UNCOMMON,
-	/obj/item/storage/fancy/rollingpapers = W_RARE,
+	/obj/item/storage/box/rollingpapers = W_RARE,
 	/obj/item/storage/box/hug = W_RARE,
 	/obj/item/tank/jetpack/improvised = W_MYTHICAL,
 	/obj/item/rcl/ghetto = W_MYTHICAL,

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1363,6 +1363,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	icon = 'icons/obj/cigarettes.dmi'
 	icon_state = "cig_paper_pack"
+	foldable = null
 
 /obj/item/storage/box/rollingpapers/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -1357,6 +1357,28 @@
 	desc = "A bag containing fresh, dry coffee robusta beans. Ethically sourced and packaged by Waffle Corp."
 	beantype = /obj/item/reagent_containers/food/snacks/grown/coffee/robusta
 
+/obj/item/storage/box/rollingpapers
+	name = "rolling paper pack"
+	desc = "A pack of Nanotrasen brand rolling papers."
+	w_class = WEIGHT_CLASS_TINY
+	icon = 'icons/obj/cigarettes.dmi'
+	icon_state = "cig_paper_pack"
+
+/obj/item/storage/box/rollingpapers/Initialize(mapload)
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_items = 10
+	STR.set_holdable(list(/obj/item/rollingpaper))
+
+/obj/item/storage/box/rollingpapers/PopulateContents()
+	for(var/i in 1 to 10)
+		new /obj/item/rollingpaper(src)
+
+/obj/item/storage/box/rollingpapers/update_overlays()
+	. = ..()
+	if(!contents.len)
+		. += "[icon_state]_empty"
+
 #define CARTON_PLAIN "plain ice cream"
 #define CARTON_VANILLA "vanilla ice cream"
 #define CARTON_CHOCOLATE "chocolate ice cream"

--- a/code/game/objects/items/storage/fancy.dm
+++ b/code/game/objects/items/storage/fancy.dm
@@ -378,30 +378,6 @@
 	for(var/i in 1 to 6)
 		new /obj/item/clothing/mask/cigarette/rollie/mindbreaker(src)
 
-/obj/item/storage/fancy/rollingpapers
-	name = "rolling paper pack"
-	desc = "A pack of Nanotrasen brand rolling papers."
-	w_class = WEIGHT_CLASS_TINY
-	icon = 'icons/obj/cigarettes.dmi'
-	icon_state = "cig_paper_pack"
-	icon_type = "rolling paper"
-	spawn_type = /obj/item/rollingpaper
-
-/obj/item/storage/fancy/rollingpapers/Initialize(mapload)
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 10
-	STR.set_holdable(list(/obj/item/rollingpaper))
-
-/obj/item/storage/fancy/rollingpapers/PopulateContents()
-	for(var/i in 1 to 10)
-		new /obj/item/rollingpaper(src)
-
-/obj/item/storage/fancy/rollingpapers/update_overlays()
-	. = ..()
-	if(!contents.len)
-		. += "[icon_state]_empty"
-
 /////////////
 //CIGAR BOX//
 /////////////

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -191,7 +191,7 @@
 	id = "rollingpapers"
 	build_type = BIOGENERATOR
 	materials = list(/datum/material/biomass = 50)
-	build_path = /obj/item/storage/fancy/rollingpapers
+	build_path = /obj/item/storage/box/rollingpapers
 	category = list("initial", "Organic Materials")
 
 /datum/design/cloth

--- a/code/modules/vending/cigarette.dm
+++ b/code/modules/vending/cigarette.dm
@@ -13,7 +13,7 @@
 					/obj/item/storage/fancy/cigarettes/cigpack_nonico = 3,
 					/obj/item/storage/box/matches = 10,
 					/obj/item/lighter/greyscale = 4,
-					/obj/item/storage/fancy/rollingpapers = 5)
+					/obj/item/storage/box/rollingpapers = 5)
 	contraband = list(/obj/item/clothing/mask/vape = 5)
 	premium = list(/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 3,
 				   /obj/item/lighter = 3,
@@ -35,7 +35,7 @@
 					/obj/item/storage/fancy/cigarettes/cigpack_midori = 1,
 					/obj/item/storage/box/matches = 10,
 					/obj/item/lighter/greyscale = 4,
-					/obj/item/storage/fancy/rollingpapers = 5)
+					/obj/item/storage/box/rollingpapers = 5)
 
 /obj/machinery/vending/cigarette/beach //Used in the lavaland_biodome_beach.dmm ruin
 	name = "\improper ShadyCigs Ultra"
@@ -50,7 +50,7 @@
 					/obj/item/storage/fancy/cigarettes/cigpack_cannabis = 5,
 					/obj/item/storage/box/matches = 10,
 					/obj/item/lighter/greyscale = 4,
-					/obj/item/storage/fancy/rollingpapers = 5)
+					/obj/item/storage/box/rollingpapers = 5)
 	premium = list(/obj/item/storage/fancy/cigarettes/cigpack_mindbreaker = 5,
 					/obj/item/clothing/mask/vape = 5,
 					/obj/item/lighter = 3)


### PR DESCRIPTION
# Document the changes in your pull request
Fixes #21116 
Fixes #20725 
Rolling paper box turned forever invisible once you removed a paper from it. This fixes that.

# Testing
empty ![image](https://github.com/user-attachments/assets/d0637efe-df90-450e-9fe6-2824b57f55e5)
one ![image](https://github.com/user-attachments/assets/6f18952d-63cc-4a87-b0aa-c011e4d940a4)
full ![image](https://github.com/user-attachments/assets/53d2fd65-9ac8-4148-ab31-59d00d8aa3f8)

:cl: ktlwjec
bugfix: Rolling paper pack will no longer turn invisible after removing a rolling paper.
/:cl: