### PR TITLE
Prevents infinite duplication of jungleland ores

### DIFF
--- a/code/modules/projectiles/projectile/special/plasma.dm
+++ b/code/modules/projectiles/projectile/special/plasma.dm
@@ -34,9 +34,9 @@
 	. = ..()
 	if(istype(newloc,/turf/open/floor/plating/dirt/jungleland))
 		var/turf/open/floor/plating/dirt/jungleland/JG = newloc
-		JG.spawn_rock()
 		if(explosive) //so the plasmacutter ore upgrade spawns double
 			JG.spawn_ores()
+		JG.spawn_rock()
 		if(mine_range > 0)
 			mine_range -= 2 //mine_range is less effective on lavaland
 			range++

--- a/yogstation/code/modules/jungleland/jungle_turfs.dm
+++ b/yogstation/code/modules/jungleland/jungle_turfs.dm
@@ -91,6 +91,8 @@ Temperature: 126.85 °C (400 K)
 	spawn_ores()
 
 /turf/open/floor/plating/dirt/jungleland/proc/spawn_ores()
+	if(ore_present == ORE_EMPTY || !can_spawn_ore)
+		return
 	var/datum/ore_patch/ore = GLOB.jungle_ores[ ore_present ]
 	if(ore)
 		ore.spawn_at(src)

--- a/yogstation/code/modules/jungleland/jungle_turfs.dm
+++ b/yogstation/code/modules/jungleland/jungle_turfs.dm
@@ -85,10 +85,10 @@ Temperature: 126.85 °C (400 K)
 /turf/open/floor/plating/dirt/jungleland/proc/spawn_rock()
 	if(ore_present == ORE_EMPTY || !can_spawn_ore)
 		return
-	can_spawn_ore = FALSE
 	if(spawn_overlay)
 		add_overlay(image(icon='yogstation/icons/obj/jungle.dmi',icon_state="dug_spot",layer=BELOW_OBJ_LAYER))
 	spawn_ores()
+	can_spawn_ore = FALSE
 
 /turf/open/floor/plating/dirt/jungleland/proc/spawn_ores()
 	if(ore_present == ORE_EMPTY || !can_spawn_ore)


### PR DESCRIPTION
it was bypassing the mining check

# Testing
gotta

:cl:  
bugfix: Prevents infinite duplication of jungleland ores
/:cl:
