### PR TITLE
[All Stations] Removes Access Control for the Shipbreaking Area

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -28513,6 +28513,22 @@
 "ibk" = (
 /turf/open/floor/plating,
 /area/maintenance/central)
+"ibr" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Shipbreaking Bay"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/ramp_middle,
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "ibs" = (
 /obj/structure/chair/sofa/corner{
 	dir = 4
@@ -29406,19 +29422,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"irf" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Shipbreaking External Access"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/turf/open/floor/plating/airless,
-/area/escapepodbay)
 "irh" = (
 /obj/effect/turf_decal/stripes{
 	dir = 8
@@ -30608,23 +30611,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"iKH" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Shipbreaking Bay"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/ramp_middle,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "iKT" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 8
@@ -54249,6 +54235,21 @@
 /obj/structure/dresser,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"pVI" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Shipbreaking External Access"
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "pVK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8
@@ -59987,6 +59988,18 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/captain)
+"rJO" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Shipbreaking External Access"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/escapepodbay)
 "rJT" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -68108,22 +68121,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"uam" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Shipbreaking External Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "uau" = (
 /obj/effect/turf_decal/stripes/white/line,
 /turf/open/floor/plasteel,
@@ -125215,7 +125212,7 @@ sFM
 aXI
 sVl
 msW
-iKH
+ibr
 shY
 shY
 rFs
@@ -127011,7 +127008,7 @@ msb
 msb
 rUZ
 wgX
-uam
+pVI
 wgX
 wgX
 aNY
@@ -127525,7 +127522,7 @@ aES
 aNg
 rUZ
 rUZ
-irf
+rJO
 rUZ
 rUZ
 acb

--- a/_maps/map_files/DonutStation/DonutStation.dmm
+++ b/_maps/map_files/DonutStation/DonutStation.dmm
@@ -3426,9 +3426,9 @@
 /area/space/nearstation)
 "bnJ" = (
 /obj/machinery/conveyor{
+	dir = 5;
 	id = "garbage";
-	name = " recycler conveyor belt";
-	dir = 5
+	name = " recycler conveyor belt"
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
@@ -3444,6 +3444,21 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"bok" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Shipbreaking Bay"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "bom" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -7889,9 +7904,9 @@
 	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/door/window/brigdoor/security/cell{
+	dir = 8;
 	id = "Cell 2";
-	name = "Cell 2";
-	dir = 8
+	name = "Cell 2"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -9457,9 +9472,9 @@
 	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/door/window/brigdoor/security/cell{
+	dir = 8;
 	id = "Cell 3";
-	name = "Cell 3";
-	dir = 8
+	name = "Cell 3"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -12305,7 +12320,9 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 23
+	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "eVV" = (
@@ -18325,22 +18342,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"hAd" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Shipbreaking External Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/turf/open/floor/plating,
-/area/escapepodbay)
 "hAf" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/railing{
@@ -24130,9 +24131,9 @@
 /area/maintenance/fore)
 "jYA" = (
 /obj/machinery/conveyor{
+	dir = 4;
 	id = "garbage";
-	name = " recycler conveyor belt";
-	dir = 4
+	name = " recycler conveyor belt"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -24465,22 +24466,6 @@
 /obj/structure/lattice/catwalk,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
-"kfe" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Shipbreaking Bay"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "kfk" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -28282,8 +28267,8 @@
 /obj/structure/table/wood,
 /obj/item/taperecorder,
 /obj/item/storage/secure/safe{
-	pixel_y = -28;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = -28
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
@@ -34085,9 +34070,9 @@
 "oeo" = (
 /obj/machinery/recycler,
 /obj/machinery/conveyor{
+	dir = 4;
 	id = "garbage";
-	name = " recycler conveyor belt";
-	dir = 4
+	name = " recycler conveyor belt"
 	},
 /turf/open/floor/plasteel/burnt,
 /area/maintenance/disposal)
@@ -36442,8 +36427,8 @@
 	layer = 2.9
 	},
 /obj/machinery/door/window/eastleft{
-	name = "Mail";
-	dir = 2
+	dir = 2;
+	name = "Mail"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -38951,6 +38936,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"qiV" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Shipbreaking External Access"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/escapepodbay)
 "qjj" = (
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/grimy,
@@ -39928,9 +39925,9 @@
 /area/maintenance/port)
 "qBV" = (
 /obj/machinery/conveyor{
+	dir = 6;
 	id = "garbage";
-	name = " recycler conveyor belt";
-	dir = 6
+	name = " recycler conveyor belt"
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -42143,19 +42140,6 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
-"rAN" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Shipbreaking External Access"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/turf/open/floor/plating,
-/area/escapepodbay)
 "rAR" = (
 /obj/structure/railing{
 	dir = 4
@@ -46187,6 +46171,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"tmd" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Shipbreaking External Access"
+	},
+/turf/open/floor/plating,
+/area/escapepodbay)
 "tmx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -50427,7 +50426,9 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/power/apc/auto_name/north,
+/obj/machinery/power/apc/auto_name/north{
+	pixel_y = 23
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "uXD" = (
@@ -50577,9 +50578,9 @@
 	},
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/door/window/brigdoor/security/cell{
+	dir = 8;
 	id = "Cell 1";
-	name = "Cell 1";
-	dir = 8
+	name = "Cell 1"
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -89337,7 +89338,7 @@ fCV
 jMF
 tNO
 psN
-kfe
+bok
 jjC
 hfv
 idJ
@@ -89838,7 +89839,7 @@ xSu
 rch
 rch
 mcq
-hAd
+tmd
 rch
 rch
 mcq
@@ -90346,7 +90347,7 @@ xSu
 xSu
 xSu
 rch
-rAN
+qiV
 rch
 xSu
 ylr

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -14547,24 +14547,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"gNl" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance{
-	name = "Shipbreaking Maintenance"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/ramp_middle,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/turf/open/floor/plating,
-/area/maintenance/department/eva)
 "gNJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -16024,8 +16006,8 @@
 /obj/structure/closet/secure_closet/brig,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/machinery/airalarm{
-	pixel_y = -24;
-	dir = 1
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -16413,22 +16395,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"hFT" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Shipbreaking External Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/turf/open/floor/plating,
-/area/escapepodbay)
 "hGw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22589,19 +22555,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/aft)
-"kMi" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Shipbreaking External Access"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/turf/open/floor/plating,
-/area/escapepodbay)
 "kMo" = (
 /obj/structure/chair/pew/right{
 	dir = 1
@@ -22949,6 +22902,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"kXQ" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Shipbreaking External Access"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/escapepodbay)
 "kYc" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -34526,8 +34491,8 @@
 	id = "chapelgun";
 	name = "Mass Driver Controller";
 	pixel_x = -24;
-	req_access = list("chapel_office");
-	pixel_y = -4
+	pixel_y = -4;
+	req_access = list("chapel_office")
 	},
 /turf/open/floor/plating,
 /area/chapel/office)
@@ -36953,6 +36918,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"rPy" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Shipbreaking External Access"
+	},
+/turf/open/floor/plating,
+/area/escapepodbay)
 "rPz" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 1
@@ -46218,6 +46198,23 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
+"wqX" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	name = "Shipbreaking Maintenance"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/ramp_middle,
+/turf/open/floor/plating,
+/area/maintenance/department/eva)
 "wqZ" = (
 /obj/machinery/light{
 	dir = 1
@@ -95665,7 +95662,7 @@ cBB
 wUI
 jcQ
 myl
-gNl
+wqX
 nwQ
 lSl
 oxf
@@ -97461,7 +97458,7 @@ vRP
 vRP
 iLQ
 iLQ
-hFT
+rPy
 iLQ
 iLQ
 iLQ
@@ -97975,7 +97972,7 @@ vRP
 aCD
 aCD
 eQY
-kMi
+kXQ
 eQY
 aCD
 vRP

--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -13455,7 +13455,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/apc/auto_name/west{
+	pixel_x = -25
+	},
 /turf/open/floor/plasteel,
 /area/engine/engine_smes)
 "dWi" = (
@@ -14174,8 +14176,8 @@
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_y = -25;
-	specialfunctions = 4;
-	req_access = list("brig")
+	req_access = list("brig");
+	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -14790,8 +14792,8 @@
 	name = "Cell Window Control";
 	pixel_x = -5;
 	pixel_y = -3;
-	specialfunctions = 4;
-	req_access = list("brig")
+	req_access = list("brig");
+	specialfunctions = 4
 	},
 /obj/machinery/button/door{
 	id = "briglockdown";
@@ -23712,8 +23714,8 @@
 	name = "Cell Window Control";
 	pixel_x = 5;
 	pixel_y = 27;
-	specialfunctions = 4;
-	req_access = list("security")
+	req_access = list("security");
+	specialfunctions = 4
 	},
 /obj/machinery/button/door{
 	id = "briglockdown";
@@ -37388,35 +37390,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"kQA" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
-	dir = 8
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Shipbreaking Bay"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "kQR" = (
 /obj/structure/table/wood,
 /obj/item/folder,
@@ -44536,10 +44509,10 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/button/door{
 	id = "Podbaydoor";
+	name = "Shipbreaking External Control";
 	pixel_x = 24;
 	pixel_y = -1;
-	req_access = list("external_airlocks");
-	name = "Shipbreaking External Control"
+	req_access = list("external_airlocks")
 	},
 /turf/open/floor/plasteel/dark,
 /area/escapepodbay)
@@ -57044,8 +57017,8 @@
 /area/hallway/primary/fore)
 "quD" = (
 /obj/machinery/firealarm{
-	pixel_y = 38;
-	dir = 1
+	dir = 1;
+	pixel_y = 38
 	},
 /obj/machinery/computer/ai_server_console,
 /turf/open/floor/plasteel/grimy,
@@ -62654,7 +62627,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "san" = (
-/obj/machinery/airalarm/directional/west,
+/obj/machinery/airalarm/directional/west{
+	pixel_x = -24
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -62928,19 +62903,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"sdI" = (
-/obj/effect/turf_decal/stripes/end,
-/obj/structure/closet/emcloset,
-/obj/machinery/button/door{
-	id = "Podbaydoor";
-	pixel_x = -24;
-	pixel_y = -1;
-	req_access = list("external_airlocks");
-	name = "Shipbreaking External Control"
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "sdJ" = (
 /obj/machinery/camera{
 	c_tag = "Break Room";
@@ -66234,6 +66196,19 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/captain,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
+"tad" = (
+/obj/effect/turf_decal/stripes/end,
+/obj/structure/closet/emcloset,
+/obj/machinery/button/door{
+	id = "Podbaydoor";
+	name = "Shipbreaking External Control";
+	pixel_x = -24;
+	pixel_y = -1;
+	req_access = null
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "tal" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -78196,6 +78171,34 @@
 	},
 /turf/open/floor/plating/snowed/smoothed,
 /area/medical/virology)
+"wpm" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/warning/lower/corner{
+	dir = 8
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Shipbreaking Bay"
+	},
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "wpx" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/med_data/laptop{
@@ -244538,7 +244541,7 @@ eXr
 oeD
 qHW
 sxN
-kQA
+wpm
 sxN
 meg
 moF
@@ -244797,7 +244800,7 @@ qHW
 hwM
 pXc
 xFL
-sdI
+tad
 sxN
 ozK
 ueX

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -6302,6 +6302,18 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"aSA" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Access"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/escapepodbay)
 "aSG" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass/fifty,
@@ -33970,19 +33982,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"jcd" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Access"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/turf/open/floor/plating,
-/area/escapepodbay)
 "jcf" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/atmospherics/components/unary/passive_vent{
@@ -42886,6 +42885,22 @@
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
+"mxC" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Shipbreaking Bay"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/ramp_middle,
+/turf/open/floor/plasteel,
+/area/escapepodbay)
 "mxL" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -52167,23 +52182,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"pQy" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Shipbreaking Bay"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/ramp_middle,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/turf/open/floor/plasteel,
-/area/escapepodbay)
 "pQS" = (
 /obj/structure/window/reinforced,
 /obj/structure/chair/stool{
@@ -65109,22 +65107,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"uDq" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Shipbreaking External Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
-/turf/open/floor/plating,
-/area/escapepodbay)
 "uDL" = (
 /obj/structure/closet/l3closet/virology,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -66125,6 +66107,21 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"uWA" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Shipbreaking External Access"
+	},
+/turf/open/floor/plating,
+/area/escapepodbay)
 "uWF" = (
 /obj/machinery/camera{
 	c_tag = "Auxillary Base Construction Dock";
@@ -125642,7 +125639,7 @@ iEt
 hHb
 bQx
 tro
-pQy
+mxC
 guW
 rZU
 mUk
@@ -127951,7 +127948,7 @@ iOc
 gXs
 ptH
 ptH
-uDq
+uWA
 ptH
 uxv
 uxv
@@ -128465,7 +128462,7 @@ aaa
 gXs
 pEf
 xJr
-jcd
+aSA
 xJr
 gXs
 aaa


### PR DESCRIPTION
# Document the changes in your pull request

Title -- anyone can now enter the shipbreaking room and use the airlocks.

# Why is this good for the game?

Per asking person who worked on shipbreaking (Cowbot) it's intended for anyone who wants to do it to be able to do so -- having it need external airlock access defeats this.

May look into the shipbreaking suits being nerfed to balance anyone being able to just walk in and get 3 hardsuits.

# Changelog

:cl:
tweak: Removed access blocks to shipbreaking
experimental: May alter shipbreaking hardsuits to be subpar for things other than what they're accessed for
/:cl:
