### PR TITLE
Fixes crafted donuts never, ever getting their sprinkles

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_pastry.dm
+++ b/code/modules/food_and_drinks/food/snacks_pastry.dm
@@ -8,7 +8,7 @@
 	icon_state = "donut1"
 	bitesize = 5
 	bonus_reagents = list(/datum/reagent/consumable/sugar = 1)
-	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/sprinkles = 1, /datum/reagent/consumable/sugar = 2)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/sugar = 2)
 	filling_color = "#D2691E"
 	tastes = list("donut" = 1)
 	foodtype = JUNKFOOD | GRAIN | FRIED | SUGAR | BREAKFAST
@@ -27,7 +27,7 @@
 	is_frosted = TRUE
 	name = "frosted [name]"
 	icon_state = frosted_icon //delish!
-	reagents.add_reagent(/datum/reagent/consumable/sprinkles, 1)
+	reagents.add_reagent(/datum/reagent/consumable/sprinkles, 2)
 	filling_color = "#FF69B4"
 	return TRUE
 

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
@@ -31,6 +31,12 @@
 	result = /obj/item/reagent_containers/food/snacks/donut
 	category = CAT_PASTRY
 
+/datum/crafting_recipe/food/donut/on_craft_completion(mob/user, atom/result)
+	. = ..()
+	var/obj/item/reagent_containers/food/snacks/donut/donut_result = result
+	if(donut_result.is_frosted)
+		donut_result.reagents.add_reagent(/datum/reagent/consumable/sprinkles, 2)
+
 /datum/crafting_recipe/food/jellydonut
 	name = "Jelly Donut"
 	reqs = list(


### PR DESCRIPTION
# Document the changes in your pull request
Original PR: https://github.com/tgstation/tgstation/pull/86652

Only manually spawned donuts currently get sprinkles. This fixes it so that crafted frosted donuts get sprinkles (2u). I've removed it off the base donut too, so only frosted ones get this.

Bug fix but also I don't think unfrosted donuts should contain sprinkles even though this was intended, so I removed that with this.

# Testing
Grinded both types of basic donut (frosted and unfrosted), both manually spawned in and crafted. Sprinkles appear when expected.

:cl: vinylspiders, ktlwjec
bugfix: Crafted frosted donuts contain sprinkles.
/:cl: