### PR TITLE
Fixes bug that allowed non-carbons to strip carbons

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -368,7 +368,7 @@
 	if (.)
 		return
 
-	if (!iscarbon(usr))
+	if (!iscarbon(usr) && !iscyborg(usr))
 		to_chat(usr, span_warning("You don't have the dexterity to do this!"))
 		return
 

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -368,6 +368,10 @@
 	if (.)
 		return
 
+	if (!iscarbon(usr))
+		to_chat(usr, span_warning("You don't have the dexterity to do this!"))
+		return
+
 	. = TRUE
 
 	var/mob/user = usr


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Added carbon check & cyborg check to ui_act

Non carbons can still see the menu, but not interact with it

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
bugfix: Fixed non-carbons stripping humans
/:cl:
