### PR TITLE
fixes cleaning airlocks with soap

### DIFF
--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -135,7 +135,7 @@
 		if(door.obj_flags & CMAGGED)
 			user.visible_message("[user] starts to clean the ooze off \the [door.name]'s access panel.", "You start to clean the ooze off \the [door.name]'s access panel.")
 			if(do_after(user, src.cleanspeed, door))
-				to_chat(user, span_notice("You clean the ooze off [src]'s access panel."))
+				to_chat(user, span_notice("You clean the ooze off \the [door.name]'s access panel."))
 				door.obj_flags &= ~CMAGGED
 				decreaseUses(user)
 			return

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -132,7 +132,7 @@
 		return
 	if(istype(target, /obj/machinery/door))
 		var/obj/machinery/door/door = target
-		if(door.obj_flags && CMAGGED)
+		if(door.obj_flags & CMAGGED)
 			user.visible_message("[user] starts to clean the ooze off \the [door.name]'s access panel.", "You start to clean the ooze off \the [door.name]'s access panel.")
 			if(do_after(user, src.cleanspeed, door))
 				to_chat(span_notice(" You clean the ooze off [src]'s access panel."))

--- a/code/game/objects/items/clown_items.dm
+++ b/code/game/objects/items/clown_items.dm
@@ -135,7 +135,7 @@
 		if(door.obj_flags & CMAGGED)
 			user.visible_message("[user] starts to clean the ooze off \the [door.name]'s access panel.", "You start to clean the ooze off \the [door.name]'s access panel.")
 			if(do_after(user, src.cleanspeed, door))
-				to_chat(span_notice(" You clean the ooze off [src]'s access panel."))
+				to_chat(user, span_notice("You clean the ooze off [src]'s access panel."))
 				door.obj_flags &= ~CMAGGED
 				decreaseUses(user)
 			return


### PR DESCRIPTION
# Document the changes in your pull request
Fixes #22420 i dont know what im doing honestly but it works

# Testing
![image](https://github.com/user-attachments/assets/d4c44bb5-caf2-4443-aacf-235a8d121c09)
![image](https://github.com/user-attachments/assets/fcfd476e-bfbe-41e1-95ea-7082e2f90439)
![image](https://github.com/user-attachments/assets/654f3721-850c-4fe2-8cf6-ba3a230f7eac)

I noticed this text didnt show up so I fixed that too.
![image](https://github.com/user-attachments/assets/1374158b-13ab-4e2e-a1b5-22a0893fb5c6)

:cl: ktlwjec
bugfix: You can clean doors with soap again.
/:cl: