### PR TITLE
Fixes the spawn liquid admin verb being invisible

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -24,7 +24,8 @@ GLOBAL_PROTECT(admin_verbs_default)
 	/client/proc/debugstatpanel,
 	/client/proc/clear_mfa,
 	/client/proc/show_rights,
-	/client/proc/remove_liquid
+	/client/proc/remove_liquid,
+	/client/proc/spawn_liquid
 	)
 GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())
 GLOBAL_PROTECT(admin_verbs_admin)
@@ -256,8 +257,7 @@ GLOBAL_LIST_INIT(admin_verbs_hideable, list(
 	/client/proc/cmd_display_del_log,
 	/client/proc/toggle_combo_hud,
 	/client/proc/debug_huds,
-	/client/proc/admincryo,
-	/client/proc/spawn_liquid
+	/client/proc/admincryo
 	))
 GLOBAL_PROTECT(admin_verbs_hideable)
 


### PR DESCRIPTION
apparently that list just makes verbs hideable, not that it provides them in the first place

# Testing
probably should? but i mean it's right next to remove liquid which did appear, so it's probably fine?

nothing player facing

:cl:
/:cl:
