### PR TITLE
Adjusts Slime Person Burn/Cold modifiers

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -15,8 +15,8 @@
 	damage_overlay_type = ""
 	liked_food = MEAT
 	coldmod = 3
-	heatmod = 0.8
-	burnmod = 0.8 // = 1/2x generic burn damage
+	heatmod = 0.5
+	burnmod = 0.8 // now only 20% as effective!
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/jelly
 	swimming_component = /datum/component/swimming/dissolve

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -14,9 +14,9 @@
 	mutantlungs = /obj/item/organ/lungs/slime
 	damage_overlay_type = ""
 	liked_food = MEAT
-	coldmod = 6
-	heatmod = 0.5
-	burnmod = 0.5 // = 1/2x generic burn damage
+	coldmod = 3
+	heatmod = 0.8
+	burnmod = 0.8 // = 1/2x generic burn damage
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	species_language_holder = /datum/language_holder/jelly
 	swimming_component = /datum/component/swimming/dissolve


### PR DESCRIPTION
# Document the changes in your pull request

Adjusts slime person burnmod to 0.8 instead of 0.5
Adjusts slime person coldmod to 3 instead of 6

# Why is this good for the game?

0.5 is too much, laser/burn damage is one of the most prolific forms of damage we have, and letting them reduce any amount they take by half will only stack with the other benefits of xeniobiology.

6 was too much for them to take as well, and should be reduced as compensation

# Testing

no

# Changelog

:cl:  

tweak: tweaks slime people damage mods

/:cl:
