### PR TITLE
Heretic actions now transfer on clone

### DIFF
--- a/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
+++ b/code/modules/antagonists/eldritch_cult/eldritch_antag.dm
@@ -254,6 +254,16 @@
 		current = mob_override
 	current.faction -= "heretics"
 
+/datum/antagonist/heretic/on_body_transfer(mob/living/old_body, mob/living/new_body)
+	. = ..()
+	if(old_body == new_body) // if they were using a temporary body
+		return
+
+	for(var/knowledge_index in researched_knowledge)
+		var/datum/eldritch_knowledge/knowledge = researched_knowledge[knowledge_index]
+		knowledge.on_lose(old_body, src)
+		knowledge.on_gain(new_body, src)
+
 /datum/antagonist/heretic/get_admin_commands()
 	. = ..()
 	.["Equip"] = CALLBACK(src, PROC_REF(equip_cultist))


### PR DESCRIPTION
# Document the changes in your pull request

Didn't account for mind transfer

making cowbot pay me

# Why is this good for the game?
less oversights = good

# Testing

spawn with these
![chrome_kjp0ifPcMs](https://github.com/user-attachments/assets/204bbf07-7f3d-406d-bcbe-0a2a650f4ec1)

got cloned, new body had the actions instead now
![chrome_ajxK3TcV71](https://github.com/user-attachments/assets/daf9353b-900d-497d-a751-408aa8dbb964)


# Changelog

:cl: ToasterBiome, Cowbot93
bugfix: Heretic spells now get transferred on clone  
/:cl:
