### PR TITLE
removes pda cartridge from a vendor

### DIFF
--- a/code/modules/vending/assist.dm
+++ b/code/modules/vending/assist.dm
@@ -8,8 +8,7 @@
 					/obj/item/assembly/igniter = 3,
 					/obj/item/assembly/signaler = 4,
 					/obj/item/assembly/signaler/button = 2,
-					/obj/item/wirecutters = 1,
-					/obj/item/cartridge/signal = 4)
+					/obj/item/wirecutters = 1)
 	premium = list(/obj/item/laserlevel = 1)
 	contraband = list(/obj/item/assembly/timer = 2,
 					  /obj/item/assembly/voice = 2,


### PR DESCRIPTION
# Document the changes in your pull request
Fixes #21193 Removes generic signaller cartridge from the vendor.

# Why is this good for the game?
Looks like it was missed in the PR to remove cartridges from all places except the clerk's vendor.

# Testing
![image](https://github.com/user-attachments/assets/baadbc05-4e78-4237-9b2f-81d9dfb31f3a)

:cl: ktlwjec
rscdel: Generic signaller cartridge from vendomat.
/:cl: