### PR TITLE
Makes beepsky do stamina damage instead of an instant stun, for real this time 2 electric boogaloo

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -275,7 +275,7 @@ Auto Patrol: []"},
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
 		threat = H.assess_threat(judgement_criteria, weaponcheck=CALLBACK(src, PROC_REF(check_for_weapons)))
-		if(H.check_shields(src, baton_damage, "[src]'s baton"))
+		if(H.check_shields(src, baton_damage, "[src]'s baton", MELEE_ATTACK, damage_type = STAMINA))
 			return
 	else
 		threat = C.assess_threat(judgement_criteria, weaponcheck=CALLBACK(src, PROC_REF(check_for_weapons)))


### PR DESCRIPTION
reopens this https://github.com/yogstation13/Yogstation/pull/18857

# Document the changes in your pull request

This makes beepsky take 2 hits to down an unarmored person and 3 hits to down an armored person, instead of instantly stunning on hit. Also fixes the attack not caring about armor or block chance, and increased the health while adding flat damage reduction to make it harder to kill.

Specifics:
Health of 50 (up from 25) and 6 flat damage reduction, welding tools deal 9 damage to it (6 hits to kill) and toolboxes deal 7 to it (8 hits to kill). Lasers will deal 14 damage to it (4 shots to kill). Anything weaker than a mosin will not be able to one-shot it anymore and trying to melee it with anything less than esword-level damage or anti-stuns will not be successful.
Attack does 60 stamina damage, 2 hits to down an unarmored person and 3 hits against someone with at least 17 energy armor.

# Why is this good for the game?

its time for him to modernize

# Changelog 

:cl:  Cowbot92 & SapphicOverload

tweak: tweaks beepsky

/:cl:
