### PR TITLE
Fixes quiet mode toggle being available to non-donators

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/legacy_yog_toggles.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/legacy_yog_toggles.tsx
@@ -1,6 +1,7 @@
-import { FeatureToggle, CheckboxInput } from "../base";
+import { FeatureToggle, CheckboxInput, FeatureValueProps } from "../base";
 import { BooleanLike } from "common/react";
 import { useBackend } from "../../../../../backend";
+import { PreferencesMenuData } from "../../../data";
 
 export const quiet_mode: FeatureToggle = {
   name: "Quiet mode",

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/legacy_yog_toggles.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/legacy_yog_toggles.tsx
@@ -1,10 +1,22 @@
 import { FeatureToggle, CheckboxInput } from "../base";
+import { BooleanLike } from "common/react";
+import { useBackend } from "../../../../../backend";
 
 export const quiet_mode: FeatureToggle = {
   name: "Quiet mode",
   category: "DONATOR",
   description: "You cannot be chosen as an antagonist or antagonist target.",
-  component: CheckboxInput,
+  component: (
+    props: FeatureValueProps<BooleanLike, boolean>,
+    context,
+  ) => {
+    const { data } = useBackend<PreferencesMenuData>(context);
+
+    return (<CheckboxInput
+      {...props}
+      disabled={(data.content_unlocked & 2) === 0}
+    />);
+  },
 };
 
 export const pref_mood: FeatureToggle = {


### PR DESCRIPTION
# Document the changes in your pull request

It didnt actually work (because I made it force itself off every roundstart for non-donators) but it's been "available" since the preferences PR because we couldn't figure out how to disable it

# Why is this good for the game?
It will be less confusing for non-donators having a random donator option available

# Testing
![image](https://github.com/user-attachments/assets/b0ccee12-f03e-4474-8978-4e1621224cfe)

# Changelog

:cl:
bugfix: Fixes oversight where non-donators have access to the quiet mode toggle
/:cl:
