### PR TITLE
Gives Poly a new line (mutually exclusive with #22505)

### DIFF
--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -864,7 +864,7 @@ GLOBAL_LIST_INIT(strippable_parrot_items, create_strippable_list(list(
 /mob/living/simple_animal/parrot/Poly
 	name = "Poly"
 	desc = "Poly the Parrot. An expert on quantum cracker theory."
-	speak = list("Poly wanna cracker!", ":e Check the crystal, you chucklefucks!",":e Wire the solars, you lazy bums!",":e WHO TOOK THE DAMN HARDSUITS?",":e OH GOD ITS ABOUT TO DELAMINATE CALL THE SHUTTLE")
+	speak = list("Poly wanna cracker!", ":e Check the crystal, you chucklefucks!",":e Wire the solars, you lazy bums!",":e WHO TOOK THE DAMN HARDSUITS?",":e OH GOD ITS ABOUT TO DELAMINATE CALL THE SHUTTLE",":e I THOUGHT THAT HEATING THE COOLANT WOULD MAKE MORE POWER")
 	gold_core_spawnable = NO_SPAWN
 	speak_chance = 3
 	var/memory_saved = FALSE


### PR DESCRIPTION
Meant to be mutually exclusive with https://github.com/yogstation13/Yogstation/pull/22505 , but if you want to merge both then I can not stop you
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request
Adds a new line to Poly's stock set, based on the tragedy of 53531
![HEATINGTHECOOLANT](https://github.com/user-attachments/assets/3575e0e3-f86d-4972-bacd-2ff49c1e5a6d)

# Why is this good for the game?
funny, blame crazy_drakkon for the idea
![HEATINGTHECOOLANT2](https://github.com/user-attachments/assets/0a31cbb5-c4d9-4aca-8cd1-22dfb21b54fc)


# Testing
None done, presumably none needed - it's a single string added with what looks like proper syntax

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:  
rscadd: Added a new standard line for Poly.
/:cl:
