### PR TITLE
Increases AOE of the ion rifle and ion cannon

### DIFF
--- a/code/modules/projectiles/projectile/special/ion.dm
+++ b/code/modules/projectiles/projectile/special/ion.dm
@@ -7,7 +7,7 @@
 	armor_flag = ENERGY
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/ion
 	var/ion_severity = EMP_HEAVY // Heavy EMP effects that don't spread to adjacent tiles
-	var/ion_range = 1
+	var/ion_range = 2
 
 /obj/projectile/ion/on_hit(atom/target, blocked = FALSE)
 	..()
@@ -20,4 +20,4 @@
 
 /obj/projectile/ion/heavy
 	ion_severity = 15 // STRONG ions
-	ion_range = 2
+	ion_range = 3


### PR DESCRIPTION
# Document the changes in your pull request

The ion rifle originally had a small aoe and was removed when sarah reworked EMPs, potentially accidentally. It really SHOULD have that aoe as that was part of what made it useful. Additionally the ion cannon (mech ion weapon) also had its range reduced by 1 so this brings it back up to EMPing things up to 2 tiles away.

# Why is this good for the game?

EMP weapons (the ion rifle) needed a little love after being nerfed slightly due to a rework. Also this makes the ion cannon cool again.

# Testing

Ion rifle:
![image](https://github.com/user-attachments/assets/93c8e9ef-cc98-4679-8d00-d4f1ff3a5a47)

Ion cannon:
![image](https://github.com/user-attachments/assets/161f534d-2ff8-4c0e-953c-9f5e05a6cc80)


# Wiki Documentation
Ion rifle: radius of 1 (2 in the code since 1 radius is the tile itself)
Ion cannon: radius increased to 2 (3 in code for above reason)

# Changelog

:cl:  
 
tweak: Increases the radii of the ion rifle and ion cannon to pre-EMP rework values

/:cl:
