### PR TITLE
Buffs nerve support to be useable and not a trap

### DIFF
--- a/code/modules/research/nanites/nanite_programs/buffing.dm
+++ b/code/modules/research/nanites/nanite_programs/buffing.dm
@@ -3,7 +3,7 @@
 /datum/nanite_program/nervous
 	name = "Nerve Support"
 	desc = "The nanites act as a secondary nervous system, reducing the amount of time the host is stunned."
-	use_rate = 20
+	use_rate = 7
 	rogue_types = list(/datum/nanite_program/nerve_decay)
 
 /datum/nanite_program/nervous/enable_passive_effect()
@@ -11,12 +11,14 @@
 	if(ishuman(host_mob))
 		var/mob/living/carbon/human/H = host_mob
 		H.physiology.stun_mod *= 0.75
+		H.physiology.stamina_mod *= 0.75
 
 /datum/nanite_program/nervous/disable_passive_effect()
 	. = ..()
 	if(ishuman(host_mob))
 		var/mob/living/carbon/human/H = host_mob
 		H.physiology.stun_mod /= 0.75
+		H.physiology.stamina_mod /= 0.75
 
 /datum/nanite_program/hardening
 	name = "Dermal Hardening"


### PR DESCRIPTION
20/tick was a little too much for 25% stun reduction in hindsight, especially when it doesn't work retroactively. Also the stamina damage reduction makes sense for it with so many sources of stamina damage now.

# Document the changes in your pull request

Cost per tick reduced to 7 (same as bio reconstruction).
Now also reduces stamina damage by 25%.

# Why is this good for the game?

Now it's actually useful and not a "delete all your nanites in 5 seconds" trap that has a decent chance of doing nothing for you while still not being something you want running all the time. Plus, nanites can get nuked real quick with EMPs/ions if you're up against security/

# Testing
Damn close to a variable change, doesn't really need it.

# Wiki Documentation

Nerve support cost now 7 and reduces stamina damage

# Changelog

:cl:  

tweak: Nerve support nanite program cost reduced from 20 to 7
tweak: Nerve support now also reduces stamina damage by 25%
/:cl:
