### PR TITLE
Adjusts Lone Op's weight increase requirements & sets a general weight for it to spawn/

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -631,29 +631,29 @@ This is here to make the tiles around the station mininuke change when it's arme
 		START_PROCESSING(SSobj, src)
 	AddComponent(/datum/component/stationloving, !fake)
 
-// /obj/item/disk/nuclear/process()
-// 	if(fake)
-// 		STOP_PROCESSING(SSobj, src)
-// 		CRASH("A fake nuke disk tried to call process(). Who the fuck and how the fuck")
-// 	var/turf/newturf = get_turf(src)
-// 	if(newturf && lastlocation == newturf)
-// 		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*0.0001))
-// 			var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
-// 			if(istype(loneop) && loneop.occurrences < loneop.max_occurrences)
-// 				loneop.weight += 1
-// 				if(loneop.weight % 5 == 0 && SSticker.totalPlayers > 1)
-// 					message_admins("[src] is stationary in [ADMIN_VERBOSEJMP(newturf)]. The weight of Lone Operative is now [loneop.weight].")
-// 				log_game("[src] is stationary for too long in [loc_name(newturf)], and has increased the weight of the Lone Operative event to [loneop.weight].")
+/obj/item/disk/nuclear/process()
+	if(fake)
+		STOP_PROCESSING(SSobj, src)
+		CRASH("A fake nuke disk tried to call process(). Who the fuck and how the fuck")
+	var/turf/newturf = get_turf(src)
+	if(newturf && lastlocation == newturf)
+		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*0.0001))
+			var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
+			if(istype(loneop) && (loneop.occurrences < loneop.max_occurrences) && SSticker.totalPlayers >= 25)
+				loneop.weight += 1
+				if(loneop.weight % 5 == 0 && SSticker.totalPlayers > 1)
+					message_admins("[src] is stationary in [ADMIN_VERBOSEJMP(newturf)]. The weight of Lone Operative is now [loneop.weight].")
+				log_game("[src] is stationary for too long in [loc_name(newturf)], and has increased the weight of the Lone Operative event to [loneop.weight].")
 
-// 	else
-// 		lastlocation = newturf
-// 		last_disk_move = world.time
-// 		var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
-// 		if(istype(loneop) && loneop.occurrences < loneop.max_occurrences && prob(loneop.weight))
-// 			loneop.weight = max(loneop.weight - 1, 0)
-// 			if(loneop.weight % 5 == 0 && SSticker.totalPlayers > 1)
-// 				message_admins("[src] is on the move (currently in [ADMIN_VERBOSEJMP(newturf)]). The weight of Lone Operative is now [loneop.weight].")
-// 			log_game("[src] being on the move has reduced the weight of the Lone Operative event to [loneop.weight].")
+	else
+		lastlocation = newturf
+		last_disk_move = world.time
+		var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
+		if(istype(loneop) && loneop.occurrences < loneop.max_occurrences && prob(loneop.weight))
+			loneop.weight = max(loneop.weight - 1, 0)
+			if(loneop.weight % 5 == 0 && SSticker.totalPlayers > 1)
+				message_admins("[src] is on the move (currently in [ADMIN_VERBOSEJMP(newturf)]). The weight of Lone Operative is now [loneop.weight].")
+			log_game("[src] being on the move has reduced the weight of the Lone Operative event to [loneop.weight].")
 
 /obj/item/disk/nuclear/examine(mob/user)
 	. = ..()

--- a/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclearbomb.dm
@@ -631,29 +631,29 @@ This is here to make the tiles around the station mininuke change when it's arme
 		START_PROCESSING(SSobj, src)
 	AddComponent(/datum/component/stationloving, !fake)
 
-/obj/item/disk/nuclear/process()
-	if(fake)
-		STOP_PROCESSING(SSobj, src)
-		CRASH("A fake nuke disk tried to call process(). Who the fuck and how the fuck")
-	var/turf/newturf = get_turf(src)
-	if(newturf && lastlocation == newturf)
-		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*0.0001))
-			var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
-			if(istype(loneop) && loneop.occurrences < loneop.max_occurrences)
-				loneop.weight += 1
-				if(loneop.weight % 5 == 0 && SSticker.totalPlayers > 1)
-					message_admins("[src] is stationary in [ADMIN_VERBOSEJMP(newturf)]. The weight of Lone Operative is now [loneop.weight].")
-				log_game("[src] is stationary for too long in [loc_name(newturf)], and has increased the weight of the Lone Operative event to [loneop.weight].")
+// /obj/item/disk/nuclear/process()
+// 	if(fake)
+// 		STOP_PROCESSING(SSobj, src)
+// 		CRASH("A fake nuke disk tried to call process(). Who the fuck and how the fuck")
+// 	var/turf/newturf = get_turf(src)
+// 	if(newturf && lastlocation == newturf)
+// 		if(last_disk_move < world.time - 5000 && prob((world.time - 5000 - last_disk_move)*0.0001))
+// 			var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
+// 			if(istype(loneop) && loneop.occurrences < loneop.max_occurrences)
+// 				loneop.weight += 1
+// 				if(loneop.weight % 5 == 0 && SSticker.totalPlayers > 1)
+// 					message_admins("[src] is stationary in [ADMIN_VERBOSEJMP(newturf)]. The weight of Lone Operative is now [loneop.weight].")
+// 				log_game("[src] is stationary for too long in [loc_name(newturf)], and has increased the weight of the Lone Operative event to [loneop.weight].")
 
-	else
-		lastlocation = newturf
-		last_disk_move = world.time
-		var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
-		if(istype(loneop) && loneop.occurrences < loneop.max_occurrences && prob(loneop.weight))
-			loneop.weight = max(loneop.weight - 1, 0)
-			if(loneop.weight % 5 == 0 && SSticker.totalPlayers > 1)
-				message_admins("[src] is on the move (currently in [ADMIN_VERBOSEJMP(newturf)]). The weight of Lone Operative is now [loneop.weight].")
-			log_game("[src] being on the move has reduced the weight of the Lone Operative event to [loneop.weight].")
+// 	else
+// 		lastlocation = newturf
+// 		last_disk_move = world.time
+// 		var/datum/round_event_control/operative/loneop = locate(/datum/round_event_control/operative) in SSevents.control
+// 		if(istype(loneop) && loneop.occurrences < loneop.max_occurrences && prob(loneop.weight))
+// 			loneop.weight = max(loneop.weight - 1, 0)
+// 			if(loneop.weight % 5 == 0 && SSticker.totalPlayers > 1)
+// 				message_admins("[src] is on the move (currently in [ADMIN_VERBOSEJMP(newturf)]). The weight of Lone Operative is now [loneop.weight].")
+// 			log_game("[src] being on the move has reduced the weight of the Lone Operative event to [loneop.weight].")
 
 /obj/item/disk/nuclear/examine(mob/user)
 	. = ..()

--- a/code/modules/events/operative.dm
+++ b/code/modules/events/operative.dm
@@ -3,6 +3,7 @@
 	typepath = /datum/round_event/ghost_role/operative
 	weight = 0 //Admin only
 	max_occurrences = 1
+	min_players = 25
 	dynamic_should_hijack = TRUE
 
 /datum/round_event/ghost_role/operative


### PR DESCRIPTION
# Document the changes in your pull request

Adds 25 min player weight to Lone Op, adjusts the disk processing so the weight # chance doesn't increase unless current total pop is above or equal to 25 players

# Why is this good for the game?

A lot of rounds end early because a Lone Operative rolled while none of the 4-10 crew members thought to secure the disk. This is not a deletion of Lone Op, and it can be re-enabled at a later time.

# Changelog

:cl:
tweak: Adjusts Lone Operative spawn chances

/:cl:
