### PR TITLE
Changes admin perms for spawning and removing liquids

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -23,7 +23,8 @@ GLOBAL_PROTECT(admin_verbs_default)
 	/client/proc/clear_all_pipenets,
 	/client/proc/debugstatpanel,
 	/client/proc/clear_mfa,
-	/client/proc/show_rights
+	/client/proc/show_rights,
+	/client/proc/remove_liquid
 	)
 GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())
 GLOBAL_PROTECT(admin_verbs_admin)
@@ -132,9 +133,7 @@ GLOBAL_LIST_INIT(admin_verbs_fun, list(
 	/client/proc/admin_away,
 	/client/proc/centcom_podlauncher,/*Open a window to launch a Supplypod and configure it or it's contents*/
 	/client/proc/load_json_admin_event,
-	/client/proc/event_role_manager,
-	/client/proc/spawn_liquid,
-	/client/proc/remove_liquid
+	/client/proc/event_role_manager
 	))
 GLOBAL_PROTECT(admin_verbs_fun)
 GLOBAL_LIST_INIT(admin_verbs_spawn, list(/datum/admins/proc/spawn_atom, /datum/admins/proc/podspawn_atom, /datum/admins/proc/spawn_cargo, /datum/admins/proc/spawn_objasmob, /client/proc/respawn_character, /datum/admins/proc/beaker_panel))
@@ -257,7 +256,8 @@ GLOBAL_LIST_INIT(admin_verbs_hideable, list(
 	/client/proc/cmd_display_del_log,
 	/client/proc/toggle_combo_hud,
 	/client/proc/debug_huds,
-	/client/proc/admincryo
+	/client/proc/admincryo,
+	/client/proc/spawn_liquid
 	))
 GLOBAL_PROTECT(admin_verbs_hideable)
 


### PR DESCRIPTION
Both were under "fun" perms
Moves remove liquids to default admin perms, just like fix air
Moves spawn liquids to regular admin perms, like drop bomb

# Why is this good for the game?
being able to spawn or remove liquids should probably be available to maintainers
as liquids are a pretty big system that could end up bugging

# Testing
no need

# Changelog

nothing player facing

:cl:
/:cl:
