### PR TITLE
Break machinery objective take into account multi z stations and only assigns station machines

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1597,7 +1597,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 		var/iteration = 1
 		while(!target_obj_type && targets_len >= iteration)
 			for(var/obj/machinery/machine as anything in GLOB.machines)
-				if(machine.z in station_zs && istype(machine, potential_target_types[iteration]) && get_area(machine) in GLOB.the_station_areas)
+				if((machine.z in station_zs) && istype(machine, potential_target_types[iteration]) && (get_area(machine) in GLOB.the_station_areas))
 					target_obj_type = potential_target_types[iteration]
 					break
 			iteration++

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1573,7 +1573,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 
 /datum/objective/break_machinery/finalize()
 	target_areas = list()
-	var/station_z = SSmapping.levels_by_trait(ZTRAIT_STATION)[1]
+	var/list/station_zs = SSmapping.levels_by_trait(ZTRAIT_STATION)
 	if(!target_obj_type) // Select our target machine if there is none pre-set
 		potential_target_types = list(
 			// SCIENCE
@@ -1597,7 +1597,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 		var/iteration = 1
 		while(!target_obj_type && targets_len >= iteration)
 			for(var/obj/machinery/machine as anything in GLOB.machines)
-				if(machine.z == station_z && istype(machine, potential_target_types[iteration]))
+				if(machine.z in station_zs && istype(machine, potential_target_types[iteration]) && get_area(machine) in GLOB.the_station_areas)
 					target_obj_type = potential_target_types[iteration]
 					break
 			iteration++
@@ -1612,12 +1612,10 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	for(var/obj/machinery/machine as anything in GLOB.machines)
 		if(!istype(machine, target_obj_type))
 			continue
-		if(machine.z != station_z)
+		if(machine.z in station_zs)
 			continue
-		if(!istype(get_area(machine), /area))
+		if(!(get_area(machine) in GLOB.the_station_areas))
 			continue
-		if(istype(get_area(machine), /area/shuttle))
-			continue //no whiteship machines
 		eligible_machines |= machine
 
 	eligible_machines = shuffle(eligible_machines)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1612,7 +1612,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	for(var/obj/machinery/machine as anything in GLOB.machines)
 		if(!istype(machine, target_obj_type))
 			continue
-		if(machine.z in station_zs)
+		if(!(machine.z in station_zs))
 			continue
 		if(!(get_area(machine) in GLOB.the_station_areas))
 			continue


### PR DESCRIPTION
# Document the changes in your pull request

- always got the lowest z level for the objective, this means that icemeta would look at the bottom most station level always
- got non-station machines too, so on icemeta you'd have to venture to random machines in the lower Z levels to a machine nobody cares about

# Why is this good for the game?
More consistent + actually keeps these objectives station-side

# Testing
<!-- Describe what testing you did with this PR. Try to be thorough, especially if this is a larger project. -->


# Changelog

:cl:
tweak: Break machinery objective take into account multi z stations and only assigns station machines
/:cl:
