### PR TITLE
[All Stations] Corrects and cleans up Mech Bay wiring

### DIFF
--- a/_maps/map_files/AsteroidStation/AsteroidStation.dmm
+++ b/_maps/map_files/AsteroidStation/AsteroidStation.dmm
@@ -7762,9 +7762,6 @@
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/mechbay)
 "bJC" = (
@@ -8514,12 +8511,6 @@
 "bXz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
@@ -9381,12 +9372,6 @@
 /area/security/main)
 "cij" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
 "cin" = (
@@ -12057,9 +12042,6 @@
 	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
 "cYN" = (
@@ -24201,9 +24183,6 @@
 	pixel_y = 24;
 	req_access = list("robotics")
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /obj/machinery/button/door{
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
@@ -32864,13 +32843,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"jpN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/circuit,
-/area/science/robotics/mechbay)
 "jqc" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -34392,9 +34364,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
 	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/mechbay)
@@ -36296,9 +36265,6 @@
 "ktk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/mechbay)
@@ -41231,9 +41197,6 @@
 "mch" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 2
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/mechbay)
@@ -66922,9 +66885,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -26
@@ -79933,9 +79893,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
 "xLv" = (
@@ -80029,9 +79986,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
@@ -110856,9 +110810,9 @@ aQZ
 gLE
 bXz
 cij
-jpN
 cij
-jpN
+cij
+cij
 ktk
 adX
 aFu

--- a/_maps/map_files/DonutStation/DonutStation.dmm
+++ b/_maps/map_files/DonutStation/DonutStation.dmm
@@ -22399,6 +22399,9 @@
 	dir = 4;
 	network = list("ss13","Research")
 	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
 "joZ" = (
@@ -32280,7 +32283,7 @@
 "nrZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
@@ -32830,9 +32833,6 @@
 /area/maintenance/port/aft)
 "nGk" = (
 /obj/machinery/mech_bay_recharge_port,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "nGL" = (
@@ -34128,9 +34128,6 @@
 /area/engine/engineering)
 "ofh" = (
 /obj/machinery/computer/mech_bay_power_console,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "ofi" = (
@@ -35226,12 +35223,6 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "oEp" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/mech_bay_recharge_floor,
 /area/science/robotics/mechbay)
@@ -38612,9 +38603,6 @@
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "qda" = (
@@ -40575,12 +40563,6 @@
 "qRr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/mech_bay_recharge_floor,

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -11752,9 +11752,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "fyD" = (
@@ -20323,9 +20320,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay"
 	},
@@ -21356,9 +21350,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -23365,9 +23356,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -25409,9 +25397,6 @@
 /turf/open/floor/plasteel/broken/two,
 /area/science/mixing)
 "mfl" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
 	},
@@ -26724,7 +26709,6 @@
 /area/maintenance/department/science/central)
 "mMm" = (
 /obj/machinery/mech_bay_recharge_port,
-/obj/structure/cable,
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -24
@@ -29156,12 +29140,6 @@
 "nXH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -35892,15 +35870,6 @@
 "rpM" = (
 /turf/open/floor/wood,
 /area/hallway/primary/central)
-"rpU" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/lab)
 "rpY" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -43275,9 +43244,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -89534,7 +89500,7 @@ sOU
 tqI
 kYl
 cXu
-rpU
+nXH
 cJd
 fgW
 gqK

--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -21972,9 +21972,6 @@
 /obj/item/radio/intercom{
 	pixel_y = 20
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "gxe" = (
@@ -22506,9 +22503,6 @@
 "gFq" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)

--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -273,12 +273,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
-"ady" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
 "adJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/light/small{
@@ -27963,9 +27957,6 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "ilv" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "ily" = (
@@ -30039,12 +30030,6 @@
 /obj/machinery/light_switch{
 	pixel_x = -23;
 	pixel_y = -2
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
@@ -59472,9 +59457,6 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos/distro)
 "reD" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = -28
 	},
@@ -59532,9 +59514,6 @@
 /area/ai_monitored/storage/satellite)
 "reY" = (
 /obj/machinery/mech_bay_recharge_port,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
 "rfe" = (
@@ -71619,9 +71598,6 @@
 /turf/open/floor/plasteel,
 /area/engine/foyer)
 "uBx" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
@@ -83871,12 +83847,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"xOM" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
 "xOO" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -244776,8 +244746,8 @@ pex
 lkZ
 wXZ
 reD
-ady
-ady
+ilv
+ilv
 iNJ
 ilv
 tSS
@@ -245036,7 +245006,7 @@ reY
 eco
 dkB
 reY
-xOM
+ilv
 tSS
 lpq
 gIl

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -7722,12 +7722,6 @@
 /turf/closed/wall,
 /area/medical/chemistry)
 "bfI" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "bfK" = (
@@ -7742,9 +7736,6 @@
 	},
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
@@ -7974,9 +7965,6 @@
 "bhy" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
@@ -8460,9 +8448,6 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -24
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
@@ -14084,9 +14069,6 @@
 	pixel_x = -6;
 	pixel_y = 24
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
 "cpL" = (
@@ -15314,13 +15296,7 @@
 "cHN" = (
 /obj/machinery/holopad,
 /obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
@@ -19352,6 +19328,9 @@
 	dir = 8;
 	name = "Mech Bay APC";
 	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/mech_bay_recharge_floor,
 /area/science/robotics/mechbay)
@@ -44866,7 +44845,7 @@
 /area/maintenance/port)
 "ndK" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-8"
 	},
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
@@ -119490,9 +119469,9 @@ baT
 baT
 eHW
 uJu
-bhM
 biJ
 bhM
+biJ
 biO
 blA
 sHM
@@ -120004,9 +119983,9 @@ aYV
 aYV
 xyG
 iQL
-bhM
 biJ
-bhM
+biJ
+biJ
 btw
 blA
 iEY


### PR DESCRIPTION
# Document the changes in your pull request

Removes wires unneeded that connect to chargers and computers. Makes sure wires go to APCs on the stations where they were missing

# Testing
![image](https://github.com/user-attachments/assets/83f299c8-0a1f-4759-b52f-1106fc4a57fc)
![image](https://github.com/user-attachments/assets/c8424bfb-3fa7-421a-b761-10c30d72ae56)

# Changelog

:cl:
bugfix: Correctly wires APCs that were improperly done
tweak: Removed wires connecting to machines that did not need them
/:cl:
