### PR TITLE
Fixes holotool bugs that annoyed me

### DIFF
--- a/code/game/atom/atom_tool_acts.dm
+++ b/code/game/atom/atom_tool_acts.dm
@@ -57,9 +57,9 @@
 
 ///Check if the multitool has an item in it's data buffer
 /atom/proc/multitool_check_buffer(user, obj/item/tool, silent = FALSE)
-	if(istype(tool, /obj/item/multitool))
-		return TRUE
-	if(istype(tool, /obj/item/holotool))
+	if(isnull(tool))
+		return FALSE
+	if(tool.tool_behaviour == TOOL_MULTITOOL)
 		return TRUE
 	if(user && !silent)
 		to_chat(user, span_warning("[tool] has no data buffer!"))

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -128,12 +128,12 @@
 
 //Checks if we're holding a tool that has given quality
 //Returns the tool that has the best version of this quality
-/mob/proc/is_holding_tool_quality(quality)
+/mob/proc/is_holding_tool_quality(expected_tool_type)
 	var/obj/item/best_item
 	var/best_quality = INFINITY
 
 	for(var/obj/item/I in held_items)
-		if(I.tool_behaviour == quality && I.toolspeed < best_quality)
+		if(I.tool_behaviour == expected_tool_type && I.toolspeed < best_quality)
 			best_item = I
 			best_quality = I.toolspeed
 	return best_item

--- a/yogstation/code/game/machinery/telecomms/machine_interactions.dm
+++ b/yogstation/code/game/machinery/telecomms/machine_interactions.dm
@@ -1,14 +1,9 @@
 /obj/machinery/telecomms/get_multitool(mob/user) // Proc override, to improve compatibility with holotools and other silly multitool-like devices
-    if(isAI(user))
-        var/mob/living/silicon/ai/U = user
-        return U.aiMulti
-    if(iscyborg(user) && in_range(user,src)) // I couldn't tell you why this has a range requirement, that's just what was in the original code.
-        var/obj/held_thing = user.get_active_held_item()
-        if(multitool_check_buffer(user, held_thing))
-            return held_thing
-        else
-            return
-    var/obj/item/held_item = user.is_holding_tool_quality(TOOL_MULTITOOL)
-    if(multitool_check_buffer(user, held_item))
-        return held_item
-    return
+	if(isAI(user)) //AIs have an internal multitool they use instead.
+		var/mob/living/silicon/ai/U = user
+		return U.aiMulti
+	if(iscyborg(user) && !in_range(user, src)) //Cyborgs must be in range
+		return
+	var/obj/item/held_item = user.is_holding_tool_quality(TOOL_MULTITOOL)
+	if(multitool_check_buffer(user, held_item, silent = TRUE))
+		return held_item


### PR DESCRIPTION
# Document the changes in your pull request

Holotools now only work as a multitool when it's set to be a multitool
Removes istype checks for multitools
Fixes ghosts clicking on telecomm machines and being spammed with " has no data buffer!"

# Why is this good for the game?

Fixes bugs, makes the holotool work more as the tool its set to.

# Testing

Tried using multitool both as a human and borg, putting it away and taking it out on the telecomms hub.

holotool testing
https://github.com/user-attachments/assets/cb25aa78-f77e-4a3c-bb5f-ea3ae0546ca4

# Changelog

:cl:
bugfix: Holotools should now only work as multitools when they are set to the multitool setting.
bugfix: Ghosts no longer get spammed when using telecomms machines.
/:cl:
