### PR TITLE
Minor rewrite to slimeperson jelly blood

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -192,6 +192,8 @@
 #define HAIRCOLOR		26
 #define FACEHAIRCOLOR	27
 #define MUTCOLORS_SECONDARY		28
+/// doesn't care about their blood level through normal means, but still has it
+#define STABLEBLOOD 29
 
 //organ slots
 #define ORGAN_SLOT_BRAIN "brain"

--- a/code/datums/blood_types.dm
+++ b/code/datums/blood_types.dm
@@ -81,7 +81,7 @@
 
 /datum/blood_type/jelly
 	name = "J"
-	color = COLOR_MAROON 
+	color = COLOR_DARK_MODERATE_LIME_GREEN
 	compatible_types = list(/datum/blood_type/jelly)
 
 ////////////////////////////////////////////////////////////////

--- a/code/datums/blood_types.dm
+++ b/code/datums/blood_types.dm
@@ -81,7 +81,7 @@
 
 /datum/blood_type/jelly
 	name = "J"
-	color = "#801E28" 
+	color = COLOR_MAROON 
 	compatible_types = list(/datum/blood_type/jelly)
 
 ////////////////////////////////////////////////////////////////

--- a/code/datums/blood_types.dm
+++ b/code/datums/blood_types.dm
@@ -79,6 +79,11 @@
 	color = "#cbee63" //slightly more yellowy than regular liquid electricity because of the grey scale image used
 	compatible_types = list(/datum/blood_type/electricity)
 
+/datum/blood_type/jelly
+	name = "J"
+	color = "#801E28" 
+	compatible_types = list(/datum/blood_type/jelly)
+
 ////////////////////////////////////////////////////////////////
 //-----------------Wonky simplemob(?) bloodtypes--------------//
 ////////////////////////////////////////////////////////////////

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -325,7 +325,7 @@
 		temp -= ORGAN_SLOT_LIVER
 	if(HAS_TRAIT_FROM(H, TRAIT_NOBREATH, SPECIES_TRAIT))
 		temp -= ORGAN_SLOT_LUNGS
-	if(NOBLOOD in H.dna?.species.species_traits || STABLEBLOOD in H.dna?.species.species_traits)
+	if((NOBLOOD in H.dna?.species.species_traits) || (STABLEBLOOD in H.dna?.species.species_traits))
 		temp -= ORGAN_SLOT_HEART
 	var/organ_type = organ_list[pick(temp)]
 	var/obj/item/organ/prosthetic = new organ_type(quirk_holder)
@@ -350,7 +350,7 @@
 		temp -= ORGAN_SLOT_LIVER
 	if(TRAIT_NOBREATH in species.inherent_traits)
 		temp -= ORGAN_SLOT_LUNGS
-	if(NOBLOOD in species.species_traits || STABLEBLOOD in species.species_traits)
+	if((NOBLOOD in species.species_traits) || (STABLEBLOOD in species.species_traits))
 		temp -= ORGAN_SLOT_HEART
 	qdel(species)
 	if(temp.len <= 0)

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -325,7 +325,7 @@
 		temp -= ORGAN_SLOT_LIVER
 	if(HAS_TRAIT_FROM(H, TRAIT_NOBREATH, SPECIES_TRAIT))
 		temp -= ORGAN_SLOT_LUNGS
-	if(NOBLOOD in H.dna?.species.species_traits)
+	if(NOBLOOD in H.dna?.species.species_traits || STABLEBLOOD in H.dna?.species.species_traits)
 		temp -= ORGAN_SLOT_HEART
 	var/organ_type = organ_list[pick(temp)]
 	var/obj/item/organ/prosthetic = new organ_type(quirk_holder)
@@ -350,8 +350,9 @@
 		temp -= ORGAN_SLOT_LIVER
 	if(TRAIT_NOBREATH in species.inherent_traits)
 		temp -= ORGAN_SLOT_LUNGS
-	if(NOBLOOD in species.species_traits)
+	if(NOBLOOD in species.species_traits || STABLEBLOOD in species.species_traits)
 		temp -= ORGAN_SLOT_HEART
+	qdel(species)
 	if(temp.len <= 0)
 		return "You have no organs to replace!"
 

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -421,7 +421,9 @@
 /datum/quirk/cyberorgan/heart/check_quirk(datum/preferences/prefs)
 	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
 	var/datum/species/species = new species_type
-	if(NOBLOOD in species.species_traits) // species with NOBLOOD don't have a heart
+	var/disallowed_trait = (NOBLOOD in species.species_traits || STABLEBLOOD in species.species_traits) // species with NOBLOOD don't have a heart
+	qdel(species)
+	if(disallowed_trait)
 		return "You don't have a heart!"
 	return ..()
 

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -421,7 +421,7 @@
 /datum/quirk/cyberorgan/heart/check_quirk(datum/preferences/prefs)
 	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
 	var/datum/species/species = new species_type
-	var/disallowed_trait = (NOBLOOD in species.species_traits || STABLEBLOOD in species.species_traits) // species with NOBLOOD don't have a heart
+	var/disallowed_trait = ((NOBLOOD in species.species_traits) || (STABLEBLOOD in species.species_traits)) // species with NOBLOOD don't have a heart
 	qdel(species)
 	if(disallowed_trait)
 		return "You don't have a heart!"

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -25,7 +25,7 @@
 // Takes care blood loss and regeneration
 /mob/living/carbon/human/handle_blood()
 
-	if(NOBLOOD in dna.species.species_traits || bleedsuppress || (HAS_TRAIT(src, TRAIT_FAKEDEATH)))
+	if(NOBLOOD in dna.species.species_traits || bleedsuppress || (HAS_TRAIT(src, TRAIT_FAKEDEATH)) || STABLEBLOOD in dna.species.species_traits)
 		return
 
 	if(mind && IS_BLOODSUCKER(src)) // Prevents Bloodsuckers from naturally regenerating Blood - Even while on masquerade

--- a/code/modules/mob/living/blood.dm
+++ b/code/modules/mob/living/blood.dm
@@ -25,7 +25,7 @@
 // Takes care blood loss and regeneration
 /mob/living/carbon/human/handle_blood()
 
-	if(NOBLOOD in dna.species.species_traits || bleedsuppress || (HAS_TRAIT(src, TRAIT_FAKEDEATH)) || STABLEBLOOD in dna.species.species_traits)
+	if((NOBLOOD in dna.species.species_traits) || bleedsuppress || (HAS_TRAIT(src, TRAIT_FAKEDEATH)) || (STABLEBLOOD in dna.species.species_traits))
 		return
 
 	if(mind && IS_BLOODSUCKER(src)) // Prevents Bloodsuckers from naturally regenerating Blood - Even while on masquerade

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -10,6 +10,7 @@
 	inherent_traits = list(TRAIT_TOXINLOVER)
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/slime
 	exotic_blood = /datum/reagent/toxin/slimejelly
+	exotic_bloodtype = "J" //this isn't used for anything other than bloodsplatter colours
 	mutanttongue = /obj/item/organ/tongue/slime
 	mutantlungs = /obj/item/organ/lungs/slime
 	damage_overlay_type = ""

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -6,7 +6,7 @@
 	default_color = "00FF90"
 	say_mod = "chirps"
 	bubble_icon = BUBBLE_SLIME
-	species_traits = list(MUTCOLORS, EYECOLOR, NOBLOOD, HAIR)
+	species_traits = list(MUTCOLORS, EYECOLOR, STABLEBLOOD, HAIR)
 	inherent_traits = list(TRAIT_TOXINLOVER)
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/slime
 	exotic_blood = /datum/reagent/toxin/slimejelly
@@ -196,7 +196,7 @@
 	plural_form = "Slimepeople"
 	id = SPECIES_SLIMEPERSON
 	default_color = "00FFFF"
-	species_traits = list(MUTCOLORS,EYECOLOR,HAIR,FACEHAIR,NOBLOOD)
+	species_traits = list(MUTCOLORS,EYECOLOR,HAIR,FACEHAIR,STABLEBLOOD)
 	say_mod = "says"
 	hair_color = "mutcolor"
 	hair_alpha = 150

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -6,7 +6,7 @@
 	default_color = "00FF90"
 	say_mod = "chirps"
 	bubble_icon = BUBBLE_SLIME
-	species_traits = list(MUTCOLORS, EYECOLOR, STABLEBLOOD, HAIR)
+	species_traits = list(MUTCOLORS, EYECOLOR, STABLEBLOOD, HAIR, HAS_FLESH)
 	inherent_traits = list(TRAIT_TOXINLOVER)
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/slime
 	exotic_blood = /datum/reagent/toxin/slimejelly
@@ -197,7 +197,7 @@
 	plural_form = "Slimepeople"
 	id = SPECIES_SLIMEPERSON
 	default_color = "00FFFF"
-	species_traits = list(MUTCOLORS,EYECOLOR,HAIR,FACEHAIR,STABLEBLOOD)
+	species_traits = list(MUTCOLORS,EYECOLOR,HAIR,FACEHAIR,STABLEBLOOD, HAS_FLESH)
 	say_mod = "says"
 	hair_color = "mutcolor"
 	hair_alpha = 150
@@ -211,7 +211,7 @@
 	var/list/mob/living/carbon/bodies
 
 /datum/species/jelly/slime/on_species_loss(mob/living/carbon/C)
-	bodies -= C // This means that the other bodies maintain a link
+	LAZYREMOVE(bodies, C)// This means that the other bodies maintain a link
 	// so if someone mindswapped into them, they'd still be shared.
 	bodies = null
 	C.blood_volume = min(C.blood_volume, BLOOD_VOLUME_NORMAL(C))
@@ -220,10 +220,7 @@
 /datum/species/jelly/slime/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	..()
 	if(ishuman(C))
-		if(!bodies || !bodies.len)
-			bodies = list(C)
-		else
-			bodies |= C
+		LAZYADD(bodies, C)
 
 
 //If you're cloned you get your body pool back
@@ -296,7 +293,7 @@
 	H.notransform = 0
 
 	var/datum/species/jelly/slime/origin_datum = H.dna.species
-	origin_datum.bodies |= spare
+	LAZYADD(origin_datum.bodies, spare)
 
 	var/datum/species/jelly/slime/spare_datum = spare.dna.species
 	spare_datum.bodies = origin_datum.bodies
@@ -421,11 +418,11 @@
 	var/datum/species/jelly/slime/SS = H.dna.species
 
 	if(QDELETED(dupe)) 					//Is there a body?
-		SS.bodies -= dupe
+		LAZYREMOVE(SS.bodies, dupe)
 		return FALSE
 
 	if(!isslimeperson(dupe)) 			//Is it a slimeperson?
-		SS.bodies -= dupe
+		LAZYREMOVE(SS.bodies, dupe)
 		return FALSE
 
 	if(H.stat != CONSCIOUS) 			//Are we alive and awake?
@@ -434,10 +431,10 @@
 	if(dupe.stat != CONSCIOUS) 			//Is it alive and awake?
 		return FALSE
 
-	if(dupe.mind && dupe.mind.active) 	//Is it unoccupied?
+	if(dupe?.mind?.active) 	//Is it unoccupied?
 		return FALSE
 
-	if(!(dupe in SS.bodies))			//Do we actually own it?
+	if(!LAZYFIND(SS.bodies, dupe))			//Do we actually own it?
 		return FALSE
 
 	return TRUE

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -23,9 +23,6 @@
 	swimming_component = /datum/component/swimming/dissolve
 	hair_color = "mutcolor"
 	hair_alpha = 140
-	liked_food = TOXIC
-	disliked_food = GROSS
-	toxic_food = PINEAPPLE
 
 	species_abilities = list(/datum/action/innate/regenerate_limbs)
 

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -23,6 +23,9 @@
 	swimming_component = /datum/component/swimming/dissolve
 	hair_color = "mutcolor"
 	hair_alpha = 140
+	liked_food = TOXIC
+	disliked_food = GROSS
+	toxic_food = PINEAPPLE
 
 	species_abilities = list(/datum/action/innate/regenerate_limbs)
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -549,7 +549,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 /mob/living/carbon/proc/needs_heart()
 	if(HAS_TRAIT(src, TRAIT_STABLEHEART))
 		return FALSE
-	if(dna && dna.species && (NOBLOOD in dna.species.species_traits)) //not all carbons have species!
+	if(dna?.species && ((NOBLOOD in dna.species.species_traits) || (STABLEBLOOD in dna.species.species_traits))) //not all carbons have species!
 		return FALSE
 	return TRUE
 

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -128,7 +128,7 @@
 /datum/reagent/toxin/slimejelly
 	name = "Slime Jelly"
 	description = "A gooey semi-liquid produced from one of the deadliest lifeforms in existence. SO REAL."
-	color = "#801E28" // rgb: 128, 30, 40
+	color = COLOR_MAROON // rgb: 128, 30, 40
 	toxpwr = 0
 	taste_description = "slime"
 	taste_mult = 1.3

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -128,7 +128,7 @@
 /datum/reagent/toxin/slimejelly
 	name = "Slime Jelly"
 	description = "A gooey semi-liquid produced from one of the deadliest lifeforms in existence. SO REAL."
-	color = COLOR_MAROON // rgb: 128, 30, 40
+	color = COLOR_DARK_MODERATE_LIME_GREEN // rgb: 128, 30, 40
 	toxpwr = 0
 	taste_description = "slime"
 	taste_mult = 1.3

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -108,7 +108,7 @@
 		failed = TRUE
 
 /obj/item/organ/heart/get_availability(datum/species/species)
-	return !(NOBLOOD in species.species_traits)
+	return !((NOBLOOD in species.species_traits) || (STABLEBLOOD in species.species_traits))
 
 /obj/item/organ/heart/cursed
 	name = "cursed heart"

--- a/yogstation/code/modules/mob/living/carbon/human/human.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/human.dm
@@ -20,6 +20,6 @@
 	race = /datum/species/vox
 
 /mob/living/carbon/human/get_blood_state()
-	if(NOBLOOD in dna.species.species_traits) //Can't have blood problems if your species doesn't have any blood, innit?
+	if((NOBLOOD in dna.species.species_traits) || (STABLEBLOOD in dna.species.species_traits)) //Can't have blood problems if your species doesn't have any blood, innit?
 		return BLOOD_SAFE
 	. = ..()


### PR DESCRIPTION
Slimepeople handle their blood in a different way than other species
They used noblood to essentially disable the downsides of low blood which allowed them to do whatever
When i fixed noblood still letting the species draw blood and analyzing blood levels with an analyzer it removed the ability for slime people to do interesting things

So i've added a new species trait STABLEBLOOD
It does two things
Remove the need for a heart and prevent spawning with one
Prevent getting affected by having low or high blood levels

This means slime people will now be able to bleed, spilling jelly all over the place
but they won't die even if they look like a crumpled up juice packet (they'll cannibalize limbs and become a nugget)

also changed the colour because slime jelly looking red doesn't feel right to me

new colour
![image](https://github.com/user-attachments/assets/c9d905bb-1888-4bc0-9c0c-b9cdee32351f)


# Testing
![image](https://github.com/user-attachments/assets/7294ea6c-982c-416e-aa02-a0a350bb5b57)
![image](https://github.com/user-attachments/assets/6af5ae78-9a5c-42be-8700-8c8423fb8c1f)


:cl:  
bugfix: fixes slimepeople being unable to draw jelly blood using a syringe
bugfix: fixes slimepeople being completely immune to all forms of bleeding
tweak: Slime jelly is now a dark lime green instead of maroon
/:cl:
