### PR TITLE
Makes defib wall mount standard on all stations

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -46295,6 +46295,19 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"nzB" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/stasis{
+	dir = 4
+	},
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = 0;
+	pixel_y = -31
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/sleeper)
 "nzK" = (
 /obj/machinery/ai/networking{
 	label = "Subcontroller";
@@ -64932,15 +64945,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"tcY" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/stasis{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
 "tdc" = (
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 5
@@ -108337,7 +108341,7 @@ rWu
 brj
 ppp
 uYv
-tcY
+nzB
 wOY
 dmS
 ugr

--- a/_maps/map_files/DonutStation/DonutStation.dmm
+++ b/_maps/map_files/DonutStation/DonutStation.dmm
@@ -3426,9 +3426,9 @@
 /area/space/nearstation)
 "bnJ" = (
 /obj/machinery/conveyor{
+	dir = 5;
 	id = "garbage";
-	name = " recycler conveyor belt";
-	dir = 5
+	name = " recycler conveyor belt"
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
@@ -7889,9 +7889,9 @@
 	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/door/window/brigdoor/security/cell{
+	dir = 8;
 	id = "Cell 2";
-	name = "Cell 2";
-	dir = 8
+	name = "Cell 2"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -9457,9 +9457,9 @@
 	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/door/window/brigdoor/security/cell{
+	dir = 8;
 	id = "Cell 3";
-	name = "Cell 3";
-	dir = 8
+	name = "Cell 3"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -12305,7 +12305,9 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 23
+	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "eVV" = (
@@ -24130,9 +24132,9 @@
 /area/maintenance/fore)
 "jYA" = (
 /obj/machinery/conveyor{
+	dir = 4;
 	id = "garbage";
-	name = " recycler conveyor belt";
-	dir = 4
+	name = " recycler conveyor belt"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -28282,8 +28284,8 @@
 /obj/structure/table/wood,
 /obj/item/taperecorder,
 /obj/item/storage/secure/safe{
-	pixel_y = -28;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = -28
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
@@ -34085,9 +34087,9 @@
 "oeo" = (
 /obj/machinery/recycler,
 /obj/machinery/conveyor{
+	dir = 4;
 	id = "garbage";
-	name = " recycler conveyor belt";
-	dir = 4
+	name = " recycler conveyor belt"
 	},
 /turf/open/floor/plasteel/burnt,
 /area/maintenance/disposal)
@@ -36442,8 +36444,8 @@
 	layer = 2.9
 	},
 /obj/machinery/door/window/eastleft{
-	name = "Mail";
-	dir = 2
+	dir = 2;
+	name = "Mail"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -39928,9 +39930,9 @@
 /area/maintenance/port)
 "qBV" = (
 /obj/machinery/conveyor{
+	dir = 6;
 	id = "garbage";
-	name = " recycler conveyor belt";
-	dir = 6
+	name = " recycler conveyor belt"
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -46187,6 +46189,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"tmr" = (
+/obj/machinery/stasis{
+	dir = 4
+	},
+/obj/structure/window{
+	dir = 8
+	},
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/sleeper)
 "tmx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -50139,15 +50153,6 @@
 "uRy" = (
 /turf/open/floor/carpet/black,
 /area/crew_quarters/bar)
-"uRH" = (
-/obj/machinery/stasis{
-	dir = 4
-	},
-/obj/structure/window{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
 "uSS" = (
 /obj/effect/landmark/stationroom/maint/tenxten,
 /turf/template_noop,
@@ -50427,7 +50432,9 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 23
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "uXD" = (
@@ -50577,9 +50584,9 @@
 	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/door/window/brigdoor/security/cell{
+	dir = 8;
 	id = "Cell 1";
-	name = "Cell 1";
-	dir = 8
+	name = "Cell 1"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -83288,7 +83295,7 @@ pev
 gQw
 gAQ
 dAp
-uRH
+tmr
 uhX
 pMJ
 fJI

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -3009,6 +3009,15 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"bxF" = (
+/obj/machinery/stasis{
+	dir = 8
+	},
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/sleeper)
 "bxI" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -16024,8 +16033,8 @@
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/airalarm{
-	pixel_y = -24;
-	dir = 1
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -34526,8 +34535,8 @@
 	id = "chapelgun";
 	name = "Mass Driver Controller";
 	pixel_x = -24;
-	req_access = list("chapel_office");
-	pixel_y = -4
+	pixel_y = -4;
+	req_access = list("chapel_office")
 	},
 /turf/open/floor/plating,
 /area/chapel/office)
@@ -41089,12 +41098,6 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
-"tTF" = (
-/obj/machinery/stasis{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
 "tTT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -80528,7 +80531,7 @@ dog
 cqi
 gLV
 nXR
-tTF
+bxF
 klA
 gcJ
 rjs

--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -10499,6 +10499,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science/research)
+"ddW" = (
+/obj/machinery/stasis{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_x = -31;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/sleeper)
 "deg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer2{
 	dir = 8
@@ -13455,7 +13468,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -25
+	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "dWi" = (
@@ -14174,8 +14189,8 @@
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_y = -25;
-	specialfunctions = 4;
-	req_access = list("brig")
+	req_access = list("brig");
+	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -14790,8 +14805,8 @@
 	name = "Cell Window Control";
 	pixel_x = -5;
 	pixel_y = -3;
-	specialfunctions = 4;
-	req_access = list("brig")
+	req_access = list("brig");
+	specialfunctions = 4
 	},
 /obj/machinery/button/door{
 	id = "briglockdown";
@@ -23712,8 +23727,8 @@
 	name = "Cell Window Control";
 	pixel_x = 5;
 	pixel_y = 27;
-	specialfunctions = 4;
-	req_access = list("security")
+	req_access = list("security");
+	specialfunctions = 4
 	},
 /obj/machinery/button/door{
 	id = "briglockdown";
@@ -44536,10 +44551,10 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/button/door{
 	id = "Podbaydoor";
+	name = "Shipbreaking External Control";
 	pixel_x = 24;
 	pixel_y = -1;
-	req_access = list("external_airlocks");
-	name = "Shipbreaking External Control"
+	req_access = list("external_airlocks")
 	},
 /turf/open/floor/plasteel/dark,
 /area/escapepodbay)
@@ -57044,8 +57059,8 @@
 /area/hallway/primary/fore)
 "quD" = (
 /obj/machinery/firealarm{
-	pixel_y = 38;
-	dir = 1
+	dir = 1;
+	pixel_y = 38
 	},
 /obj/machinery/computer/ai_server_console,
 /turf/open/floor/plasteel/grimy,
@@ -62654,7 +62669,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "san" = (
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/airalarm/directional/west{
+	pixel_x = -24
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -62933,10 +62950,10 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/button/door{
 	id = "Podbaydoor";
+	name = "Shipbreaking External Control";
 	pixel_x = -24;
 	pixel_y = -1;
-	req_access = list("external_airlocks");
-	name = "Shipbreaking External Control"
+	req_access = list("external_airlocks")
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel,
@@ -76295,15 +76312,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"vQu" = (
-/obj/machinery/stasis{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
 "vQC" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/turf_decal/stripes/line{
@@ -238082,7 +238090,7 @@ qGE
 kQb
 npj
 lMl
-vQu
+ddW
 lMl
 jxS
 saz

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -46642,19 +46642,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hydroponics/garden)
-"nQi" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/stasis{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay Treatment Center";
-	network = list("ss13","medbay")
-	},
-/turf/open/floor/plasteel/dark,
-/area/medical/sleeper)
 "nQl" = (
 /turf/template_noop,
 /area/science/test_area)
@@ -49384,6 +49371,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"oPu" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/stasis{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Medbay Treatment Center";
+	network = list("ss13","medbay")
+	},
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel/dark,
+/area/medical/sleeper)
 "oPJ" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/cafeteria,
@@ -112047,7 +112050,7 @@ lKd
 kub
 pDs
 bvj
-nQi
+oPu
 sha
 bDR
 lXo

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -63,7 +63,6 @@
 	new /obj/item/door_remote/chief_medical_officer(src)
 	new /obj/item/clothing/neck/petcollar(src)
 	new /obj/item/pet_carrier(src)
-	new /obj/item/wallframe/defib_mount(src)
 	new /obj/item/circuitboard/machine/techfab/department/medical(src)
 	new /obj/item/storage/photo_album/CMO(src)
 	new /obj/item/clipboard/yog/paperwork/cmo(src)


### PR DESCRIPTION
# Document the changes in your pull request

Makes the defib mount standard in all station medbays, no longer requiring a CMO to take the one out of their locker to do it.
Removes the mount from the CMO locker for balance.

# Why is this good for the game?

Lack of Heads of Staff at round start make it inconsistent. Would prefer stuff that gets done every round to just be standard.

# Testing
Mount gone from locker
![image](https://github.com/user-attachments/assets/ddc09440-2f9f-43d2-8459-5c591ce90e61)

Box
![image](https://github.com/user-attachments/assets/85b4911c-6df9-45ed-8b4b-671ed18ba999)

Meta
![image](https://github.com/user-attachments/assets/7c8fe97f-8705-45c3-9930-36edf899b1e9)

Gax
![image](https://github.com/user-attachments/assets/9fa4eddc-1298-4c6c-ad4a-dc24d46c0e8a)

Asteroid
![image](https://github.com/user-attachments/assets/0214f709-001c-45eb-b3d4-c26668f0a0a3)

Donut
![image](https://github.com/user-attachments/assets/48315041-b7ae-410f-8cfb-0b037085a079)


# Changelog

:cl:
rscadd: Put a loaded defib mount on all standard stations: Box, Meta, Gax, Asteroid, Donut
rscdel: Removed defib mount from CMO locker
/:cl:
