### PR TITLE
Nuclear fallout now triggers gamma alert level when it starts

### DIFF
--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -987,10 +987,9 @@
 
 /datum/weather/nuclear_fallout/telegraph()
 	..()
+	if(SSsecurity_level.get_current_level_as_number() < SEC_LEVEL_GAMMA)//if for some reason, it's already gamma, don't bother making it gamma
+		SSsecurity_level.set_level(SEC_LEVEL_GAMMA) //gamma is cool and good (also lets people powergame to save their lives)
 	status_alarm(TRUE)
-	if(SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_GAMMA)//if for some reason, it's already gamma, don't bother making it gamma
-		return
-	SSsecurity_level.set_level(SEC_LEVEL_GAMMA) //gamma is cool and good (also lets people powergame to save their lives)
 
 /datum/weather/nuclear_fallout/proc/status_alarm(active)	//Makes the status displays show the radiation warning for those who missed the announcement.
 	var/datum/radio_frequency/frequency = SSradio.return_frequency(FREQ_STATUS_DISPLAYS)

--- a/code/modules/power/reactor/reactor.dm
+++ b/code/modules/power/reactor/reactor.dm
@@ -988,6 +988,9 @@
 /datum/weather/nuclear_fallout/telegraph()
 	..()
 	status_alarm(TRUE)
+	if(SSsecurity_level.get_current_level_as_number() >= SEC_LEVEL_GAMMA)//if for some reason, it's already gamma, don't bother making it gamma
+		return
+	SSsecurity_level.set_level(SEC_LEVEL_GAMMA) //gamma is cool and good (also lets people powergame to save their lives)
 
 /datum/weather/nuclear_fallout/proc/status_alarm(active)	//Makes the status displays show the radiation warning for those who missed the announcement.
 	var/datum/radio_frequency/frequency = SSradio.return_frequency(FREQ_STATUS_DISPLAYS)


### PR DESCRIPTION
# Why is this good for the game?
unless you're rad immune, you're gonna die to nuclear fallout
making it gamma gives you a brief time to powergame in whatever way you want in order to try and save yourself

# Testing
![image](https://github.com/user-attachments/assets/03a71360-2de1-4c34-a706-de532a7adc65)

:cl:
tweak: Nuclear fallout now triggers gamma alert level when it starts
/:cl:
