### PR TITLE
fixes miner mirror recall cooldown

### DIFF
--- a/yogstation/code/modules/mining/lavaland/doppelmirror.dm
+++ b/yogstation/code/modules/mining/lavaland/doppelmirror.dm
@@ -68,7 +68,7 @@
 		to_chat(user, span_notice("You knock on the mirror and call your reflection back into focus."))
 		reflected.forceMove(src)
 		update_icon(inhabited = TRUE)
-		COOLDOWN_START(src, next_search, COOLDOWN_RECALL)
+		COOLDOWN_START(src, next_recall, COOLDOWN_RECALL)
 	if(istype(action, /datum/action/item_action/rerollmirror))
 		if(!reflected)
 			to_chat(user, span_notice("The mirror is dormant."))


### PR DESCRIPTION
# Document the changes in your pull request

changes the recall ability of the mirror to affect the correct timer at least i think those are the right words


# Testing
the phrases in the cd's match up so i think that counts as testing

# Changelog

:cl:  
bugfix: fixes ominous mirror recall cooldown
/:cl:
