### PR TITLE
Adds more chemicals to allergic reaction quirk + changes the reaction

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -748,6 +748,7 @@
 		if(COOLDOWN_FINISHED(src, allergies)) //if it wasn't ongoing, give a prompt
 			to_chat(quirk_holder, span_userdanger("You forgot you were allergic to [allergy.name]!"))
 		COOLDOWN_START(src, allergies, cooldown_duration) //start it, or refresh the ongoing
+		H.adjustToxLoss(1, TRUE, TRUE)
 
 	if(!COOLDOWN_FINISHED(src, allergies))
 		H.emote("choke")
@@ -758,8 +759,6 @@
 		H.silent = max(H.silent, 3) //can't speak, your throat is swollen shut
 
 	else if(!COOLDOWN_FINISHED(src, allergies)) //if the cooldown is going
-		H.adjustToxLoss(1, TRUE, TRUE)
-
 		//external indicator that it's happening
 		if(prob(30)) 
 			switch(rand(0, 2))

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -748,30 +748,33 @@
 		COOLDOWN_START(src, allergies, cooldown_duration) //start it, or refresh the ongoing
 
 	if(anaphylaxis)
-		M.emote("choke")
-		M.losebreath += 5
+		H.emote("choke")
+		H.losebreath += 5
+		H.adjustStaminaLoss(10)
+		H.clear_stamina_regen()
+		H.silent = max(M.silent, 4) //can't speak, your throat is swollen shut
 		return //don't do any of the regular stuff
 
 	if(!COOLDOWN_FINISHED(src, allergies)) //if the cooldown is going
-		M.adjustToxLoss(1, TRUE, TRUE)
+		H.adjustToxLoss(1, TRUE, TRUE)
 
 		//external indicator that it's happening
 		if(prob(60)) 
 			switch(rand(0, 2))
 				if(0)
-					M.emote("cough")
+					H.emote("cough")
 				if(1)
-					M.emote("sneeze")
+					H.emote("sneeze")
 				if(2)
-					M.emote("choke")
+					H.emote("choke")
 
 		switch(rand(0, 10)) //negative effect
 			if(0 to 5)
 				to_chat(M, span_danger("Your eyes swell up and you can barely see!"))
-				M.adjust_eye_blur(3)
+				H.adjust_eye_blur(3)
 			if(6 to 9) //nice
 				to_chat(M, span_danger("You scratch at an itch."))
-				M.adjustBruteLoss(4*REM, 0)
+				H.adjustBruteLoss(4*REM, 0)
 			if(10)
 				to_chat(M, span_userdanger("You go into anaphylactic shock!"))
 				anaphylaxis = TRUE

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -713,7 +713,7 @@
 	var/reagent_id
 	COOLDOWN_DECLARE(allergies)
 	/// how long allergies last after getting rid of the allergen
-	var/cooldown_duration = 20 SECONDS 
+	var/cooldown_duration = 10 SECONDS 
 	/// Wether the person is experiencing anaphylatic shock or not
 	var/anaphylaxis = FALSE
 	/// How long anaphylactic shock lasts

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -702,7 +702,7 @@
 		/datum/reagent/medicine/salbutamol,
 
 		/datum/reagent/drug/caffeine, //get fucked
-		
+
 		/datum/reagent/medicine/mutadone,
 		/datum/reagent/medicine/charcoal, //this isn't about realism, it's about sending a message
 		/datum/reagent/medicine/mannitol, //i am a spiteful god and my creations will suffer
@@ -754,7 +754,7 @@
 		H.losebreath += 5
 		H.adjustStaminaLoss(10)
 		H.clear_stamina_regen()
-		H.silent = max(M.silent, 4) //can't speak, your throat is swollen shut
+		H.silent = max(H.silent, 4) //can't speak, your throat is swollen shut
 		return //don't do any of the regular stuff
 
 	if(!COOLDOWN_FINISHED(src, allergies)) //if the cooldown is going
@@ -772,13 +772,13 @@
 
 		switch(rand(0, 10)) //negative effect
 			if(0 to 5)
-				to_chat(M, span_danger("Your eyes swell up and you can barely see!"))
+				to_chat(H, span_danger("Your eyes swell up and you can barely see!"))
 				H.adjust_eye_blur(3)
 			if(6 to 9) //nice
-				to_chat(M, span_danger("You scratch at an itch."))
-				H.adjustBruteLoss(4*REM, 0)
+				to_chat(H, span_danger("You scratch at an itch."))
+				H.adjustBruteLoss(4, 0)
 			if(10)
-				to_chat(M, span_userdanger("You go into anaphylactic shock!"))
+				to_chat(H, span_userdanger("You go into anaphylactic shock!"))
 				anaphylaxis = TRUE
 				addtimer(VARSET_CALLBACK(src, anaphylaxis, FALSE), cooldown_duration)
 

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -747,16 +747,15 @@
 			to_chat(quirk_holder, span_userdanger("You forgot you were allergic to [allergy.name]!"))
 		COOLDOWN_START(src, allergies, cooldown_duration) //start it, or refresh the ongoing
 
+	if(anaphylaxis)
+		M.emote("choke")
+		M.losebreath += 5
+		return //don't do any of the regular stuff
+
 	if(!COOLDOWN_FINISHED(src, allergies)) //if the cooldown is going
 		M.adjustToxLoss(1, TRUE, TRUE)
 
 		//external indicator that it's happening
-		if(anaphylaxis) //always choking
-			M.emote("choke")
-			M.losebreath += 5
-			return //don't do any of the regular stuff
-
-
 		if(prob(60)) 
 			switch(rand(0, 2))
 				if(0)

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -748,7 +748,6 @@
 		if(COOLDOWN_FINISHED(src, allergies)) //if it wasn't ongoing, give a prompt
 			to_chat(quirk_holder, span_userdanger("You forgot you were allergic to [allergy.name]!"))
 		COOLDOWN_START(src, allergies, cooldown_duration) //start it, or refresh the ongoing
-		H.adjustToxLoss(1, TRUE, TRUE)
 
 	if(!COOLDOWN_FINISHED(src, allergies))
 		H.emote("choke")

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -749,16 +749,15 @@
 			to_chat(quirk_holder, span_userdanger("You forgot you were allergic to [allergy.name]!"))
 		COOLDOWN_START(src, allergies, cooldown_duration) //start it, or refresh the ongoing
 
-	if(!COOLDOWN_FINISHED(src, allergies)anaphylaxis)
+	if(!COOLDOWN_FINISHED(src, allergies))
 		H.emote("choke")
 		H.losebreath += 3
 		H.adjust_eye_blur(2)
 		H.adjustStaminaLoss(4)
 		H.clear_stamina_regen()
 		H.silent = max(H.silent, 3) //can't speak, your throat is swollen shut
-		return //don't do any of the regular stuff
 
-	if(!COOLDOWN_FINISHED(src, allergies)) //if the cooldown is going
+	else if(!COOLDOWN_FINISHED(src, allergies)) //if the cooldown is going
 		H.adjustToxLoss(1, TRUE, TRUE)
 
 		//external indicator that it's happening

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -717,7 +717,7 @@
 	/// how long allergies last after getting rid of the allergen
 	var/cooldown_duration = 10 SECONDS 
 	/// Wether the person is experiencing anaphylatic shock or not
-	var/anaphylaxis = FALSE
+	COOLDOWN_DECLARE(anaphylaxis)
 	/// How long anaphylactic shock lasts
 	var/shock_duration = 15 SECONDS
 
@@ -749,19 +749,20 @@
 			to_chat(quirk_holder, span_userdanger("You forgot you were allergic to [allergy.name]!"))
 		COOLDOWN_START(src, allergies, cooldown_duration) //start it, or refresh the ongoing
 
-	if(anaphylaxis)
+	if(!COOLDOWN_FINISHED(src, allergies)anaphylaxis)
 		H.emote("choke")
-		H.losebreath += 5
-		H.adjustStaminaLoss(10)
+		H.losebreath += 3
+		H.adjust_eye_blur(2)
+		H.adjustStaminaLoss(4)
 		H.clear_stamina_regen()
-		H.silent = max(H.silent, 4) //can't speak, your throat is swollen shut
+		H.silent = max(H.silent, 3) //can't speak, your throat is swollen shut
 		return //don't do any of the regular stuff
 
 	if(!COOLDOWN_FINISHED(src, allergies)) //if the cooldown is going
 		H.adjustToxLoss(1, TRUE, TRUE)
 
 		//external indicator that it's happening
-		if(prob(60)) 
+		if(prob(30)) 
 			switch(rand(0, 2))
 				if(0)
 					H.emote("cough")
@@ -770,17 +771,17 @@
 				if(2)
 					H.emote("choke")
 
-		switch(rand(0, 10)) //negative effect
-			if(0 to 5)
-				to_chat(H, span_danger("Your eyes swell up and you can barely see!"))
-				H.adjust_eye_blur(3)
-			if(6 to 9) //nice
-				to_chat(H, span_danger("You scratch at an itch."))
-				H.adjustBruteLoss(4, 0)
-			if(10)
-				to_chat(H, span_userdanger("You go into anaphylactic shock!"))
-				anaphylaxis = TRUE
-				addtimer(VARSET_CALLBACK(src, anaphylaxis, FALSE), cooldown_duration)
+		if(prob(40))
+			switch(rand(0, 10)) //negative effect
+				if(0 to 5)
+					to_chat(H, span_danger("Your eyes swell up and you can barely see!"))
+					H.adjust_eye_blur(3)
+				if(6 to 9) //nice
+					to_chat(H, span_danger("You scratch at an itch."))
+					H.adjustBruteLoss(2)
+				if(10)
+					to_chat(H, span_userdanger("You go into anaphylactic shock!"))
+					COOLDOWN_START(src, allergies, shock_duration)
 
 /datum/quirk/kleptomaniac
 	name = "Kleptomaniac"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -701,6 +701,8 @@
 		/datum/reagent/medicine/pen_acid,
 		/datum/reagent/medicine/salbutamol,
 
+		/datum/reagent/drug/caffeine, //get fucked
+		
 		/datum/reagent/medicine/mutadone,
 		/datum/reagent/medicine/charcoal, //this isn't about realism, it's about sending a message
 		/datum/reagent/medicine/mannitol, //i am a spiteful god and my creations will suffer

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -759,7 +759,7 @@
 
 	else if(!COOLDOWN_FINISHED(src, allergies)) //if the cooldown is going
 		//external indicator that it's happening
-		if(prob(30)) 
+		if(prob(50)) 
 			switch(rand(0, 2))
 				if(0)
 					H.emote("cough")
@@ -768,7 +768,7 @@
 				if(2)
 					H.emote("choke")
 
-		if(prob(40))
+		if(prob(50))
 			switch(rand(0, 10)) //negative effect
 				if(0 to 5)
 					to_chat(H, span_danger("Your eyes swell up and you can barely see!"))

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -685,29 +685,47 @@
 	mob_trait = TRAIT_ALLERGIC
 	gain_text = span_danger("You remember your allergic reaction to a common medicine.")
 	lose_text = span_notice("You no longer are allergic to medicine.")
-	var/allergy_chem_list = list(	/datum/reagent/medicine/inacusiate,
-									/datum/reagent/medicine/silver_sulfadiazine,
-									/datum/reagent/medicine/styptic_powder,
-									/datum/reagent/medicine/omnizine,
-									/datum/reagent/medicine/oculine,
-									/datum/reagent/medicine/neurine,
-									/datum/reagent/medicine/bicaridine,
-									/datum/reagent/medicine/kelotane,
-									/datum/reagent/medicine/c2/libital,
-									/datum/reagent/medicine/c2/aiuri) //Everything in the list can be healed from another source round-start
+
+	var/allergy_chem_list = list(	
+		/datum/reagent/medicine/inacusiate,
+		/datum/reagent/medicine/silver_sulfadiazine,
+		/datum/reagent/medicine/styptic_powder,
+		/datum/reagent/medicine/omnizine,
+		/datum/reagent/medicine/oculine,
+		/datum/reagent/medicine/neurine,
+		/datum/reagent/medicine/bicaridine,
+		/datum/reagent/medicine/kelotane,
+		/datum/reagent/medicine/c2/libital,
+		/datum/reagent/medicine/c2/aiuri,
+		/datum/reagent/medicine/atropine,
+		/datum/reagent/medicine/pen_acid,
+		/datum/reagent/medicine/salbutamol,
+
+		/datum/reagent/medicine/mutadone,
+		/datum/reagent/medicine/charcoal, //this isn't about realism, it's about sending a message
+		/datum/reagent/medicine/mannitol, //i am a spiteful god and my creations will suffer
+		/datum/reagent/medicine/cryoxadone, //mortals shall look to the heavens and cry "why must you subject us to this cruel torment"
+		/datum/reagent/medicine/synthflesh, //i shall look upon at them and laugh
+		/datum/reagent/water //FOR I AM THE GOD OF THIS WORLD AND MY WORD IS LAW
+		)
+
+	/// Allergy reagent
 	var/reagent_id
-	var/cooldown_time = 1 MINUTES //Cant act again until the first wears off
-	var/cooldown = FALSE
+	COOLDOWN_DECLARE(allergies)
+	/// how long allergies last after getting rid of the allergen
+	var/cooldown_duration = 20 SECONDS 
+	/// Wether the person is experiencing anaphylatic shock or not
+	var/anaphylaxis = FALSE
+	/// How long anaphylactic shock lasts
+	var/shock_duration = 15 SECONDS
 
 /datum/quirk/allergic/check_quirk(datum/preferences/prefs)
 	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
-	species_type = new species_type()
-	var/disallowed_trait = (TRAIT_MEDICALIGNORE in species_type.inherent_traits)
-	qdel(species_type)
+	var/disallowed_trait = !(initial(species_type.inherent_biotypes) & MOB_ORGANIC)
 
 	if(disallowed_trait)
-		return "You don't benefit from the use of medicine."
-	return ..()
+		return "You don't process normal chemicals!"
+	return FALSE
 
 /datum/quirk/allergic/on_spawn()
 	reagent_id = pick(allergy_chem_list)
@@ -718,20 +736,47 @@
 
 /datum/quirk/allergic/on_process()
 	var/mob/living/carbon/H = quirk_holder
+
+	if(H.stat == DEAD)
+		return
+
 	var/datum/reagent/allergy = GLOB.chemical_reagents_list[reagent_id]
-	if(cooldown == FALSE && H.reagents.has_reagent(reagent_id))
-		to_chat(quirk_holder, span_danger("You forgot you were allergic to [allergy.name]!"))
-		H.reagents.add_reagent(/datum/reagent/toxin/histamine, rand(5,10))
-		cooldown = TRUE
-		addtimer(VARSET_CALLBACK(src, cooldown, FALSE), cooldown_time)
 
-/datum/quirk/allergic/check_quirk(datum/preferences/prefs)
-	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
-	var/disallowed_trait = !(initial(species_type.inherent_biotypes) & MOB_ORGANIC)
+	if(H.reagents.has_reagent(reagent_id)) //check if there are chems
+		if(COOLDOWN_FINISHED(src, allergies)) //if it wasn't ongoing, give a prompt
+			to_chat(quirk_holder, span_userdanger("You forgot you were allergic to [allergy.name]!"))
+		COOLDOWN_START(src, allergies, cooldown_duration) //start it, or refresh the ongoing
 
-	if(disallowed_trait)
-		return "You don't process normal chemicals!"
-	return FALSE
+	if(!COOLDOWN_FINISHED(src, allergies)) //if the cooldown is going
+		M.adjustToxLoss(1, TRUE, TRUE)
+
+		//external indicator that it's happening
+		if(anaphylaxis) //always choking
+			M.emote("choke")
+			M.losebreath += 5
+			return //don't do any of the regular stuff
+
+
+		if(prob(60)) 
+			switch(rand(0, 2))
+				if(0)
+					M.emote("cough")
+				if(1)
+					M.emote("sneeze")
+				if(2)
+					M.emote("choke")
+
+		switch(rand(0, 10)) //negative effect
+			if(0 to 5)
+				to_chat(M, span_danger("Your eyes swell up and you can barely see!"))
+				M.adjust_eye_blur(3)
+			if(6 to 9) //nice
+				to_chat(M, span_danger("You scratch at an itch."))
+				M.adjustBruteLoss(4*REM, 0)
+			if(10)
+				to_chat(M, span_userdanger("You go into anaphylactic shock!"))
+				anaphylaxis = TRUE
+				addtimer(VARSET_CALLBACK(src, anaphylaxis, FALSE), cooldown_duration)
 
 /datum/quirk/kleptomaniac
 	name = "Kleptomaniac"


### PR DESCRIPTION
No longer relies on histamine to do it's effect, meaning you can't just charcoal away an allergic reaction
adds a chance to go into anaphlyactic shock, which makes you rapidly lose breath, prevents speaking, and does stamina damage

also adds a few more chemicals to allergic reaction

# Why is this good for the game?
makes the quirk not an almost free 2 points
could realistically make it give 3 points now

# Testing
![image](https://github.com/user-attachments/assets/b50d9af9-e4b2-4a8f-a743-59f7e6447af3)
![image](https://github.com/user-attachments/assets/f36cd762-a006-4bc9-b925-8530bfe8f707)


:cl:  
tweak: adds more chemicals that allergic reaction quirk can pick
tweak: makes the allergic reaction quirk actually have a noticeable downside
/:cl:
