### PR TITLE
fixes AIs using laser gun ability while dead

### DIFF
--- a/code/game/objects/items/robot/ai_upgrades.dm
+++ b/code/game/objects/items/robot/ai_upgrades.dm
@@ -160,6 +160,8 @@
 		return FALSE
 	if(!burstmode_activated && !COOLDOWN_FINISHED(src, next_activate)) // Burstmode is not ready.
 		return FALSE
+	if(owner.stat == DEAD) 
+		return FALSE
 
 /datum/action/innate/ai/ranged/cameragun/do_ability(mob/living/caller, params, atom/target)
 	var/turf/loc_target = get_turf(target)


### PR DESCRIPTION
# Document the changes in your pull request
AIs cannot use the laser gun ability while dead.
Closes #22545

# Testing
![image](https://github.com/user-attachments/assets/eef69505-a113-4406-a1b6-1e572773af71)
Is now disabled and cannot be used.

# Changelog
:cl:
bugfix: AI laser gun ability can no longer be used while dead.
/:cl:
