### PR TITLE
[s] Fixes mech afterburner + mop killing people instantly

### DIFF
--- a/code/game/mecha/equipment/weapons/melee_weapons.dm
+++ b/code/game/mecha/equipment/weapons/melee_weapons.dm
@@ -698,6 +698,8 @@
 	return ..()
 
 /obj/item/mecha_parts/mecha_equipment/melee_weapon/mop/proc/on_pre_move(obj/mecha/mech, atom/newloc)
+	if(mech.equipment_disabled || mech.completely_disabled)
+		return
 	if(!auto_sweep)
 		return
 	var/mop_dir = get_dir(mech, newloc)


### PR DESCRIPTION
Mop moves people forward which makes the afterburner hit them repeatedly until they die

:cl:  
bugfix: Fixed mech afterburner + mop killing people instantly
/:cl:
