### PR TITLE
adjusts slurring from 51 drunk level to 16 drunk level and makes you slur different amounts based on your drunk level

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -244,10 +244,10 @@
 #define set_derpspeech(duration) set_timed_status_effect(duration, /datum/status_effect/speech/stutter/derpspeech)
 #define set_derpspeech_if_lower(duration) set_timed_status_effect(duration, /datum/status_effect/speech/stutter/derpspeech, TRUE)
 
-#define adjust_slurring(duration) adjust_timed_status_effect(duration, /datum/status_effect/speech/slurring/drunk)
-#define adjust_slurring_up_to(duration, up_to) adjust_timed_status_effect(duration, /datum/status_effect/speech/slurring/drunk, up_to)
-#define set_slurring(duration) set_timed_status_effect(duration, /datum/status_effect/speech/slurring/drunk)
-#define set_slurring_if_lower(duration) set_timed_status_effect(duration, /datum/status_effect/speech/slurring/drunk, TRUE)
+#define adjust_slurring(duration) adjust_timed_status_effect(duration, /datum/status_effect/speech/slurring/generic)
+#define adjust_slurring_up_to(duration, up_to) adjust_timed_status_effect(duration, /datum/status_effect/speech/slurring/generic, up_to)
+#define set_slurring(duration) set_timed_status_effect(duration, /datum/status_effect/speech/slurring/generic)
+#define set_slurring_if_lower(duration) set_timed_status_effect(duration, /datum/status_effect/speech/slurring/generic, TRUE)
 
 #define adjust_dizzy(duration) adjust_timed_status_effect(duration, /datum/status_effect/dizziness)
 #define adjust_dizzy_up_to(duration, up_to) adjust_timed_status_effect(duration, /datum/status_effect/dizziness, up_to)

--- a/code/datums/status_effects/debuffs/drunk.dm
+++ b/code/datums/status_effects/debuffs/drunk.dm
@@ -151,6 +151,11 @@
 		owner.adjustBruteLoss(-0.1, FALSE)
 		owner.adjustFireLoss(-0.06, FALSE)
 
+	// over 21 normal people will start to slur
+	if(drunk_value >= 21)
+		if(!HAS_TRAIT(owner, TRAIT_ALCOHOL_TOLERANCE))
+			owner.adjust_slurring_up_to(2.4 SECONDS, 7 SECONDS)
+
 	// Over 41, we have a 30% chance to gain confusion, and we will always have 20 seconds of dizziness.
 	if(drunk_value >= 41)
 		if(prob(30))
@@ -162,7 +167,7 @@
 			owner.adjustBruteLoss(-0.2, FALSE)
 			owner.adjustFireLoss(-0.09, FALSE)
 
-	// Over 51, we have a 3% chance to gain a lot of confusion and vomit, and we will always have 50 seconds of dizziness and normal drinkers will start to slur
+	// Over 51, we have a 3% chance to gain a lot of confusion and vomit, and we will always have 50 seconds of dizziness
 	if(drunk_value >= 51)
 		owner.set_dizzy_if_lower(50 SECONDS)
 		if(prob(3))
@@ -170,8 +175,6 @@
 			if(iscarbon(owner))
 				var/mob/living/carbon/carbon_owner = owner
 				carbon_owner.vomit() // Vomiting clears toxloss - consider this a blessing
-		if(!HAS_TRAIT(owner, TRAIT_ALCOHOL_TOLERANCE))
-			owner.adjust_slurring_up_to(2.4 SECONDS, 7 SECONDS)
 
 	// Over 71, we will constantly have blurry eyes
 	if(drunk_value >= 71)

--- a/code/datums/status_effects/debuffs/drunk.dm
+++ b/code/datums/status_effects/debuffs/drunk.dm
@@ -146,7 +146,7 @@
 
 	// Over 11, Light drinkers will constantly gain slurring up to 10 seconds of slurring.
 	if(HAS_TRAIT(owner, TRAIT_LIGHT_DRINKER) & (drunk_value >= 11))
-		owner.adjust_slurring_up_to(2.4 SECONDS, 10 SECONDS)
+		owner.adjust_timed_status_effect(4 SECONDS, /datum/status_effect/speech/slurring/drunk, max_duration = 10 SECONDS)
 	if(HAS_TRAIT(owner, TRAIT_DRUNK_HEALING) & (drunk_value >= 11)) // To save headache this will be separate for drunken resilience & effects stack with lower tiers
 		owner.adjustBruteLoss(-0.1, FALSE)
 		owner.adjustFireLoss(-0.06, FALSE)
@@ -154,7 +154,7 @@
 	// over 21 normal people will start to slur
 	if(drunk_value >= 21)
 		if(!HAS_TRAIT(owner, TRAIT_ALCOHOL_TOLERANCE))
-			owner.adjust_slurring_up_to(2.4 SECONDS, 7 SECONDS)
+			owner.adjust_timed_status_effect(4 SECONDS, /datum/status_effect/speech/slurring/drunk, max_duration = 20 SECONDS)
 
 	// Over 41, we have a 30% chance to gain confusion, and we will always have 20 seconds of dizziness.
 	if(drunk_value >= 41)
@@ -189,7 +189,7 @@
 		if(owner.stat == CONSCIOUS && prob(5))
 			to_chat(owner, span_warning("Maybe you should lie down for a bit..."))
 		if(HAS_TRAIT(owner, TRAIT_ALCOHOL_TOLERANCE))
-			owner.adjust_slurring_up_to(2.4 SECONDS, 4 SECONDS)
+			owner.adjust_timed_status_effect(4 SECONDS, /datum/status_effect/speech/slurring/drunk, max_duration = 20 SECONDS)
 
 	// Over 91, we gain even more toxloss, brain damage, and have a chance of dropping into a long sleep
 	if(drunk_value >= 91)

--- a/code/datums/status_effects/debuffs/speech_debuffs.dm
+++ b/code/datums/status_effects/debuffs/speech_debuffs.dm
@@ -191,13 +191,35 @@
 
 	return modified_char
 
-/datum/status_effect/speech/slurring/drunk
-	id = "drunk_slurring"
+/datum/status_effect/speech/slurring/generic
+	id = "generic_slurring"
 	common_prob = 33
-	uncommon_prob = 5
+	uncommon_prob = 0
 	replacement_prob = 5
 	doubletext_prob = 10
 	text_modification_file = "slurring_drunk_text.json"
+
+/datum/status_effect/speech/slurring/drunk
+	id = "drunk_slurring"
+	// These defaults are updated when speech event occur.
+	common_prob = -1
+	uncommon_prob = -1
+	replacement_prob = -1
+	doubletext_prob = -1
+	text_modification_file = "slurring_drunk_text.json"
+
+/datum/status_effect/speech/slurring/drunk/handle_message(datum/source, list/message_args)
+	var/current_drunkness = owner.get_drunk_amount()
+	// These numbers are arbitarily picked
+	// Common replacements start at about 20, and maxes out at about 85
+	common_prob = clamp((current_drunkness * 0.8) - 16, 0, 50)
+	// Uncommon replacements (burping) start at 50 and max out at 110 (when you are dying)
+	uncommon_prob = clamp((current_drunkness * 0.2) - 10, 0, 12)
+	// Replacements start at 20 and max out at about 60
+	replacement_prob = clamp((current_drunkness * 0.4) - 8, 0, 12)
+	// Double texting start out at about 25 and max out at about 60
+	doubletext_prob = clamp((current_drunkness * 0.5) - 12, 0, 20)
+	return ..()
 
 /datum/status_effect/speech/slurring/cult
 	id = "cult_slurring"


### PR DESCRIPTION
# Document the changes in your pull request

it's way too high now you gotta get blitzed to even start slurring, so i adjusted it from 51 to 21, light drinkers still start at 11

also ports part of https://github.com/tgstation/tgstation/pull/75459

# Why is this good for the game?
Sluring are good

# Changelog

:cl: MrMelbert, ToasterBiome
tweak: People start slurring at drunk level 16 now instead of 51
rscadd: people slur at different drunk levels now
/:cl:
