### PR TITLE
Access Tweaks & Fixes

### DIFF
--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -16,7 +16,7 @@
 
 	outfit = /datum/outfit/job/chemist
 
-	added_access = list(ACCESS_MORGUE, ACCESS_SURGERY, ACCESS_GENETICS, ACCESS_CLONING)
+	added_access = list(ACCESS_MORGUE, ACCESS_SURGERY, ACCESS_GENETICS, ACCESS_CLONING, ACCESS_VIROLOGY)
 	base_access = list(ACCESS_MEDICAL, ACCESS_CHEMISTRY, ACCESS_MECH_MEDICAL)
 	paycheck = PAYCHECK_MEDIUM
 	paycheck_department = ACCOUNT_MED

--- a/code/modules/jobs/job_types/curator.dm
+++ b/code/modules/jobs/job_types/curator.dm
@@ -13,8 +13,8 @@
 
 	alt_titles = list("Librarian", "Journalist", "Archivist", "Cartographer", "Space Archaeologist")
 
-	added_access = list(ACCESS_MAINT_TUNNELS, ACCESS_EXTERNAL_AIRLOCKS, ACCESS_AUX_BASE)
-	base_access = list(ACCESS_SERVICE, ACCESS_LIBRARY, ACCESS_CONSTRUCTION, ACCESS_MINING_STATION)
+	added_access = list(ACCESS_MAINT_TUNNELS, ACCESS_AUX_BASE)
+	base_access = list(ACCESS_SERVICE, ACCESS_LIBRARY, ACCESS_CONSTRUCTION, ACCESS_MINING_STATION, ACCESS_EXTERNAL_AIRLOCKS)
 
 	paycheck = PAYCHECK_EASY
 	paycheck_department = ACCOUNT_CIV

--- a/code/modules/jobs/job_types/scientist.dm
+++ b/code/modules/jobs/job_types/scientist.dm
@@ -12,7 +12,7 @@
 	alt_titles = list("Researcher", "Toxins Specialist", "Physicist", "Test Associate", "Anomalist", "Quantum Physicist", "Theoretical Physicist", "Xenobiologist", "Explosives Technician", "Hypothetical Physicist")
 	outfit = /datum/outfit/job/scientist
 
-	added_access = list(ACCESS_ROBO_CONTROL, ACCESS_GENETICS)
+	added_access = list(ACCESS_ROBO_CONTROL, ACCESS_GENETICS, ACCESS_ROBOTICS)
 	base_access = list(ACCESS_SCIENCE, ACCESS_RESEARCH, ACCESS_TOXINS, ACCESS_TOXINS_STORAGE,
 					ACCESS_EXPERIMENTATION, ACCESS_XENOBIOLOGY, ACCESS_AUX_BASE, ACCESS_MECH_SCIENCE)
 


### PR DESCRIPTION
# Document the changes in your pull request

Primarily began as fixing Scientists not having access to Robotics during lowpop, tweaked two other things that just seemed overall helpful or useful to those jobs.

1. Scientist gets Robotics access at lowpop.
2. Chemist gets Virology access at lowpop. Of all the tangential non-doctor jobs, chemist is the one most entwined with Viro as they're the ones making the cures.
3. Curator gets External Airlocks access as a basic thing. They usually just fuck off to space anyway why give them an extra step?

# Why is this good for the game?

Low-impact tweaks for 2 and 3 that smooth out potential snags.

# Testing
![image](https://github.com/user-attachments/assets/54ce52a3-3f80-493c-9472-38655d7c51ec)
![image](https://github.com/user-attachments/assets/57e4ff70-90b0-4be1-81c9-9ef101c93684)

(main 2, curator one harder to do on my own as turning off skeleton crew is a PITA)



# Wiki Documentation

Access stuff all around needs some work I'll go through that soon.

# Changelog

:cl:  
bugfix: Scientists get Robotics access with skeleton crew access
tweak: Chemists get Virology access with skeleton crew access
tweak: Curators get base external airlocks access, no longer needing skeleton crew.
/:cl:
