### PR TITLE
[All Stations] Removes External Airlock access requirement for the Shipbreaking doors

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -29416,7 +29416,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating/airless,
 /area/escapepodbay)
 "irh" = (
@@ -30622,7 +30621,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/ramp_middle,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "iKT" = (
@@ -68125,7 +68123,6 @@
 /obj/machinery/door/airlock/external{
 	name = "Shipbreaking External Access"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "uau" = (

--- a/_maps/map_files/DonutStation/DonutStation.dmm
+++ b/_maps/map_files/DonutStation/DonutStation.dmm
@@ -18340,7 +18340,6 @@
 /obj/machinery/door/airlock/external{
 	name = "Shipbreaking External Access"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating,
 /area/escapepodbay)
 "hAf" = (
@@ -24480,7 +24479,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "kfk" = (
@@ -42155,7 +42153,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating,
 /area/escapepodbay)
 "rAR" = (

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -16435,7 +16435,6 @@
 /obj/machinery/door/airlock/external{
 	name = "Shipbreaking External Access"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating,
 /area/escapepodbay)
 "hGw" = (
@@ -22608,7 +22607,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating,
 /area/escapepodbay)
 "kMo" = (
@@ -26154,7 +26152,6 @@
 /obj/effect/turf_decal/ramp_middle{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "mwk" = (

--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -68568,15 +68568,13 @@
 /turf/open/floor/plasteel,
 /area/security/prison)
 "tIJ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Podbay Maintenence"
-	},
+/obj/machinery/door/airlock/maintenance,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/starboard/secondary)
 "tIS" = (

--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -37429,7 +37429,6 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Shipbreaking Bay"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "kQR" = (
@@ -44553,8 +44552,7 @@
 	id = "Podbaydoor";
 	name = "Shipbreaking External Control";
 	pixel_x = 24;
-	pixel_y = -1;
-	req_access = list("external_airlocks")
+	pixel_y = -1
 	},
 /turf/open/floor/plasteel/dark,
 /area/escapepodbay)
@@ -62952,8 +62950,7 @@
 	id = "Podbaydoor";
 	name = "Shipbreaking External Control";
 	pixel_x = -24;
-	pixel_y = -1;
-	req_access = list("external_airlocks")
+	pixel_y = -1
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel,

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -33980,7 +33980,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating,
 /area/escapepodbay)
 "jcf" = (
@@ -52184,7 +52183,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/ramp_middle,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
 "pQS" = (
@@ -65125,7 +65123,6 @@
 /obj/machinery/door/airlock/external{
 	name = "Shipbreaking External Access"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/external,
 /turf/open/floor/plating,
 /area/escapepodbay)
 "uDL" = (


### PR DESCRIPTION
# Document the changes in your pull request

Title

# Why is this good for the game?

The activity is intended to be enjoyed by anyone who wants, making a person need to find someone to give them access to go do it is counterproductive.

# Changelog

:cl:
tweak: Everyone can enter the shipbreaking area now.
/:cl:
