### PR TITLE
[ICEMETA] Replaces the SM's cooling with liquid plasma

### DIFF
--- a/_maps/RandomRuins/StationRuins/MetaStation/meta_sm.dmm
+++ b/_maps/RandomRuins/StationRuins/MetaStation/meta_sm.dmm
@@ -20,6 +20,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"aA" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/lava/plasma/ice_moon,
+/area/icemoon/top_layer/outdoors)
 "aH" = (
 /obj/structure/table,
 /obj/effect/turf_decal/delivery,
@@ -93,6 +97,13 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"cm" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/lava/plasma/ice_moon,
+/area/icemoon/top_layer/outdoors)
 "cq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -314,12 +325,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"le" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/top_layer/outdoors)
 "li" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -612,13 +617,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"qA" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/top_layer/outdoors)
 "qE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -642,10 +640,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
-"qR" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/top_layer/outdoors)
 "qV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -831,12 +825,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"vJ" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/top_layer/outdoors)
 "vU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -886,6 +874,12 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"wW" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/lava/plasma/ice_moon,
+/area/icemoon/top_layer/outdoors)
 "xf" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
 /turf/closed/wall,
@@ -944,6 +938,13 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"zn" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/turf/open/lava/plasma/ice_moon,
+/area/icemoon/top_layer/outdoors)
 "zE" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -992,6 +993,12 @@
 /obj/machinery/atmospherics/components/trinary/filter/flipped/critical,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"AY" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/turf/open/lava/plasma/ice_moon,
+/area/icemoon/top_layer/outdoors)
 "Bf" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -1008,12 +1015,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"Bg" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/top_layer/outdoors)
 "Bn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1088,6 +1089,12 @@
 /obj/machinery/bounty_board,
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
+"DY" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/turf/open/lava/plasma/ice_moon,
+/area/icemoon/top_layer/outdoors)
 "Et" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -1155,12 +1162,6 @@
 /obj/structure/lattice,
 /obj/structure/girder/reinforced,
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/icemoon/top_layer/outdoors)
-"Fp" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/top_layer/outdoors)
 "Fz" = (
 /obj/structure/cable{
@@ -1440,6 +1441,9 @@
 "OD" = (
 /turf/template_noop,
 /area/template_noop)
+"OK" = (
+/turf/open/lava/plasma/ice_moon,
+/area/icemoon/top_layer/outdoors)
 "OR" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Supermatter Engine"
@@ -1459,12 +1463,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"Pm" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/top_layer/outdoors)
 "Pz" = (
 /obj/machinery/door/airlock/engineering/glass/critical{
 	heat_proof = 1;
@@ -1491,13 +1489,6 @@
 /obj/structure/window/plasma/reinforced,
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"PK" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/top_layer/outdoors)
 "Qa" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
@@ -1520,6 +1511,12 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"Qp" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/turf/open/lava/plasma/ice_moon,
+/area/icemoon/top_layer/outdoors)
 "Qx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1615,6 +1612,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"TA" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/turf/open/lava/plasma/ice_moon,
+/area/icemoon/top_layer/outdoors)
 "TU" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
@@ -2019,8 +2022,8 @@ MT
 mI
 Ju
 xf
-qR
-Bg
+aA
+Qp
 OD
 OD
 OD
@@ -2045,11 +2048,11 @@ oX
 li
 aK
 mS
-mU
-le
-vJ
-Bg
-mU
+OK
+TA
+DY
+Qp
+OK
 "}
 (13,1,1) = {"
 dO
@@ -2071,11 +2074,11 @@ UM
 Et
 fK
 xf
-qR
-PK
-PK
-PK
-Bg
+aA
+cm
+cm
+cm
+Qp
 "}
 (14,1,1) = {"
 dO
@@ -2097,11 +2100,11 @@ SM
 vl
 SM
 jp
-vJ
-PK
-PK
-PK
-Pm
+DY
+cm
+cm
+cm
+wW
 "}
 (15,1,1) = {"
 dO
@@ -2123,11 +2126,11 @@ hL
 Zz
 Ev
 jp
-Fp
-PK
-PK
-PK
-Bg
+AY
+cm
+cm
+cm
+Qp
 "}
 (16,1,1) = {"
 dO
@@ -2149,11 +2152,11 @@ hr
 NY
 Rt
 jp
-vJ
-PK
-PK
-PK
-Pm
+DY
+cm
+cm
+cm
+wW
 "}
 (17,1,1) = {"
 dO
@@ -2175,11 +2178,11 @@ bX
 jZ
 wb
 jp
-Fp
-PK
-PK
-PK
-Bg
+AY
+cm
+cm
+cm
+Qp
 "}
 (18,1,1) = {"
 dO
@@ -2201,11 +2204,11 @@ Vz
 Zy
 KF
 jp
-vJ
-PK
-PK
-PK
-Pm
+DY
+cm
+cm
+cm
+wW
 "}
 (19,1,1) = {"
 nA
@@ -2227,11 +2230,11 @@ jp
 jp
 jp
 jp
-Fp
-qA
-qA
-qA
-Bg
+AY
+zn
+zn
+zn
+Qp
 "}
 (20,1,1) = {"
 nA
@@ -2254,10 +2257,10 @@ nA
 nA
 mU
 mU
-Fp
-Pm
-Fp
-Pm
+AY
+wW
+AY
+wW
 "}
 (21,1,1) = {"
 nA


### PR DESCRIPTION
# Document the changes in your pull request

Replaces under the SM cooling loop to be liquid plasma river instead of snow turfs. Icemoon is 180K but HE pipes on plasma rivers chill things down to 73K, so will hopefully make it more bearable to play on

![chrome_y16m2gZlDU](https://github.com/user-attachments/assets/456003bc-efa0-461d-923a-20ce25194411)


# Why is this good for the game?
I like IceMeta and a big complaint is that wrangling engines is difficult

# Wiki Documentation

Looks like this now

# Changelog

:cl:  
mapping: IceMeta SM is now plasma cooled
/:cl:
