### PR TITLE
Fixes jungleland structures being vulnerable to the acid they spawn on

### DIFF
--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -375,7 +375,7 @@
 	icon_state = "basalt"
 	desc = "A volcanic rock. Pioneers used to ride these babies for miles."
 	icon = 'icons/obj/flora/rocks.dmi'
-	resistance_flags = FIRE_PROOF
+	resistance_flags = FIRE_PROOF | UNACIDABLE
 	density = TRUE
 	var/obj/item/stack/mineResult = /obj/item/stack/ore/glass/basalt
 

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -375,7 +375,7 @@
 	icon_state = "basalt"
 	desc = "A volcanic rock. Pioneers used to ride these babies for miles."
 	icon = 'icons/obj/flora/rocks.dmi'
-	resistance_flags = FIRE_PROOF | UNACIDABLE
+	resistance_flags = parent_type::resistance_flags | UNACIDABLE
 	density = TRUE
 	var/obj/item/stack/mineResult = /obj/item/stack/ore/glass/basalt
 

--- a/yogstation/code/modules/jungleland/jungle_structures.dm
+++ b/yogstation/code/modules/jungleland/jungle_structures.dm
@@ -212,6 +212,7 @@
 	icon = 'yogstation/icons/obj/jungle.dmi'
 	anchored = TRUE
 	density = FALSE
+	resistance_flags = FLAMMABLE | UNACIDABLE
 
 	var/picked_result
 	var/picked_amt


### PR DESCRIPTION
rocks overwrote the parent's flag
herbs never had the flag in the first place

# Testing
just a flag change, i can test if needed

:cl:
bugfix: Fixes jungleland structures being vulnerable to the acid they spawn on
/:cl:
