### PR TITLE
Tweaks the thrall buff skills for darkspawn warlock

### DIFF
--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/thrall_spells.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/thrall_spells.dm
@@ -357,7 +357,7 @@
 
 ////////////////////////////Temporary speed boost//////////////////////////
 /datum/action/cooldown/spell/pointed/thrallbuff/speed
-	name = "Thrall envigorate"
+	name = "Thrall invigorate"
 	desc = "Target a location, gives a temporary speed boost to all thralls within a 9x9 area."
 	button_icon_state = "speedboost_veils"
 	language_output = "Vyzthun"

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/thrall_spells.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/thrall_spells.dm
@@ -301,7 +301,7 @@
 	/// Colour of the outline that gets temporarily applied
 	var/outline_colour
 	/// Duration of the buff (also used for the visual effect)
-	var/buff_duration = 9
+	var/buff_duration = 1 SECONDS
 
 /datum/action/cooldown/spell/pointed/thrallbuff/before_cast(atom/cast_on)
 	. = ..()
@@ -348,12 +348,12 @@
 	desc = "Target a location, heals all thralls within a 9x9 area."
 	button_icon_state = "heal_veils"
 	language_output = "Plyn othra"
-	outline_colour = COLOR_VIBRANT_LIME
 	var/heal_amount = 70
 
 /datum/action/cooldown/spell/pointed/thrallbuff/heal/empower(mob/living/carbon/target)
 	to_chat(target, span_velvet("You feel healed."))
-	target.heal_ordered_damage(heal_amount, list(STAMINA, BURN, BRUTE, TOX, OXY, CLONE, BRAIN), BODYPART_ANY)
+	if(target.heal_ordered_damage(heal_amount, list(STAMINA, BURN, BRUTE, TOX, OXY, CLONE, BRAIN), BODYPART_ANY))
+		new /obj/effect/temp_visual/heal(get_turf(target), COLOR_GREEN) //if it does any healing, spawn a heal visual, maybe it won't blow the cover of a thrall that happens to be full health
 
 ////////////////////////////Temporary speed boost//////////////////////////
 /datum/action/cooldown/spell/pointed/thrallbuff/speed

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/thrall_spells.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/thrall_spells.dm
@@ -352,7 +352,7 @@
 
 /datum/action/cooldown/spell/pointed/thrallbuff/heal/empower(mob/living/carbon/target)
 	to_chat(target, span_velvet("You feel healed."))
-	if(target.heal_ordered_damage(heal_amount, list(STAMINA, BURN, BRUTE, TOX, OXY, CLONE, BRAIN), BODYPART_ANY))
+	if(target.heal_ordered_damage(heal_amount, list(BURN, BRUTE, TOX, OXY, STAMINA, CLONE, BRAIN), BODYPART_ANY))
 		new /obj/effect/temp_visual/heal(get_turf(target), COLOR_GREEN) //if it does any healing, spawn a heal visual, maybe it won't blow the cover of a thrall that happens to be full health
 
 ////////////////////////////Temporary speed boost//////////////////////////

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/thrall_spells.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/thrall_spells.dm
@@ -348,7 +348,7 @@
 	desc = "Target a location, heals all thralls within a 9x9 area."
 	button_icon_state = "heal_veils"
 	language_output = "Plyn othra"
-	outline_colour = COLOR_GREEN
+	outline_colour = COLOR_VIBRANT_LIME
 	var/heal_amount = 70
 
 /datum/action/cooldown/spell/pointed/thrallbuff/heal/empower(mob/living/carbon/target)

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/thrall_spells.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_abilities/thrall_spells.dm
@@ -311,7 +311,7 @@
 
 /datum/action/cooldown/spell/pointed/thrallbuff/cast(atom/cast_on) //this looks like a mess, i'm sure it can be optimized
 	. = ..()
-	if(get_dist(cast_on, owner) > 10)
+	if(get_dist(cast_on, owner) > 7)
 		playsound(get_turf(cast_on), sound, 50, TRUE)
 	owner.balloon_alert(owner, "[language_output]")
 	for(var/mob/living/carbon/target in range(buff_range, cast_on))

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_upgrades/utility_upgrades.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_upgrades/utility_upgrades.dm
@@ -128,7 +128,7 @@
 	learned_abilities = list(/datum/action/cooldown/spell/pointed/thrallbuff/heal)
 	
 /datum/psi_web/thrall_speed
-	name = "Thrall Envigorate"
+	name = "Thrall Invigorate"
 	desc = "Target a location, gives a temporary speed boost to all thralls within a 9x9 area."
 	lore_description = "Thralls are expendable, push them until they break."
 	icon_state = "speedboost_veils"

--- a/yogstation/code/modules/antagonists/darkspawn/darkspawn_upgrades/utility_upgrades.dm
+++ b/yogstation/code/modules/antagonists/darkspawn/darkspawn_upgrades/utility_upgrades.dm
@@ -119,23 +119,23 @@
 	
 /datum/psi_web/thrall_heal
 	name = "Thrall Recovery"
-	desc = "Heals all vthralls for an amount of brute and burn."
+	desc = "Target a location, heals all thralls within a 9x9 area."
 	lore_description = "While thralls are expendable, they do have their use."
 	icon_state = "heal_veils"
 	willpower_cost = 1
 	shadow_flags = DARKSPAWN_WARLOCK
 	menu_tab = STORE_UTILITY
-	learned_abilities = list(/datum/action/cooldown/spell/thrallbuff/heal)
+	learned_abilities = list(/datum/action/cooldown/spell/pointed/thrallbuff/heal)
 	
 /datum/psi_web/thrall_speed
 	name = "Thrall Envigorate"
-	desc = "Give all thralls a temporary movespeed bonus."
+	desc = "Target a location, gives a temporary speed boost to all thralls within a 9x9 area."
 	lore_description = "Thralls are expendable, push them until they break."
 	icon_state = "speedboost_veils"
 	willpower_cost = 1
 	shadow_flags = DARKSPAWN_WARLOCK
 	menu_tab = STORE_UTILITY
-	learned_abilities = list(/datum/action/cooldown/spell/thrallbuff/speed)
+	learned_abilities = list(/datum/action/cooldown/spell/pointed/thrallbuff/speed)
 	
 /datum/psi_web/elucidate
 	name = "Elucidate"


### PR DESCRIPTION
# Why is this good for the game?
i was going through the darkspawn wiki page, updating the tips and giving a rough breakdown of the classes
i realized that the thrall buff skills were just poorly designed, they had no real depth to them, just spam them on cooldown and it usually worked out
there was also no visual indicator that anything was happening, so it could result in ambiguity as to why someone suddenly stood back up
using the buffs should out the warlock and any thralls that benefit from them as they can be quite strong
making them targeted aoes adds depth to their use as it only affects a certain number of thralls at any given time

buffed them a bit to balance it out

# Testing
![image](https://github.com/user-attachments/assets/55ea1f62-69b6-432e-b7e8-fd174260406f)

:cl:  
tweak: Darkspawn warlock thrallbuff skills now need to target an area
tweak: Thrall envigorate has a slightly stronger speed buff
tweak: Thrall recovery heals for more and only heals stamina if there's no other damage
tweak: Thrallbuff skills now have a visual indicator that they've done something
/:cl:
