### PR TITLE
Adds access req to fuel rod crates

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1234,8 +1234,9 @@
 
 /datum/supply_pack/engine/fuel_rod_basic
 	name = "Uranium-235 Fuel Rods Crate"
-	desc = "Contains 5 Enriched Uranium Control Rods."
+	desc = "Contains 5 Enriched Uranium Control Rods. Requires engineering access to open."
 	cost = 5000
+	access_view = ACCESS_ENGINEERING
 	contains = list(/obj/item/fuel_rod,
 					/obj/item/fuel_rod,
 					/obj/item/fuel_rod,
@@ -1247,8 +1248,9 @@
 
 /datum/supply_pack/engine/fuel_rod_plutonium
 	name = "Plutonium-239 Fuel Rods Crate"
-	desc = "Contains 5 Plutonium-239 Control Rods."
+	desc = "Contains 5 Plutonium-239 Control Rods. Requires engineering access to open."
 	cost = 15000
+	access_view = ACCESS_ENGINEERING
 	contains = list(/obj/item/fuel_rod/plutonium,
 					/obj/item/fuel_rod/plutonium,
 					/obj/item/fuel_rod/plutonium,


### PR DESCRIPTION
# Document the changes in your pull request
As it says on the tin

# Why is this good for the game?
Silly greyshirts with little to no hazard gear or sense of self preservation may accidentally do stuff with these they shouldn't

# Testing
need to

# Wiki Documentation
Yes

# Changelog
:cl:
tweak: Reactor fuel rod crates now need engineering access to open
/:cl:
