### PR TITLE
Fixes bombnanas coming from silver slime extracts, also makes it appear slippery

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1106,7 +1106,8 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		/obj/item/reagent_containers/food/snacks/store/bread,
 		/obj/item/reagent_containers/food/snacks/grown/nettle,
 		/obj/item/reagent_containers/food/snacks/fish, // debug fish
-		/obj/item/reagent_containers/food/snacks/powercrepe //obscenely strong for a food item and shouldn't just be randomly spawned
+		/obj/item/reagent_containers/food/snacks/powercrepe, //obscenely strong for a food item and shouldn't just be randomly spawned
+		/obj/item/reagent_containers/food/snacks/grown/banana/bombanana //They were made in a factory. A bomb factory. They're bombs.
 		)
 	blocked |= typesof(/obj/item/reagent_containers/food/snacks/customizable)
 

--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -182,13 +182,11 @@
 	trash = /obj/item/grown/bananapeel/bombanana
 	bitesize = 1
 	customfoodfilling = FALSE
-	seed = null
 	tastes = list("explosives" = 10)
 	list_reagents = list(/datum/reagent/consumable/nutriment/vitamin = 1)
 
 /obj/item/grown/bananapeel/bombanana
 	desc = "A peel from a banana. Why is it beeping?"
-	seed = null
 	var/det_time = 50
 	var/obj/item/grenade/syndieminibomb/concussion/bomb
 


### PR DESCRIPTION
bombnanas coming from random food was probably an oversight, they're pretty damn big bombs

# Testing
![image](https://github.com/user-attachments/assets/98ecf51f-6aba-49d2-8226-80b80ad6f20e)
![image](https://github.com/user-attachments/assets/54ca280f-7927-4c13-ba2e-8b8aef0f5ffd)

:cl:  
bugfix: Bombnanas no longer come from silver slime extracts
bugfix: Bombnanas now appear slippery like their non bomb counterparts
/:cl:
