### PR TITLE
Breaching missiles now explode on windows too

### DIFF
--- a/code/modules/projectiles/projectile/special/rocket.dm
+++ b/code/modules/projectiles/projectile/special/rocket.dm
@@ -54,7 +54,8 @@
 	/turf/closed,
 	/obj/mecha,
 	/obj/machinery/door/,
-	/obj/machinery/door/poddoor/shutters
+	/obj/machinery/door/poddoor/shutters,
+	/obj/structure/window
 	)
 
 /obj/item/broken_missile


### PR DESCRIPTION
Plasma glass could tank breaching missiles all day :)

# Document the changes in your pull request

Adds windows to the list of sturdy objects for breaching missiles to breach, since they can be very sturdy.

# Why is this good for the game?

No building a glass castle

# Testing
will

# Wiki Documentation

explodes on windows

# Changelog


:cl:  

tweak: Breaching missiles now explode on windows rather than bouncing off

/:cl:
