### PR TITLE
Adds day/night cycle to icemoon

### DIFF
--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -1002,7 +1002,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/icemoon/top_layer/outdoors)
+/area/solar/starboard/fore/icemoon)
 "apf" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -1407,7 +1407,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/starboard/aft)
+/area/solar/starboard/aft/icemoon)
 "awF" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -1717,7 +1717,7 @@
 /area/medical/paramedic)
 "azV" = (
 /turf/closed/wall/r_wall,
-/area/solar/starboard/aft)
+/area/solar/starboard/aft/icemoon)
 "azX" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -2940,7 +2940,7 @@
 "aRc" = (
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/starboard/fore)
+/area/solar/starboard/fore/icemoon)
 "aRk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -4427,7 +4427,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "bnn" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/firedoor/border_only{
@@ -4846,7 +4846,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "buc" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -5136,7 +5136,7 @@
 	name = "turbine vent"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/top_layer/outdoors)
+/area/solar/starboard/fore/icemoon)
 "bzm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 1
@@ -5369,7 +5369,7 @@
 "bBY" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/starboard/fore)
+/area/solar/starboard/fore/icemoon)
 "bCd" = (
 /obj/structure/window/reinforced,
 /obj/machinery/door/firedoor/border_only{
@@ -6497,7 +6497,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/starboard/aft)
+/area/solar/starboard/aft/icemoon)
 "bSY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -7819,7 +7819,7 @@
 	name = "pressure chamber vent"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "cmH" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
@@ -9115,7 +9115,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "cJp" = (
 /obj/structure/chair/office/light{
 	dir = 1;
@@ -11105,7 +11105,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "dor" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -11151,7 +11151,7 @@
 "dpo" = (
 /obj/structure/lattice,
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/port/aft)
+/area/solar/port/aft/icemoon)
 "dpv" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -12647,7 +12647,7 @@
 	name = "pressure chamber vent"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/starboard/aft)
+/area/solar/starboard/aft/icemoon)
 "dKA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -13288,7 +13288,7 @@
 "dTV" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "dUc" = (
 /obj/item/cigbutt,
 /obj/effect/landmark/blobstart,
@@ -14075,7 +14075,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/starboard/fore)
+/area/solar/starboard/fore/icemoon)
 "egt" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -14943,7 +14943,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "ete" = (
 /obj/machinery/door/airlock/wood{
 	name = "Psychiatrists office"
@@ -15382,7 +15382,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "ezG" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
@@ -16241,7 +16241,7 @@
 /area/storage/primary)
 "eOp" = (
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/port/aft)
+/area/solar/port/aft/icemoon)
 "eOq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17922,7 +17922,7 @@
 "foD" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/port/aft)
+/area/solar/port/aft/icemoon)
 "foR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -18842,7 +18842,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/starboard/fore)
+/area/solar/starboard/fore/icemoon)
 "fDG" = (
 /obj/structure/grille,
 /turf/closed/wall/r_wall,
@@ -20207,7 +20207,7 @@
 	name = "pressure chamber vent"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "fXy" = (
 /turf/baseturf_bottom,
 /area/science/test_area)
@@ -20293,7 +20293,7 @@
 "fYh" = (
 /obj/structure/lattice,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/starboard/aft)
+/area/solar/starboard/aft/icemoon)
 "fYm" = (
 /turf/closed/wall,
 /area/mine/eva)
@@ -21643,7 +21643,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/aft)
+/area/solar/port/aft/icemoon)
 "grD" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -23780,7 +23780,7 @@
 "gUW" = (
 /obj/structure/lattice,
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "gVb" = (
 /obj/structure/table/wood/poker,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -24003,7 +24003,7 @@
 /area/icemoon/top_layer/outdoors)
 "gXr" = (
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "gXD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -24108,7 +24108,7 @@
 "gZI" = (
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/aft)
+/area/solar/port/aft/icemoon)
 "gZN" = (
 /obj/machinery/light{
 	dir = 8
@@ -24396,7 +24396,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/port/aft)
+/area/solar/port/aft/icemoon)
 "hew" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/machinery/atmospherics/pipe/simple/violet/visible{
@@ -24579,7 +24579,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/starboard/fore)
+/area/solar/starboard/fore/icemoon)
 "hhg" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -26563,7 +26563,7 @@
 /area/crew_quarters/bar)
 "hKJ" = (
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/aft)
+/area/solar/port/aft/icemoon)
 "hKO" = (
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
@@ -26685,7 +26685,7 @@
 "hMM" = (
 /obj/structure/lattice,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/aft)
+/area/solar/port/aft/icemoon)
 "hMS" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -28840,7 +28840,7 @@
 "iwq" = (
 /obj/structure/lattice,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "iwt" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -29387,7 +29387,7 @@
 /area/quartermaster/qm)
 "iEc" = (
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/starboard/aft)
+/area/solar/starboard/aft/icemoon)
 "iEf" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/atmospherics/miner/carbon_dioxide,
@@ -30487,7 +30487,7 @@
 	icon_state = "1-4"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/top_layer/outdoors)
+/area/solar/starboard/fore/icemoon)
 "iVp" = (
 /obj/machinery/computer/operating,
 /turf/open/floor/plasteel/white,
@@ -37734,7 +37734,7 @@
 	name = "pressure chamber vent"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/aft)
+/area/solar/port/aft/icemoon)
 "kWx" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -38463,7 +38463,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/port/aft)
+/area/solar/port/aft/icemoon)
 "ljo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/carpet,
@@ -39333,7 +39333,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/starboard/fore)
+/area/solar/starboard/fore/icemoon)
 "lvc" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/closet/emcloset,
@@ -39762,7 +39762,7 @@
 	name = "pressure chamber vent"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/aft)
+/area/solar/port/aft/icemoon)
 "lCF" = (
 /obj/effect/landmark/stationroom/maint/fivexthree,
 /turf/baseturf_bottom,
@@ -41242,7 +41242,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/starboard/aft)
+/area/solar/starboard/aft/icemoon)
 "lWQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -42958,7 +42958,7 @@
 "mvF" = (
 /obj/structure/steam_fissure,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/starboard/aft)
+/area/solar/starboard/aft/icemoon)
 "mvR" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -43477,7 +43477,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "mCF" = (
 /obj/structure/sign/departments/minsky/supply/mining{
 	pixel_y = 32
@@ -44729,7 +44729,7 @@
 "mSs" = (
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "mSt" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -45026,7 +45026,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/starboard/aft)
+/area/solar/starboard/aft/icemoon)
 "mWa" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
@@ -47395,7 +47395,7 @@
 /area/medical/medbay/central)
 "nEU" = (
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "nFi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -47894,7 +47894,7 @@
 "nMu" = (
 /obj/structure/cable,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/starboard/fore)
+/area/solar/starboard/fore/icemoon)
 "nMw" = (
 /obj/structure/closet{
 	name = "Evidence Closet 2"
@@ -49102,7 +49102,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/port/aft)
+/area/solar/port/aft/icemoon)
 "ocp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -49773,7 +49773,7 @@
 	luminosity = 2
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/aft)
+/area/solar/port/aft/icemoon)
 "olV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -50780,7 +50780,7 @@
 /obj/structure/lattice,
 /obj/structure/lattice,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/starboard/fore)
+/area/solar/starboard/fore/icemoon)
 "oAe" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -51517,7 +51517,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "oMP" = (
 /obj/effect/spawner/structure/window/reinforced/tinted,
 /turf/open/floor/plating,
@@ -51564,7 +51564,7 @@
 /area/crew_quarters/kitchen)
 "oNM" = (
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/starboard/aft)
+/area/solar/starboard/aft/icemoon)
 "oNV" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -51923,7 +51923,7 @@
 	luminosity = 2
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/aft)
+/area/solar/port/aft/icemoon)
 "oTz" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -52606,11 +52606,11 @@
 "pel" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "pep" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/aft)
+/area/solar/port/aft/icemoon)
 "pex" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -52856,7 +52856,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "piX" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -53633,7 +53633,7 @@
 	name = "turbine vent"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/starboard/aft)
+/area/solar/starboard/aft/icemoon)
 "psT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -55322,7 +55322,7 @@
 	icon_state = "0-4"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/starboard/aft)
+/area/solar/starboard/aft/icemoon)
 "pVA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -56171,6 +56171,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"qiK" = (
+/turf/closed/wall/r_wall,
+/area/solar/starboard/fore/icemoon)
 "qiM" = (
 /obj/item/radio/intercom{
 	pixel_y = 26
@@ -58997,7 +59000,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "qWM" = (
 /turf/closed/wall/r_wall,
 /area/engine/foyer)
@@ -59061,7 +59064,7 @@
 /area/quartermaster/storage)
 "qYd" = (
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/starboard/fore)
+/area/solar/starboard/fore/icemoon)
 "qYg" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -59294,7 +59297,7 @@
 /area/crew_quarters/kitchen)
 "rbL" = (
 /turf/closed/wall/r_wall,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "rbU" = (
 /turf/closed/wall,
 /area/janitor)
@@ -59464,7 +59467,7 @@
 "req" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/starboard/aft)
+/area/solar/starboard/aft/icemoon)
 "reA" = (
 /obj/machinery/shower{
 	pixel_y = 20
@@ -60561,7 +60564,7 @@
 "rwS" = (
 /obj/item/stack/cable_coil,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/starboard/aft)
+/area/solar/starboard/aft/icemoon)
 "rxg" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/bodycontainer/crematorium{
@@ -60653,7 +60656,7 @@
 "ryw" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/starboard/aft)
+/area/solar/starboard/aft/icemoon)
 "ryA" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/tcommsat/server";
@@ -60757,7 +60760,7 @@
 /area/science/mixing)
 "rzO" = (
 /turf/closed/wall/r_wall,
-/area/solar/port/aft)
+/area/solar/port/aft/icemoon)
 "rzP" = (
 /obj/structure/window/reinforced,
 /obj/machinery/computer/cargo/request{
@@ -61105,7 +61108,7 @@
 "rFl" = (
 /obj/structure/cable,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "rFA" = (
 /turf/open/floor/plasteel/dark,
 /area/security/interrogation)
@@ -61460,7 +61463,7 @@
 "rLd" = (
 /obj/structure/steam_fissure,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "rLi" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -62312,7 +62315,7 @@
 "rWS" = (
 /obj/structure/lattice,
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/starboard/aft)
+/area/solar/starboard/aft/icemoon)
 "rXa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -63189,7 +63192,7 @@
 "siG" = (
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/starboard/fore)
+/area/solar/starboard/fore/icemoon)
 "siJ" = (
 /obj/structure/ethernet_cable{
 	icon_state = "1-4"
@@ -64354,7 +64357,7 @@
 "szv" = (
 /obj/structure/steam_fissure,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/top_layer/outdoors)
+/area/solar/starboard/fore/icemoon)
 "szB" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod One"
@@ -65930,7 +65933,7 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/starboard/aft)
+/area/solar/starboard/aft/icemoon)
 "sWn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/westleft{
@@ -67062,7 +67065,7 @@
 	},
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/starboard/aft)
+/area/solar/starboard/aft/icemoon)
 "tlI" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -72311,7 +72314,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "uJv" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Courtroom"
@@ -74122,7 +74125,7 @@
 "vkJ" = (
 /obj/structure/steam_fissure,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/aft)
+/area/solar/port/aft/icemoon)
 "vkK" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -74164,7 +74167,7 @@
 "vkY" = (
 /obj/structure/lattice,
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/starboard/fore)
+/area/solar/starboard/fore/icemoon)
 "vla" = (
 /obj/effect/turf_decal/trimline/purple/warning/lower{
 	dir = 8
@@ -75034,7 +75037,7 @@
 "vwU" = (
 /obj/structure/cable,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/aft)
+/area/solar/port/aft/icemoon)
 "vxh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -76145,7 +76148,7 @@
 	name = "pressure chamber vent"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/top_layer/outdoors)
+/area/solar/starboard/fore/icemoon)
 "vMU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -76213,7 +76216,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/solar/starboard/aft)
+/area/solar/starboard/aft/icemoon)
 "vOG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -76745,7 +76748,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/starboard/fore)
+/area/solar/starboard/fore/icemoon)
 "vWo" = (
 /obj/machinery/vending/medical,
 /obj/effect/turf_decal/trimline/blue/line{
@@ -77731,7 +77734,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/port/fore)
+/area/solar/port/fore/icemoon)
 "wjp" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -78061,7 +78064,7 @@
 	icon_state = "0-2"
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/top_layer/outdoors)
+/area/solar/starboard/fore/icemoon)
 "wnq" = (
 /obj/machinery/power/apc/highcap/fifteen_k{
 	areastring = "/area/hallway/secondary/entry";
@@ -78086,7 +78089,7 @@
 /area/maintenance/starboard)
 "wnF" = (
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/starboard/fore)
+/area/solar/starboard/fore/icemoon)
 "wnP" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
@@ -78300,7 +78303,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/starboard/aft)
+/area/solar/starboard/aft/icemoon)
 "wqp" = (
 /obj/item/radio/intercom{
 	pixel_y = -28
@@ -80208,7 +80211,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer,
-/area/solar/port/aft)
+/area/solar/port/aft/icemoon)
 "wRC" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
@@ -81079,7 +81082,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/solar/port/aft)
+/area/solar/port/aft/icemoon)
 "xfc" = (
 /obj/machinery/light{
 	dir = 8
@@ -85320,7 +85323,7 @@
 "yiu" = (
 /obj/structure/lattice,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/solar/starboard/fore)
+/area/solar/starboard/fore/icemoon)
 "yiy" = (
 /obj/structure/sign/poster/official/random,
 /turf/closed/wall,
@@ -260100,11 +260103,11 @@ bkq
 qYd
 wnF
 wnF
-bdu
-bdu
-bdu
-bdu
-bdu
+qiK
+qiK
+qiK
+qiK
+qiK
 wnF
 wnF
 qYd
@@ -260614,11 +260617,11 @@ bkq
 qYd
 wnF
 wnF
-bdu
-bdu
+qiK
+qiK
 apa
-bdu
-bdu
+qiK
+qiK
 yiu
 wnF
 yiu

--- a/code/controllers/subsystem/daylight.dm
+++ b/code/controllers/subsystem/daylight.dm
@@ -1,6 +1,9 @@
+#define NIGHT_TURF_BRIGHTNESS 0.1
+
 SUBSYSTEM_DEF(daylight)
 	name = "Daylight"
 	wait = 2 SECONDS
+	flags = SS_NO_INIT
 	/// Time required to complete a full day-night cycle
 	var/daylight_time = 24 MINUTES
 	/// All areas that should update their lighting based on time of day
@@ -17,4 +20,4 @@ SUBSYSTEM_DEF(daylight)
 	var/light_alpha = round(255 * light_coefficient)
 	var/light_color = rgb(255, 130 + 125 * light_coefficient, 130 + 125 * light_coefficient)
 	for(var/area/lit_area as anything in daylight_areas)
-		lit_area.set_base_lighting(light_color, light_alpha)
+		lit_area.set_base_lighting(light_color, light_alpha * lit_area.daylight_multiplier)

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -681,6 +681,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	flags_1 = NONE
 	ambience_index = AMBIENCE_ENGI
 	sound_environment = SOUND_AREA_SPACE
+	lights_always_start_on = TRUE
 	minimap_color = "#6b6b6b"
 	airlock_wires = /datum/wires/airlock/engineering
 
@@ -709,9 +710,17 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Starboard Quarter (SE) Solar Array"
 	icon_state = "panelsAS"
 
+/area/solar/starboard/aft/icemoon
+	name = "Southeast (SE) Geothermal Station" // it's a planetary station and not a ship, cardinal directions apply
+	uses_daylight = TRUE
+
 /area/solar/starboard/fore
 	name = "Starboard Bow (NE) Solar Array"
 	icon_state = "panelsFS"
+
+/area/solar/starboard/fore/icemoon
+	name = "Northeast (NE) Geothermal Station"
+	uses_daylight = TRUE
 
 /area/solar/port
 	name = "Port (W) Solar Array"
@@ -721,9 +730,17 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	name = "Port Quarter (SW) Solar Array"
 	icon_state = "panelsAP"
 
+/area/solar/port/aft/icemoon
+	name = "Southwest (SW) Geothermal Station"
+	uses_daylight = TRUE
+
 /area/solar/port/fore
 	name = "Port Bow (NW) Solar Array"
 	icon_state = "panelsFP"
+
+/area/solar/port/fore/icemoon
+	name = "Northwest (NW) Geothermal Station"
+	uses_daylight = TRUE
 
 
 //Solar Maint

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -138,6 +138,8 @@
 
 	/// Whether to cycle brightness based on time of day
 	var/uses_daylight = FALSE
+	/// Daylight brightness
+	var/daylight_multiplier = 1
 	
 /**
   * A list of teleport locations

--- a/code/game/area/areas/mining.dm
+++ b/code/game/area/areas/mining.dm
@@ -181,6 +181,8 @@
 	power_light = FALSE
 	requires_power = TRUE
 	ambience_index = AMBIENCE_MINING
+	uses_daylight = TRUE
+	daylight_multiplier = 0.7
 
 /area/icemoon/top_layer/outdoors
 	name = "Icemoon Wastes"

--- a/code/game/turfs/closed/minerals.dm
+++ b/code/game/turfs/closed/minerals.dm
@@ -243,7 +243,8 @@
 
 /turf/closed/mineral/random/high_chance/snow/top_layer
 	light_range = 2
-	light_power = 0.1
+	light_power = NIGHT_TURF_BRIGHTNESS
+	light_color = COLOR_STARLIGHT
 	mineralSpawnChanceList = list(
 		/turf/closed/mineral/uranium/ice/icemoon/top_layer = 35, /turf/closed/mineral/diamond/ice/icemoon/top_layer = 25, /turf/closed/mineral/gold/ice/icemoon/top_layer = 40, /turf/closed/mineral/titanium/ice/icemoon/top_layer = 45,
 		/turf/closed/mineral/silver/ice/icemoon/top_layer = 50, /turf/closed/mineral/plasma/ice/icemoon/top_layer = 50, /turf/closed/mineral/bscrystal/ice/icemoon/top_layer = 15, /turf/closed/mineral/dilithium/ice/icemoon/top_layer = 15)
@@ -335,7 +336,8 @@
 
 /turf/closed/mineral/random/snow/top_layer
 	light_range = 2
-	light_power = 0.1
+	light_power = NIGHT_TURF_BRIGHTNESS
+	light_color = COLOR_STARLIGHT
 	mineralSpawnChanceList = list(
 		/turf/closed/mineral/uranium/ice/icemoon/top_layer = 5, /turf/closed/mineral/diamond/ice/icemoon/top_layer = 1, /turf/closed/mineral/gold/ice/icemoon/top_layer = 10, /turf/closed/mineral/titanium/ice/icemoon/top_layer = 10,
 		/turf/closed/mineral/silver/ice/icemoon/top_layer = 12, /turf/closed/mineral/plasma/ice/icemoon/top_layer = 19, /turf/closed/mineral/iron/ice/icemoon/top_layer = 40,
@@ -409,7 +411,8 @@
 
 /turf/closed/mineral/iron/ice/icemoon/top_layer
 	light_range = 2
-	light_power = 0.1
+	light_power = NIGHT_TURF_BRIGHTNESS
+	light_color = COLOR_STARLIGHT
 
 /turf/closed/mineral/uranium
 	mineralType = /obj/item/stack/ore/uranium
@@ -452,7 +455,8 @@
 
 /turf/closed/mineral/uranium/ice/icemoon/top_layer
 	light_range = 2
-	light_power = 0.1
+	light_power = NIGHT_TURF_BRIGHTNESS
+	light_color = COLOR_STARLIGHT
 
 /turf/closed/mineral/diamond
 	mineralType = /obj/item/stack/ore/diamond
@@ -495,7 +499,8 @@
 
 /turf/closed/mineral/diamond/ice/icemoon/top_layer
 	light_range = 2
-	light_power = 0.1
+	light_power = NIGHT_TURF_BRIGHTNESS
+	light_color = COLOR_STARLIGHT
 
 /turf/closed/mineral/gold
 	mineralType = /obj/item/stack/ore/gold
@@ -538,7 +543,8 @@
 
 /turf/closed/mineral/gold/ice/icemoon/top_layer
 	light_range = 2
-	light_power = 0.1
+	light_power = NIGHT_TURF_BRIGHTNESS
+	light_color = COLOR_STARLIGHT
 
 /turf/closed/mineral/silver
 	mineralType = /obj/item/stack/ore/silver
@@ -581,7 +587,8 @@
 
 /turf/closed/mineral/silver/ice/icemoon/top_layer
 	light_range = 2
-	light_power = 0.1
+	light_power = NIGHT_TURF_BRIGHTNESS
+	light_color = COLOR_STARLIGHT
 
 /turf/closed/mineral/titanium
 	mineralType = /obj/item/stack/ore/titanium
@@ -624,8 +631,8 @@
 
 /turf/closed/mineral/titanium/ice/icemoon/top_layer
 	light_range = 2
-	light_power = 0.1
-
+	light_power = NIGHT_TURF_BRIGHTNESS
+	light_color = COLOR_STARLIGHT
 
 /turf/closed/mineral/plasma
 	mineralType = /obj/item/stack/ore/plasma
@@ -668,7 +675,8 @@
 
 /turf/closed/mineral/plasma/ice/icemoon/top_layer
 	light_range = 2
-	light_power = 0.1
+	light_power = NIGHT_TURF_BRIGHTNESS
+	light_color = COLOR_STARLIGHT
 
 /turf/closed/mineral/bananium
 	mineralType = /obj/item/stack/ore/bananium
@@ -752,7 +760,8 @@
 
 /turf/closed/mineral/bscrystal/ice/icemoon/top_layer
 	light_range = 2
-	light_power = 0.1
+	light_power = NIGHT_TURF_BRIGHTNESS
+	light_color = COLOR_STARLIGHT
 
 /turf/closed/mineral/volcanic
 	environment_type = "basalt"
@@ -977,7 +986,8 @@
 
 /turf/closed/mineral/gibtonite/ice/icemoon/top_layer
 	light_range = 2
-	light_power = 0.1
+	light_power = NIGHT_TURF_BRIGHTNESS
+	light_color = COLOR_STARLIGHT
 
 /turf/closed/mineral/magmite
 	mineralType = /obj/item/magmite

--- a/code/game/turfs/open/floor/plating/asteroid.dm
+++ b/code/game/turfs/open/floor/plating/asteroid.dm
@@ -208,7 +208,8 @@
 
 /turf/open/floor/plating/asteroid/snow/icemoon/top_layer
 	light_range = 2
-	light_power = 0.1
+	light_power = NIGHT_TURF_BRIGHTNESS
+	light_color = COLOR_STARLIGHT
 
 /turf/open/lava/plasma/ice_moon
 	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
@@ -252,7 +253,8 @@
 
 /turf/open/floor/plating/asteroid/snow/ice/icemoon/top_layer
 	light_range = 2
-	light_power = 0.1
+	light_power = NIGHT_TURF_BRIGHTNESS
+	light_color = COLOR_STARLIGHT
 
 /turf/open/floor/plating/asteroid/snow/ice/burn_tile()
 	return FALSE

--- a/code/game/turfs/open/floor/plating/misc_plating.dm
+++ b/code/game/turfs/open/floor/plating/misc_plating.dm
@@ -225,7 +225,8 @@
 
 /turf/open/floor/plating/ice/icemoon/top_layer
 	light_range = 2
-	light_power = 0.1
+	light_power = NIGHT_TURF_BRIGHTNESS
+	light_color = COLOR_STARLIGHT
 
 /turf/open/floor/plating/snowed
 	name = "snowed-over plating"

--- a/yogstation/code/game/turfs/simulated/minerals.dm
+++ b/yogstation/code/game/turfs/simulated/minerals.dm
@@ -40,4 +40,5 @@
 
 /turf/closed/mineral/dilithium/ice/icemoon/top_layer
 	light_range = 2
-	light_power = 0.1
+	light_power = NIGHT_TURF_BRIGHTNESS
+	light_color = COLOR_STARLIGHT

--- a/yogstation/code/modules/jungleland/jungle_turfs.dm
+++ b/yogstation/code/modules/jungleland/jungle_turfs.dm
@@ -82,7 +82,7 @@ Temperature: 126.85 °C (400 K)
 	var/ore_present = ORE_EMPTY
 	var/spawn_overlay = TRUE
 	var/can_mine = TRUE
-	light_power = 0.1
+	light_power = NIGHT_TURF_BRIGHTNESS
 	light_range = 2 // fullbright it for proper shadows and darkspawn interaction
 	light_color = COLOR_STARLIGHT
 
@@ -194,7 +194,7 @@ Temperature: 126.85 °C (400 K)
 	planetary_atmos = TRUE
 	baseturfs = /turf/open/water/smooth/toxic_pit
 
-	light_power = 0.15 // reflects the moonlight
+	light_power = NIGHT_TURF_BRIGHTNESS + 0.05 // reflects the moonlight
 	light_range = 2 // fullbright it for proper shadows and darkspawn interaction
 	light_color = COLOR_STARLIGHT
 


### PR DESCRIPTION
# Document the changes in your pull request

Icemoon now uses the day/night cycle system currently used for jungleland (#22554), also fixes the geothermal power station areas being called "solar arrays"

# Why is this good for the game?

![image](https://github.com/user-attachments/assets/a409e000-be13-46fc-a116-3b582aa426c1)

![image](https://github.com/user-attachments/assets/3c180a96-13da-487e-bc9b-0b66fc29f847)

![image](https://github.com/user-attachments/assets/853040a1-50f0-42c7-8edf-3117922c8689)

Looks cool, no noticeable impact on performance.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
tweak: Icemoon now uses the day/night cycle
mapping: Icemoon's geothermal power stations are no longer named solar arrays
/:cl:
