### PR TITLE
unpoplocks buster arm

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -334,7 +334,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	from the arm which momentarily keeps victims in place. Due to its unorthodox nature, the box includes 3 monkey cubes to familiarize the user with the arm functions. Users are \
 	warned that the arm renders them unable to wear gloves and sticks out of most outerwear."
 	item = /obj/item/storage/box/syndie_kit/buster
-	player_minimum = 25
 	cost = 15
 	manufacturer = /datum/corporation/traitor/cybersun
 	surplus = 0


### PR DESCRIPTION
# Document the changes in your pull request
makes it so buster arm no longer requires 25pop for use

# Why is this good for the game?
it was recently toned down to be less powerful with reduced crowd control/immobilize times and removal of the stun that came from grabbing people, so i'm hoping it's more fitting for lower pops while still being able to cause a scene 

# Wiki Documentation

https://wiki.yogstation.net/wiki/Syndicate_Items
the 25pop part of the buster arm

# Changelog


:cl:  
 
tweak: tweaked buster arm to have no poplock
/:cl:
