### PR TITLE
Fix luminescent being unable to activate extracts

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -584,9 +584,12 @@
 	var/activation_type = SLIME_ACTIVATE_MINOR
 	var/datum/species/jelly/luminescent/species
 
-/datum/action/innate/use_extract/New(_species)
-	..()
-	species = _species
+/datum/action/innate/use_extract/link_to(Target)
+	. = ..()
+	if(ishuman(target))
+		var/mob/living/carbon/human/humie = target
+		if(humie?.dna?.species)
+			species = humie.dna.species
 
 /datum/action/innate/use_extract/IsAvailable(feedback = FALSE)
 	if(..())

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -456,11 +456,12 @@
 		around.</span>",
 		span_notice("...and move this one instead."))
 
-
-///////////////////////////////////LUMINESCENTS//////////////////////////////////////////
-
-//Luminescents are able to consume and use slime extracts, without them decaying.
-
+////////////////////////////////////////////////////////////////////////////////////
+//--------------------------------Luminescents------------------------------------//
+////////////////////////////////////////////////////////////////////////////////////
+/**
+ * Luminescents are able to consume and use slime extracts, without them decaying.
+ */
 /datum/species/jelly/luminescent
 	name = "Luminescent"
 	plural_form = null


### PR DESCRIPTION
forgot to update one proc when changing everything else

# Testing
![image](https://github.com/user-attachments/assets/d855e338-20b7-44e7-8bd8-95d21c75e03b)

:cl:  
bugfix: Fix luminescent being unable to activate extracts
/:cl:
