### PR TITLE
reduces time for each step of hdd theft objective

### DIFF
--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -288,7 +288,7 @@
 		return FALSE
 
 	to_chat(user, span_notice("You can see [front_panel_screws] screw\s. You start unscrewing [front_panel_screws == 1 ? "it" : "them"]..."))
-	while(tool.use_tool(src, user, 7.5 SECONDS, volume=100))
+	while(tool.use_tool(src, user, 2 SECONDS, volume=100))
 		front_panel_screws--
 
 		if(front_panel_screws <= 0)
@@ -304,7 +304,7 @@
 		return FALSE
 
 	to_chat(user, span_notice("You can see [source_code_hdd] in a secure housing behind the front panel. You begin to pry it loose..."))
-	if(tool.use_tool(src, user, 15 SECONDS, volume=100))
+	if(tool.use_tool(src, user, 8 SECONDS, volume=100))
 		to_chat(user, span_notice("You destroy the housing, prying [source_code_hdd] free."))
 		deconstruction_state = HDD_PRIED
 	return TRUE
@@ -314,7 +314,7 @@
 		return FALSE
 
 	to_chat(user, span_notice("There are [hdd_wires] wire\s connected to [source_code_hdd]. You start cutting [hdd_wires == 1 ? "it" : "them"]..."))
-	while(tool.use_tool(src, user, 7.5 SECONDS, volume=100))
+	while(tool.use_tool(src, user, 2 SECONDS, volume=100))
 		hdd_wires--
 
 		if(hdd_wires <= 0)


### PR DESCRIPTION
# Document the changes in your pull request

Unscrewing screws: 7.5 seconds -> 2 seconds each (4 total)
Prying front panel: 15 seconds -> 8 seconds
Cutting hard drive wires: 7.5 seconds -> 2 seconds each (6 total)

Total time: 90 seconds -> 28 seconds

28 seconds is still a long time

# Why is this good for the game?
Lizards are soo cold prone that even with winter coats they are dying, also takes FOREVER which is not the intention (the intention is making a bunch of noise so sec beats you up)

# Changelog

:cl:
tweak: ripping out the master r&d hard drive is faster now
/:cl:
