### PR TITLE
custom bread slices are no longer toast

### DIFF
--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -247,8 +247,8 @@
 	icon_state = "bowl"
 
 /obj/item/reagent_containers/food/snacks/customizable/sandwich
-	name = "toast"
-	desc = "A timeless classic."
+	name = "bread slice"
+	desc = "A slice of delicious bread with additional toppings."
 	ingredients_placement = INGREDIENTS_STACK
 	icon = 'icons/obj/food/burgerbread.dmi'
 	icon_state = "breadslice"


### PR DESCRIPTION
# Document the changes in your pull request
When you customise bread slices they show as bread slices, not toast.

# Why is this good for the game?
Oversight from when I added toast really. Adding food to bread slices should keep them as bread slices, not toast.

# Testing
![image](https://github.com/user-attachments/assets/aaaafcf0-42ce-4ae0-b672-f6ea5bd3d454)

:cl: ktlwjec
tweak: Custom bread slices are not toast.
/:cl: