### PR TITLE
changed french language key from V to W

### DIFF
--- a/code/modules/language/french.dm
+++ b/code/modules/language/french.dm
@@ -4,7 +4,7 @@
 	speech_verb = "says"
 	ask_verb = "asks"
 	exclaim_verb = "exclaims"
-	key = "v"
+	key = "w"
 	flags = TONGUELESS_SPEECH
 	space_chance = 100
 	default_priority = 80


### PR DESCRIPTION
Closes https://github.com/yogstation13/Yogstation/issues/22532


# Document the changes in your pull request
Changed the French language's key from V to W
<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Prefix the PR title with [admin] if it involves something admin related. 
Prefix the PR title with [s] if you are fixing a game-breaking exploit, so that it is not announced on the Yogstation Discord and the server.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->

# Why is this good for the game?
No longer conflicts with Vox-pidgin which is also V

W for oui
<!-- Describe why you think this change is good for the game. This section is not required for bugfixes. -->

# Testing
N/A, doesn't conflict with any other language
<!-- Describe what testing you did with this PR. Try to be thorough, especially if this is a larger project.


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
bugfix: French language key is now W, no longer conflicts with Vox-pidgin which is V
/:cl:
