### PR TITLE
Removes some antag only foods from silver slime extract

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1105,6 +1105,9 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		/obj/item/reagent_containers/food/snacks/grown/shell, //base types
 		/obj/item/reagent_containers/food/snacks/store/bread,
 		/obj/item/reagent_containers/food/snacks/grown/nettle,
+		/obj/item/reagent_containers/food/snacks/burger/cluwneburger, //permanent cluwnification
+		/obj/item/reagent_containers/food/snacks/burger/roburger, //permanent borgification
+		/obj/item/reagent_containers/food/snacks/burger/roburgerbig, //same thing
 		/obj/item/reagent_containers/food/snacks/fish, // debug fish
 		/obj/item/reagent_containers/food/snacks/powercrepe //obscenely strong for a food item and shouldn't just be randomly spawned
 		)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1108,8 +1108,12 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		/obj/item/reagent_containers/food/snacks/burger/cluwneburger, //permanent cluwnification
 		/obj/item/reagent_containers/food/snacks/burger/roburger, //permanent borgification
 		/obj/item/reagent_containers/food/snacks/burger/roburgerbig, //same thing
+		/obj/item/reagent_containers/food/snacks/pizza/margherita/robo, //same thing again
 		/obj/item/reagent_containers/food/snacks/meat/slab/gondola, //permanent gondolaification
 		/obj/item/reagent_containers/food/snacks/donkpocket/gondola, //same thing
+		/obj/item/reagent_containers/food/snacks/meat/raw_cutlet/gondola, //same thing
+		/obj/item/reagent_containers/food/snacks/meat/cutlet/gondola, //same thing
+		/obj/item/reagent_containers/food/snacks/donkpocket/warm/gondola, //same thing
 		/obj/item/reagent_containers/food/snacks/fish, // debug fish
 		/obj/item/reagent_containers/food/snacks/powercrepe //obscenely strong for a food item and shouldn't just be randomly spawned
 		)

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1108,6 +1108,8 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		/obj/item/reagent_containers/food/snacks/burger/cluwneburger, //permanent cluwnification
 		/obj/item/reagent_containers/food/snacks/burger/roburger, //permanent borgification
 		/obj/item/reagent_containers/food/snacks/burger/roburgerbig, //same thing
+		/obj/item/reagent_containers/food/snacks/meat/slab/gondola, //permanent gondolaification
+		/obj/item/reagent_containers/food/snacks/donkpocket/gondola, //same thing
 		/obj/item/reagent_containers/food/snacks/fish, // debug fish
 		/obj/item/reagent_containers/food/snacks/powercrepe //obscenely strong for a food item and shouldn't just be randomly spawned
 		)


### PR DESCRIPTION
Roburger
Big Roburger
Robo margherita pizza
Cluwneburger
Gondola meat
warm gondola pocket
Gondola pocket
Gondola cutlet
Cooked gondola cutlet

# Why is this good for the game?
why buy it for TC when you can just get it from slime extract (sure it's random, but it's free)

# Testing
no need, just adding typepaths to a list

:cl:  
tweak: Removes antag only foods from silver slime extract
/:cl:
