### PR TITLE
Fixes ipc insurgents being invisible if swapping from any organic species

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -427,6 +427,8 @@ ipc martial arts stuff
 		TRAIT_NODEFIB,
 		TRAIT_NOHUNGER //nuclear powered or some shit, idk
 		)
+	mutant_bodyparts = list("ipc_antenna", "ipc_chassis") //no screen
+	species_abilities = list() //no screen change
 
 //infiltrators
 /datum/species/ipc/self/insurgent
@@ -514,9 +516,9 @@ ipc martial arts stuff
 	fixed_mut_color = fake_species.fixed_mut_color
 	H.bubble_icon = fake_species.bubble_icon
 	yogs_draw_robot_hair = TRUE
-	var/robotic = (fake_species.inherent_biotypes & MOB_ROBOTIC)
+	
 	for(var/obj/item/bodypart/O in H.bodyparts)
-		O.render_like_organic = robotic //make sure to copy limbs as normal
+		O.render_like_organic = TRUE // Makes limbs render like organic limbs instead of augmented limbs, check bodyparts.dm
 
 	ADD_TRAIT(H, TRAIT_DISGUISED, type)
 	H.update_body_parts()

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -275,7 +275,8 @@
 
 /obj/item/organ/tongue/robot/handle_speech(datum/source, list/speech_args)
 	..()
-	speech_args[SPEECH_SPANS] |= SPAN_ROBOT
+	if(!HAS_TRAIT(source, TRAIT_DISGUISED)) //disguised voice font
+		speech_args[SPEECH_SPANS] |= SPAN_ROBOT
 
 /obj/item/organ/tongue/snail
 	name = "snailtongue"


### PR DESCRIPTION
i hate how limb icon code works

# Testing
using an ethereal so you can actually tell something's changed as it's one of the species that defaults to human
![image](https://github.com/user-attachments/assets/a9e89049-0e79-40f9-a9e0-f6ddc56b70e6)
![image](https://github.com/user-attachments/assets/bdc5c08b-f225-4a23-9e42-f2011670ce3e)


:cl:  
bugfix: Fixes ipc insurgents being invisible if swapping from any organic species
bugfix: Fixes ipc insurgents having robotic speech font while disguised
/:cl:
