### PR TITLE
Lets you construct a multiz power adapter and adds multiz disposal pipes to the RPD

### DIFF
--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -59,6 +59,8 @@ GLOBAL_LIST_INIT(disposal_pipe_recipes, list(
 		new /datum/pipe_info/disposal("Sort Junction",	/obj/structure/disposalpipe/sorting/mail, PIPE_TRIN_M),
 		new /datum/pipe_info/disposal("Rotator", 		/obj/structure/disposalpipe/rotator, PIPE_ONEDIR_FLIPPABLE),
 		new /datum/pipe_info/disposal("Trunk",			/obj/structure/disposalpipe/trunk),
+		new /datum/pipe_info/disposal("Deck Up",		/obj/structure/disposalpipe/trunk/multiz),
+		new /datum/pipe_info/disposal("Deck Down",		/obj/structure/disposalpipe/trunk/multiz/down),
 		new /datum/pipe_info/disposal("Bin",			/obj/machinery/disposal/bin, PIPE_ONEDIR),
 		new /datum/pipe_info/disposal("Outlet",			/obj/structure/disposaloutlet),
 		new /datum/pipe_info/disposal("Chute",			/obj/machinery/disposal/deliveryChute),

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -526,7 +526,8 @@ By design, d1 is the smallest direction and d2 is the highest
 	restraints_icon.color = color
 
 	var/list/radial_menu = list(
-	"Cable restraints" = restraints_icon
+		"Multi-deck power adapter" = image(icon = 'icons/obj/power.dmi', icon_state = "cablerelay-broken-cable"),
+		"Cable restraints" = restraints_icon
 	)
 
 	var/layer_result = show_radial_menu(user, src, radial_menu, custom_check = CALLBACK(src, PROC_REF(check_menu), user), require_near = TRUE, tooltips = TRUE)
@@ -538,6 +539,13 @@ By design, d1 is the smallest direction and d2 is the highest
 				if(use(CABLE_RESTRAINTS_COST))
 					var/obj/item/restraints/handcuffs/cable/restraints = new(null, cable_color)
 					user.put_in_hands(restraints)
+		if("Multi-deck power adapter")
+			if(locate(/obj/machinery/power/deck_relay) in user.loc)
+				to_chat(user, span_danger("You can't place another relay here!"))
+				return
+			if(use(1))
+				new /obj/machinery/power/deck_relay(user.loc)
+				user.visible_message("[user] constructs a deck relay.")
 	update_appearance()
 
 ///////////////////////////////////


### PR DESCRIPTION
# Document the changes in your pull request

Lets you actually construct things to "repair" multiz areas

power adapter = use cable coil in hand

ladders coming later when i think of a way for it to be not ridiculously op

# Why is this good for the game?
Ability to repair destroyed multiz things

# Testing
<!-- Describe what testing you did with this PR. Try to be thorough, especially if this is a larger project. -->

# Wiki Documentation

new things in here

# Changelog

:cl:  
rscadd: You can no construct multiz power adapters
rscadd: Multiz disposal pipes added to the RPD
/:cl:
