### PR TITLE
Fixes mechs getting stuck permanently if thrown during an afterburner charge

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1014,6 +1014,9 @@
 
 	. = TRUE // No failure conditions past this point.
 
+	if(throwing?.callback) // Already being thrown, make sure to invoke any callbacks
+		throwing.callback.Invoke()
+
 	var/datum/thrownthing/TT = new()
 	TT.thrownthing = src
 	TT.target = target


### PR DESCRIPTION
Calling throw_at on something already being thrown wouldn't call the original throw's callback

:cl:  
bugfix: Fixed mechs getting stuck permanently if thrown during an afterburner charge
/:cl:
