### PR TITLE
Removes styptic powder and silver sulfadiazine vials from the Hypovendor

### DIFF
--- a/yogstation/code/modules/vending/hypomed.dm
+++ b/yogstation/code/modules/vending/hypomed.dm
@@ -11,8 +11,6 @@
 	premium = list(	/obj/item/hypospray = 5,
 					/obj/item/reagent_containers/glass/bottle/vial/libital = 10,
 					/obj/item/reagent_containers/glass/bottle/vial/aiuri = 10,
-					/obj/item/reagent_containers/glass/bottle/vial/styptic = 10,
-					/obj/item/reagent_containers/glass/bottle/vial/silver_sulfadiazine = 10,
 					/obj/item/reagent_containers/glass/bottle/vial/charcoal = 10,
 					/obj/item/reagent_containers/glass/bottle/vial/perfluorodecalin = 10,
 					/obj/item/reagent_containers/glass/bottle/vial/epi = 10,


### PR DESCRIPTION
# Why is this good for the game?
-Prevents bypassing chemistry when making hypomixes
-Removes noob trap because styptic powder and silver sulfadiazine do toxin damage when injected (hypospray 99% of the time)
-it's still in the advanced kits

# Testing
gotta, but i shouldn't really need to

:cl:
tweak: Removes styptic powder and silver sulfadiazine vials from the Hypovendor
/:cl:
