### PR TITLE
makes burning surgical mats drop plastic instead of metal

### DIFF
--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -460,6 +460,8 @@
 	can_buckle = FALSE
 	bolts = FALSE
 	var/obj/picked_up = /obj/item/surgical_mat
+	buildstacktype = /obj/item/stack/sheet/plastic
+	buildstackamount = 3
 
 /obj/structure/bed/surgical_mat/Initialize(mapload)
 	..()


### PR DESCRIPTION
# Document the changes in your pull request

subtype of bed moment

# Changelog

:cl: M4565, ToasterBiome
bugfix: makes burning surgical mats drop plastic instead of metal
/:cl:
