### PR TITLE
stops vermin bites producing infinite mice

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_vend.dm
+++ b/code/modules/food_and_drinks/food/snacks_vend.dm
@@ -213,7 +213,8 @@
 	. = ..()
 	contained_animal = new /mob/living/simple_animal/mouse/fat(get_turf(src))
 	to_chat(user, span_warning("You pry open the [src]. A [contained_animal.name] falls out from inside!"))
-	On_Consume(user)//give trash
+	user.put_in_hands(new /obj/item/trash/vermin) //give trash
+	qdel(src)
 
 /obj/item/reagent_containers/food/snacks/vermin/attack(mob/living/M, mob/user, def_zone)
 	to_chat(user, span_warning("You need to open [src]' lid first."))

--- a/code/modules/food_and_drinks/food/snacks_vend.dm
+++ b/code/modules/food_and_drinks/food/snacks_vend.dm
@@ -213,8 +213,8 @@
 	. = ..()
 	contained_animal = new /mob/living/simple_animal/mouse/fat(get_turf(src))
 	to_chat(user, span_warning("You pry open the [src]. A [contained_animal.name] falls out from inside!"))
-	user.put_in_hands(new /obj/item/trash/vermin) //give trash
 	qdel(src)
+	user.put_in_hands(new /obj/item/trash/vermin) //give trash
 
 /obj/item/reagent_containers/food/snacks/vermin/attack(mob/living/M, mob/user, def_zone)
 	to_chat(user, span_warning("You need to open [src]' lid first."))


### PR DESCRIPTION
# Document the changes in your pull request
You could inject anything into vermin bites to prevent it from giving trash - making an infinite mouse source.
Fixes #22190 

# Testing
![image](https://github.com/user-attachments/assets/79e91dcd-55df-43de-a26b-fce558d11bb2)
tested, works

:cl: ktlwjec 
bugfix: Infinite mice gone from vermin bites.
/:cl: