### PR TITLE
[PARTIAL REVERT] Transfers security envirosuits from secdrobes to cargo

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -493,7 +493,7 @@
 
 /datum/supply_pack/security/stormtrooper
 	name = "Stormtrooper Crate"
-	desc = "Three Sets of standard issue Stormtrooper Armor, Should help you defeat light-wielding wizards. Requires Security access to open."
+	desc = "Three sets of standard issue stormtrooper armor. Should help you defeat light-wielding wizards. Requires Security access to open."
 	cost = 10000
 	contains = list(/obj/item/clothing/suit/armor/stormtrooper,
 					/obj/item/clothing/suit/armor/stormtrooper,
@@ -502,6 +502,17 @@
 					/obj/item/clothing/head/helmet/stormtrooper,
 					/obj/item/clothing/head/helmet/stormtrooper)
 	crate_name = "stormtrooper crate"
+	crate_type = /obj/structure/closet/crate/secure/gear
+
+/datum/supply_pack/security/plasma_secsuit
+	name = "Plasmaman Security Envirosuit Crate"
+	desc = "Contains two sets of lightly-armored security envirosuits for Plasmamen. Order now and we'll throw in two free helmets! Requires Security access to open."
+	cost = 4000
+	contains = list(/obj/item/clothing/under/plasmaman/security,
+					/obj/item/clothing/under/plasmaman/security,
+					/obj/item/clothing/head/helmet/space/plasmaman/security,
+					/obj/item/clothing/head/helmet/space/plasmaman/security)
+	crate_name = "security envirosuit crate"
 	crate_type = /obj/structure/closet/crate/secure/gear
 
 //////////////////////////////////////////////////////////////////////////////

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -58,9 +58,7 @@
 					/obj/item/clothing/head/helmet/secconhelm = 3,
 					/obj/item/clothing/suit/armor/secconcoat = 3,
 					/obj/item/clothing/head/beret/sec/secconhat = 3,
-					/obj/item/clothing/suit/armor/secconvest = 3,
-					/obj/item/clothing/under/plasmaman/security = 3,
-					/obj/item/clothing/head/helmet/space/plasmaman/security = 3)
+					/obj/item/clothing/suit/armor/secconvest = 3)
 	premium = list(/obj/item/clothing/under/rank/security/navyblue = 3,
 					/obj/item/clothing/suit/armor/officerjacket = 3,
 					/obj/item/clothing/head/beret/sec/navyofficer = 3)


### PR DESCRIPTION
# Document the changes in your pull request

- Security envirosuit/helms no longer appear in secdrobes
- They now appear in an access-locked security envirosuit crates, orderable with 4000cr (same as EVA suits) from cargo

# Why is this good for the game?
Added in #21546, the goal was to give plasmaman secoffs a place to get their armored clothes back, as there was literally no way to replace them if, say, they were burnt to nothing, or a vampire poofed your helmet (which for some reason they can still do).

Now the issue we've created by adding these two items to every secdrobe on the map, is that we have given anyone who hacks 1x (one) red door and left clicks on the vending menu, or any security officer access to:
- A jumpsuit with armor, max fire protection, and a free fire extinguisher
- Weld-proof, space-proof helmet with max fire protection and a free light toggle

And for anyone willing to give up the standard security drip, any non-plasmaman can now grab those two blatantly better options, which really shouldn't be an option we give them. So now cargo has them, forcing ~~powergamers~~ people to go more out of their way if they _really_ want a pair, while still giving plasmaman secoffs a place to replace their gear.

# Testing
![image](https://github.com/user-attachments/assets/c790038a-043d-4213-bbdd-9e752469b712)

![image](https://github.com/user-attachments/assets/6eee5202-b4a7-491b-8b4f-2af1772290fd)


# Wiki Documentation
Yes we'll need to update this page
https://wiki.yogstation.net/wiki/Vending_machines

# Changelog
:cl:
rscdel: Removed security envirosuits from SecDrobes
rscadd: Added security envirosuit crates to cargo, purchasable with 4000cr 
/:cl:
