### PR TITLE
Buffs radscrub

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1125,6 +1125,8 @@
 	if(!amount || (amount < RAD_MOB_SKIN_PROTECTION) || HAS_TRAIT(src, TRAIT_RADIMMUNE))
 		return
 
+	amount *= rad_insulation
+
 	amount -= RAD_BACKGROUND_RADIATION // This will always be at least 1 because of how skin protection is calculated
 
 	var/blocked = getarmor(null, RAD)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1828,7 +1828,7 @@
 	self_consuming = TRUE
 	/// Holds the old rad insulation that the mob had
 	var/old_insulation = RAD_NO_INSULATION
-	/// The insulation amount that this medicine provides
+	/// The insulation amount that this medicine provides to objects
 	var/insulation_provided = RAD_MEDIUM_INSULATION
 
 /datum/reagent/medicine/radscrub/reaction_mob(mob/living/M, methods=TOUCH, reac_volume, show_message = TRUE, permeability = 1)
@@ -1843,11 +1843,10 @@
 	..()
 	//store the person's original insulation so they're only extra protected while it's in their system
 	old_insulation = L.rad_insulation
-	if(insulation_provided > L.rad_insulation)
-		L.rad_insulation = insulation_provided
+	L.rad_insulation -= old_insulation //this reduces rad insulation to 0 (immunity)
 
 /datum/reagent/medicine/radscrub/on_mob_end_metabolize(mob/living/L)
-	L.rad_insulation = old_insulation
+	L.rad_insulation += old_insulation
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
 		C.vomit(stun = FALSE) //it binds with the radioactive particles inside you, and they have to come out somehow

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1824,9 +1824,12 @@
 	name = "Rad Scrub Plus"
 	description = "Are your chairs, tables, bottles and assitants glowing green? Spray em down Donk Co's new patented cleaner, Rad Scrub Plus! WARNING: SWALLOWING OR INGESTING RAD SCRUB PLUS MAY RESULT NAUSUA, POISONING, OR MESOTHELIOMA"
 	color = "#9f5a2f"
-	var/old_insulation = RAD_NO_INSULATION
 	taste_description = "metallic dust"
 	self_consuming = TRUE
+	/// Holds the old rad insulation that the mob had
+	var/old_insulation = RAD_NO_INSULATION
+	/// The insulation amount that this medicine provides
+	var/insulation_provided = RAD_MEDIUM_INSULATION
 
 /datum/reagent/medicine/radscrub/reaction_mob(mob/living/M, methods=TOUCH, reac_volume, show_message = TRUE, permeability = 1)
 	if(methods & (TOUCH|VAPOR))
@@ -1840,7 +1843,8 @@
 	..()
 	//store the person's original insulation so they're only extra protected while it's in their system
 	old_insulation = L.rad_insulation
-	L.rad_insulation = RAD_LIGHT_INSULATION
+	if(insulation_provided > L.rad_insulation)
+		L.rad_insulation = insulation_provided
 
 /datum/reagent/medicine/radscrub/on_mob_end_metabolize(mob/living/L)
 	L.rad_insulation = old_insulation
@@ -1854,9 +1858,16 @@
 	var/datum/component/radioactive/radiation = O.GetComponent(/datum/component/radioactive)
 	if(radiation)
 		radiation.strength -= max(0, reac_volume * (RAD_BACKGROUND_RADIATION * 5))
+
 	O.wash(CLEAN_RAD | CLEAN_TYPE_WEAK)
-	if(O.rad_insulation < RAD_LIGHT_INSULATION)
-		O.rad_insulation = RAD_LIGHT_INSULATION
+	if(O.rad_insulation < insulation_provided)
+		O.rad_insulation = insulation_provided
+
+	for(var/obj/thing in O.get_all_contents()) //also clean any contents stored within
+		thing.wash(CLEAN_RAD | CLEAN_TYPE_WEAK)
+		if(thing.rad_insulation < insulation_provided)
+			thing.rad_insulation = insulation_provided
+
 
 #undef PERF_BASE_DAMAGE
 #undef REQUIRED_STRANGE_REAGENT_FOR_REVIVAL


### PR DESCRIPTION
# Why is this good for the game?
Radiation is pretty difficult to combat, radscrub was coded specifically to deal with the aftermath of radiation, and prevent/reduce future radiation
It rarely if ever gets made because it simply wasn't strong enough

Also makes it's mob radiation preventative measures good enough to actually be worth using, it already caused toxin damage over time, might as well make the upside actually worth it

# Testing
gotta

:cl:
tweak: Radscrub now provides slightly more rad insulation
tweak: Radscrub now also scrubs items inside of others (think backpacks)
tweak: Radscrub now provides temporary radiation immunity to mobs that consume it
/:cl:
