### PR TITLE
Revert "Closing the gap between station & lavaland"

### DIFF
--- a/_maps/shuttles/mining_box.dmm
+++ b/_maps/shuttles/mining_box.dmm
@@ -37,9 +37,7 @@
 	shuttle_id = "mining";
 	name = "mining shuttle";
 	port_direction = 4;
-	width = 7;
-	ignitionTime = 10;
-	callTime = 10
+	width = 7
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4

--- a/_maps/shuttles/mining_delta.dmm
+++ b/_maps/shuttles/mining_delta.dmm
@@ -292,9 +292,7 @@
 	shuttle_id = "mining";
 	name = "mining shuttle";
 	port_direction = 8;
-	width = 7;
-	callTime = 10;
-	ignitionTime = 10
+	width = 7
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4

--- a/_maps/shuttles/mining_kilo.dmm
+++ b/_maps/shuttles/mining_kilo.dmm
@@ -73,9 +73,7 @@
 	shuttle_id = "mining";
 	name = "mining shuttle";
 	port_direction = 4;
-	width = 7;
-	callTime = 10;
-	ignitionTime = 10
+	width = 7
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/mining)


### PR DESCRIPTION
Reverts yogstation13/Yogstation#22089

Not everything needs to be done as quick as possible. With the total time on the mining shuttle per ship being 3 seconds, there's no reason to make small talk while waiting for a third person to get on the ship. There's no time to get into place incase you're getting ready to jump somebody on the way to the landing bay, and there's even less time for miners to talk to each other since they're only gonna be in close proximity for the time it takes to sneeze. If someone is caught waiting for another to get onto the ship, the thought of the guy who wasn't waiting isn't gonna be "oh they waited for me how nice," but "why did they wait when the shuttle teleports are they dumb"  