### PR TITLE
add sprites to the drip suit

### DIFF
--- a/code/modules/clothing/under/costume.dm
+++ b/code/modules/clothing/under/costume.dm
@@ -344,13 +344,12 @@
 /obj/item/clothing/under/costume/drip
 	name = "incredibly fashionable outfit"
 	desc = "Expensive-looking designer vest. It radiates an aggressively attractive aura. You feel putting this on would change you forever."
-	icon = 'icons/obj/clothing/uniforms.dmi'
-	worn_icon = 'icons/mob/clothing/uniform/uniform.dmi'
-	icon_state = "drippy"
-	item_state = "drippy"
+	icon_state = "SwagOutfit"
+	item_state = "SwagOutfit"
 	armor = list(MELEE = 10, BULLET = 10, LASER = 10, ENERGY = 10, BOMB = 10, BIO = 10, RAD = 10, FIRE = 100, ACID = 100)
 	resistance_flags = FIRE_PROOF | ACID_PROOF | LAVA_PROOF//Miners Bizzare Adventure Drip is Unbreakable
 	can_adjust = FALSE
+	mutantrace_variation = DIGITIGRADE_VARIATION
 
 /obj/item/clothing/under/costume/drip/equipped(mob/user, slot)
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request
before
![dreamseeker 08_27_24_06_54](https://github.com/user-attachments/assets/8cba384f-6729-45f5-aa4b-be3b0606dfd5)
after
![dreamseeker 08_27_24_08_20](https://github.com/user-attachments/assets/4e32f32e-4634-418f-9c13-ed37e4ace01c)
digitigrade variation work
![dreamseeker 08_27_24_07_31](https://github.com/user-attachments/assets/a18e52ff-c318-4041-b064-e1c125533c73)
it will be visible under the explorer suit
![dreamseeker 08_27_24_07_08](https://github.com/user-attachments/assets/0afd62a0-1231-4428-9782-037830fad88b)
# Testing
yes


# Spriting
it was in the files

# Changelog
:cl:
imageadd: added drip suit sprites
/:cl:
