### PR TITLE
You can no longer RCD space transit tiles if it's not part of a shuttle

### DIFF
--- a/code/game/turfs/open/space/transit.dm
+++ b/code/game/turfs/open/space/transit.dm
@@ -86,7 +86,7 @@
 /turf/open/space/transit/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
 	if(!CanBuildHere()) //no RCDing transit space if we arent part of a shuttle
 		return FALSE
-	..()
+	return ..()
 	
 
 /turf/open/space/transit/south

--- a/code/game/turfs/open/space/transit.dm
+++ b/code/game/turfs/open/space/transit.dm
@@ -83,6 +83,12 @@
 /turf/open/space/transit/CanBuildHere()
 	return SSshuttle.is_in_shuttle_bounds(src)
 
+/turf/open/space/transit/rcd_vals(mob/user, obj/item/construction/rcd/the_rcd)
+	if(!CanBuildHere()) //no RCDing transit space if we arent part of a shuttle
+		return FALSE
+	..()
+	
+
 /turf/open/space/transit/south
 	dir = SOUTH
 


### PR DESCRIPTION
# Document the changes in your pull request

Yep, just adding this in here...

# Why is this good for the game?
There's an exploit to get to centcom through the tear, this fixes it

# Testing
Tried to do the exploit, didn't work

# Changelog

:cl: glaenjoyer, ToasterBiome
tweak: You can no longer RCD space transit tiles if it's not part of a shuttle
/:cl:
