### PR TITLE
Adds a graph to the supermatter monitor

### DIFF
--- a/code/modules/modular_computers/file_system/programs/engineering/sm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/sm_monitor.dm
@@ -128,11 +128,14 @@
 		if(!air)
 			active = null
 			return
-		if(active.corruptor_attached)
-			data_corrupted = TRUE
 
 		data["active"] = TRUE
-		if(data_corrupted) //yes it goes negative, that's even more funny
+		data["powerData"] = active.powerData
+		data["radsData"] = active.radsData
+		data["tempData"] = active.tempData
+		data["kpaData"] = active.kpaData
+		data["molesData"] = active.molesData
+		if(active.corruptor_attached) //yes it goes negative, that's even more funny
 			data["SM_integrity"] = active.get_fake_integrity()
 			data["SM_power"] = active.power + round((rand()-0.5)*12000,1) 
 			data["SM_radiation"] = active.last_rads + round((rand()-0.5)*12000,1) 

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -219,6 +219,13 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	var/damage_mod = 1
 	var/heal_mod = 1
 
+	//Data, because graphs are cool
+	var/list/powerData = list()
+	var/list/radsData = list()
+	var/list/tempData = list()
+	var/list/kpaData = list()
+	var/list/molesData = list()
+
 /obj/machinery/power/supermatter_crystal/Initialize(mapload)
 	. = ..()
 	uid = gl_uid++
@@ -789,6 +796,24 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 				damage += DAMAGE_HARDCAP * explosion_point //Can't cheat by spacing the crystal to buy time, it will just delaminate faster
 			if(prob(2))
 				empulse(src, 10-support_integrity) //EMPs must always be spewing every so often to ensure that containment is guaranteed to fail.
+	
+	// I FUCKING LOVE DATA!!!!!!
+	powerData += power
+	if(powerData.len > 100)
+		powerData.Cut(1, 2)
+	radsData += last_rads
+	if(radsData.len > 100)
+		radsData.Cut(1, 2)
+	tempData += env.return_temperature()
+	if(tempData.len > 100)
+		tempData.Cut(1, 2)
+	kpaData += env.return_pressure()
+	if(kpaData.len > 100)
+		kpaData.Cut(1, 2)
+	molesData += env.total_moles()
+	if(molesData.len > 100)
+		molesData.Cut(1, 2)
+
 	return 1
 
 /obj/machinery/power/supermatter_crystal/bullet_act(obj/projectile/Proj)

--- a/tgui/packages/tgui/interfaces/NtosSupermatterMonitor.js
+++ b/tgui/packages/tgui/interfaces/NtosSupermatterMonitor.js
@@ -2,7 +2,7 @@ import { sortBy } from 'common/collections';
 import { flow } from 'common/fp';
 import { toFixed } from 'common/math';
 import { useBackend } from '../backend';
-import { Button, LabeledList, ProgressBar, Section, Stack, Table } from '../components';
+import { Button, Chart, LabeledList, ProgressBar, Section, Stack, Table } from '../components';
 import { NtosWindow } from '../layouts';
 
 const logScale = value => Math.log2(16 + Math.max(0, value)) - 4;
@@ -11,7 +11,7 @@ export const NtosSupermatterMonitor = (props, context) => {
   return (
     <NtosWindow
       width={600}
-      height={350}
+      height={500}
       resizable>
       <NtosWindow.Content scrollable>
         <NtosSupermatterMonitorContent />
@@ -42,122 +42,173 @@ export const NtosSupermatterMonitorContent = (props, context) => {
   ])(data.gases || []);
   const gasMaxAmount = Math.max(1, ...gases.map(gas => gas.amount));
   return (
-    <Stack>
-      <Stack.Item width="270px">
-        <Section title="Metrics">
-          <LabeledList>
-            <LabeledList.Item label="Integrity">
-              <ProgressBar
-                value={SM_integrity / 100}
-                ranges={{
-                  good: [0.90, Infinity],
-                  average: [0.5, 0.90],
-                  bad: [-Infinity, 0.5],
-                }} />
-            </LabeledList.Item>
-            <LabeledList.Item label="Relative EER">
-              <ProgressBar
-                value={SM_power}
-                minValue={0}
-                maxValue={5000}
-                ranges={{
-                  good: [-Infinity, 5000],
-                  average: [5000, 7000],
-                  bad: [7000, Infinity],
-                }}>
-                {toFixed(SM_power) + ' MeV/cm3'}
-              </ProgressBar>
-            </LabeledList.Item>
-            <LabeledList.Item label="Radiation">
-              <ProgressBar
-                value={SM_radiation}
-                minValue={0}
-                maxValue={7000}
-                ranges={{
-                  // The threshold where enough radiation gets to the
-                  // collectors to start generating power. Experimentally
-                  // determined, because radiation waves are inscrutable.
-                  grey: [-Infinity, 320],
-                  good: [320, 5000],
-                  average: [5000, 7000],
-                  bad: [7000, Infinity],
-                }}>
-                {toFixed(SM_radiation) + ' Sv/h'}
-              </ProgressBar>
-            </LabeledList.Item>
-            <LabeledList.Item label="Temperature">
-              <ProgressBar
-                value={logScale(SM_ambienttemp)}
-                minValue={0}
-                maxValue={logScale(10000)}
-                ranges={{
-                  teal: [-Infinity, logScale(80)],
-                  good: [logScale(80), logScale(373)],
-                  average: [logScale(373), logScale(1000)],
-                  bad: [logScale(1000), Infinity],
-                }}>
-                {toFixed(SM_ambienttemp) + ' K'}
-              </ProgressBar>
-            </LabeledList.Item>
-            <LabeledList.Item label="Pressure">
-              <ProgressBar
-                value={logScale(SM_ambientpressure)}
-                minValue={0}
-                maxValue={logScale(50000)}
-                ranges={{
-                  good: [logScale(1), logScale(300)],
-                  average: [-Infinity, logScale(1000)],
-                  bad: [logScale(1000), +Infinity],
-                }}>
-                {toFixed(SM_ambientpressure) + ' kPa'}
-              </ProgressBar>
-            </LabeledList.Item>
-            <LabeledList.Item label="Total Moles">
-              <ProgressBar
-                value={logScale(SM_moles)}
-                minValue={0}
-                maxValue={logScale(50000)}
-                ranges={{
-                  good: [-Infinity, logScale(1800 * 0.75)],
-                  average: [
-                    logScale(1800 * 0.75),
-                    logScale(1800),
-                  ],
-                  bad: [logScale(1800), Infinity],
-                }}>
-                {toFixed(SM_moles) + ' moles'}
-              </ProgressBar>
-            </LabeledList.Item>
-          </LabeledList>
-        </Section>
-      </Stack.Item>
-      <Stack.Item grow={1} basis={0}>
-        <Section
-          title="Gases"
-          buttons={(
-            <Button
-              icon="arrow-left"
-              content="Back"
-              onClick={() => act('PRG_clear')} />
-          )}>
-          <LabeledList>
-            {gases.map(gas => (
-              <LabeledList.Item
-                key={gas.name}
-                label={gas.name}>
+    <>
+      <Stack>
+        <Stack.Item width="270px">
+          <Section title="Metrics">
+            <LabeledList>
+              <LabeledList.Item label="Integrity">
                 <ProgressBar
-                  value={gas.amount}
-                  color={gas.ui_color}
+                  value={SM_integrity / 100}
+                  ranges={{
+                    good: [0.90, Infinity],
+                    average: [0.5, 0.90],
+                    bad: [-Infinity, 0.5],
+                  }} />
+              </LabeledList.Item>
+              <LabeledList.Item label="Relative EER" labelColor="yellow">
+                <ProgressBar
+                  value={SM_power}
                   minValue={0}
-                  maxValue={gasMaxAmount}>
-                  {toFixed(gas.amount, 2) + '%'}
+                  maxValue={5000}
+                  ranges={{
+                    good: [-Infinity, 5000],
+                    average: [5000, 7000],
+                    bad: [7000, Infinity],
+                  }}>
+                  {toFixed(SM_power) + ' MeV/cm3'}
                 </ProgressBar>
               </LabeledList.Item>
-            ))}
-          </LabeledList>
-        </Section>
-      </Stack.Item>
-    </Stack>
+              <LabeledList.Item label="Radiation" labelColor="green">
+                <ProgressBar
+                  value={SM_radiation}
+                  minValue={0}
+                  maxValue={7000}
+                  ranges={{
+                    // The threshold where enough radiation gets to the
+                    // collectors to start generating power. Experimentally
+                    // determined, because radiation waves are inscrutable.
+                    grey: [-Infinity, 320],
+                    good: [320, 5000],
+                    average: [5000, 7000],
+                    bad: [7000, Infinity],
+                  }}>
+                  {toFixed(SM_radiation) + ' Sv/h'}
+                </ProgressBar>
+              </LabeledList.Item>
+              <LabeledList.Item label="Temperature" labelColor="red">
+                <ProgressBar
+                  value={logScale(SM_ambienttemp)}
+                  minValue={0}
+                  maxValue={logScale(10000)}
+                  ranges={{
+                    teal: [-Infinity, logScale(80)],
+                    good: [logScale(80), logScale(373)],
+                    average: [logScale(373), logScale(1000)],
+                    bad: [logScale(1000), Infinity],
+                  }}>
+                  {toFixed(SM_ambienttemp) + ' K'}
+                </ProgressBar>
+              </LabeledList.Item>
+              <LabeledList.Item label="Pressure" labelColor="white">
+                <ProgressBar
+                  value={logScale(SM_ambientpressure)}
+                  minValue={0}
+                  maxValue={logScale(50000)}
+                  ranges={{
+                    good: [logScale(1), logScale(300)],
+                    average: [-Infinity, logScale(1000)],
+                    bad: [logScale(1000), +Infinity],
+                  }}>
+                  {toFixed(SM_ambientpressure) + ' kPa'}
+                </ProgressBar>
+              </LabeledList.Item>
+              <LabeledList.Item label="Total Moles" labelColor="purple">
+                <ProgressBar
+                  value={logScale(SM_moles)}
+                  minValue={0}
+                  maxValue={logScale(50000)}
+                  ranges={{
+                    good: [-Infinity, logScale(1800 * 0.75)],
+                    average: [
+                      logScale(1800 * 0.75),
+                      logScale(1800),
+                    ],
+                    bad: [logScale(1800), Infinity],
+                  }}>
+                  {toFixed(SM_moles) + ' moles'}
+                </ProgressBar>
+              </LabeledList.Item>
+            </LabeledList>
+          </Section>
+        </Stack.Item>
+        <Stack.Item grow={1} basis={0}>
+          <Section
+            title="Gases"
+            buttons={(
+              <Button
+                icon="arrow-left"
+                content="Back"
+                onClick={() => act('PRG_clear')} />
+            )}>
+            <LabeledList>
+              {gases.map((gas, index) => (
+                <LabeledList.Item
+                  key={index}
+                  label={gas.name}>
+                  <ProgressBar
+                    value={gas.amount}
+                    color={gas.ui_color}
+                    minValue={0}
+                    maxValue={gasMaxAmount}>
+                    {toFixed(gas.amount, 2) + '%'}
+                  </ProgressBar>
+                </LabeledList.Item>
+              ))}
+            </LabeledList>
+          </Section>
+        </Stack.Item>
+      </Stack>
+      <StatsHistory/>
+    </>
+  );
+};
+
+export const StatsHistory = (props, context) => {
+  const { act, data } = useBackend(context);
+  const powerData = data.powerData.map((value, i) => [i, value]);
+  const radsData = data.radsData.map((value, i) => [i, value]);
+  const tempData = data.tempData.map((value, i) => [i, value]);
+  const kpaData = data.kpaData.map((value, i) => [i, value]);
+  const molesData = data.molesData.map((value, i) => [i, value]);
+  return (
+    <Section fill title="History:" height="200px" mt={1}>
+      <Chart.Line
+        fillPositionedParent
+        data={powerData}
+        rangeX={[0, powerData.length - 1]}
+        rangeY={[0, Math.max(10000, ...data.powerData)]}
+        strokeColor="rgba(255, 215, 0, 1)"
+        fillColor="rgba(255, 215, 0, 0.1)" />
+      <Chart.Line
+        fillPositionedParent
+        data={radsData}
+        rangeX={[0, radsData.length - 1]}
+        rangeY={[0, Math.max(10000, ...data.radsData)]}
+        strokeColor="rgba(0, 255, 0 , 1)"
+        fillColor="rgba(0, 255, 0 , 0.1)" />
+      <Chart.Line
+        fillPositionedParent
+        data={tempData}
+        rangeX={[0, tempData.length - 1]}
+        rangeY={[0, Math.max(10000, ...data.tempData)]}
+        strokeColor="rgba(255, 0, 0 , 1)"
+        fillColor="rgba(255, 0, 0 , 0.1)" />
+      <Chart.Line
+        fillPositionedParent
+        data={kpaData}
+        rangeX={[0, kpaData.length - 1]}
+        rangeY={[0, Math.max(5000, ...data.kpaData)]}
+        strokeColor="rgba(255, 255, 255 , 1)"
+        fillColor="rgba(255, 255, 255 , 0.1)" />
+      <Chart.Line
+        fillPositionedParent
+        data={molesData}
+        rangeX={[0, molesData.length - 1]}
+        rangeY={[0, Math.max(2500, ...data.molesData)]}
+        strokeColor="rgba(255, 0, 255 , 1)"
+        fillColor="rgba(255, 0, 255 , 0.1)" />
+    </Section>
   );
 };
 

--- a/tgui/packages/tgui/interfaces/NtosSupermatterMonitor.js
+++ b/tgui/packages/tgui/interfaces/NtosSupermatterMonitor.js
@@ -159,7 +159,7 @@ export const NtosSupermatterMonitorContent = (props, context) => {
           </Section>
         </Stack.Item>
       </Stack>
-      <StatsHistory/>
+      <StatsHistory />
     </>
   );
 };


### PR DESCRIPTION
Adds additional information for how different properties like temperature and radiation levels change over time. Makes cool patterns during a supermatter surge.

![image](https://github.com/user-attachments/assets/728806f9-9a83-4272-a743-437e96c4067c)


:cl:
tweak: Supermatter monitor now shows a graph of its metrics over time
/:cl:
