### PR TITLE
New Emergency Shuttle: The Fleet

### DIFF
--- a/_maps/shuttles/emergency_fleet.dmm
+++ b/_maps/shuttles/emergency_fleet.dmm
@@ -1,14 +1,4 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"aa" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/window{
-	dir = 4
-	},
-/obj/structure/window{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/shuttle/escape)
 "ah" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/delivery/white,
@@ -26,28 +16,16 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "ap" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "fleettoi";
-	map_pad_link_id = "fleetcom2toi"
-	},
 /obj/structure/sign/directions/command{
-	pixel_y = 9
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetesc2com";
+	linked_to = "fleetcom";
+	name = "Portal to Cargo Shuttle"
 	},
 /turf/open/floor/light,
-/area/shuttle/escape)
-"ar" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "EmFleet1"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "at" = (
 /obj/structure/chair/comfy/shuttle{
@@ -62,11 +40,6 @@
 /obj/structure/toilet{
 	desc = "The HT-451, a torque rotation-based, waste disposal unit for small matter. This one seems remarkably dirty.";
 	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "sec_cell_flasher2";
-	pixel_x = 6;
-	pixel_y = -24
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
@@ -141,10 +114,26 @@
 "cU" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /mob/living/simple_animal/hostile/retaliate/goat/inverted,
-/obj/machinery/door/window/brigdoor/westright{
-	req_access_txt = "55"
+/obj/machinery/door/window/northleft{
+	dir = 8;
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio{
+	dir = 8
 	},
 /turf/open/indestructible/grass/jungle,
+/area/shuttle/escape)
+"cZ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "dh" = (
 /obj/structure/window/reinforced{
@@ -152,8 +141,12 @@
 	},
 /obj/structure/flora/ausbushes/fullgrass,
 /mob/living/simple_animal/hostile/retaliate/goat/twisted,
-/obj/machinery/door/window/brigdoor/westright{
-	req_access_txt = "55"
+/obj/machinery/door/window/northleft{
+	dir = 8;
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio{
+	dir = 8
 	},
 /turf/open/indestructible/grass/jungle,
 /area/shuttle/escape)
@@ -182,7 +175,18 @@
 	pixel_y = 3
 	},
 /obj/item/storage/firstaid/fire,
+/obj/machinery/door/window/northleft{
+	name = "First-Aid Supplies";
+	red_alert_access = 1;
+	dir = 8
+	},
+/obj/effect/mapping_helpers/windoor/access/all/medical/general{
+	dir = 8
+	},
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"dA" = (
+/turf/open/indestructible/sound/pool/end,
 /area/shuttle/escape)
 "dD" = (
 /obj/structure/window/reinforced{
@@ -194,9 +198,11 @@
 	name = "Sprinkles Goat";
 	desc = "You can feel your teeth getting numb."
 	},
-/obj/machinery/door/window/brigdoor/southleft{
-	req_access_txt = "55"
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen";
+	dir = 2
 	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio,
 /turf/open/indestructible/grass/jungle,
 /area/shuttle/escape)
 "dE" = (
@@ -239,9 +245,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/sign/poster/official/space_cops{
-	pixel_x = -32
-	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "el" = (
@@ -249,10 +252,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -32
-	},
-/obj/machinery/button{
-	pixel_x = -21;
-	id = "fleetsup"
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
@@ -266,10 +265,6 @@
 /obj/item/radio/intercom{
 	pixel_y = -26
 	},
-/obj/item/storage/pod{
-	pixel_x = 4;
-	pixel_y = 32
-	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
 	},
@@ -277,7 +272,7 @@
 /area/shuttle/escape)
 "ey" = (
 /obj/machinery/vending/boozeomat/all_access,
-/turf/open/floor/carpet/plainblue,
+/turf/open/floor/carpet/blue,
 /area/shuttle/escape)
 "eB" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -288,17 +283,20 @@
 /obj/machinery/defibrillator_mount/loaded{
 	pixel_y = 32
 	},
-/obj/item/healthanalyzer/advanced,
-/obj/item/clothing/glasses/hud/health,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "eG" = (
-/obj/machinery/button/flasher{
-	id = "cockpit_flasher";
-	pixel_x = 6;
-	pixel_y = -24
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
 	},
-/turf/open/floor/mineral/titanium/white,
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetpod2";
+	linked_to = "fleetesc2pod2";
+	name = "Portal to Escape Lounge Shuttle"
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "eX" = (
 /obj/machinery/door/firedoor/border_only{
@@ -308,14 +306,17 @@
 /area/shuttle/escape)
 "eZ" = (
 /obj/structure/pool_ladder,
-/turf/open/indestructible/sound/pool,
+/turf/open/indestructible/sound/pool/end,
 /area/shuttle/escape)
 "fd" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/window{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/grass,
 /area/shuttle/escape)
 "fg" = (
 /obj/machinery/modular_computer/console/preset/engineering,
@@ -328,8 +329,7 @@
 /obj/structure/sink{
 	color = "#FFD700";
 	dir = 8;
-	pixel_x = -12;
-	name = "golden sink"
+	pixel_x = -12
 	},
 /turf/open/floor/carpet/royalblack,
 /area/shuttle/escape)
@@ -339,10 +339,6 @@
 /obj/item/mop,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -32
-	},
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
@@ -392,15 +388,11 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"fN" = (
-/obj/structure/sign/departments/minsky/security/security,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
-/area/shuttle/escape)
 "fQ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/conveyor{
 	dir = 1;
-	id = "EmFleet3"
+	id = "EmFleet1"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -419,6 +411,19 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"ga" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetcom2toi";
+	linked_to = "fleettoi";
+	name = "Portal to Luxury Restroom Pod"
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
 "gz" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -432,7 +437,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = 25
 	},
-/turf/open/floor/carpet/blue,
+/turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "gD" = (
 /obj/machinery/computer/secure_data{
@@ -440,6 +445,9 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
@@ -453,31 +461,27 @@
 	pixel_x = 3;
 	req_access_txt = "55"
 	},
-/obj/machinery/door/window/brigdoor/southright,
 /mob/living/simple_animal/hostile/retaliate/clown/mutant/blob,
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen";
+	dir = 2
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio,
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "gR" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/table/reinforced,
-/obj/item/stack/packageWrap,
 /obj/item/stack/wrapping_paper{
 	pixel_x = 3;
-	pixel_y = 4
+	pixel_y = 3
 	},
+/obj/item/stack/packageWrap,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "gS" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "fleetpod1";
-	map_pad_link_id = "fleetesc2pod1";
-	name = "Teleport to Evac Shuttle"
-	},
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 9
-	},
-/turf/open/floor/light,
+/obj/structure/sign/departments/minsky/medical/medical2,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "gX" = (
 /obj/machinery/light{
@@ -494,16 +498,8 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "hi" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "fleetsci";
-	map_pad_link_id = "fleetesc2sci";
-	name = "Teleport to Evac Shuttle"
-	},
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 9
-	},
-/turf/open/floor/light,
+/obj/structure/sign/departments/minsky/supply/cargo,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "hk" = (
 /obj/structure/chair/comfy/shuttle{
@@ -543,7 +539,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/conveyor{
 	dir = 1;
-	id = "EmFleet1"
+	id = "EmFleet2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
@@ -556,14 +552,6 @@
 	name = "Emergency Shuttle Airlock"
 	},
 /turf/open/floor/plating,
-/area/shuttle/escape)
-"ij" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "EmFleet3"
-	},
-/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "im" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -583,13 +571,14 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "io" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "fleetesc2sci";
-	map_pad_link_id = "fleetsci";
-	name = "Teleport to Experimental Specimens Shuttle"
-	},
 /obj/structure/sign/directions/science{
-	pixel_y = 9
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetesc2sci";
+	linked_to = "fleetsci";
+	name = "Portal to Experiment Transport Shuttle"
 	},
 /turf/open/floor/light,
 /area/shuttle/escape)
@@ -612,16 +601,13 @@
 	},
 /area/shuttle/escape)
 "iM" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "fleetmed";
-	map_pad_link_id = "fleetesc2med";
-	name = "Teleport to Evac Shuttle"
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
 	},
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 9
+/obj/structure/sign/poster/official/report_crimes{
+	pixel_x = 32
 	},
-/turf/open/floor/light,
+/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "iN" = (
 /obj/effect/spawner/structure/window/shuttle,
@@ -632,7 +618,7 @@
 /obj/effect/turf_decal/box/white/corners{
 	dir = 8
 	},
-/obj/structure/closet/crate/secure/gear,
+/obj/structure/closet/crate/secure/owned/cheap/gear,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "iV" = (
@@ -653,6 +639,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
+/obj/structure/sign/poster/contraband/missing_gloves{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "jh" = (
@@ -664,6 +653,9 @@
 "js" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/closet/emcloset,
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "jw" = (
@@ -689,26 +681,26 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "jK" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "fleeteng";
-	map_pad_link_id = "fleetesc2eng";
-	name = "Teleport to Evac Shuttle"
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "EmFleet1"
 	},
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 9
-	},
-/turf/open/floor/light,
+/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "jM" = (
 /obj/structure/window/reinforced{
 	dir = 1;
 	pixel_y = 4
 	},
-/obj/machinery/door/window/brigdoor/eastleft{
-	req_access_txt = "55"
-	},
 /mob/living/simple_animal/hostile/retaliate/clown/lube,
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio{
+	dir = 4
+	},
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "jP" = (
@@ -726,7 +718,7 @@
 	pixel_x = -3
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/carpet/blue,
+/turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "ki" = (
 /obj/effect/turf_decal/tile/darkblue{
@@ -851,10 +843,14 @@
 /obj/structure/window/reinforced{
 	pixel_y = -3
 	},
-/obj/machinery/door/window/brigdoor/eastleft{
-	req_access_txt = "55"
-	},
 /mob/living/simple_animal/hostile/retaliate/clown/banana,
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio{
+	dir = 4
+	},
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "lb" = (
@@ -877,25 +873,14 @@
 	dir = 9
 	},
 /obj/structure/table/reinforced,
-/obj/item/clothing/glasses/hud/health,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "lw" = (
 /obj/effect/turf_decal{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"lN" = (
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal{
-	dir = 4
-	},
-/obj/effect/turf_decal{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/window{
-	id = "fleeteng2"
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -916,11 +901,28 @@
 	dir = 8;
 	pixel_x = -4
 	},
-/obj/machinery/door/window/brigdoor/northright{
-	req_access_txt = "55"
-	},
 /mob/living/simple_animal/hostile/retaliate/clown/mutant,
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio{
+	dir = 1
+	},
 /turf/open/floor/mineral/bananium,
+/area/shuttle/escape)
+"md" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/closet/secure_closet{
+	name = "Plasmaman Supplies Locker";
+	req_access_txt = "5"
+	},
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/tank/internals/plasmaman,
+/obj/machinery/status_display/evac{
+	pixel_y = -32
+	},
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "mf" = (
 /obj/structure/closet/wardrobe/white,
@@ -935,16 +937,11 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "mE" = (
-/obj/machinery/quantumpad{
-	map_pad_link_id = "fleetesc2com";
-	map_pad_id = "fleetcom";
-	name = "Teleport to Evac Shuttle"
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 9
-	},
-/turf/open/floor/light,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "mG" = (
 /obj/effect/turf_decal/tile/darkblue{
@@ -988,10 +985,13 @@
 	pixel_x = 3
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/door/window/brigdoor/northleft{
-	req_access_txt = "55"
-	},
 /mob/living/simple_animal/hostile/retaliate/goat/ras,
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio{
+	dir = 1
+	},
 /turf/open/indestructible/grass/jungle,
 /area/shuttle/escape)
 "mX" = (
@@ -1001,13 +1001,17 @@
 	name = "Station Intercom (General)";
 	pixel_y = 25
 	},
-/turf/open/floor/carpet/blue,
+/turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "ni" = (
-/obj/machinery/door/window/brigdoor/eastleft{
-	req_access_txt = "47"
-	},
 /mob/living/simple_animal/hostile/retaliate/clown,
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio{
+	dir = 4
+	},
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "nk" = (
@@ -1017,9 +1021,11 @@
 	},
 /obj/structure/flora/ausbushes/fullgrass,
 /mob/living/simple_animal/hostile/retaliate/goat/tiny,
-/obj/machinery/door/window/brigdoor/southleft{
-	req_access_txt = "55"
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen";
+	dir = 2
 	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio,
 /turf/open/indestructible/grass/jungle,
 /area/shuttle/escape)
 "no" = (
@@ -1030,8 +1036,7 @@
 	dir = 4;
 	pixel_x = 3
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/carpet/blue,
+/turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "nv" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -1080,8 +1085,12 @@
 	},
 /obj/structure/flora/ausbushes/fullgrass,
 /mob/living/simple_animal/hostile/retaliate/goat/goatgoat,
-/obj/machinery/door/window/brigdoor/westright{
-	req_access_txt = "55"
+/obj/machinery/door/window/northleft{
+	dir = 8;
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio{
+	dir = 8
 	},
 /turf/open/indestructible/grass/jungle,
 /area/shuttle/escape)
@@ -1096,11 +1105,25 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
-"nY" = (
-/obj/machinery/door/window/brigdoor/eastleft{
-	req_access_txt = "55"
+"nV" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/window{
+	dir = 8
 	},
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/shuttle/escape)
+"nY" = (
 /mob/living/simple_animal/hostile/retaliate/clown/honkling,
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio{
+	dir = 4
+	},
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "oj" = (
@@ -1109,6 +1132,10 @@
 	},
 /obj/machinery/modular_computer/console/preset/research,
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"oo" = (
+/obj/item/pool/rubber_ring,
+/turf/open/indestructible/sound/pool/end,
 /area/shuttle/escape)
 "ot" = (
 /obj/structure/shuttle/engine/heater,
@@ -1123,7 +1150,10 @@
 /area/shuttle/escape)
 "oz" = (
 /obj/machinery/suit_storage_unit/cmo,
-/turf/open/floor/carpet/plainblue,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "oK" = (
 /obj/structure/shuttle/engine/propulsion,
@@ -1132,11 +1162,6 @@
 "pa" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
-	},
-/obj/machinery/button/flasher{
-	id = "sec_cockpit_flasher1";
-	pixel_x = 6;
-	pixel_y = -24
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -32
@@ -1156,12 +1181,17 @@
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "pi" = (
-/obj/machinery/flasher{
-	id = "cockpit_flasher";
-	pixel_x = 6;
-	pixel_y = 24
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
 	},
-/turf/open/floor/mineral/titanium/blue,
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetpod3";
+	linked_to = "fleetesc2pod3";
+	name = "Portal to Escape Lounge Shuttle"
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "pn" = (
 /obj/effect/turf_decal/tile/brown/full,
@@ -1200,16 +1230,14 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "qo" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "fleetpod2";
-	map_pad_link_id = "fleetesc2pod2";
-	name = "Teleport to Evac Shuttle"
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/belt/utility,
+/obj/item/clothing/head/welding,
+/obj/structure/sign/poster/official/build{
+	pixel_y = -32
 	},
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 9
-	},
-/turf/open/floor/light,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "qs" = (
 /obj/machinery/stasis{
@@ -1237,10 +1265,13 @@
 	dir = 8;
 	pixel_x = -4
 	},
-/obj/machinery/door/window/brigdoor/northright{
-	req_access_txt = "55"
-	},
 /mob/living/simple_animal/cockroach/clownbug,
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio{
+	dir = 1
+	},
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "qM" = (
@@ -1258,11 +1289,14 @@
 	dir = 4;
 	pixel_x = 3
 	},
-/obj/machinery/door/window/brigdoor/northright{
-	req_access_txt = "55"
-	},
 /mob/living/simple_animal/pet/cat/clown{
 	name = "Cat Clown"
+	},
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio{
+	dir = 1
 	},
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
@@ -1295,9 +1329,11 @@
 	},
 /obj/structure/flora/ausbushes/fullgrass,
 /mob/living/simple_animal/hostile/retaliate/goat/huge,
-/obj/machinery/door/window/brigdoor/southleft{
-	req_access_txt = "55"
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen";
+	dir = 2
 	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio,
 /turf/open/indestructible/grass/jungle,
 /area/shuttle/escape)
 "rq" = (
@@ -1316,19 +1352,14 @@
 /obj/structure/closet/emcloset,
 /obj/item/roller,
 /obj/item/roller,
-/obj/item/roller,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "rx" = (
-/obj/structure/sign/directions/command{
-	pixel_y = 9
+/obj/effect/turf_decal/tile/brown/full,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/quantumpad{
-	map_pad_link_id = "fleetcom";
-	map_pad_id = "fleetesc2com";
-	name = "Teleport to Command Shuttle"
-	},
-/turf/open/floor/light,
+/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "rE" = (
 /obj/structure/extinguisher_cabinet{
@@ -1350,70 +1381,57 @@
 /area/shuttle/escape)
 "rZ" = (
 /obj/structure/sign/directions/security{
-	pixel_y = 9
+	pixel_y = 13
 	},
-/obj/machinery/quantumpad{
-	map_pad_id = "fleetesc2sec";
-	map_pad_link_id = "fleetsec";
-	name = "Teleport to Brig Shuttle"
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetesc2sec";
+	linked_to = "fleetsec";
+	name = "Portal to Prisoner Transfer Shuttle"
 	},
 /turf/open/floor/light,
 /area/shuttle/escape)
 "sj" = (
-/obj/machinery/door/window/brigdoor/northright{
-	req_access_txt = "55"
-	},
 /mob/living/simple_animal/hostile/retaliate/clown/fleshclown,
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio{
+	dir = 1
+	},
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "sy" = (
-/obj/machinery/door/airlock/security,
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"sB" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	id_tag = "fleetpod2"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
+/obj/effect/mapping_helpers/airlock/access/all/security/basic,
+/obj/machinery/door/airlock/security,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"sB" = (
+/obj/structure/sign/departments/minsky/security/security,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
 /area/shuttle/escape)
 "sC" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "sL" = (
-/obj/structure/chair/comfy/shuttle{
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "EmFleet2"
+	},
+/obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/item/radio/intercom{
-	pixel_x = 32
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/button/door{
-	pixel_x = -25;
-	id = "fleetpod2"
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"sN" = (
-/obj/structure/sign/departments/minsky/engineering/engineering,
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "sT" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
-	},
-/obj/machinery/button/flasher{
-	id = "sec_cockpit_flasher2";
-	pixel_x = -6;
-	pixel_y = -24
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 32
@@ -1431,9 +1449,22 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"sY" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetcom";
+	linked_to = "fleetesc2com";
+	name = "Portal to Escape Lounge Shuttle"
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
 "sZ" = (
 /obj/machinery/computer/security,
-/turf/open/floor/carpet/blue,
+/turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "tb" = (
 /obj/effect/turf_decal/pool,
@@ -1451,10 +1482,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/door/airlock/security/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
-	},
+/obj/machinery/door/airlock/security,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "tk" = (
@@ -1472,27 +1500,35 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
+"tG" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetesc2pod1";
+	linked_to = "fleetpod1";
+	name = "Portal to Escape Pod One"
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
 "tI" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/belt/utility,
 /obj/item/clothing/head/welding,
+/obj/structure/sign/poster/official/safety_eye_protection{
+	pixel_y = -32
+	},
 /turf/open/floor/plating,
-/area/shuttle/escape)
-"tK" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "EmFleet2"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "tL" = (
 /obj/machinery/computer/crew,
-/turf/open/floor/carpet/blue,
+/turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "tM" = (
 /obj/effect/turf_decal/tile/darkblue{
@@ -1539,16 +1575,6 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/button/flasher{
-	id = "sec_cockpit_flasher1";
-	pixel_x = 6;
-	pixel_y = 32
-	},
-/obj/machinery/button/flasher{
-	id = "sec_cockpit_flasher2";
-	pixel_x = 6;
-	pixel_y = 24
-	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "tW" = (
@@ -1569,9 +1595,11 @@
 	desc = "Suspiciously normal...";
 	name = "Normal Goat"
 	},
-/obj/machinery/door/window/brigdoor/southleft{
-	req_access_txt = "55"
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen";
+	dir = 2
 	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio,
 /turf/open/indestructible/grass/jungle,
 /area/shuttle/escape)
 "ug" = (
@@ -1618,9 +1646,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/sign/poster/official/obey{
-	pixel_x = 32
-	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "uv" = (
@@ -1654,12 +1679,15 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "uE" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)"
 	},
-/turf/open/floor/plating,
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "uF" = (
 /turf/open/floor/carpet/royalblack,
@@ -1670,20 +1698,10 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "va" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "fleetpod3";
-	map_pad_link_id = "fleetesc2pod3";
-	name = "Teleport to Evac Shuttle"
+/obj/machinery/status_display/evac{
+	pixel_y = 32
 	},
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 9
-	},
-/turf/open/floor/light,
-/area/shuttle/escape)
-"vg" = (
-/obj/structure/sign/departments/minsky/medical/medical2,
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/turf/open/floor/carpet/royalblack,
 /area/shuttle/escape)
 "vl" = (
 /obj/structure/shuttle/engine/heater,
@@ -1695,15 +1713,13 @@
 /area/shuttle/escape)
 "vv" = (
 /obj/structure/fans/tiny,
-/obj/machinery/door/poddoor/shutters/window{
-	id = "fleetsup"
-	},
+/obj/machinery/door/poddoor/shutters/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "vG" = (
 /obj/effect/spawner/lootdrop/three_course_meal,
 /obj/structure/table/glass,
-/turf/open/floor/carpet/plainblue,
+/turf/open/floor/carpet/blue,
 /area/shuttle/escape)
 "vM" = (
 /obj/structure/sink{
@@ -1744,10 +1760,13 @@
 /area/shuttle/escape)
 "wa" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/door/window/brigdoor/northleft{
-	req_access_txt = "55"
-	},
 /mob/living/simple_animal/hostile/retaliate/goat/star,
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio{
+	dir = 1
+	},
 /turf/open/indestructible/grass/jungle,
 /area/shuttle/escape)
 "wb" = (
@@ -1770,6 +1789,15 @@
 	pixel_y = 3
 	},
 /obj/item/storage/firstaid/brute,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/northleft{
+	name = "First-Aid Supplies";
+	red_alert_access = 1;
+	dir = 2
+	},
+/obj/effect/mapping_helpers/windoor/access/all/medical/general,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "wp" = (
@@ -1793,26 +1821,16 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "wy" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "fleetesc2med";
-	map_pad_link_id = "fleetmed";
-	name = ""Teleport to Ambulance Shuttle"
-	},
 /obj/structure/sign/directions/medical{
-	pixel_y = 9
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetesc2med";
+	linked_to = "fleetmed";
+	name = "Portal to Ambulance Shuttle"
 	},
 /turf/open/floor/light,
-/area/shuttle/escape)
-"wB" = (
-/obj/effect/turf_decal{
-	dir = 1
-	},
-/obj/machinery/button{
-	pixel_x = -23;
-	pixel_y = -21;
-	id = "fleeteng1"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "wD" = (
 /obj/effect/turf_decal/tile/brown/full,
@@ -1844,10 +1862,6 @@
 "wO" = (
 /obj/machinery/computer/atmos_alert,
 /turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
-"wT" = (
-/obj/structure/sign/departments/minsky/supply/cargo,
-/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "wX" = (
 /obj/machinery/light,
@@ -1936,20 +1950,25 @@
 	pixel_x = 3
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/door/window/brigdoor/northleft{
-	req_access_txt = "55"
-	},
 /mob/living/simple_animal/hostile/retaliate/goat/glowing,
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio{
+	dir = 1
+	},
 /turf/open/indestructible/grass/jungle,
 /area/shuttle/escape)
 "xS" = (
-/obj/structure/sign/departments/minsky/command/evac,
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/obj/structure/chair/comfy/teal{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "xT" = (
-/obj/structure/table/reinforced,
-/obj/item/pet_carrier,
-/obj/item/bodybag/bluespace,
+/obj/structure/closet/crate/critter,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "yc" = (
@@ -1964,14 +1983,15 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "yi" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "fleetesc2pod2";
-	map_pad_link_id = "fleetpod2";
-	name = "Teleport to Private Pod Two"
-	},
 /obj/structure/sign/directions/evac{
 	dir = 2;
-	pixel_y = 9
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetesc2pod3";
+	linked_to = "fleetpod3";
+	name = "Portal to Escape Pod Three"
 	},
 /turf/open/floor/light,
 /area/shuttle/escape)
@@ -2021,7 +2041,7 @@
 /area/shuttle/escape)
 "zt" = (
 /obj/machinery/pool_filter,
-/turf/open/indestructible/sound/pool,
+/turf/open/indestructible/sound/pool/end,
 /area/shuttle/escape)
 "zu" = (
 /obj/structure/window/shuttle,
@@ -2036,13 +2056,27 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "zM" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "fleetesc2eng";
-	map_pad_link_id = "fleeteng";
-	name = "Teleport to Pod Mechanic sShuttle"
-	},
 /obj/structure/sign/directions/engineering{
-	pixel_y = 9
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetesc2eng";
+	linked_to = "fleeteng";
+	name = "Portal to Pod Repair Shuttle"
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
+"zR" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleeteng";
+	linked_to = "fleetesc2eng";
+	name = "Portal to Escape Lounge Shuttle"
 	},
 /turf/open/floor/light,
 /area/shuttle/escape)
@@ -2067,12 +2101,14 @@
 	dir = 4;
 	pixel_x = 3
 	},
-/obj/machinery/door/window/brigdoor/southright{
-	req_access_txt = "55"
-	},
 /mob/living/simple_animal/hostile/retaliate/clown/thin{
 	dir = 4
 	},
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen";
+	dir = 2
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio,
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "Az" = (
@@ -2087,16 +2123,11 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"AQ" = (
-/obj/structure/sign/poster/official/safety_eye_protection,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
 "AV" = (
 /obj/structure/chair/comfy/teal{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/carpet/blue,
+/turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "Bb" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -2116,7 +2147,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/conveyor_switch{
 	id = "EmFleet1";
-	pixel_x = 10;
 	pixel_y = 14
 	},
 /obj/machinery/door/firedoor/border_only{
@@ -2143,8 +2173,7 @@
 /obj/structure/sink{
 	color = "#FFD700";
 	dir = 4;
-	pixel_x = 12;
-	name = "golden sink"
+	pixel_x = 12
 	},
 /obj/structure/mirror{
 	pixel_x = 26
@@ -2159,20 +2188,7 @@
 /obj/effect/turf_decal{
 	dir = 8
 	},
-/obj/machinery/door/poddoor/shutters/window{
-	id = "fleeteng1"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"BQ" = (
-/obj/effect/turf_decal{
-	dir = 1
-	},
-/obj/machinery/button{
-	pixel_x = 23;
-	pixel_y = -21;
-	id = "fleeteng2"
-	},
+/obj/machinery/door/poddoor/shutters/window,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Ca" = (
@@ -2218,16 +2234,15 @@
 	pixel_y = 3
 	},
 /obj/item/storage/firstaid/toxin,
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"Cn" = (
-/obj/structure/chair/comfy/shuttle{
+/obj/machinery/door/window/northleft{
+	name = "First-Aid Supplies";
+	red_alert_access = 1;
 	dir = 8
 	},
-/obj/structure/sign/poster/official/report_crimes{
-	pixel_x = 32
+/obj/effect/mapping_helpers/windoor/access/all/medical/general{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Cv" = (
 /obj/structure/window/shuttle,
@@ -2240,11 +2255,6 @@
 "CA" = (
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/machinery/flasher{
-	id = "sec_cockpit_flasher1";
-	pixel_x = 6;
-	pixel_y = 24
 	},
 /obj/machinery/vending/cola/random,
 /obj/structure/sign/poster/official/safety_report{
@@ -2288,27 +2298,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
-"CZ" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/conveyor_switch{
-	id = "EmFleet3";
-	pixel_x = 10;
-	pixel_y = 14
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
 "Dg" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Emergency Shuttle Brig";
-	req_access_txt = "2"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/mapping_helpers/airlock/access/all/security/basic,
+/obj/machinery/door/airlock/security/glass,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "Dh" = (
@@ -2331,21 +2327,22 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "Ds" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	id_tag = "fleetpod1"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "DC" = (
-/obj/machinery/door/window/brigdoor/southright{
-	req_access_txt = "55"
-	},
 /mob/living/simple_animal/hostile/retaliate/clown/clownhulk/chlown,
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen";
+	dir = 2
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio,
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "DD" = (
@@ -2375,6 +2372,19 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"Ec" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetpod1";
+	linked_to = "fleetesc2pod1";
+	name = "Portal to Escape Lounge Shuttle"
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
 "Ej" = (
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/mineral/titanium/blue,
@@ -2388,11 +2398,17 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Eq" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
 	},
-/turf/open/floor/plating,
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetmed";
+	linked_to = "fleetesc2med";
+	name = "Portal to Escape Lounge Shuttle"
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "Er" = (
 /obj/structure/chair/comfy/shuttle{
@@ -2406,16 +2422,16 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
-/turf/open/floor/carpet/plainblue,
+/turf/open/floor/carpet/blue,
 /area/shuttle/escape)
 "Ev" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/table/reinforced,
-/obj/item/clothing/gloves/fingerless,
 /obj/item/clothing/gloves/fingerless{
 	pixel_x = 3;
-	pixel_y = 4
+	pixel_y = 3
 	},
+/obj/item/clothing/gloves/fingerless,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "Ew" = (
@@ -2423,23 +2439,24 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/machinery/door/airlock/titanium/glass{
-	req_access_txt = "55"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
+/obj/machinery/door/airlock/titanium/glass,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "EA" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/door/window/brigdoor/northleft{
-	req_access_txt = "55"
-	},
 /mob/living/simple_animal/hostile/retaliate/goat/suspicious,
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio{
+	dir = 1
+	},
 /turf/open/indestructible/grass/jungle,
 /area/shuttle/escape)
 "ED" = (
@@ -2452,20 +2469,18 @@
 	dir = 4
 	},
 /obj/structure/reagent_dispensers/fueltank,
-/obj/structure/sign/warning/nosmoking/circle{
-	pixel_x = 32
-	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "EJ" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "fleetsec";
-	map_pad_link_id = "fleetesc2sec";
-	name = "Teleport to Evac Shuttle"
-	},
 /obj/structure/sign/directions/evac{
 	dir = 2;
-	pixel_y = 9
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetsec";
+	linked_to = "fleetesc2sec";
+	name = "Portal to Escape Lounge Shuttle"
 	},
 /turf/open/floor/light,
 /area/shuttle/escape)
@@ -2486,16 +2501,33 @@
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
+"Ff" = (
+/obj/machinery/suit_storage_unit/command,
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/indestructible/carpet/blue,
+/area/shuttle/escape)
 "Fp" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/obj/structure/sign/directions/command{
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleettoi";
+	linked_to = "fleetcom2toi";
+	name = "Portal to Luxury Command Shuttle"
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "FF" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /mob/living/simple_animal/hostile/retaliate/goat/cottoncandy,
-/obj/machinery/door/window/brigdoor/southleft{
-	req_access_txt = "55"
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen";
+	dir = 2
 	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio,
 /turf/open/indestructible/grass/jungle,
 /area/shuttle/escape)
 "FI" = (
@@ -2577,13 +2609,15 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "Gq" = (
-/obj/machinery/door/window/brigdoor/southright{
-	req_access_txt = "55"
-	},
 /mob/living/simple_animal/hostile/retaliate/clown{
 	desc = "Suspiciously normal...";
 	name = "Normal Clown"
 	},
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen";
+	dir = 2
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio,
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "Gx" = (
@@ -2592,19 +2626,21 @@
 	pixel_x = 3
 	},
 /obj/machinery/door/firedoor/border_only,
-/turf/open/floor/carpet/blue,
+/turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "GB" = (
-/obj/structure/closet/secure_closet/brig,
-/obj/machinery/button/flasher{
-	id = "sec_cell_flasher1";
-	pixel_x = -6;
-	pixel_y = 24
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "EmFleet3"
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 32
+/obj/machinery/light{
+	dir = 4
 	},
-/turf/open/floor/mineral/plastitanium/red/brig,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "GC" = (
 /obj/structure/window/reinforced{
@@ -2612,10 +2648,13 @@
 	pixel_x = -4
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/door/window/brigdoor/northleft{
-	req_access_txt = "55"
-	},
 /mob/living/simple_animal/hostile/retaliate/goat/legitgoat,
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio{
+	dir = 1
+	},
 /turf/open/indestructible/grass/jungle,
 /area/shuttle/escape)
 "GE" = (
@@ -2662,7 +2701,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = 25
 	},
-/turf/open/floor/carpet/blue,
+/turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "Hu" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -2685,7 +2724,7 @@
 	dir = 4;
 	pixel_x = 3
 	},
-/turf/open/floor/carpet/blue,
+/turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "HC" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -2714,10 +2753,6 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
-"Ik" = (
-/obj/structure/sign/departments/science,
-/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "IF" = (
 /obj/structure/statue/diamond/captain,
@@ -2754,46 +2789,62 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"Ja" = (
+/obj/machinery/suit_storage_unit/command,
+/turf/open/indestructible/carpet/blue,
+/area/shuttle/escape)
 "Jc" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "fleetcom2toi";
-	map_pad_link_id = "fleettoi"
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/turf/open/floor/light,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "Je" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 5
 	},
 /obj/structure/table/reinforced,
-/obj/item/healthanalyzer,
+/obj/structure/table/reinforced,
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Jm" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetsup";
+	linked_to = "fleetesc2sup";
+	name = "Portal to Escape Lounge Shuttle"
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "Jp" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Js" = (
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/carpet/plainblue,
+/turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "JA" = (
-/obj/machinery/door/window/southleft{
-	name = "Brig Desk";
-	req_access_txt = "1"
-	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/window/southleft{
+	base_state = "right";
+	icon_state = "right";
+	name = "Brig Desk"
+	},
+/obj/effect/mapping_helpers/windoor/access/all/security/general,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "JB" = (
 /obj/machinery/suit_storage_unit/hos,
-/turf/open/floor/carpet/plainblue,
-/area/shuttle/escape)
-"JJ" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/suit_storage_unit/command,
-/turf/open/floor/carpet/plainblue,
+/turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "JM" = (
 /obj/effect/turf_decal/tile/brown/full,
@@ -2823,11 +2874,12 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "Kl" = (
-/obj/machinery/door/airlock/shuttle,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/shuttle,
+/obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Kp" = (
@@ -2850,12 +2902,18 @@
 	dir = 8;
 	light_color = "#e8eaff"
 	},
-/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 3;
+	pixel_y = 3
+	},
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/belt/utility,
 /obj/item/clothing/head/welding,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
+	},
+/obj/structure/sign/poster/contraband/tools{
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
@@ -2865,23 +2923,14 @@
 	pixel_x = -4
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/machinery/door/window/brigdoor/northleft{
-	req_access_txt = "55"
-	},
 /mob/living/simple_animal/hostile/retaliate/goat/rainbow,
-/turf/open/indestructible/grass/jungle,
-/area/shuttle/escape)
-"KI" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/conveyor_switch{
-	id = "EmFleet2";
-	pixel_x = 10;
-	pixel_y = 14
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen"
 	},
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/indestructible/grass/jungle,
 /area/shuttle/escape)
 "KL" = (
 /obj/item/pool/pool_noodle,
@@ -2903,31 +2952,19 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "Lk" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock";
-	id_tag = "fleetpod3"
+/obj/structure/sign/warning/nosmoking,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"Lr" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/conveyor_switch{
+	id = "EmFleet3";
+	pixel_y = 14
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"Lr" = (
-/obj/structure/chair/comfy/shuttle{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_x = 32
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/button/door{
-	pixel_x = -25;
-	id = "fleetpod1"
-	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "Lv" = (
 /obj/machinery/door/firedoor/border_only,
@@ -2940,30 +2977,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"Ly" = (
-/obj/structure/sign/departments/xenobio,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
 "LO" = (
 /obj/effect/turf_decal/tile/brown/full,
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"Md" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/window{
-	dir = 8
-	},
-/obj/structure/window{
-	dir = 1
-	},
-/turf/open/floor/grass,
 /area/shuttle/escape)
 "Ms" = (
 /obj/effect/turf_decal/tile/brown/full,
@@ -2984,29 +3007,25 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"MH" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
 "ML" = (
-/obj/machinery/door/airlock/vault{
-	req_access_txt = "53"
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/mapping_helpers/airlock/access/all/supply/qm,
+/obj/machinery/door/airlock/vault,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "MX" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "fleetsup";
-	map_pad_link_id = "fleetesc2sup";
-	name = "Teleport to Evac Shuttle"
-	},
 /obj/structure/sign/directions/evac{
 	dir = 2;
-	pixel_y = 9
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetesc2pod2";
+	linked_to = "fleetpod2";
+	name = "Portal to Escape Pod Two"
 	},
 /turf/open/floor/light,
 /area/shuttle/escape)
@@ -3048,12 +3067,13 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "Nq" = (
-/obj/machinery/quantumpad{
-	map_pad_link_id = "fleetsup";
-	map_pad_id = "fleetesc2sup"
-	},
 /obj/structure/sign/directions/supply{
-	pixel_y = 9
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetesc2sup";
+	linked_to = "fleetsup"
 	},
 /turf/open/floor/light,
 /area/shuttle/escape)
@@ -3079,12 +3099,14 @@
 /turf/open/floor/carpet/blue,
 /area/shuttle/escape)
 "NZ" = (
-/obj/machinery/door/window/brigdoor/northright{
-	req_access_txt = "55"
-	},
 /obj/item/reagent_containers/food/snacks/burger/clown{
-	desc = "They turned a clown into a burger. Funniest shit you've ever seen.";
-	pixel_y = -6
+	desc = "They turned a clown into a burger. Funniest shit you've ever seen."
+	},
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio{
+	dir = 1
 	},
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
@@ -3126,25 +3148,22 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
 	},
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "OG" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "fleetesc2pod3";
-	map_pad_link_id = "fleetpod3";
-	name = "Teleport to Private Pod Three"
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/conveyor_switch{
+	id = "EmFleet2";
+	pixel_y = 14
 	},
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 9
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/turf/open/floor/light,
+/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "OM" = (
 /obj/machinery/vending/security,
-/obj/structure/sign/poster/official/twelve_gauge{
-	pixel_y = 32
-	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "OV" = (
@@ -3172,11 +3191,12 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "Pl" = (
-/obj/machinery/door/airlock/security,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
+/obj/effect/mapping_helpers/airlock/access/all/security/basic,
+/obj/machinery/door/airlock/security,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "Pq" = (
@@ -3192,7 +3212,7 @@
 	dir = 4;
 	pixel_x = 3
 	},
-/turf/open/floor/carpet/blue,
+/turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "PA" = (
 /obj/structure/chair/comfy/teal{
@@ -3202,8 +3222,7 @@
 	dir = 8;
 	pixel_x = -3
 	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/carpet/blue,
+/turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "PF" = (
 /obj/machinery/shuttle_manipulator{
@@ -3247,19 +3266,14 @@
 	dir = 4;
 	pixel_x = 3
 	},
-/obj/machinery/door/window/brigdoor/northright{
-	req_access_txt = "55"
-	},
 /mob/living/simple_animal/hostile/retaliate/clown/clownhulk/honcmunculus,
-/turf/open/floor/mineral/bananium,
-/area/shuttle/escape)
-"PV" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "EmFleet2"
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio{
+	dir = 1
+	},
+/turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "PY" = (
 /obj/machinery/door/firedoor/border_only{
@@ -3273,11 +3287,6 @@
 "Qg" = (
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/machinery/flasher{
-	id = "sec_cockpit_flasher2";
-	pixel_x = -6;
-	pixel_y = 24
 	},
 /obj/machinery/vending/snack/random,
 /obj/structure/sign/poster/official/here_for_your_safety{
@@ -3320,11 +3329,6 @@
 /area/shuttle/escape)
 "QX" = (
 /obj/structure/closet/secure_closet/brig,
-/obj/machinery/button/flasher{
-	id = "sec_cell_flasher2";
-	pixel_x = 6;
-	pixel_y = 24
-	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "QY" = (
@@ -3422,9 +3426,11 @@
 	},
 /obj/structure/flora/ausbushes/fullgrass,
 /mob/living/simple_animal/hostile/retaliate/goat/chocolate,
-/obj/machinery/door/window/brigdoor/southleft{
-	req_access_txt = "55"
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen";
+	dir = 2
 	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio,
 /turf/open/indestructible/grass/jungle,
 /area/shuttle/escape)
 "RL" = (
@@ -3435,15 +3441,15 @@
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/fueltank,
-/obj/structure/sign/warning/nosmoking/circle{
-	pixel_x = -32
-	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Sa" = (
 /obj/structure/closet/crate/necropolis,
 /obj/item/clothing/shoes/drip,
 /obj/item/clothing/under/costume/drip,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "Sj" = (
@@ -3475,20 +3481,17 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"SM" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/storage/belt/utility,
-/obj/item/clothing/head/welding,
-/obj/structure/sign/poster/official/build{
-	pixel_y = -32
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "SO" = (
 /obj/structure/table/reinforced,
 /obj/item/soap,
 /turf/open/floor/plating,
+/area/shuttle/escape)
+"SQ" = (
+/obj/effect/turf_decal/tile/brown/full,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "SR" = (
 /obj/structure/table,
@@ -3544,8 +3547,12 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "Tq" = (
-/obj/structure/window/shuttle,
-/turf/open/floor/grass,
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "EmFleet3"
+	},
+/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "TB" = (
 /obj/structure/extinguisher_cabinet{
@@ -3556,8 +3563,12 @@
 "TD" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /mob/living/simple_animal/hostile/retaliate/goat,
-/obj/machinery/door/window/brigdoor/westright{
-	req_access_txt = "55"
+/obj/machinery/door/window/northleft{
+	dir = 8;
+	name = "Containment Pen"
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio{
+	dir = 8
 	},
 /turf/open/indestructible/grass/jungle,
 /area/shuttle/escape)
@@ -3565,11 +3576,6 @@
 /obj/structure/toilet{
 	desc = "The HT-451, a torque rotation-based, waste disposal unit for small matter. This one seems remarkably dirty.";
 	dir = 8
-	},
-/obj/machinery/flasher{
-	id = "sec_cell_flasher1";
-	pixel_x = -6;
-	pixel_y = -24
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
@@ -3598,10 +3604,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/button/door{
-	pixel_x = -25;
-	id = "fleetpod3"
-	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "Ua" = (
@@ -3612,7 +3614,7 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Uc" = (
-/obj/structure/closet/crate/secure/gear,
+/obj/structure/closet/crate/secure/owned/gear,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "Uo" = (
@@ -3629,7 +3631,11 @@
 /area/shuttle/escape)
 "UA" = (
 /obj/machinery/suit_storage_unit/captain,
-/turf/open/floor/carpet/plainblue,
+/obj/machinery/light/small{
+	brightness = 3;
+	dir = 8
+	},
+/turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "UI" = (
 /obj/machinery/stasis{
@@ -3642,7 +3648,20 @@
 /area/shuttle/escape)
 "UJ" = (
 /obj/machinery/suit_storage_unit/ce,
-/turf/open/floor/carpet/plainblue,
+/turf/open/indestructible/carpet/blue,
+/area/shuttle/escape)
+"UQ" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetsci";
+	linked_to = "fleetesc2sci";
+	name = "Portal to Escape Lounge Shuttle"
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "Va" = (
 /obj/structure/closet/crate/secure/plasma,
@@ -3651,7 +3670,6 @@
 "Vn" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
-/obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Vw" = (
@@ -3661,8 +3679,6 @@
 /obj/machinery/defibrillator_mount/loaded{
 	pixel_y = -32
 	},
-/obj/item/healthanalyzer/advanced,
-/obj/item/clothing/glasses/hud/health,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "VA" = (
@@ -3698,11 +3714,11 @@
 "Wl" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/table/reinforced,
-/obj/item/hand_labeler,
 /obj/item/hand_labeler{
-	pixel_x = 3;
-	pixel_y = 4
+	pixel_y = 3;
+	pixel_x = 3
 	},
+/obj/item/hand_labeler,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "Wu" = (
@@ -3727,14 +3743,12 @@
 "Wy" = (
 /obj/structure/toilet{
 	color = "#FFD700";
-	icon_state = "toilet00";
-	name = "golden toilet";
-	desc = "The HT-451, a torque rotation-based, waste disposal unit for small matter. This one seems remarkably gaudy."
+	icon_state = "toilet00"
 	},
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/structure/sign/painting{
+/obj/structure/sign/poster/contraband/lusty_xenomorph{
 	pixel_y = 32
 	},
 /turf/open/floor/carpet/royalblack,
@@ -3747,6 +3761,7 @@
 /area/shuttle/escape)
 "WO" = (
 /obj/effect/turf_decal,
+/obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "WQ" = (
@@ -3754,20 +3769,22 @@
 	dir = 8;
 	pixel_x = -4
 	},
-/obj/machinery/door/window/brigdoor/southright{
-	req_access_txt = "55"
-	},
 /mob/living/simple_animal/hostile/retaliate/clown/clownhulk,
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen";
+	dir = 2
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio,
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "WV" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/table/reinforced,
-/obj/item/destTagger,
 /obj/item/destTagger{
 	pixel_x = 3;
-	pixel_y = 4
+	pixel_y = 3
 	},
+/obj/item/destTagger,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
@@ -3779,7 +3796,7 @@
 	pixel_x = -3
 	},
 /obj/machinery/computer/aifixer,
-/turf/open/floor/carpet/blue,
+/turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "Xf" = (
 /obj/effect/turf_decal/box/white/corners{
@@ -3819,7 +3836,7 @@
 	pixel_x = -3
 	},
 /obj/machinery/computer/card,
-/turf/open/floor/carpet/blue,
+/turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "Yo" = (
 /obj/effect/spawner/structure/window/plastitanium,
@@ -3848,10 +3865,12 @@
 	dir = 8;
 	pixel_x = -4
 	},
-/obj/machinery/door/window/brigdoor/southright{
-	req_access_txt = "55"
-	},
 /mob/living/simple_animal/hostile/retaliate/clown/longface,
+/obj/machinery/door/window/northleft{
+	name = "Containment Pen";
+	dir = 2
+	},
+/obj/effect/mapping_helpers/windoor/access/all/science/xenobio,
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
 "YQ" = (
@@ -3867,6 +3886,16 @@
 	pixel_y = 3
 	},
 /obj/item/storage/firstaid/o2,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/window/northleft{
+	name = "First-Aid Supplies";
+	red_alert_access = 1
+	},
+/obj/effect/mapping_helpers/windoor/access/all/medical/general{
+	dir = 1
+	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Zu" = (
@@ -3898,16 +3927,8 @@
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
 "ZM" = (
-/obj/machinery/quantumpad{
-	map_pad_id = "fleetesc2pod1";
-	map_pad_link_id = "fleetpod1";
-	name = "Teleport to Private Pod One"
-	},
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 9
-	},
-/turf/open/floor/light,
+/obj/structure/sign/departments/minsky/engineering/engineering,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 
 (1,1,1) = {"
@@ -3928,7 +3949,7 @@ RL
 RL
 RL
 Cg
-fN
+sB
 te
 Nl
 oK
@@ -3962,9 +3983,9 @@ YQ
 (2,1,1) = {"
 Rn
 Er
-Lr
+TX
 Ds
-gS
+Ec
 ii
 YQ
 qN
@@ -3983,7 +4004,7 @@ vl
 oK
 YQ
 RE
-RE
+cr
 rE
 hk
 Uv
@@ -3996,7 +4017,7 @@ JY
 Rr
 Uo
 cr
-RE
+cr
 YQ
 YQ
 RE
@@ -4004,7 +4025,7 @@ cr
 rq
 tW
 cr
-RE
+cr
 YQ
 YQ
 "}
@@ -4069,7 +4090,7 @@ RL
 vM
 TI
 RL
-GB
+QX
 tY
 re
 RL
@@ -4111,7 +4132,7 @@ RE
 cr
 cr
 cr
-RE
+cr
 YQ
 YQ
 RL
@@ -4170,7 +4191,7 @@ RL
 QX
 tY
 re
-Fp
+RL
 gD
 GH
 Kc
@@ -4208,7 +4229,7 @@ YQ
 cr
 Wy
 wb
-ap
+Fp
 hv
 YQ
 YQ
@@ -4236,7 +4257,7 @@ GK
 Uv
 Ox
 tb
-Ri
+dA
 Ri
 Ri
 lb
@@ -4249,13 +4270,13 @@ gz
 nv
 IW
 Hu
-iM
-cr
+Eq
+Lk
 YQ
 "}
 (8,1,1) = {"
 cr
-uF
+va
 BN
 xo
 Nj
@@ -4272,7 +4293,7 @@ RL
 Qg
 VA
 SR
-Cn
+iM
 vl
 oK
 YQ
@@ -4307,7 +4328,7 @@ RE
 cr
 cr
 cr
-RE
+cr
 YQ
 YQ
 YQ
@@ -4326,7 +4347,7 @@ ot
 oK
 YQ
 Rn
-rx
+ap
 rH
 Uv
 Uv
@@ -4383,7 +4404,7 @@ Nh
 Uv
 Ox
 tb
-Ri
+dA
 Ri
 KL
 Ri
@@ -4397,18 +4418,18 @@ wh
 kQ
 jP
 ru
-vg
+gS
 YQ
 "}
 (11,1,1) = {"
 YQ
 RE
 cr
-wT
-ug
+hi
+cZ
 cr
 cr
-wT
+hi
 ug
 cr
 cr
@@ -4424,20 +4445,20 @@ ep
 YH
 YQ
 RE
-RE
-ZM
+cr
+tG
+MX
 yi
-OG
 bZ
 Uv
 wp
 EQ
-lb
+oo
 Ri
 Ri
 Ri
 cr
-RE
+cr
 YQ
 RE
 cr
@@ -4457,7 +4478,7 @@ cT
 VB
 fw
 cr
-MX
+Jm
 Lw
 lO
 KG
@@ -4493,7 +4514,7 @@ cr
 cg
 Yz
 Yz
-jw
+md
 cr
 YQ
 YQ
@@ -4504,7 +4525,7 @@ Au
 cw
 VB
 VB
-VB
+SQ
 LO
 uq
 Kc
@@ -4625,7 +4646,7 @@ kY
 nY
 jM
 cr
-RE
+cr
 YQ
 YQ
 YQ
@@ -4641,7 +4662,7 @@ cr
 dx
 Cm
 cr
-RE
+cr
 YQ
 YQ
 "}
@@ -4679,7 +4700,7 @@ oK
 YQ
 YQ
 RE
-sN
+ZM
 ug
 cr
 RE
@@ -4700,15 +4721,15 @@ Ms
 Ww
 VB
 VB
-VB
+rx
 LO
 Kc
 Kc
 Kc
-CZ
+Lr
 Kc
 Kc
-KI
+OG
 Kc
 Kc
 Bp
@@ -4732,7 +4753,7 @@ nU
 vU
 yw
 cr
-RE
+cr
 YQ
 YQ
 YQ
@@ -4753,15 +4774,15 @@ MZ
 cr
 js
 ah
-ij
+Tq
+GB
+Tq
+ie
+sL
+ie
+jK
 fQ
-ij
-PV
-tK
-PV
-ie
-ar
-ie
+jK
 Nl
 ep
 YH
@@ -4780,7 +4801,7 @@ hR
 vU
 vU
 Lv
-jK
+zR
 vl
 ep
 YH
@@ -4836,9 +4857,9 @@ ep
 YQ
 Rn
 Er
-sL
-sB
-qo
+TX
+Ds
+eG
 ii
 "}
 (20,1,1) = {"
@@ -4879,7 +4900,7 @@ Bu
 DD
 xa
 cr
-RE
+cr
 YQ
 YQ
 YQ
@@ -4893,19 +4914,19 @@ oK
 (21,1,1) = {"
 YQ
 RE
-fd
-fd
-Kp
-Kp
-Kp
-Kp
-Kp
-Kp
-Kp
-Kp
-Kp
-Kp
-Kp
+mE
+mE
+mE
+mE
+mE
+mE
+mE
+mE
+mE
+mE
+mE
+mE
+mE
 RE
 YQ
 YQ
@@ -4941,9 +4962,9 @@ YQ
 "}
 (22,1,1) = {"
 RE
-MH
-JJ
-aa
+cr
+Ja
+fd
 Rx
 Rx
 Rx
@@ -4955,8 +4976,8 @@ Rx
 Rx
 Rx
 Rx
-MH
-RE
+cr
+cr
 YQ
 YQ
 YQ
@@ -5033,7 +5054,7 @@ WO
 Zx
 Zx
 Zx
-wB
+lw
 RV
 cr
 "}
@@ -5042,15 +5063,15 @@ Rn
 JB
 Js
 Yz
-Tq
-Tq
+zu
+zu
 KT
 KT
 KT
 KT
 KT
-Tq
-Tq
+zu
+zu
 Bq
 Yz
 Es
@@ -5065,8 +5086,8 @@ Bb
 MF
 fV
 dt
-hi
-Ly
+UQ
+cr
 YQ
 RE
 cr
@@ -5083,7 +5104,7 @@ ch
 ch
 ch
 lw
-SM
+qo
 cr
 "}
 (25,1,1) = {"
@@ -5091,7 +5112,7 @@ Rn
 WY
 PA
 Yz
-Tq
+zu
 Rs
 kO
 QY
@@ -5099,10 +5120,10 @@ kO
 kO
 kO
 PF
-Tq
+zu
 IF
 ll
-Jc
+ga
 uL
 ep
 ep
@@ -5125,7 +5146,7 @@ vU
 vU
 lW
 jh
-hv
+kt
 Vn
 WO
 lp
@@ -5140,7 +5161,7 @@ Rn
 mX
 AV
 pO
-Tq
+zu
 HQ
 kO
 ai
@@ -5148,7 +5169,7 @@ QY
 kO
 kO
 JU
-Tq
+zu
 fF
 TB
 cr
@@ -5174,7 +5195,7 @@ cG
 vU
 lW
 Ky
-hv
+kt
 SO
 WO
 cr
@@ -5202,7 +5223,7 @@ Yz
 Yz
 zd
 cr
-xS
+cr
 cr
 RE
 YQ
@@ -5213,7 +5234,7 @@ rn
 yS
 rn
 up
-Ik
+cr
 YQ
 Rn
 MC
@@ -5223,7 +5244,7 @@ vU
 vU
 lW
 Oo
-hv
+kt
 XH
 WO
 cr
@@ -5249,9 +5270,9 @@ kO
 iF
 Yz
 Yz
-eG
+Yz
 cr
-pi
+yv
 KY
 iN
 YQ
@@ -5272,7 +5293,7 @@ vU
 vU
 lW
 If
-hv
+kt
 qM
 WO
 RE
@@ -5285,7 +5306,7 @@ hv
 (29,1,1) = {"
 Rn
 gB
-AV
+xS
 pO
 XP
 kO
@@ -5301,7 +5322,7 @@ pO
 Yz
 Kl
 Ej
-mE
+sY
 iN
 YQ
 YQ
@@ -5315,7 +5336,7 @@ cr
 YQ
 RE
 cr
-nH
+uE
 vU
 vU
 vU
@@ -5329,7 +5350,7 @@ ch
 ch
 lw
 tI
-AQ
+cr
 "}
 (30,1,1) = {"
 Rn
@@ -5348,7 +5369,7 @@ iF
 Yz
 Yz
 Yz
-SS
+cr
 yv
 Ke
 iN
@@ -5376,12 +5397,12 @@ WO
 Zx
 Zx
 Zx
-BQ
+lw
 EF
 cr
 "}
 (31,1,1) = {"
-uE
+Rn
 tL
 AV
 Yz
@@ -5398,7 +5419,7 @@ Yz
 Yz
 xk
 cr
-xS
+cr
 cr
 RE
 YQ
@@ -5421,11 +5442,11 @@ cr
 cr
 cr
 cr
-lN
-lN
-lN
-lN
-lN
+BP
+BP
+BP
+BP
+BP
 cr
 RE
 "}
@@ -5434,7 +5455,7 @@ Rn
 Hg
 AV
 pO
-Tq
+zu
 Wu
 kO
 kO
@@ -5442,7 +5463,7 @@ xI
 ai
 kO
 kU
-Tq
+zu
 nN
 TB
 cr
@@ -5483,7 +5504,7 @@ Rn
 Ps
 no
 Yz
-Tq
+zu
 xv
 kO
 kO
@@ -5491,7 +5512,7 @@ kO
 xI
 kO
 We
-Tq
+zu
 NG
 Yz
 vG
@@ -5516,7 +5537,7 @@ vT
 PY
 Pb
 cr
-RE
+cr
 YQ
 YQ
 YQ
@@ -5532,15 +5553,15 @@ Rn
 UJ
 Js
 Yz
-Tq
-Tq
+zu
+zu
 IM
 IM
 IM
 IM
 IM
-Tq
-Tq
+zu
+zu
 dQ
 Yz
 vG
@@ -5572,8 +5593,8 @@ YQ
 Rn
 Er
 TX
-Lk
-va
+Ds
+pi
 ii
 "}
 (35,1,1) = {"
@@ -5627,28 +5648,28 @@ oK
 "}
 (36,1,1) = {"
 RE
-MH
-JJ
-Md
-PM
-PM
-PM
-PM
-PM
-PM
-PM
-PM
-PM
-PM
-PM
-MH
-RE
-YQ
-YQ
-YQ
-YQ
-YQ
 cr
+Ff
+nV
+PM
+PM
+PM
+PM
+PM
+PM
+PM
+PM
+PM
+PM
+PM
+cr
+cr
+YQ
+YQ
+YQ
+YQ
+YQ
+RE
 cr
 dh
 cU
@@ -5663,7 +5684,7 @@ nU
 vU
 yw
 cr
-RE
+cr
 YQ
 YQ
 YQ
@@ -5677,19 +5698,19 @@ YQ
 (37,1,1) = {"
 YQ
 RE
-Eq
-Eq
-Ar
-Ar
-Ar
-Ar
-Ar
-Ar
-Ar
-Ar
-Ar
-Ar
-Ar
+Jc
+Jc
+Jc
+Jc
+Jc
+Jc
+Jc
+Jc
+Jc
+Jc
+Jc
+Jc
+Jc
 RE
 YQ
 YQ
@@ -5698,17 +5719,17 @@ YQ
 YQ
 YQ
 YQ
+RE
 cr
 cr
 cr
-cr
-cr
+RE
 YQ
 YQ
 YQ
 YQ
 RE
-sN
+ZM
 ug
 cr
 RE

--- a/_maps/shuttles/emergency_fleet.dmm
+++ b/_maps/shuttles/emergency_fleet.dmm
@@ -1,0 +1,5725 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/shuttle/escape)
+"ah" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"ai" = (
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"am" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"ap" = (
+/obj/machinery/quantumpad{
+	map_pad_id = "fleettoi";
+	map_pad_link_id = "fleetcom2toi"
+	},
+/obj/structure/sign/directions/command{
+	pixel_y = 9
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
+"ar" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "EmFleet1"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"at" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"aK" = (
+/obj/structure/toilet{
+	desc = "The HT-451, a torque rotation-based, waste disposal unit for small matter. This one seems remarkably dirty.";
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "sec_cell_flasher2";
+	pixel_x = 6;
+	pixel_y = -24
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"bl" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"bn" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/escape)
+"bJ" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
+	},
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"bO" = (
+/obj/machinery/computer/station_alert,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"bZ" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/vending/snack/random,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"cg" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/closet/crate/freezer/blood,
+/obj/machinery/iv_drip,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"ch" = (
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"cl" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"cr" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"cw" = (
+/obj/effect/turf_decal/tile/brown/full,
+/obj/item/radio/intercom{
+	layer = 3.3;
+	name = "Station Intercom (General)";
+	pixel_y = 32;
+	pixel_x = -32
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"cG" = (
+/obj/machinery/shuttle_manipulator,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"cT" = (
+/obj/effect/turf_decal/tile/brown/full,
+/obj/machinery/vending/cola/random,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"cU" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/simple_animal/hostile/retaliate/goat/inverted,
+/obj/machinery/door/window/brigdoor/westright{
+	req_access_txt = "55"
+	},
+/turf/open/indestructible/grass/jungle,
+/area/shuttle/escape)
+"dh" = (
+/obj/structure/window/reinforced{
+	pixel_y = -3
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/simple_animal/hostile/retaliate/goat/twisted,
+/obj/machinery/door/window/brigdoor/westright{
+	req_access_txt = "55"
+	},
+/turf/open/indestructible/grass/jungle,
+/area/shuttle/escape)
+"ds" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"dt" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"dx" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/fire{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/fire,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"dD" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/simple_animal/hostile/retaliate/goat/confetti{
+	name = "Sprinkles Goat";
+	desc = "You can feel your teeth getting numb."
+	},
+/obj/machinery/door/window/brigdoor/southleft{
+	req_access_txt = "55"
+	},
+/turf/open/indestructible/grass/jungle,
+/area/shuttle/escape)
+"dE" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"dQ" = (
+/obj/structure/statue/gold/cmo{
+	anchored = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"dT" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass_large,
+/obj/effect/turf_decal/stripes/full,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"ee" = (
+/obj/machinery/status_display/evac{
+	pixel_y = -32
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"eh" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/space_cops{
+	pixel_x = -32
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"el" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/reagent_dispensers/watertank,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -32
+	},
+/obj/machinery/button{
+	pixel_x = -21;
+	id = "fleetsup"
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"ep" = (
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"eu" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = -26
+	},
+/obj/item/storage/pod{
+	pixel_x = 4;
+	pixel_y = 32
+	},
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"ey" = (
+/obj/machinery/vending/boozeomat/all_access,
+/turf/open/floor/carpet/plainblue,
+/area/shuttle/escape)
+"eB" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = 32
+	},
+/obj/item/healthanalyzer/advanced,
+/obj/item/clothing/glasses/hud/health,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"eG" = (
+/obj/machinery/button/flasher{
+	id = "cockpit_flasher";
+	pixel_x = 6;
+	pixel_y = -24
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"eX" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"eZ" = (
+/obj/structure/pool_ladder,
+/turf/open/indestructible/sound/pool,
+/area/shuttle/escape)
+"fd" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"fg" = (
+/obj/machinery/modular_computer/console/preset/engineering,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"fp" = (
+/obj/structure/mirror{
+	pixel_x = -26
+	},
+/obj/structure/sink{
+	color = "#FFD700";
+	dir = 8;
+	pixel_x = -12;
+	name = "golden sink"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/shuttle/escape)
+"fw" = (
+/obj/effect/turf_decal/tile/brown/full,
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -32
+	},
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"fC" = (
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue,
+/obj/structure/table/glass,
+/obj/effect/spawner/lootdrop/three_course_meal,
+/obj/item/kitchen/fork,
+/obj/item/reagent_containers/food/drinks/drinkingglass/filled{
+	list_reagents = list(/datum/reagent/consumable/wine = 50)
+	},
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"fF" = (
+/obj/structure/statue/gold/hos,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"fL" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"fN" = (
+/obj/structure/sign/departments/minsky/security/security,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/escape)
+"fQ" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "EmFleet3"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"fV" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"gz" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"gB" = (
+/obj/machinery/computer/emergency_shuttle,
+/obj/item/radio/intercom{
+	layer = 3.3;
+	name = "Station Intercom (General)";
+	pixel_y = 25
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"gD" = (
+/obj/machinery/computer/secure_data{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"gH" = (
+/obj/machinery/light,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"gJ" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 3;
+	req_access_txt = "55"
+	},
+/obj/machinery/door/window/brigdoor/southright,
+/mob/living/simple_animal/hostile/retaliate/clown/mutant/blob,
+/turf/open/floor/mineral/bananium,
+/area/shuttle/escape)
+"gR" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced,
+/obj/item/stack/packageWrap,
+/obj/item/stack/wrapping_paper{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"gS" = (
+/obj/machinery/quantumpad{
+	map_pad_id = "fleetpod1";
+	map_pad_link_id = "fleetesc2pod1";
+	name = "Teleport to Evac Shuttle"
+	},
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 9
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
+"gX" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"hh" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/electrical,
+/obj/item/clothing/gloves/color/yellow,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"hi" = (
+/obj/machinery/quantumpad{
+	map_pad_id = "fleetsci";
+	map_pad_link_id = "fleetesc2sci";
+	name = "Teleport to Evac Shuttle"
+	},
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 9
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
+"hk" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"hr" = (
+/obj/effect/turf_decal/pool,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/noslip,
+/area/shuttle/escape)
+"hv" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"hR" = (
+/obj/machinery/telecomms/relay/preset/telecomms{
+	generates_heat = 0;
+	use_power = 0
+	},
+/obj/machinery/door/window,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/circuit/telecomms/server,
+/area/shuttle/escape)
+"ie" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "EmFleet1"
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"ii" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"ij" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "EmFleet3"
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"im" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	use_power = 0;
+	pixel_y = 33
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"io" = (
+/obj/machinery/quantumpad{
+	map_pad_id = "fleetesc2sci";
+	map_pad_link_id = "fleetsci";
+	name = "Teleport to Experimental Specimens Shuttle"
+	},
+/obj/structure/sign/directions/science{
+	pixel_y = 9
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
+"iy" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"iF" = (
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/stairs/goon/white_stairs_middle{
+	dir = 1
+	},
+/area/shuttle/escape)
+"iM" = (
+/obj/machinery/quantumpad{
+	map_pad_id = "fleetmed";
+	map_pad_link_id = "fleetesc2med";
+	name = "Teleport to Evac Shuttle"
+	},
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 9
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
+"iN" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"iO" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
+	},
+/obj/structure/closet/crate/secure/gear,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"iV" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"iY" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/item/paper_bin,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"jh" = (
+/obj/machinery/computer/station_alert{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"js" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"jw" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/closet/secure_closet{
+	name = "Plasmaman Supplies Locker";
+	req_access_txt = "5"
+	},
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/tank/internals/plasmaman,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"jz" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"jK" = (
+/obj/machinery/quantumpad{
+	map_pad_id = "fleeteng";
+	map_pad_link_id = "fleetesc2eng";
+	name = "Teleport to Evac Shuttle"
+	},
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 9
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
+"jM" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 4
+	},
+/obj/machinery/door/window/brigdoor/eastleft{
+	req_access_txt = "55"
+	},
+/mob/living/simple_animal/hostile/retaliate/clown/lube,
+/turf/open/floor/mineral/bananium,
+/area/shuttle/escape)
+"jP" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"jW" = (
+/obj/effect/turf_decal/box/white/corners,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"jZ" = (
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -3
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"ki" = (
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue,
+/obj/machinery/light/floor,
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"kt" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"kC" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = -32
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"kL" = (
+/obj/effect/turf_decal/pool{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/noslip,
+/area/shuttle/escape)
+"kM" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"kO" = (
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue,
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"kQ" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = -4;
+	pixel_y = 10
+	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone{
+	pixel_x = 7;
+	pixel_y = 10
+	},
+/obj/item/wrench/medical,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"kU" = (
+/obj/machinery/shuttle_manipulator{
+	layer = 3.3;
+	pixel_x = 1;
+	pixel_y = 12
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"kY" = (
+/obj/structure/window/reinforced{
+	pixel_y = -3
+	},
+/obj/machinery/door/window/brigdoor/eastleft{
+	req_access_txt = "55"
+	},
+/mob/living/simple_animal/hostile/retaliate/clown/banana,
+/turf/open/floor/mineral/bananium,
+/area/shuttle/escape)
+"lb" = (
+/obj/item/pool/rubber_ring,
+/turf/open/indestructible/sound/pool,
+/area/shuttle/escape)
+"ll" = (
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"lp" = (
+/obj/structure/shuttle/engine/propulsion{
+	broken = 1;
+	dir = 8
+	},
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"ls" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
+	},
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/hud/health,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"lw" = (
+/obj/effect/turf_decal{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"lN" = (
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal{
+	dir = 4
+	},
+/obj/effect/turf_decal{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/window{
+	id = "fleeteng2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"lO" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"lW" = (
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"ma" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/obj/machinery/door/window/brigdoor/northright{
+	req_access_txt = "55"
+	},
+/mob/living/simple_animal/hostile/retaliate/clown/mutant,
+/turf/open/floor/mineral/bananium,
+/area/shuttle/escape)
+"mf" = (
+/obj/structure/closet/wardrobe/white,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"mx" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"mE" = (
+/obj/machinery/quantumpad{
+	map_pad_link_id = "fleetesc2com";
+	map_pad_id = "fleetcom";
+	name = "Teleport to Evac Shuttle"
+	},
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 9
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
+"mG" = (
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"mO" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 3
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/door/window/brigdoor/northleft{
+	req_access_txt = "55"
+	},
+/mob/living/simple_animal/hostile/retaliate/goat/ras,
+/turf/open/indestructible/grass/jungle,
+/area/shuttle/escape)
+"mX" = (
+/obj/machinery/computer/station_alert,
+/obj/item/radio/intercom{
+	layer = 3.3;
+	name = "Station Intercom (General)";
+	pixel_y = 25
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"ni" = (
+/obj/machinery/door/window/brigdoor/eastleft{
+	req_access_txt = "47"
+	},
+/mob/living/simple_animal/hostile/retaliate/clown,
+/turf/open/floor/mineral/bananium,
+/area/shuttle/escape)
+"nk" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 3
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/simple_animal/hostile/retaliate/goat/tiny,
+/obj/machinery/door/window/brigdoor/southleft{
+	req_access_txt = "55"
+	},
+/turf/open/indestructible/grass/jungle,
+/area/shuttle/escape)
+"no" = (
+/obj/structure/chair/comfy/teal{
+	dir = 1
+	},
+/obj/structure/window{
+	dir = 4;
+	pixel_x = 3
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"nv" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4;
+	name = "Connector Port (Air Supply)"
+	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"ny" = (
+/obj/effect/turf_decal/pool{
+	dir = 4
+	},
+/obj/structure/chair/comfy/plastic{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/noslip,
+/area/shuttle/escape)
+"nE" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"nH" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)"
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"nM" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/simple_animal/hostile/retaliate/goat/goatgoat,
+/obj/machinery/door/window/brigdoor/westright{
+	req_access_txt = "55"
+	},
+/turf/open/indestructible/grass/jungle,
+/area/shuttle/escape)
+"nN" = (
+/obj/structure/statue/gold/ce{
+	anchored = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"nU" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"nY" = (
+/obj/machinery/door/window/brigdoor/eastleft{
+	req_access_txt = "55"
+	},
+/mob/living/simple_animal/hostile/retaliate/clown/honkling,
+/turf/open/floor/mineral/bananium,
+/area/shuttle/escape)
+"oj" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/machinery/modular_computer/console/preset/research,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"ot" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"oz" = (
+/obj/machinery/suit_storage_unit/cmo,
+/turf/open/floor/carpet/plainblue,
+/area/shuttle/escape)
+"oK" = (
+/obj/structure/shuttle/engine/propulsion,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"pa" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/button/flasher{
+	id = "sec_cockpit_flasher1";
+	pixel_x = 6;
+	pixel_y = -24
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -32
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"pb" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/escape)
+"pi" = (
+/obj/machinery/flasher{
+	id = "cockpit_flasher";
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"pn" = (
+/obj/effect/turf_decal/tile/brown/full,
+/obj/machinery/vending/wardrobe/cargo_wardrobe,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"px" = (
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"pA" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"pM" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/escape)
+"pO" = (
+/obj/machinery/light/floor,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"pR" = (
+/obj/structure/shuttle/engine/huge,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"qj" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 9
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"qo" = (
+/obj/machinery/quantumpad{
+	map_pad_id = "fleetpod2";
+	map_pad_link_id = "fleetesc2pod2";
+	name = "Teleport to Evac Shuttle"
+	},
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 9
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
+"qs" = (
+/obj/machinery/stasis{
+	dir = 8
+	},
+/obj/machinery/shower{
+	pixel_y = 20
+	},
+/turf/open/floor/noslip,
+/area/shuttle/escape)
+"qy" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"qB" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"qE" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/obj/machinery/door/window/brigdoor/northright{
+	req_access_txt = "55"
+	},
+/mob/living/simple_animal/cockroach/clownbug,
+/turf/open/floor/mineral/bananium,
+/area/shuttle/escape)
+"qM" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"qN" = (
+/obj/machinery/porta_turret/syndicate/energy/raven{
+	dir = 9
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/escape)
+"qQ" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 3
+	},
+/obj/machinery/door/window/brigdoor/northright{
+	req_access_txt = "55"
+	},
+/mob/living/simple_animal/pet/cat/clown{
+	name = "Cat Clown"
+	},
+/turf/open/floor/mineral/bananium,
+/area/shuttle/escape)
+"qZ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock{
+	name = "Unit 2"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/escape)
+"re" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"rn" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"ro" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/simple_animal/hostile/retaliate/goat/huge,
+/obj/machinery/door/window/brigdoor/southleft{
+	req_access_txt = "55"
+	},
+/turf/open/indestructible/grass/jungle,
+/area/shuttle/escape)
+"rq" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"ru" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/structure/closet/emcloset,
+/obj/item/roller,
+/obj/item/roller,
+/obj/item/roller,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"rx" = (
+/obj/structure/sign/directions/command{
+	pixel_y = 9
+	},
+/obj/machinery/quantumpad{
+	map_pad_link_id = "fleetcom";
+	map_pad_id = "fleetesc2com";
+	name = "Teleport to Command Shuttle"
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
+"rE" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"rF" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"rH" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"rZ" = (
+/obj/structure/sign/directions/security{
+	pixel_y = 9
+	},
+/obj/machinery/quantumpad{
+	map_pad_id = "fleetesc2sec";
+	map_pad_link_id = "fleetsec";
+	name = "Teleport to Brig Shuttle"
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
+"sj" = (
+/obj/machinery/door/window/brigdoor/northright{
+	req_access_txt = "55"
+	},
+/mob/living/simple_animal/hostile/retaliate/clown/fleshclown,
+/turf/open/floor/mineral/bananium,
+/area/shuttle/escape)
+"sy" = (
+/obj/machinery/door/airlock/security,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"sB" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock";
+	id_tag = "fleetpod2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"sC" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"sL" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_x = 32
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	pixel_x = -25;
+	id = "fleetpod2"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"sN" = (
+/obj/structure/sign/departments/minsky/engineering/engineering,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"sT" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/button/flasher{
+	id = "sec_cockpit_flasher2";
+	pixel_x = -6;
+	pixel_y = -24
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"sW" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/light,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"sZ" = (
+/obj/machinery/computer/security,
+/turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"tb" = (
+/obj/effect/turf_decal/pool,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/chair/comfy/plastic,
+/turf/open/floor/noslip,
+/area/shuttle/escape)
+"te" = (
+/obj/docking_port/mobile/emergency{
+	name = "Fleet emergency shuttle"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/security/glass{
+	name = "Emergency Shuttle Brig";
+	req_access_txt = "2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"tk" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"tz" = (
+/obj/structure/table/glass,
+/obj/effect/spawner/lootdrop/three_course_meal,
+/obj/item/kitchen/fork,
+/obj/item/reagent_containers/food/drinks/drinkingglass/filled{
+	list_reagents = list(/datum/reagent/consumable/wine = 50)
+	},
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"tI" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/belt/utility,
+/obj/item/clothing/head/welding,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"tK" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "EmFleet2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"tL" = (
+/obj/machinery/computer/crew,
+/turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"tM" = (
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue,
+/obj/structure/chair/office,
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"tP" = (
+/obj/machinery/door/airlock/external/glass,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"tV" = (
+/obj/machinery/computer/security{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/button/flasher{
+	id = "sec_cockpit_flasher1";
+	pixel_x = 6;
+	pixel_y = 32
+	},
+/obj/machinery/button/flasher{
+	id = "sec_cockpit_flasher2";
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"tW" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/machinery/sleeper{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"tY" = (
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"ub" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/simple_animal/hostile/retaliate/goat{
+	desc = "Suspiciously normal...";
+	name = "Normal Goat"
+	},
+/obj/machinery/door/window/brigdoor/southleft{
+	req_access_txt = "55"
+	},
+/turf/open/indestructible/grass/jungle,
+/area/shuttle/escape)
+"ug" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"up" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 6
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/camera,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"uq" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"us" = (
+/obj/machinery/holopad,
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"uu" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/obey{
+	pixel_x = 32
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"uv" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/computer/med_data,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"uw" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/vending/wallmed{
+	name = "Emergency NanoMed";
+	use_power = 0;
+	pixel_y = 33
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"uy" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"uE" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"uF" = (
+/turf/open/floor/carpet/royalblack,
+/area/shuttle/escape)
+"uL" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/shuttle/tinted,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"va" = (
+/obj/machinery/quantumpad{
+	map_pad_id = "fleetpod3";
+	map_pad_link_id = "fleetesc2pod3";
+	name = "Teleport to Evac Shuttle"
+	},
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 9
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
+"vg" = (
+/obj/structure/sign/departments/minsky/medical/medical2,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"vl" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"vv" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor/shutters/window{
+	id = "fleetsup"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"vG" = (
+/obj/effect/spawner/lootdrop/three_course_meal,
+/obj/structure/table/glass,
+/turf/open/floor/carpet/plainblue,
+/area/shuttle/escape)
+"vM" = (
+/obj/structure/sink{
+	pixel_y = 23
+	},
+/obj/structure/mirror{
+	pixel_x = -1;
+	pixel_y = 34
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"vN" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"vT" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"vU" = (
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"wa" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/door/window/brigdoor/northleft{
+	req_access_txt = "55"
+	},
+/mob/living/simple_animal/hostile/retaliate/goat/star,
+/turf/open/indestructible/grass/jungle,
+/area/shuttle/escape)
+"wb" = (
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/carpet/royalblack,
+/area/shuttle/escape)
+"wh" = (
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"wm" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/brute{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/brute,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"wp" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"wt" = (
+/obj/machinery/light,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)"
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"wy" = (
+/obj/machinery/quantumpad{
+	map_pad_id = "fleetesc2med";
+	map_pad_link_id = "fleetmed";
+	name = ""Teleport to Ambulance Shuttle"
+	},
+/obj/structure/sign/directions/medical{
+	pixel_y = 9
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
+"wB" = (
+/obj/effect/turf_decal{
+	dir = 1
+	},
+/obj/machinery/button{
+	pixel_x = -23;
+	pixel_y = -21;
+	id = "fleeteng1"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"wD" = (
+/obj/effect/turf_decal/tile/brown/full,
+/obj/machinery/computer/cargo/request,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"wE" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
+	},
+/obj/structure/closet/crate/secure/radiation,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"wF" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"wL" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)"
+	},
+/obj/item/radio,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"wO" = (
+/obj/machinery/computer/atmos_alert,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"wT" = (
+/obj/structure/sign/departments/minsky/supply/cargo,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"wX" = (
+/obj/machinery/light,
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"wZ" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"xa" = (
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"xk" = (
+/obj/structure/statue/sandstone/venus{
+	dir = 8;
+	pixel_x = -1;
+	pixel_y = 9
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"xo" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/carpet/royalblack,
+/area/shuttle/escape)
+"xv" = (
+/obj/effect/turf_decal/ramp_middle{
+	dir = 8
+	},
+/obj/effect/turf_decal/ramp_middle,
+/obj/effect/turf_decal/ramp_corner{
+	dir = 4
+	},
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"xz" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/obj/machinery/computer/operating,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"xI" = (
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue,
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"xN" = (
+/obj/structure/chair/comfy/shuttle,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"xR" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 3
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/door/window/brigdoor/northleft{
+	req_access_txt = "55"
+	},
+/mob/living/simple_animal/hostile/retaliate/goat/glowing,
+/turf/open/indestructible/grass/jungle,
+/area/shuttle/escape)
+"xS" = (
+/obj/structure/sign/departments/minsky/command/evac,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"xT" = (
+/obj/structure/table/reinforced,
+/obj/item/pet_carrier,
+/obj/item/bodybag/bluespace,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"yc" = (
+/obj/structure/table,
+/obj/item/paper/pamphlet/centcom,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"yg" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"yi" = (
+/obj/machinery/quantumpad{
+	map_pad_id = "fleetesc2pod2";
+	map_pad_link_id = "fleetpod2";
+	name = "Teleport to Private Pod Two"
+	},
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 9
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
+"yq" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"yv" = (
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"yw" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"yB" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"yC" = (
+/obj/structure/closet/wardrobe/grey,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"yM" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"yS" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"zd" = (
+/obj/structure/statue/sandstone/venus{
+	pixel_y = 9
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"zt" = (
+/obj/machinery/pool_filter,
+/turf/open/indestructible/sound/pool,
+/area/shuttle/escape)
+"zu" = (
+/obj/structure/window/shuttle,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass,
+/area/shuttle/escape)
+"zF" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
+	},
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"zM" = (
+/obj/machinery/quantumpad{
+	map_pad_id = "fleetesc2eng";
+	map_pad_link_id = "fleeteng";
+	name = "Teleport to Pod Mechanic sShuttle"
+	},
+/obj/structure/sign/directions/engineering{
+	pixel_y = 9
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
+"Ak" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Ar" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"Au" = (
+/obj/effect/turf_decal/tile/brown/full,
+/obj/machinery/computer/bounty,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Aw" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 3
+	},
+/obj/machinery/door/window/brigdoor/southright{
+	req_access_txt = "55"
+	},
+/mob/living/simple_animal/hostile/retaliate/clown/thin{
+	dir = 4
+	},
+/turf/open/floor/mineral/bananium,
+/area/shuttle/escape)
+"Az" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/carpet/royalblack,
+/area/shuttle/escape)
+"AJ" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 10
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"AQ" = (
+/obj/structure/sign/poster/official/safety_eye_protection,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"AV" = (
+/obj/structure/chair/comfy/teal{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"Bb" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)"
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Bp" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/conveyor_switch{
+	id = "EmFleet1";
+	pixel_x = 10;
+	pixel_y = 14
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Bq" = (
+/obj/structure/statue/gold/hop{
+	anchored = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"Bu" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"BN" = (
+/obj/structure/sink{
+	color = "#FFD700";
+	dir = 4;
+	pixel_x = 12;
+	name = "golden sink"
+	},
+/obj/structure/mirror{
+	pixel_x = 26
+	},
+/turf/open/floor/carpet/royalblack,
+/area/shuttle/escape)
+"BP" = (
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal{
+	dir = 4
+	},
+/obj/effect/turf_decal{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/window{
+	id = "fleeteng1"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"BQ" = (
+/obj/effect/turf_decal{
+	dir = 1
+	},
+/obj/machinery/button{
+	pixel_x = 23;
+	pixel_y = -21;
+	id = "fleeteng2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Ca" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Cd" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
+	},
+/obj/structure/closet/bombcloset,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Cg" = (
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Cl" = (
+/obj/effect/turf_decal/pool/corner,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = -32
+	},
+/turf/open/floor/noslip,
+/area/shuttle/escape)
+"Cm" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/toxin{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/toxin,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Cn" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/report_crimes{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Cv" = (
+/obj/structure/window/shuttle,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/shuttle/escape)
+"CA" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "sec_cockpit_flasher1";
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/obj/machinery/vending/cola/random,
+/obj/structure/sign/poster/official/safety_report{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"CS" = (
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"CZ" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/conveyor_switch{
+	id = "EmFleet3";
+	pixel_x = 10;
+	pixel_y = 14
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Dg" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Emergency Shuttle Brig";
+	req_access_txt = "2"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Dh" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)"
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Di" = (
+/obj/effect/turf_decal/box/white/corners,
+/obj/machinery/vending/wardrobe/sig_wardrobe,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Ds" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock";
+	id_tag = "fleetpod1"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"DC" = (
+/obj/machinery/door/window/brigdoor/southright{
+	req_access_txt = "55"
+	},
+/mob/living/simple_animal/hostile/retaliate/clown/clownhulk/chlown,
+/turf/open/floor/mineral/bananium,
+/area/shuttle/escape)
+"DD" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"DN" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/turf_decal/stripes/full,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"DP" = (
+/obj/effect/turf_decal/tile/brown/full,
+/obj/machinery/light,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"DU" = (
+/obj/effect/turf_decal/tile/brown/full,
+/obj/machinery/vending/snack/random,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Ej" = (
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"En" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/glass_large,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Eq" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Er" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Es" = (
+/obj/item/storage/box/cups,
+/obj/structure/table/glass,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/carpet/plainblue,
+/area/shuttle/escape)
+"Ev" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/fingerless,
+/obj/item/clothing/gloves/fingerless{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Ew" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/door/airlock/titanium/glass{
+	req_access_txt = "55"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"EA" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/door/window/brigdoor/northleft{
+	req_access_txt = "55"
+	},
+/mob/living/simple_animal/hostile/retaliate/goat/suspicious,
+/turf/open/indestructible/grass/jungle,
+/area/shuttle/escape)
+"ED" = (
+/obj/machinery/door/airlock/external/glass,
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"EF" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"EJ" = (
+/obj/machinery/quantumpad{
+	map_pad_id = "fleetsec";
+	map_pad_link_id = "fleetesc2sec";
+	name = "Teleport to Evac Shuttle"
+	},
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 9
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
+"EQ" = (
+/obj/effect/turf_decal/pool,
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/chair/comfy/plastic,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/walk{
+	pixel_x = 32
+	},
+/turf/open/floor/noslip,
+/area/shuttle/escape)
+"Fb" = (
+/obj/effect/turf_decal/box/white/corners,
+/obj/structure/closet/secure_closet/freezer/meat,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Fp" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/escape)
+"FF" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/simple_animal/hostile/retaliate/goat/cottoncandy,
+/obj/machinery/door/window/brigdoor/southleft{
+	req_access_txt = "55"
+	},
+/turf/open/indestructible/grass/jungle,
+/area/shuttle/escape)
+"FI" = (
+/obj/item/toy/beach_ball,
+/turf/open/indestructible/sound/pool,
+/area/shuttle/escape)
+"FP" = (
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue,
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"FY" = (
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue,
+/obj/structure/table/glass,
+/obj/effect/spawner/lootdrop/three_course_meal,
+/obj/item/kitchen/fork,
+/obj/item/reagent_containers/food/drinks/drinkingglass/filled{
+	list_reagents = list(/datum/reagent/consumable/wine = 50)
+	},
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"Ge" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Gm" = (
+/obj/structure/bed/pod,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Gq" = (
+/obj/machinery/door/window/brigdoor/southright{
+	req_access_txt = "55"
+	},
+/mob/living/simple_animal/hostile/retaliate/clown{
+	desc = "Suspiciously normal...";
+	name = "Normal Clown"
+	},
+/turf/open/floor/mineral/bananium,
+/area/shuttle/escape)
+"Gx" = (
+/obj/structure/window{
+	dir = 4;
+	pixel_x = 3
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"GB" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/machinery/button/flasher{
+	id = "sec_cell_flasher1";
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"GC" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/door/window/brigdoor/northleft{
+	req_access_txt = "55"
+	},
+/mob/living/simple_animal/hostile/retaliate/goat/legitgoat,
+/turf/open/indestructible/grass/jungle,
+/area/shuttle/escape)
+"GE" = (
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 4
+	},
+/obj/structure/chair/office{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"GH" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)"
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"GK" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/chair/comfy/shuttle,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Hg" = (
+/obj/machinery/computer/secure_data,
+/obj/item/radio/intercom{
+	layer = 3.3;
+	name = "Station Intercom (General)";
+	pixel_y = 25
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"Hu" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Hy" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/mineral/titanium/fifty{
+	pixel_x = 16
+	},
+/obj/item/stack/sheet/metal/fifty,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"HB" = (
+/obj/machinery/computer/communications,
+/obj/structure/window{
+	dir = 4;
+	pixel_x = 3
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"HC" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/effect/turf_decal/delivery/white,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"HQ" = (
+/obj/effect/turf_decal/ramp_middle,
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"HX" = (
+/obj/structure/mirror{
+	pixel_y = 36
+	},
+/obj/structure/sink{
+	pixel_y = 27
+	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/escape)
+"HZ" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"If" = (
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"Ik" = (
+/obj/structure/sign/departments/science,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"IF" = (
+/obj/structure/statue/diamond/captain,
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"IL" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/machinery/light,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"IM" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plasteel/stairs/goon/white_stairs_middle{
+	dir = 8
+	},
+/area/shuttle/escape)
+"IQ" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 1
+	},
+/obj/structure/closet/athletic_mixed,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"IW" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Jc" = (
+/obj/machinery/quantumpad{
+	map_pad_id = "fleetcom2toi";
+	map_pad_link_id = "fleettoi"
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
+"Je" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 5
+	},
+/obj/structure/table/reinforced,
+/obj/item/healthanalyzer,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Jp" = (
+/obj/effect/turf_decal/trimline/blue/filled/warning,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Js" = (
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/carpet/plainblue,
+/area/shuttle/escape)
+"JA" = (
+/obj/machinery/door/window/southleft{
+	name = "Brig Desk";
+	req_access_txt = "1"
+	},
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"JB" = (
+/obj/machinery/suit_storage_unit/hos,
+/turf/open/floor/carpet/plainblue,
+/area/shuttle/escape)
+"JJ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/suit_storage_unit/command,
+/turf/open/floor/carpet/plainblue,
+/area/shuttle/escape)
+"JM" = (
+/obj/effect/turf_decal/tile/brown/full,
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"JU" = (
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"JY" = (
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/escape)
+"Kc" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Ke" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Kl" = (
+/obj/machinery/door/airlock/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Kp" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"Ky" = (
+/obj/machinery/computer/atmos_alert{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"KG" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/belt/utility,
+/obj/item/clothing/head/welding,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"KH" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/machinery/door/window/brigdoor/northleft{
+	req_access_txt = "55"
+	},
+/mob/living/simple_animal/hostile/retaliate/goat/rainbow,
+/turf/open/indestructible/grass/jungle,
+/area/shuttle/escape)
+"KI" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/conveyor_switch{
+	id = "EmFleet2";
+	pixel_x = 10;
+	pixel_y = 14
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"KL" = (
+/obj/item/pool/pool_noodle,
+/turf/open/indestructible/sound/pool,
+/area/shuttle/escape)
+"KT" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/stairs/goon/white_stairs_middle{
+	dir = 4
+	},
+/area/shuttle/escape)
+"KY" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Lk" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock";
+	id_tag = "fleetpod3"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Lr" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_x = 32
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	pixel_x = -25;
+	id = "fleetpod1"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Lv" = (
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"Lw" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Ly" = (
+/obj/structure/sign/departments/xenobio,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"LO" = (
+/obj/effect/turf_decal/tile/brown/full,
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Shuttle Airlock"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Md" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/shuttle/escape)
+"Ms" = (
+/obj/effect/turf_decal/tile/brown/full,
+/obj/machinery/computer/shuttle/mining,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Mu" = (
+/obj/structure/closet/crate/solarpanel_small,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"MC" = (
+/obj/machinery/computer/emergency_shuttle,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"MF" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"MH" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"ML" = (
+/obj/machinery/door/airlock/vault{
+	req_access_txt = "53"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"MX" = (
+/obj/machinery/quantumpad{
+	map_pad_id = "fleetsup";
+	map_pad_link_id = "fleetesc2sup";
+	name = "Teleport to Evac Shuttle"
+	},
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 9
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
+"MZ" = (
+/obj/effect/turf_decal/tile/brown/full,
+/obj/structure/closet/wardrobe/cargotech,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Nh" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/vending/cola/random,
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Nj" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"Nl" = (
+/obj/structure/shuttle/engine/heater,
+/obj/structure/window/reinforced{
+	dir = 1;
+	layer = 2.9
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"Nq" = (
+/obj/machinery/quantumpad{
+	map_pad_link_id = "fleetsup";
+	map_pad_id = "fleetesc2sup"
+	},
+/obj/structure/sign/directions/supply{
+	pixel_y = 9
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
+"NB" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/computer/crew,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"ND" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
+	},
+/obj/structure/closet/crate/solarpanel_small,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"NG" = (
+/obj/structure/statue/gold/rd{
+	anchored = 1
+	},
+/obj/machinery/light/floor,
+/turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"NZ" = (
+/obj/machinery/door/window/brigdoor/northright{
+	req_access_txt = "55"
+	},
+/obj/item/reagent_containers/food/snacks/burger/clown{
+	desc = "They turned a clown into a burger. Funniest shit you've ever seen.";
+	pixel_y = -6
+	},
+/turf/open/floor/mineral/bananium,
+/area/shuttle/escape)
+"Ol" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"Oo" = (
+/obj/machinery/computer/emergency_shuttle{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"Os" = (
+/obj/machinery/atmospherics/components/unary/cryo_cell{
+	dir = 1;
+	layer = 3.3
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Ov" = (
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Ox" = (
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"OA" = (
+/obj/effect/turf_decal,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"OG" = (
+/obj/machinery/quantumpad{
+	map_pad_id = "fleetesc2pod3";
+	map_pad_link_id = "fleetpod3";
+	name = "Teleport to Private Pod Three"
+	},
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 9
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
+"OM" = (
+/obj/machinery/vending/security,
+/obj/structure/sign/poster/official/twelve_gauge{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"OV" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Pb" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"Pc" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Pl" = (
+/obj/machinery/door/airlock/security,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Pq" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/item/kirbyplants/photosynthetic,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"Ps" = (
+/obj/machinery/computer/med_data,
+/obj/structure/window{
+	dir = 4;
+	pixel_x = 3
+	},
+/turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"PA" = (
+/obj/structure/chair/comfy/teal{
+	dir = 1
+	},
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -3
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"PF" = (
+/obj/machinery/shuttle_manipulator{
+	layer = 3.3;
+	pixel_x = 1;
+	pixel_y = 12
+	},
+/obj/effect/turf_decal/ramp_corner,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 4
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"PH" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"PJ" = (
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"PM" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/window{
+	dir = 8
+	},
+/turf/open/floor/grass,
+/area/shuttle/escape)
+"PP" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 3
+	},
+/obj/machinery/door/window/brigdoor/northright{
+	req_access_txt = "55"
+	},
+/mob/living/simple_animal/hostile/retaliate/clown/clownhulk/honcmunculus,
+/turf/open/floor/mineral/bananium,
+/area/shuttle/escape)
+"PV" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "EmFleet2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"PY" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"Qb" = (
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Qg" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "sec_cockpit_flasher2";
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/obj/machinery/vending/snack/random,
+/obj/structure/sign/poster/official/here_for_your_safety{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Qh" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"QB" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"QP" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/escape)
+"QR" = (
+/obj/machinery/porta_turret/syndicate/energy/raven{
+	dir = 5
+	},
+/turf/closed/wall/mineral/plastitanium,
+/area/shuttle/escape)
+"QV" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"QX" = (
+/obj/structure/closet/secure_closet/brig,
+/obj/machinery/button/flasher{
+	id = "sec_cell_flasher2";
+	pixel_x = 6;
+	pixel_y = 24
+	},
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"QY" = (
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue,
+/obj/effect/turf_decal/tile/darkblue,
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"Rc" = (
+/obj/effect/turf_decal/tile/brown/full,
+/obj/machinery/computer/cargo,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Ri" = (
+/turf/open/indestructible/sound/pool,
+/area/shuttle/escape)
+"Rk" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 8
+	},
+/obj/structure/closet/wardrobe/mixed,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Rn" = (
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Rr" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock{
+	name = "Unit 1"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/escape)
+"Rs" = (
+/obj/machinery/shuttle_manipulator{
+	layer = 3.3;
+	pixel_x = 1;
+	pixel_y = 12
+	},
+/obj/effect/turf_decal/ramp_middle,
+/obj/effect/turf_decal/ramp_middle{
+	dir = 4
+	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"Rx" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/window{
+	dir = 4
+	},
+/turf/open/floor/grass,
+/area/shuttle/escape)
+"RE" = (
+/turf/closed/wall/mineral/titanium,
+/area/shuttle/escape)
+"RG" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
+	},
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"RI" = (
+/obj/structure/window/reinforced{
+	dir = 4;
+	pixel_x = 3
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/simple_animal/hostile/retaliate/goat/chocolate,
+/obj/machinery/door/window/brigdoor/southleft{
+	req_access_txt = "55"
+	},
+/turf/open/indestructible/grass/jungle,
+/area/shuttle/escape)
+"RL" = (
+/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/area/shuttle/escape)
+"RV" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Sa" = (
+/obj/structure/closet/crate/necropolis,
+/obj/item/clothing/shoes/drip,
+/obj/item/clothing/under/costume/drip,
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Sj" = (
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Sk" = (
+/obj/effect/turf_decal/trimline/purple/filled/warning,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Sm" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/machinery/computer/emergency_shuttle,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Sy" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
+	},
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"SB" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"SM" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/toolbox/mechanical,
+/obj/item/storage/belt/utility,
+/obj/item/clothing/head/welding,
+/obj/structure/sign/poster/official/build{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"SO" = (
+/obj/structure/table/reinforced,
+/obj/item/soap,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"SR" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"SS" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"SX" = (
+/obj/structure/mirror{
+	pixel_y = 34
+	},
+/obj/structure/sink{
+	pixel_y = 23
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"Th" = (
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/darkblue{
+	dir = 1
+	},
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/shuttle/escape)
+"To" = (
+/obj/effect/turf_decal/box/white/corners,
+/obj/structure/closet/secure_closet/security,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Tq" = (
+/obj/structure/window/shuttle,
+/turf/open/floor/grass,
+/area/shuttle/escape)
+"TB" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"TD" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/mob/living/simple_animal/hostile/retaliate/goat,
+/obj/machinery/door/window/brigdoor/westright{
+	req_access_txt = "55"
+	},
+/turf/open/indestructible/grass/jungle,
+/area/shuttle/escape)
+"TI" = (
+/obj/structure/toilet{
+	desc = "The HT-451, a torque rotation-based, waste disposal unit for small matter. This one seems remarkably dirty.";
+	dir = 8
+	},
+/obj/machinery/flasher{
+	id = "sec_cell_flasher1";
+	pixel_x = -6;
+	pixel_y = -24
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"TN" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"TR" = (
+/obj/structure/closet/crate/secure/gear/donut,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"TS" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/cardboard/fifty,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"TX" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_x = 32
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	pixel_x = -25;
+	id = "fleetpod3"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Ua" = (
+/obj/effect/turf_decal/trimline/purple/filled/warning,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Uc" = (
+/obj/structure/closet/crate/secure/gear,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Uo" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/toilet{
+	dir = 1
+	},
+/turf/open/floor/plasteel/freezer,
+/area/shuttle/escape)
+"Uv" = (
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"UA" = (
+/obj/machinery/suit_storage_unit/captain,
+/turf/open/floor/carpet/plainblue,
+/area/shuttle/escape)
+"UI" = (
+/obj/machinery/stasis{
+	dir = 8
+	},
+/obj/machinery/shower{
+	dir = 1
+	},
+/turf/open/floor/noslip,
+/area/shuttle/escape)
+"UJ" = (
+/obj/machinery/suit_storage_unit/ce,
+/turf/open/floor/carpet/plainblue,
+/area/shuttle/escape)
+"Va" = (
+/obj/structure/closet/crate/secure/plasma,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Vn" = (
+/obj/structure/mopbucket,
+/obj/item/mop,
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Vw" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/table/reinforced,
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/obj/machinery/defibrillator_mount/loaded{
+	pixel_y = -32
+	},
+/obj/item/healthanalyzer/advanced,
+/obj/item/clothing/glasses/hud/health,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"VA" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"VB" = (
+/obj/effect/turf_decal/tile/brown/full,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"VQ" = (
+/obj/machinery/portable_atmospherics/canister/plasma,
+/obj/machinery/door/window/brigdoor/southright{
+	req_access_txt = "24"
+	},
+/obj/effect/turf_decal/delivery/red,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"We" = (
+/obj/effect/turf_decal/ramp_middle{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 8
+	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 1
+	},
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"Wl" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced,
+/obj/item/hand_labeler,
+/obj/item/hand_labeler{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Wu" = (
+/obj/machinery/shuttle_manipulator{
+	layer = 3.3;
+	pixel_x = 1;
+	pixel_y = 12
+	},
+/obj/effect/turf_decal/ramp_middle,
+/turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"Ww" = (
+/obj/effect/turf_decal/tile/brown/full,
+/obj/item/radio/intercom{
+	layer = 3.3;
+	name = "Station Intercom (General)";
+	pixel_y = 32;
+	pixel_x = 32
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"Wy" = (
+/obj/structure/toilet{
+	color = "#FFD700";
+	icon_state = "toilet00";
+	name = "golden toilet";
+	desc = "The HT-451, a torque rotation-based, waste disposal unit for small matter. This one seems remarkably gaudy."
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/sign/painting{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/royalblack,
+/area/shuttle/escape)
+"WN" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"WO" = (
+/obj/effect/turf_decal,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"WQ" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/obj/machinery/door/window/brigdoor/southright{
+	req_access_txt = "55"
+	},
+/mob/living/simple_animal/hostile/retaliate/clown/clownhulk,
+/turf/open/floor/mineral/bananium,
+/area/shuttle/escape)
+"WV" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/table/reinforced,
+/obj/item/destTagger,
+/obj/item/destTagger{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"WY" = (
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -3
+	},
+/obj/machinery/computer/aifixer,
+/turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"Xf" = (
+/obj/effect/turf_decal/box/white/corners{
+	dir = 4
+	},
+/obj/structure/closet/wardrobe/pjs,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Xt" = (
+/obj/effect/turf_decal/tile/brown/full,
+/obj/machinery/computer/security/qm,
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"XH" = (
+/obj/structure/table/reinforced,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"XP" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs/goon/white_stairs_middle,
+/area/shuttle/escape)
+"XR" = (
+/obj/structure/table/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Yg" = (
+/obj/structure/window{
+	dir = 8;
+	pixel_x = -3
+	},
+/obj/machinery/computer/card,
+/turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"Yo" = (
+/obj/effect/spawner/structure/window/plastitanium,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Yz" = (
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"YE" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery/white,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"YH" = (
+/obj/structure/shuttle/engine/large,
+/turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"YJ" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	pixel_x = -4
+	},
+/obj/machinery/door/window/brigdoor/southright{
+	req_access_txt = "55"
+	},
+/mob/living/simple_animal/hostile/retaliate/clown/longface,
+/turf/open/floor/mineral/bananium,
+/area/shuttle/escape)
+"YQ" = (
+/turf/open/space/basic,
+/area/space)
+"YT" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/obj/structure/table/reinforced,
+/obj/item/storage/firstaid/o2{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/firstaid/o2,
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Zu" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/obj/machinery/computer/operating{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Zv" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod Airlock"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"Zx" = (
+/obj/effect/turf_decal/caution/stand_clear,
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"ZE" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"ZM" = (
+/obj/machinery/quantumpad{
+	map_pad_id = "fleetesc2pod1";
+	map_pad_link_id = "fleetpod1";
+	name = "Teleport to Private Pod One"
+	},
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 9
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
+
+(1,1,1) = {"
+RE
+cr
+cr
+cr
+Nj
+oK
+YQ
+YQ
+YQ
+YQ
+pM
+RL
+Cg
+RL
+RL
+RL
+Cg
+fN
+te
+Nl
+oK
+YQ
+YQ
+RE
+ug
+cr
+ug
+cr
+cr
+cr
+cr
+cr
+cr
+cr
+cr
+RE
+YQ
+YQ
+YQ
+YQ
+RE
+cr
+cr
+RE
+YQ
+YQ
+YQ
+"}
+(2,1,1) = {"
+Rn
+Er
+Lr
+Ds
+gS
+ii
+YQ
+qN
+RL
+RL
+RL
+eh
+yB
+pa
+RL
+CA
+bl
+yc
+Ov
+vl
+oK
+YQ
+RE
+RE
+rE
+hk
+Uv
+iy
+QB
+zu
+cr
+bn
+JY
+Rr
+Uo
+cr
+RE
+YQ
+YQ
+RE
+cr
+rq
+tW
+cr
+RE
+YQ
+YQ
+"}
+(3,1,1) = {"
+RE
+SS
+cr
+cr
+Nj
+oK
+YQ
+px
+Gm
+Qb
+Dg
+tY
+tY
+tY
+Pl
+Kc
+Kc
+Kc
+Kc
+ot
+oK
+YQ
+Rn
+xN
+Uv
+Uv
+Uv
+Uv
+Uv
+at
+cr
+HX
+QP
+cr
+cr
+vl
+oK
+YQ
+YQ
+cr
+xz
+gz
+WN
+Zu
+vl
+ep
+YH
+"}
+(4,1,1) = {"
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+RL
+vM
+TI
+RL
+GB
+tY
+re
+RL
+tV
+XR
+Kc
+Kc
+Pc
+Sj
+YQ
+Rn
+xN
+gH
+zu
+zu
+zu
+SB
+at
+cr
+JY
+JY
+qZ
+Uo
+vl
+oK
+YQ
+YQ
+cr
+qs
+Yz
+Yz
+UI
+vl
+ep
+ep
+"}
+(5,1,1) = {"
+RE
+cr
+cr
+cr
+RE
+YQ
+YQ
+RL
+RL
+RL
+RL
+OM
+tY
+tY
+Pl
+Ak
+JA
+Kc
+dE
+EJ
+Sj
+YQ
+Rn
+xN
+Uv
+Uv
+Uv
+Uv
+Uv
+at
+cr
+pb
+cr
+cr
+cr
+vl
+oK
+YQ
+YQ
+cr
+eB
+Yz
+Yz
+Vw
+cr
+YQ
+YQ
+"}
+(6,1,1) = {"
+cr
+uF
+fp
+Az
+Nj
+oK
+YQ
+RL
+SX
+aK
+RL
+QX
+tY
+re
+Fp
+gD
+GH
+Kc
+Kc
+iV
+Sj
+YQ
+Rn
+zu
+nE
+nE
+nE
+zu
+eX
+yM
+Cl
+kL
+ny
+ny
+ny
+vl
+oK
+YQ
+RE
+cr
+uw
+rF
+rF
+sW
+cr
+RE
+YQ
+"}
+(7,1,1) = {"
+cr
+Wy
+wb
+ap
+hv
+YQ
+YQ
+px
+Gm
+Qb
+Dg
+tY
+tY
+tY
+sy
+Kc
+Kc
+Kc
+Kc
+Nl
+oK
+YQ
+Rn
+zu
+zM
+io
+wy
+GK
+Uv
+Ox
+tb
+Ri
+Ri
+Ri
+lb
+vl
+oK
+YQ
+Rn
+jz
+gz
+nv
+IW
+Hu
+iM
+cr
+YQ
+"}
+(8,1,1) = {"
+cr
+uF
+BN
+xo
+Nj
+oK
+YQ
+QR
+RL
+RL
+RL
+uu
+uy
+sT
+RL
+Qg
+VA
+SR
+Cn
+vl
+oK
+YQ
+Rn
+rZ
+OV
+eX
+eX
+GK
+Uv
+Ox
+tb
+zt
+KL
+Ri
+Ri
+vl
+oK
+YQ
+Rn
+uv
+wF
+Cv
+Os
+Yz
+pA
+dT
+YQ
+"}
+(9,1,1) = {"
+RE
+cr
+cr
+cr
+RE
+YQ
+YQ
+YQ
+YQ
+YQ
+pM
+RL
+Yo
+RL
+RL
+RL
+Yo
+RL
+RL
+ot
+oK
+YQ
+Rn
+rx
+rH
+Uv
+Uv
+rH
+Uv
+Ox
+hr
+eZ
+Ri
+FI
+Ri
+vl
+oK
+YQ
+Rn
+NB
+wF
+Cv
+Os
+Yz
+Jp
+DN
+YQ
+"}
+(10,1,1) = {"
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+Rn
+Nq
+ZE
+cl
+cl
+Nh
+Uv
+Ox
+tb
+Ri
+Ri
+KL
+Ri
+vl
+oK
+YQ
+Rn
+fL
+qB
+wh
+kQ
+jP
+ru
+vg
+YQ
+"}
+(11,1,1) = {"
+YQ
+RE
+cr
+wT
+ug
+cr
+cr
+wT
+ug
+cr
+cr
+cr
+Kp
+Kp
+Kp
+cr
+cr
+cr
+Nl
+ep
+YH
+YQ
+RE
+RE
+ZM
+yi
+OG
+bZ
+Uv
+wp
+EQ
+lb
+Ri
+Ri
+Ri
+cr
+RE
+YQ
+RE
+cr
+im
+yg
+yg
+IL
+cr
+RE
+YQ
+"}
+(12,1,1) = {"
+RE
+cr
+DU
+cT
+VB
+fw
+cr
+MX
+Lw
+lO
+KG
+Ev
+Wl
+WV
+gR
+TS
+iY
+el
+ot
+ep
+ep
+YQ
+YQ
+RE
+cr
+Ar
+cr
+cr
+Ar
+cr
+cr
+cr
+Ar
+Ar
+cr
+RE
+YQ
+YQ
+YQ
+cr
+cg
+Yz
+Yz
+jw
+cr
+YQ
+YQ
+"}
+(13,1,1) = {"
+Ol
+Au
+cw
+VB
+VB
+VB
+LO
+uq
+Kc
+Kc
+Lw
+Kc
+Kc
+Lw
+Kc
+Kc
+Lw
+Kc
+Kc
+Kc
+vv
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+cr
+cg
+Yz
+Yz
+jw
+vl
+ep
+YH
+"}
+(14,1,1) = {"
+Ol
+wD
+JM
+VB
+RL
+RL
+RL
+Kc
+Cd
+iO
+Lw
+wE
+ND
+Lw
+IQ
+Rk
+Lw
+zF
+bJ
+Kc
+vv
+YQ
+YQ
+RE
+cr
+cr
+cr
+RE
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+cr
+wm
+qB
+jP
+YT
+vl
+ep
+ep
+"}
+(15,1,1) = {"
+Ol
+Rc
+JM
+DP
+RL
+Sa
+ML
+Kc
+Uc
+TR
+Lw
+Mu
+Va
+Lw
+mf
+yC
+Lw
+Ge
+sC
+Kc
+vv
+YQ
+RE
+cr
+kY
+nY
+jM
+cr
+RE
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+RE
+cr
+dx
+Cm
+cr
+RE
+YQ
+YQ
+"}
+(16,1,1) = {"
+Ol
+Xt
+JM
+VB
+RL
+RL
+RL
+Kc
+RG
+To
+Lw
+Ca
+Di
+Lw
+Xf
+Fb
+Lw
+Sy
+jW
+Kc
+vv
+YQ
+cr
+gJ
+qj
+MF
+AJ
+PP
+Nl
+oK
+YQ
+YQ
+RE
+sN
+ug
+cr
+RE
+YQ
+YQ
+YQ
+RE
+cr
+cr
+RE
+YQ
+YQ
+YQ
+"}
+(17,1,1) = {"
+Ol
+Ms
+Ww
+VB
+VB
+VB
+LO
+Kc
+Kc
+Kc
+CZ
+Kc
+Kc
+KI
+Kc
+Kc
+Bp
+Kc
+Kc
+Kc
+vv
+YQ
+cr
+DC
+QV
+xT
+HZ
+sj
+vl
+oK
+YQ
+RE
+cr
+nU
+vU
+yw
+cr
+RE
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+"}
+(18,1,1) = {"
+RE
+cr
+pn
+MZ
+MZ
+MZ
+cr
+js
+ah
+ij
+fQ
+ij
+PV
+tK
+PV
+ie
+ar
+ie
+Nl
+ep
+YH
+YQ
+cr
+WQ
+QV
+wZ
+HZ
+ma
+ot
+oK
+YQ
+Rn
+hR
+vU
+vU
+Lv
+jK
+vl
+ep
+YH
+YQ
+RE
+cr
+cr
+cr
+Nj
+oK
+"}
+(19,1,1) = {"
+YQ
+RE
+cr
+Ar
+Ar
+cr
+cr
+cr
+Ar
+cr
+cr
+cr
+Ar
+Ar
+Ar
+cr
+cr
+cr
+ot
+ep
+ep
+YQ
+cr
+cr
+vN
+ni
+Qh
+cr
+cr
+YQ
+YQ
+Rn
+wL
+vU
+vU
+vU
+Pq
+vl
+ep
+ep
+YQ
+Rn
+Er
+sL
+sB
+qo
+ii
+"}
+(20,1,1) = {"
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+cr
+Aw
+QV
+Yz
+HZ
+qQ
+cr
+YQ
+YQ
+RE
+cr
+Bu
+DD
+xa
+cr
+RE
+YQ
+YQ
+YQ
+RE
+SS
+cr
+cr
+Nj
+oK
+"}
+(21,1,1) = {"
+YQ
+RE
+fd
+fd
+Kp
+Kp
+Kp
+Kp
+Kp
+Kp
+Kp
+Kp
+Kp
+Kp
+Kp
+RE
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+cr
+Gq
+QV
+xT
+HZ
+NZ
+cr
+YQ
+YQ
+YQ
+cr
+ds
+vU
+kC
+cr
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+"}
+(22,1,1) = {"
+RE
+MH
+JJ
+aa
+Rx
+Rx
+Rx
+Rx
+Rx
+Rx
+Rx
+Rx
+Rx
+Rx
+Rx
+MH
+RE
+YQ
+YQ
+YQ
+YQ
+YQ
+cr
+YJ
+tk
+yS
+kM
+qE
+cr
+YQ
+YQ
+YQ
+cr
+mx
+PY
+YE
+cr
+cr
+cr
+cr
+BP
+BP
+BP
+BP
+BP
+cr
+RE
+"}
+(23,1,1) = {"
+Rn
+UA
+Js
+Yz
+Yz
+pO
+Yz
+Yz
+pO
+Yz
+Yz
+pO
+Yz
+Yz
+Yz
+ey
+uL
+ep
+ep
+pR
+YQ
+RE
+cr
+cr
+kt
+Ew
+kt
+cr
+cr
+YQ
+YQ
+RE
+cr
+vU
+vU
+vU
+vU
+tP
+ch
+ED
+WO
+Zx
+Zx
+Zx
+wB
+RV
+cr
+"}
+(24,1,1) = {"
+Rn
+JB
+Js
+Yz
+Tq
+Tq
+KT
+KT
+KT
+KT
+KT
+Tq
+Tq
+Bq
+Yz
+Es
+uL
+ep
+ep
+ep
+YQ
+Rn
+ls
+Bb
+MF
+fV
+dt
+hi
+Ly
+YQ
+RE
+cr
+nH
+vU
+vU
+vU
+wt
+cr
+cr
+cr
+OA
+ch
+ch
+ch
+lw
+SM
+cr
+"}
+(25,1,1) = {"
+Rn
+WY
+PA
+Yz
+Tq
+Rs
+kO
+QY
+kO
+kO
+kO
+PF
+Tq
+IF
+ll
+Jc
+uL
+ep
+ep
+ep
+YQ
+Rn
+oj
+wF
+Yz
+Yz
+Yz
+Ua
+En
+YQ
+Rn
+bO
+yq
+vU
+vU
+vU
+lW
+jh
+hv
+Vn
+WO
+lp
+Zv
+lp
+lw
+hh
+hv
+"}
+(26,1,1) = {"
+Rn
+mX
+AV
+pO
+Tq
+HQ
+kO
+ai
+QY
+kO
+kO
+JU
+Tq
+fF
+TB
+cr
+cr
+YQ
+YQ
+YQ
+YQ
+Rn
+Sm
+wF
+Yz
+Yz
+Yz
+Sk
+PH
+YQ
+Rn
+wO
+yq
+vU
+cG
+vU
+lW
+Ky
+hv
+SO
+WO
+cr
+eu
+cr
+lw
+Hy
+hv
+"}
+(27,1,1) = {"
+Rn
+sZ
+AV
+Yz
+XP
+kO
+ki
+GE
+GE
+FP
+ki
+kO
+iF
+Yz
+Yz
+zd
+cr
+xS
+cr
+RE
+YQ
+Rn
+Je
+Dh
+rn
+yS
+rn
+up
+Ik
+YQ
+Rn
+MC
+yq
+vU
+vU
+vU
+lW
+Oo
+hv
+XH
+WO
+cr
+ee
+cr
+lw
+TN
+hv
+"}
+(28,1,1) = {"
+Rn
+Yg
+jZ
+Yz
+XP
+kO
+tM
+tz
+tz
+tz
+mG
+kO
+iF
+Yz
+Yz
+eG
+cr
+pi
+KY
+iN
+YQ
+RE
+cr
+cr
+kt
+Ew
+kt
+cr
+cr
+YQ
+Rn
+fg
+yq
+vU
+vU
+vU
+lW
+If
+hv
+qM
+WO
+RE
+kt
+RE
+lw
+hh
+hv
+"}
+(29,1,1) = {"
+Rn
+gB
+AV
+pO
+XP
+kO
+tM
+fC
+us
+FY
+mG
+kO
+iF
+Yz
+pO
+Yz
+Kl
+Ej
+mE
+iN
+YQ
+YQ
+cr
+nk
+qj
+fV
+AJ
+xR
+cr
+YQ
+RE
+cr
+nH
+vU
+vU
+vU
+wt
+cr
+cr
+cr
+OA
+ch
+ch
+ch
+lw
+tI
+AQ
+"}
+(30,1,1) = {"
+Rn
+HB
+Gx
+Yz
+XP
+kO
+tM
+tz
+tz
+tz
+mG
+kO
+iF
+Yz
+Yz
+Yz
+SS
+yv
+Ke
+iN
+YQ
+YQ
+cr
+ub
+QV
+xT
+HZ
+wa
+cr
+YQ
+YQ
+RE
+cr
+vU
+vU
+vU
+vU
+tP
+ch
+ED
+WO
+Zx
+Zx
+Zx
+BQ
+EF
+cr
+"}
+(31,1,1) = {"
+uE
+tL
+AV
+Yz
+XP
+kO
+ki
+CS
+Th
+Th
+ki
+kO
+iF
+Yz
+Yz
+xk
+cr
+xS
+cr
+RE
+YQ
+YQ
+cr
+ro
+QV
+Yz
+HZ
+KH
+cr
+YQ
+YQ
+YQ
+cr
+am
+DD
+PJ
+cr
+cr
+cr
+cr
+lN
+lN
+lN
+lN
+lN
+cr
+RE
+"}
+(32,1,1) = {"
+Rn
+Hg
+AV
+pO
+Tq
+Wu
+kO
+kO
+xI
+ai
+kO
+kU
+Tq
+nN
+TB
+cr
+cr
+YQ
+YQ
+YQ
+YQ
+YQ
+cr
+cr
+vN
+TD
+Qh
+cr
+cr
+YQ
+YQ
+YQ
+cr
+gX
+vU
+wX
+cr
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+"}
+(33,1,1) = {"
+Rn
+Ps
+no
+Yz
+Tq
+xv
+kO
+kO
+kO
+xI
+kO
+We
+Tq
+NG
+Yz
+vG
+uL
+ep
+ep
+pR
+YQ
+YQ
+cr
+RI
+QV
+qy
+HZ
+mO
+Nl
+oK
+YQ
+RE
+cr
+vT
+PY
+Pb
+cr
+RE
+YQ
+YQ
+YQ
+RE
+cr
+cr
+cr
+Nj
+oK
+"}
+(34,1,1) = {"
+Rn
+UJ
+Js
+Yz
+Tq
+Tq
+IM
+IM
+IM
+IM
+IM
+Tq
+Tq
+dQ
+Yz
+vG
+uL
+ep
+ep
+ep
+YQ
+YQ
+cr
+FF
+QV
+xT
+HZ
+EA
+vl
+oK
+YQ
+Rn
+VQ
+vU
+vU
+vU
+HC
+vl
+ep
+YH
+YQ
+Rn
+Er
+TX
+Lk
+va
+ii
+"}
+(35,1,1) = {"
+Rn
+oz
+Js
+Yz
+Yz
+pO
+Yz
+Yz
+pO
+Yz
+Yz
+pO
+Yz
+Yz
+Yz
+vG
+uL
+ep
+ep
+ep
+YQ
+YQ
+cr
+dD
+tk
+rn
+kM
+GC
+ot
+oK
+YQ
+Rn
+VQ
+vU
+vU
+vU
+HC
+vl
+ep
+ep
+YQ
+RE
+SS
+cr
+cr
+Nj
+oK
+"}
+(36,1,1) = {"
+RE
+MH
+JJ
+Md
+PM
+PM
+PM
+PM
+PM
+PM
+PM
+PM
+PM
+PM
+PM
+MH
+RE
+YQ
+YQ
+YQ
+YQ
+YQ
+cr
+cr
+dh
+cU
+nM
+cr
+cr
+YQ
+YQ
+RE
+cr
+nU
+vU
+yw
+cr
+RE
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+"}
+(37,1,1) = {"
+YQ
+RE
+Eq
+Eq
+Ar
+Ar
+Ar
+Ar
+Ar
+Ar
+Ar
+Ar
+Ar
+Ar
+Ar
+RE
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+cr
+cr
+cr
+cr
+cr
+YQ
+YQ
+YQ
+YQ
+RE
+sN
+ug
+cr
+RE
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+YQ
+"}

--- a/_maps/shuttles/emergency_fleet.dmm
+++ b/_maps/shuttles/emergency_fleet.dmm
@@ -44,6 +44,12 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
+"ba" = (
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/royalblack,
+/area/shuttle/escape)
 "bl" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -54,18 +60,6 @@
 /obj/structure/mopbucket,
 /obj/item/mop,
 /turf/open/floor/plasteel/freezer,
-/area/shuttle/escape)
-"bs" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Pod Repair Shuttle"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "bJ" = (
 /obj/effect/turf_decal/box/white/corners{
@@ -115,6 +109,16 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"cD" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod 3"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "cG" = (
 /obj/machinery/shuttle_manipulator,
 /turf/open/floor/mineral/titanium/yellow,
@@ -126,7 +130,9 @@
 /area/shuttle/escape)
 "cU" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/inverted,
+/mob/living/simple_animal/hostile/retaliate/goat/inverted{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	dir = 8;
 	name = "Containment Pen"
@@ -136,12 +142,29 @@
 	},
 /turf/open/indestructible/grass/jungle,
 /area/shuttle/escape)
+"dc" = (
+/obj/effect/turf_decal{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "fleetengshutters1";
+	name = "Shutters Control";
+	pixel_x = -24;
+	pixel_y = -22
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "dh" = (
 /obj/structure/window/reinforced{
 	pixel_y = -3
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/twisted,
+/mob/living/simple_animal/hostile/retaliate/goat/twisted{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	dir = 8;
 	name = "Containment Pen"
@@ -150,6 +173,18 @@
 	dir = 8
 	},
 /turf/open/indestructible/grass/jungle,
+/area/shuttle/escape)
+"dj" = (
+/obj/machinery/door/airlock/titanium{
+	name = s
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "ds" = (
 /obj/machinery/light{
@@ -194,7 +229,8 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /mob/living/simple_animal/hostile/retaliate/goat/confetti{
 	name = "Sprinkles Goat";
-	desc = "You can feel your teeth getting numb."
+	desc = "You can feel your teeth getting numb.";
+	mob_size = 1
 	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
@@ -247,16 +283,6 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"ej" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/titanium{
-	name = "Escape Pod 3"
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
 "el" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/reagent_dispensers/watertank,
@@ -301,25 +327,25 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"eE" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/closet/secure_closet{
-	name = "Plasmaman Supplies Locker";
-	req_access_txt = "5"
-	},
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/tank/internals/plasmaman,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "eG" = (
 /obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"eW" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetesc2pod2";
+	linked_to = "fleetpod2";
+	name = "Portal to Escape Pod 2";
+	color = null
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "eX" = (
 /obj/machinery/door/firedoor/border_only{
@@ -332,8 +358,12 @@
 /turf/open/indestructible/sound/pool/end,
 /area/shuttle/escape)
 "fd" = (
-/obj/machinery/door/airlock/external/glass{
-	name = s
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "fleetcomshutters"
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -467,7 +497,9 @@
 	pixel_x = 3;
 	req_access_txt = "55"
 	},
-/mob/living/simple_animal/hostile/retaliate/clown/mutant/blob,
+/mob/living/simple_animal/hostile/retaliate/clown/mutant/blob{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
 	dir = 2
@@ -530,7 +562,7 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"hx" = (
+"hz" = (
 /obj/structure/sign/directions/evac{
 	dir = 2;
 	pixel_y = 13
@@ -569,7 +601,7 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/titanium{
-	name = "Escape Pod 3"
+	name = "Escape Pod 2"
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -671,15 +703,15 @@
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
-"jj" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
+"jo" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/window{
 	dir = 1
 	},
-/obj/machinery/door/airlock/titanium{
-	name = "Escape Pod 2"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/grass,
 /area/shuttle/escape)
 "js" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -711,6 +743,20 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"jE" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetesc2pod3";
+	linked_to = "fleetpod3";
+	name = "Portal to Escape Pod 3";
+	color = null
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
 "jK" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/conveyor{
@@ -724,7 +770,9 @@
 	dir = 1;
 	pixel_y = 4
 	},
-/mob/living/simple_animal/hostile/retaliate/clown/lube,
+/mob/living/simple_animal/hostile/retaliate/clown/lube{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	dir = 4;
 	name = "Containment Pen"
@@ -738,18 +786,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"jS" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Cargo Shuttle"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "jW" = (
 /obj/effect/turf_decal/box/white/corners,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -762,16 +798,6 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/indestructible/carpet/blue,
-/area/shuttle/escape)
-"ke" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/titanium{
-	name = "Escape Pod 1"
-	},
-/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "ki" = (
 /obj/effect/turf_decal/tile/darkblue{
@@ -807,37 +833,9 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
-"kp" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleeteng";
-	linked_to = "fleetesc2eng";
-	name = "Portal to Escape Lounge Shuttle";
-	color = null
-	},
-/turf/open/floor/light,
-/area/shuttle/escape)
 "kt" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
-/area/shuttle/escape)
-"ky" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetpod3";
-	linked_to = "fleetesc2pod3";
-	name = "Portal to Escape Lounge Shuttle";
-	color = null
-	},
-/turf/open/floor/light,
 /area/shuttle/escape)
 "kC" = (
 /obj/machinery/light,
@@ -924,7 +922,9 @@
 /obj/structure/window/reinforced{
 	pixel_y = -3
 	},
-/mob/living/simple_animal/hostile/retaliate/clown/banana,
+/mob/living/simple_animal/hostile/retaliate/clown/banana{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	dir = 4;
 	name = "Containment Pen"
@@ -938,37 +938,9 @@
 /obj/item/pool/rubber_ring,
 /turf/open/indestructible/sound/pool,
 /area/shuttle/escape)
-"lh" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetcom";
-	linked_to = "fleetesc2com";
-	name = "Portal to Escape Lounge Shuttle";
-	color = null
-	},
-/turf/open/floor/light,
-/area/shuttle/escape)
 "ll" = (
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"lm" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetsup";
-	linked_to = "fleetesc2sup";
-	name = "Portal to Escape Lounge Shuttle";
-	color = null
-	},
-/turf/open/floor/light,
 /area/shuttle/escape)
 "lp" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -982,6 +954,10 @@
 	dir = 9
 	},
 /obj/structure/table/reinforced,
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)"
+	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "lw" = (
@@ -1001,29 +977,30 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"lU" = (
-/obj/structure/sign/directions/command{
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetesc2com";
-	linked_to = "fleetcom";
-	name = "Portal to Luxury Command Shuttle";
-	color = null
-	},
-/turf/open/floor/light,
-/area/shuttle/escape)
 "lW" = (
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"lX" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Cargo Shuttle"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "ma" = (
 /obj/structure/window/reinforced{
 	dir = 8;
 	pixel_x = -4
 	},
-/mob/living/simple_animal/hostile/retaliate/clown/mutant,
+/mob/living/simple_animal/hostile/retaliate/clown/mutant{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen"
 	},
@@ -1036,23 +1013,6 @@
 /obj/structure/closet/wardrobe/white,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"mp" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetesc2pod1";
-	linked_to = "fleetpod1";
-	name = "Portal to Escape Pod 1";
-	color = null
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/turf/open/floor/light,
-/area/shuttle/escape)
 "mx" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -1062,14 +1022,20 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "mE" = (
-/obj/effect/spawner/structure/window/shuttle,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "fleetcomshutters"
+/obj/machinery/door/airlock/titanium/glass{
+	name = "Goat Specimens"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "mG" = (
 /obj/effect/turf_decal/tile/darkblue{
@@ -1107,13 +1073,30 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
+"mJ" = (
+/turf/open/indestructible/sound/pool/end,
+/area/shuttle/escape)
+"mL" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Pod Repair Shuttle"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "mO" = (
 /obj/structure/window/reinforced{
 	dir = 4;
 	pixel_x = 3
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/ras,
+/mob/living/simple_animal/hostile/retaliate/goat/ras{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen"
 	},
@@ -1121,17 +1104,6 @@
 	dir = 1
 	},
 /turf/open/indestructible/grass/jungle,
-/area/shuttle/escape)
-"mP" = (
-/obj/structure/table/reinforced,
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)"
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "mX" = (
 /obj/machinery/computer/station_alert,
@@ -1143,7 +1115,9 @@
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "ni" = (
-/mob/living/simple_animal/hostile/retaliate/clown,
+/mob/living/simple_animal/hostile/retaliate/clown{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	dir = 4;
 	name = "Containment Pen"
@@ -1159,7 +1133,9 @@
 	pixel_x = 3
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/tiny,
+/mob/living/simple_animal/hostile/retaliate/goat/tiny{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
 	dir = 2
@@ -1223,7 +1199,9 @@
 	pixel_y = 4
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/goatgoat,
+/mob/living/simple_animal/hostile/retaliate/goat/goatgoat{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	dir = 8;
 	name = "Containment Pen"
@@ -1245,7 +1223,9 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "nY" = (
-/mob/living/simple_animal/hostile/retaliate/clown/honkling,
+/mob/living/simple_animal/hostile/retaliate/clown/honkling{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	dir = 4;
 	name = "Containment Pen"
@@ -1306,8 +1286,14 @@
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "pi" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod 1"
+	},
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "pn" = (
 /obj/effect/turf_decal/tile/brown/full,
@@ -1327,18 +1313,6 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"pK" = (
-/obj/machinery/door/airlock/titanium{
-	name = s
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "pM" = (
 /turf/closed/wall/mineral/plastitanium,
@@ -1456,7 +1430,9 @@
 	pixel_x = -4
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/huge,
+/mob/living/simple_animal/hostile/retaliate/goat/huge{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
 	dir = 2
@@ -1473,6 +1449,12 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"rs" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Pod Repair Bay"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "ru" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -1488,6 +1470,20 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium,
+/area/shuttle/escape)
+"rD" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetcom2toi";
+	linked_to = "fleettoi";
+	name = "Portal to Luxury Restroom Pod";
+	color = null
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "rE" = (
 /obj/structure/extinguisher_cabinet{
@@ -1521,7 +1517,9 @@
 /turf/open/floor/light,
 /area/shuttle/escape)
 "sj" = (
-/mob/living/simple_animal/hostile/retaliate/clown/fleshclown,
+/mob/living/simple_animal/hostile/retaliate/clown/fleshclown{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen"
 	},
@@ -1546,6 +1544,20 @@
 "sC" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"sH" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleeteng";
+	linked_to = "fleetesc2eng";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "sL" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -1609,6 +1621,19 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"ty" = (
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal{
+	dir = 4
+	},
+/obj/effect/turf_decal{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/window{
+	id = "fleetengshutters2"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "tz" = (
 /obj/structure/table/glass,
 /obj/effect/spawner/lootdrop/three_course_meal,
@@ -1668,9 +1693,19 @@
 /area/shuttle/escape)
 "tP" = (
 /obj/machinery/door/airlock/external/glass{
-	name = "Pod Repair Bay"
+	name = s
 	},
 /turf/open/floor/plating,
+/area/shuttle/escape)
+"tR" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/grass,
 /area/shuttle/escape)
 "tV" = (
 /obj/machinery/computer/security{
@@ -1697,7 +1732,8 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /mob/living/simple_animal/hostile/retaliate/goat{
 	desc = "Suspiciously normal...";
-	name = "Normal Goat"
+	name = "Normal Goat";
+	mob_size = 1
 	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
@@ -1782,6 +1818,21 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
+"uA" = (
+/obj/effect/turf_decal{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "fleetengshutters2";
+	name = "Shutters Control";
+	pixel_x = 24;
+	pixel_y = -22
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "uE" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/border_only{
@@ -1801,7 +1852,32 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "va" = (
-/turf/open/indestructible/sound/pool/end,
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/closet/secure_closet{
+	name = "Plasmaman Supplies Locker";
+	req_access_txt = "5"
+	},
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/tank/internals/plasmaman,
+/obj/machinery/status_display/evac{
+	pixel_y = -32
+	},
+/turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"vh" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetpod3";
+	linked_to = "fleetesc2pod3";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "vl" = (
 /obj/structure/shuttle/engine/heater,
@@ -1862,7 +1938,9 @@
 /area/shuttle/escape)
 "wa" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/star,
+/mob/living/simple_animal/hostile/retaliate/goat/star{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen"
 	},
@@ -2053,7 +2131,9 @@
 	pixel_x = 3
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/glowing,
+/mob/living/simple_animal/hostile/retaliate/goat/glowing{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen"
 	},
@@ -2070,8 +2150,9 @@
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "xT" = (
-/obj/structure/closet/crate/critter,
-/obj/effect/turf_decal/delivery,
+/obj/structure/table/reinforced,
+/obj/item/pet_carrier,
+/obj/item/bodybag/bluespace,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "yc" = (
@@ -2092,9 +2173,9 @@
 	},
 /obj/effect/custom_portal{
 	mech_sized = 1;
-	portal_id = "fleetcom2toi";
-	linked_to = "fleettoi";
-	name = "Portal to Luxury Restroom Pod";
+	portal_id = "fleetcom";
+	linked_to = "fleetesc2com";
+	name = "Portal to Escape Lounge Shuttle";
 	color = null
 	},
 /turf/open/floor/light,
@@ -2194,7 +2275,8 @@
 	pixel_x = 3
 	},
 /mob/living/simple_animal/hostile/retaliate/clown/thin{
-	dir = 4
+	dir = 4;
+	mob_size = 1
 	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
@@ -2221,43 +2303,15 @@
 	},
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
-"AZ" = (
-/obj/item/pool/rubber_ring,
-/turf/open/indestructible/sound/pool/end,
-/area/shuttle/escape)
 "Bb" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)"
-	},
 /obj/machinery/light{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"Bc" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetpod2";
-	linked_to = "fleetesc2pod2";
-	name = "Portal to Escape Lounge Shuttle";
-	color = null
-	},
-/turf/open/floor/light,
-/area/shuttle/escape)
-"Bn" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/royalblack,
 /area/shuttle/escape)
 "Bp" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -2305,7 +2359,7 @@
 	dir = 8
 	},
 /obj/machinery/door/poddoor/shutters/window{
-	id = "fleetengshutters2"
+	id = "fleetengshutters1"
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -2423,7 +2477,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/mapping_helpers/airlock/access/all/security/basic,
 /obj/machinery/door/airlock/security/glass{
-	name = "Cell 2"
+	name = "Cell 1"
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
@@ -2434,10 +2488,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light{
 	dir = 4
-	},
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)"
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
@@ -2452,12 +2502,14 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/titanium{
-	name = "Escape Pod 2"
+	name = "Escape Pod 3"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "DC" = (
-/mob/living/simple_animal/hostile/retaliate/clown/clownhulk/chlown,
+/mob/living/simple_animal/hostile/retaliate/clown/clownhulk/chlown{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
 	dir = 2
@@ -2507,14 +2559,8 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Eq" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "fleetcomshutters"
-	},
-/turf/open/floor/plating,
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "Er" = (
 /obj/structure/chair/comfy/shuttle{
@@ -2552,13 +2598,15 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/titanium/glass{
-	name = "Goat Specimens"
+	name = "Clown Specimens"
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "EA" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/suspicious,
+/mob/living/simple_animal/hostile/retaliate/goat/suspicious{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen"
 	},
@@ -2613,23 +2661,20 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "Fp" = (
-/obj/effect/turf_decal{
-	dir = 1
-	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/button/door{
-	id = "fleetengshutters1";
-	name = "Shutters Control";
-	pixel_x = -24;
-	pixel_y = -22
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod 2"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "FF" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/cottoncandy,
+/mob/living/simple_animal/hostile/retaliate/goat/cottoncandy{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
 	dir = 2
@@ -2718,7 +2763,8 @@
 "Gq" = (
 /mob/living/simple_animal/hostile/retaliate/clown{
 	desc = "Suspiciously normal...";
-	name = "Normal Clown"
+	name = "Normal Clown";
+	mob_size = 1
 	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
@@ -2755,7 +2801,9 @@
 	pixel_x = -4
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/legitgoat,
+/mob/living/simple_animal/hostile/retaliate/goat/legitgoat{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen"
 	},
@@ -2801,6 +2849,17 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
+"He" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/mapping_helpers/airlock/access/all/security/basic,
+/obj/machinery/door/airlock/security/glass{
+	name = "Cell 2"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
 "Hg" = (
 /obj/machinery/computer/secure_data,
 /obj/item/radio/intercom{
@@ -2808,6 +2867,10 @@
 	name = "Station Intercom (General)";
 	pixel_y = 25
 	},
+/turf/open/indestructible/carpet/blue,
+/area/shuttle/escape)
+"Hm" = (
+/obj/machinery/suit_storage_unit/command,
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "Hu" = (
@@ -2862,6 +2925,20 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"Ie" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetpod2";
+	linked_to = "fleetesc2pod2";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
 "If" = (
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 1
@@ -2899,37 +2976,19 @@
 /obj/structure/closet/athletic_mixed,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"IU" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetpod1";
-	linked_to = "fleetesc2pod1";
-	name = "Portal to Escape Lounge Shuttle";
-	color = null
-	},
-/turf/open/floor/light,
-/area/shuttle/escape)
 "IW" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Jc" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetsci";
-	linked_to = "fleetesc2sci";
-	name = "Portal to Escape Lounge Shuttle";
-	color = null
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "fleetcomshutters"
 	},
-/turf/open/floor/light,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "Je" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -2939,6 +2998,10 @@
 /obj/structure/table/reinforced,
 /obj/machinery/status_display/evac{
 	pixel_x = 32
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)"
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
@@ -3043,7 +3106,9 @@
 	pixel_x = -4
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/rainbow,
+/mob/living/simple_animal/hostile/retaliate/goat/rainbow{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen"
 	},
@@ -3071,9 +3136,37 @@
 /obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
+"Lg" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetsup";
+	linked_to = "fleetesc2sup";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
 "Lk" = (
 /obj/structure/sign/warning/nosmoking,
 /turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"Lo" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetpod1";
+	linked_to = "fleetesc2pod1";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "Lr" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -3097,6 +3190,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
+"LF" = (
+/obj/structure/sign/directions/command{
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetesc2com";
+	linked_to = "fleetcom";
+	name = "Portal to Luxury Command Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
 "LO" = (
 /obj/effect/turf_decal/tile/brown/full,
 /obj/machinery/door/firedoor/border_only{
@@ -3108,16 +3214,16 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"Mj" = (
+"Ma" = (
 /obj/structure/sign/directions/evac{
 	dir = 2;
 	pixel_y = 13
 	},
 /obj/effect/custom_portal{
 	mech_sized = 1;
-	portal_id = "fleetesc2pod3";
-	linked_to = "fleetpod3";
-	name = "Portal to Escape Pod 3";
+	portal_id = "fleetsci";
+	linked_to = "fleetesc2sci";
+	name = "Portal to Escape Lounge Shuttle";
 	color = null
 	},
 /turf/open/floor/light,
@@ -3131,15 +3237,16 @@
 /obj/structure/closet/crate/solarpanel_small,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"Mv" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/window{
-	dir = 4
+"Mw" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)"
 	},
-/obj/structure/window{
-	dir = 1
+/obj/machinery/status_display/evac{
+	pixel_y = 32
 	},
-/turf/open/floor/grass,
+/turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "MC" = (
 /obj/machinery/computer/emergency_shuttle,
@@ -3160,24 +3267,34 @@
 /obj/machinery/door/airlock/vault,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"MP" = (
+"MU" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/titanium{
+	name = "Cargo Shuttle"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"MX" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetesc2pod1";
+	linked_to = "fleetpod1";
+	name = "Portal to Escape Pod 1";
+	color = null
+	},
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
-"MX" = (
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal{
-	dir = 4
-	},
-/obj/effect/turf_decal{
-	dir = 8
-	},
-/obj/machinery/door/poddoor/shutters/window{
-	id = "fleetengshutters1"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/light,
 /area/shuttle/escape)
 "MZ" = (
 /obj/effect/turf_decal/tile/brown/full,
@@ -3249,6 +3366,10 @@
 	},
 /obj/machinery/light/floor,
 /turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"NY" = (
+/obj/item/pool/rubber_ring,
+/turf/open/indestructible/sound/pool/end,
 /area/shuttle/escape)
 "NZ" = (
 /obj/item/reagent_containers/food/snacks/burger/clown{
@@ -3376,6 +3497,12 @@
 	},
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
+"PC" = (
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
 "PF" = (
 /obj/machinery/shuttle_manipulator{
 	layer = 3.3;
@@ -3406,17 +3533,6 @@
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
-"PK" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/mapping_helpers/airlock/access/all/security/basic,
-/obj/machinery/door/airlock/security/glass{
-	name = "Cell 1"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
 "PM" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/window{
@@ -3429,7 +3545,9 @@
 	dir = 4;
 	pixel_x = 3
 	},
-/mob/living/simple_animal/hostile/retaliate/clown/clownhulk/honcmunculus,
+/mob/living/simple_animal/hostile/retaliate/clown/clownhulk/honcmunculus{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen"
 	},
@@ -3533,20 +3651,6 @@
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"Rm" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetesc2pod2";
-	linked_to = "fleetpod2";
-	name = "Portal to Escape Pod 2";
-	color = null
-	},
-/turf/open/floor/light,
-/area/shuttle/escape)
 "Rn" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/border_only{
@@ -3602,7 +3706,9 @@
 	pixel_x = 3
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/chocolate,
+/mob/living/simple_animal/hostile/retaliate/goat/chocolate{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
 	dir = 2
@@ -3739,7 +3845,9 @@
 /area/shuttle/escape)
 "TD" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat,
+/mob/living/simple_animal/hostile/retaliate/goat{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	dir = 8;
 	name = "Containment Pen"
@@ -3770,16 +3878,6 @@
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/cardboard/fifty,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
-"TT" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/window{
-	dir = 8
-	},
-/obj/structure/window{
-	dir = 1
-	},
-/turf/open/floor/grass,
 /area/shuttle/escape)
 "TX" = (
 /obj/structure/chair/comfy/shuttle{
@@ -3824,10 +3922,6 @@
 	},
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
-"UD" = (
-/obj/machinery/suit_storage_unit/command,
-/turf/open/indestructible/carpet/blue,
-/area/shuttle/escape)
 "UI" = (
 /obj/machinery/stasis{
 	dir = 8
@@ -3840,21 +3934,6 @@
 "UJ" = (
 /obj/machinery/suit_storage_unit/ce,
 /turf/open/indestructible/carpet/blue,
-/area/shuttle/escape)
-"UN" = (
-/obj/effect/turf_decal{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	id = "fleetengshutters2";
-	name = "Shutters Control";
-	pixel_x = 24;
-	pixel_y = -22
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "Va" = (
 /obj/structure/closet/crate/secure/plasma,
@@ -3903,6 +3982,16 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"Wh" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod 1"
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "Wl" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -3962,7 +4051,9 @@
 	dir = 8;
 	pixel_x = -4
 	},
-/mob/living/simple_animal/hostile/retaliate/clown/clownhulk,
+/mob/living/simple_animal/hostile/retaliate/clown/clownhulk{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
 	dir = 2
@@ -4023,18 +4114,6 @@
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"XS" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/titanium{
-	name = "Cargo Shuttle"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "Yg" = (
 /obj/structure/window{
 	dir = 8;
@@ -4043,38 +4122,12 @@
 /obj/machinery/computer/card,
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
-"Yj" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/titanium{
-	name = "Escape Pod 1"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "Yo" = (
 /obj/effect/spawner/structure/window/plastitanium,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/shuttle/escape)
-"Yt" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/titanium/glass{
-	name = "Clown Specimens"
-	},
-/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Yz" = (
 /turf/open/floor/mineral/titanium/white,
@@ -4096,7 +4149,9 @@
 	dir = 8;
 	pixel_x = -4
 	},
-/mob/living/simple_animal/hostile/retaliate/clown/longface,
+/mob/living/simple_animal/hostile/retaliate/clown/longface{
+	mob_size = 1
+	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
 	dir = 2
@@ -4215,9 +4270,9 @@ YQ
 Rn
 Er
 TX
-ke
-IU
-Yj
+pi
+Lo
+Wh
 YQ
 qN
 RL
@@ -4271,7 +4326,7 @@ YQ
 px
 Gm
 Qb
-PK
+Dg
 tY
 tY
 tY
@@ -4467,7 +4522,7 @@ YQ
 px
 Gm
 Qb
-Dg
+He
 tY
 tY
 tY
@@ -4488,7 +4543,7 @@ GK
 Uv
 Ox
 tb
-va
+mJ
 Ri
 Ri
 lb
@@ -4501,13 +4556,13 @@ gz
 nv
 IW
 Hu
-hx
+hz
 Lk
 YQ
 "}
 (8,1,1) = {"
 cr
-Bn
+ba
 BN
 xo
 Nj
@@ -4578,7 +4633,7 @@ ot
 oK
 YQ
 Rn
-lU
+LF
 rH
 Uv
 Uv
@@ -4635,7 +4690,7 @@ Nh
 Uv
 Ox
 tb
-va
+mJ
 Ri
 KL
 Ri
@@ -4657,11 +4712,11 @@ YQ
 RE
 cr
 hi
-XS
+MU
 cr
 cr
 hi
-jS
+lX
 cr
 cr
 cr
@@ -4677,14 +4732,14 @@ YH
 YQ
 RE
 cr
-mp
-Rm
-Mj
+MX
+eW
+jE
 bZ
 Uv
 wp
 EQ
-AZ
+NY
 Ri
 Ri
 Ri
@@ -4709,7 +4764,7 @@ cT
 VB
 fw
 cr
-lm
+Lg
 Lw
 lO
 KG
@@ -4745,7 +4800,7 @@ cr
 cg
 Yz
 Yz
-eE
+va
 cr
 YQ
 YQ
@@ -4932,7 +4987,7 @@ YQ
 YQ
 RE
 ZM
-pK
+dj
 cr
 RE
 YQ
@@ -5032,7 +5087,7 @@ hR
 vU
 vU
 Lv
-kp
+sH
 vl
 ep
 YH
@@ -5089,9 +5144,9 @@ YQ
 Rn
 Er
 TX
-Ds
-Bc
-jj
+Fp
+Ie
+ii
 "}
 (20,1,1) = {"
 YQ
@@ -5145,19 +5200,19 @@ oK
 (21,1,1) = {"
 YQ
 RE
-mE
-mE
-mE
-mE
-mE
-mE
-mE
-mE
-mE
-mE
-mE
-mE
-mE
+fd
+fd
+fd
+fd
+fd
+fd
+fd
+fd
+fd
+fd
+fd
+fd
+fd
 RE
 YQ
 YQ
@@ -5193,9 +5248,9 @@ YQ
 "}
 (22,1,1) = {"
 RE
-pi
-UD
-Mv
+Eq
+Hm
+tR
 Rx
 Rx
 Rx
@@ -5207,7 +5262,7 @@ Rx
 Rx
 Rx
 Rx
-pi
+Eq
 cr
 YQ
 YQ
@@ -5232,11 +5287,11 @@ cr
 cr
 cr
 cr
-MX
-MX
-MX
-MX
-MX
+BP
+BP
+BP
+BP
+BP
 cr
 RE
 "}
@@ -5266,7 +5321,7 @@ RE
 cr
 cr
 kt
-Yt
+Ew
 kt
 cr
 cr
@@ -5278,14 +5333,14 @@ vU
 vU
 vU
 vU
-fd
+tP
 ch
 ED
 WO
 Zx
 Zx
 Zx
-Fp
+dc
 RV
 cr
 "}
@@ -5317,7 +5372,7 @@ Bb
 MF
 fV
 dt
-Jc
+Ma
 cr
 YQ
 RE
@@ -5354,7 +5409,7 @@ PF
 zu
 IF
 ll
-yi
+rD
 uL
 ep
 ep
@@ -5511,7 +5566,7 @@ RE
 cr
 cr
 kt
-Ew
+mE
 kt
 cr
 cr
@@ -5553,7 +5608,7 @@ pO
 Yz
 Kl
 Ej
-lh
+yi
 iN
 YQ
 YQ
@@ -5567,7 +5622,7 @@ cr
 YQ
 RE
 cr
-mP
+Mw
 vU
 vU
 vU
@@ -5601,7 +5656,7 @@ Yz
 Yz
 Yz
 cr
-MP
+PC
 Ke
 iN
 YQ
@@ -5621,14 +5676,14 @@ vU
 vU
 vU
 vU
-tP
+rs
 ch
 ED
 WO
 Zx
 Zx
 Zx
-UN
+uA
 EF
 cr
 "}
@@ -5673,11 +5728,11 @@ cr
 cr
 cr
 cr
-BP
-BP
-BP
-BP
-BP
+ty
+ty
+ty
+ty
+ty
 cr
 RE
 "}
@@ -5824,9 +5879,9 @@ YQ
 Rn
 Er
 TX
-ej
-ky
-ii
+Ds
+vh
+cD
 "}
 (35,1,1) = {"
 uE
@@ -5879,9 +5934,9 @@ oK
 "}
 (36,1,1) = {"
 RE
-pi
-UD
-TT
+Eq
+Hm
+jo
 PM
 PM
 PM
@@ -5893,7 +5948,7 @@ PM
 PM
 PM
 PM
-pi
+Eq
 cr
 YQ
 YQ
@@ -5929,19 +5984,19 @@ YQ
 (37,1,1) = {"
 YQ
 RE
-Eq
-Eq
-Eq
-Eq
-Eq
-Eq
-Eq
-Eq
-Eq
-Eq
-Eq
-Eq
-Eq
+Jc
+Jc
+Jc
+Jc
+Jc
+Jc
+Jc
+Jc
+Jc
+Jc
+Jc
+Jc
+Jc
 RE
 YQ
 YQ
@@ -5961,7 +6016,7 @@ YQ
 YQ
 RE
 ZM
-bs
+mL
 cr
 RE
 YQ

--- a/_maps/shuttles/emergency_fleet.dmm
+++ b/_maps/shuttles/emergency_fleet.dmm
@@ -1538,16 +1538,6 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"to" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/titanium{
-	name = "Escape Pod 1"
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
 "tz" = (
 /obj/structure/table/glass,
 /obj/effect/spawner/lootdrop/three_course_meal,
@@ -2458,16 +2448,6 @@
 /obj/effect/turf_decal/box/white/corners,
 /obj/machinery/vending/wardrobe/sig_wardrobe,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
-"Ds" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/titanium{
-	name = "Escape Pod 3"
-	},
-/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "DC" = (
 /mob/living/simple_animal/hostile/retaliate/clown/clownhulk/chlown,
@@ -3848,16 +3828,6 @@
 /obj/machinery/suit_storage_unit/ce,
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
-"UL" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/titanium{
-	name = "Escape Pod 2"
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
 "Va" = (
 /obj/structure/closet/crate/secure/plasma,
 /turf/open/floor/plasteel/dark,
@@ -4229,7 +4199,7 @@ YQ
 Rn
 Er
 TX
-to
+Er
 wQ
 HD
 YQ
@@ -5103,7 +5073,7 @@ YQ
 Rn
 Er
 TX
-UL
+Er
 yR
 ii
 "}
@@ -5838,7 +5808,7 @@ YQ
 Rn
 Er
 TX
-Ds
+Er
 hP
 qW
 "}

--- a/_maps/shuttles/emergency_fleet.dmm
+++ b/_maps/shuttles/emergency_fleet.dmm
@@ -120,9 +120,7 @@
 /area/shuttle/escape)
 "cU" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/inverted{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/goat/inverted,
 /obj/machinery/door/window/northleft{
 	dir = 8;
 	name = "Containment Pen"
@@ -137,9 +135,7 @@
 	pixel_y = -3
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/twisted{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/goat/twisted,
 /obj/machinery/door/window/northleft{
 	dir = 8;
 	name = "Containment Pen"
@@ -192,8 +188,7 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /mob/living/simple_animal/hostile/retaliate/goat/confetti{
 	name = "Sprinkles Goat";
-	desc = "You can feel your teeth getting numb.";
-	mob_size = 1
+	desc = "You can feel your teeth getting numb."
 	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
@@ -364,9 +359,16 @@
 /obj/effect/turf_decal/tile/darkblue,
 /obj/structure/table/glass,
 /obj/effect/spawner/lootdrop/three_course_meal,
-/obj/item/kitchen/fork,
-/obj/item/reagent_containers/food/drinks/drinkingglass/filled{
-	list_reagents = list(/datum/reagent/consumable/wine = 50)
+/obj/item/kitchen/fork{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_y = 16;
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/food/drinks/bottle/champagne{
+	pixel_y = 20;
+	pixel_x = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
@@ -446,9 +448,7 @@
 	pixel_x = 3;
 	req_access_txt = "55"
 	},
-/mob/living/simple_animal/hostile/retaliate/clown/mutant/blob{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/clown/mutant/blob,
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
 	dir = 2
@@ -695,9 +695,7 @@
 	dir = 1;
 	pixel_y = 4
 	},
-/mob/living/simple_animal/hostile/retaliate/clown/lube{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/clown/lube,
 /obj/machinery/door/window/northleft{
 	dir = 4;
 	name = "Containment Pen"
@@ -848,9 +846,7 @@
 /area/shuttle/escape)
 "kU" = (
 /obj/machinery/shuttle_manipulator{
-	layer = 3.3;
-	pixel_x = 1;
-	pixel_y = 12
+	layer = 3.3
 	},
 /obj/effect/turf_decal/ramp_middle{
 	dir = 1
@@ -875,9 +871,7 @@
 /obj/structure/window/reinforced{
 	pixel_y = -3
 	},
-/mob/living/simple_animal/hostile/retaliate/clown/banana{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/clown/banana,
 /obj/machinery/door/window/northleft{
 	dir = 4;
 	name = "Containment Pen"
@@ -950,9 +944,7 @@
 	dir = 8;
 	pixel_x = -4
 	},
-/mob/living/simple_animal/hostile/retaliate/clown/mutant{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/clown/mutant,
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen"
 	},
@@ -1035,9 +1027,7 @@
 	pixel_x = 3
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/ras{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/goat/ras,
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen"
 	},
@@ -1056,9 +1046,7 @@
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "ni" = (
-/mob/living/simple_animal/hostile/retaliate/clown{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/clown,
 /obj/machinery/door/window/northleft{
 	dir = 4;
 	name = "Containment Pen"
@@ -1074,9 +1062,7 @@
 	pixel_x = 3
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/tiny{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/goat/tiny,
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
 	dir = 2
@@ -1140,9 +1126,7 @@
 	pixel_y = 4
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/goatgoat{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/goat/goatgoat,
 /obj/machinery/door/window/northleft{
 	dir = 8;
 	name = "Containment Pen"
@@ -1164,9 +1148,7 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "nY" = (
-/mob/living/simple_animal/hostile/retaliate/clown/honkling{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/clown/honkling,
 /obj/machinery/door/window/northleft{
 	dir = 4;
 	name = "Containment Pen"
@@ -1403,9 +1385,7 @@
 	pixel_x = -4
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/huge{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/goat/huge,
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
 	dir = 2
@@ -1470,9 +1450,7 @@
 /turf/open/floor/light,
 /area/shuttle/escape)
 "sj" = (
-/mob/living/simple_animal/hostile/retaliate/clown/fleshclown{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/clown/fleshclown,
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen"
 	},
@@ -1573,9 +1551,12 @@
 "tz" = (
 /obj/structure/table/glass,
 /obj/effect/spawner/lootdrop/three_course_meal,
-/obj/item/kitchen/fork,
-/obj/item/reagent_containers/food/drinks/drinkingglass/filled{
-	list_reagents = list(/datum/reagent/consumable/wine = 50)
+/obj/item/kitchen/fork{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_y = 16;
+	pixel_x = -8
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
@@ -1658,8 +1639,7 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /mob/living/simple_animal/hostile/retaliate/goat{
 	desc = "Suspiciously normal...";
-	name = "Normal Goat";
-	mob_size = 1
+	name = "Normal Goat"
 	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
@@ -1851,9 +1831,7 @@
 /area/shuttle/escape)
 "wa" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/star{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/goat/star,
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen"
 	},
@@ -1993,9 +1971,7 @@
 /area/shuttle/escape)
 "xk" = (
 /obj/structure/statue/sandstone/venus{
-	dir = 8;
-	pixel_x = -1;
-	pixel_y = 9
+	dir = 8
 	},
 /obj/machinery/light/floor,
 /turf/open/floor/carpet/blue,
@@ -2072,9 +2048,7 @@
 	pixel_x = 3
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/glowing{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/goat/glowing,
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen"
 	},
@@ -2092,7 +2066,21 @@
 /area/shuttle/escape)
 "xT" = (
 /obj/structure/table/reinforced,
-/obj/item/pet_carrier,
+/obj/item/pet_carrier{
+	max_occupant_weight = 3;
+	name = "bluespace pet carrier";
+	desc = "A bigger-on-the-inside white-and-blue pet carrier. Good for carrying <s>meat to the chef</s> cute manmade horrors around."
+	},
+/obj/item/pet_carrier{
+	max_occupant_weight = 3;
+	name = "bluespace pet carrier";
+	desc = "A bigger-on-the-inside white-and-blue pet carrier. Good for carrying <s>meat to the chef</s> cute manmade horrors around."
+	},
+/obj/item/pet_carrier{
+	max_occupant_weight = 3;
+	name = "bluespace pet carrier";
+	desc = "A bigger-on-the-inside white-and-blue pet carrier. Good for carrying <s>meat to the chef</s> cute manmade horrors around."
+	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "yc" = (
@@ -2172,9 +2160,7 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "zd" = (
-/obj/structure/statue/sandstone/venus{
-	pixel_y = 9
-	},
+/obj/structure/statue/sandstone/venus,
 /obj/machinery/light/floor,
 /turf/open/floor/carpet/blue,
 /area/shuttle/escape)
@@ -2243,8 +2229,7 @@
 	pixel_x = 3
 	},
 /mob/living/simple_animal/hostile/retaliate/clown/thin{
-	dir = 4;
-	mob_size = 1
+	dir = 4
 	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
@@ -2284,8 +2269,7 @@
 "Bp" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/conveyor_switch{
-	id = "EmFleet1";
-	pixel_y = 14
+	id = "EmFleet1"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -2486,9 +2470,7 @@
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "DC" = (
-/mob/living/simple_animal/hostile/retaliate/clown/clownhulk/chlown{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/clown/clownhulk/chlown,
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
 	dir = 2
@@ -2617,9 +2599,7 @@
 /area/shuttle/escape)
 "EA" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/suspicious{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/goat/suspicious,
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen"
 	},
@@ -2685,9 +2665,7 @@
 /area/shuttle/escape)
 "FF" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/cottoncandy{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/goat/cottoncandy,
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
 	dir = 2
@@ -2759,9 +2737,12 @@
 /obj/effect/turf_decal/tile/darkblue,
 /obj/structure/table/glass,
 /obj/effect/spawner/lootdrop/three_course_meal,
-/obj/item/kitchen/fork,
-/obj/item/reagent_containers/food/drinks/drinkingglass/filled{
-	list_reagents = list(/datum/reagent/consumable/wine = 50)
+/obj/item/kitchen/fork{
+	pixel_x = 8
+	},
+/obj/item/reagent_containers/food/drinks/drinkingglass{
+	pixel_y = 16;
+	pixel_x = -8
 	},
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
@@ -2776,8 +2757,7 @@
 "Gq" = (
 /mob/living/simple_animal/hostile/retaliate/clown{
 	desc = "Suspiciously normal...";
-	name = "Normal Clown";
-	mob_size = 1
+	name = "Normal Clown"
 	},
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
@@ -2814,9 +2794,7 @@
 	pixel_x = -4
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/legitgoat{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/goat/legitgoat,
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen"
 	},
@@ -3107,9 +3085,7 @@
 	pixel_x = -4
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/rainbow{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/goat/rainbow,
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen"
 	},
@@ -3144,8 +3120,7 @@
 "Lr" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/conveyor_switch{
-	id = "EmFleet3";
-	pixel_y = 14
+	id = "EmFleet3"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -3345,8 +3320,7 @@
 "OG" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/conveyor_switch{
-	id = "EmFleet2";
-	pixel_y = 14
+	id = "EmFleet2"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -3430,9 +3404,7 @@
 /area/shuttle/escape)
 "PF" = (
 /obj/machinery/shuttle_manipulator{
-	layer = 3.3;
-	pixel_x = 1;
-	pixel_y = 12
+	layer = 3.3
 	},
 /obj/effect/turf_decal/ramp_corner,
 /obj/effect/turf_decal/ramp_middle{
@@ -3470,9 +3442,7 @@
 	dir = 4;
 	pixel_x = 3
 	},
-/mob/living/simple_animal/hostile/retaliate/clown/clownhulk/honcmunculus{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/clown/clownhulk/honcmunculus,
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen"
 	},
@@ -3595,9 +3565,7 @@
 /area/shuttle/escape)
 "Rs" = (
 /obj/machinery/shuttle_manipulator{
-	layer = 3.3;
-	pixel_x = 1;
-	pixel_y = 12
+	layer = 3.3
 	},
 /obj/effect/turf_decal/ramp_middle,
 /obj/effect/turf_decal/ramp_middle{
@@ -3631,9 +3599,7 @@
 	pixel_x = 3
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat/chocolate{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/goat/chocolate,
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
 	dir = 2
@@ -3794,9 +3760,7 @@
 /area/shuttle/escape)
 "TD" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/mob/living/simple_animal/hostile/retaliate/goat{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/goat,
 /obj/machinery/door/window/northleft{
 	dir = 8;
 	name = "Containment Pen"
@@ -3941,10 +3905,12 @@
 /area/shuttle/escape)
 "VQ" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
-/obj/machinery/door/window/brigdoor/southright{
-	req_access_txt = "24"
-	},
 /obj/effect/turf_decal/delivery/red,
+/obj/machinery/door/window/westleft{
+	name = "Atmospherics Canister Storage";
+	dir = 2
+	},
+/obj/effect/mapping_helpers/windoor/access/all/engineering/atmos,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "We" = (
@@ -3971,9 +3937,7 @@
 /area/shuttle/escape)
 "Wu" = (
 /obj/machinery/shuttle_manipulator{
-	layer = 3.3;
-	pixel_x = 1;
-	pixel_y = 12
+	layer = 3.3
 	},
 /obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/mineral/silver,
@@ -4017,9 +3981,7 @@
 	dir = 8;
 	pixel_x = -4
 	},
-/mob/living/simple_animal/hostile/retaliate/clown/clownhulk{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/clown/clownhulk,
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
 	dir = 2
@@ -4142,9 +4104,7 @@
 	dir = 8;
 	pixel_x = -4
 	},
-/mob/living/simple_animal/hostile/retaliate/clown/longface{
-	mob_size = 1
-	},
+/mob/living/simple_animal/hostile/retaliate/clown/longface,
 /obj/machinery/door/window/northleft{
 	name = "Containment Pen";
 	dir = 2

--- a/_maps/shuttles/emergency_fleet.dmm
+++ b/_maps/shuttles/emergency_fleet.dmm
@@ -23,7 +23,8 @@
 	mech_sized = 1;
 	portal_id = "fleetesc2com";
 	linked_to = "fleetcom";
-	name = "Portal to Cargo Shuttle"
+	name = "Portal to Cargo Shuttle";
+	color = null
 	},
 /turf/open/floor/light,
 /area/shuttle/escape)
@@ -106,6 +107,10 @@
 /obj/machinery/shuttle_manipulator,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
+"cP" = (
+/obj/item/pool/rubber_ring,
+/turf/open/indestructible/sound/pool/end,
+/area/shuttle/escape)
 "cT" = (
 /obj/effect/turf_decal/tile/brown/full,
 /obj/machinery/vending/cola/random,
@@ -122,18 +127,6 @@
 	dir = 8
 	},
 /turf/open/indestructible/grass/jungle,
-/area/shuttle/escape)
-"cZ" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "dh" = (
 /obj/structure/window/reinforced{
@@ -185,9 +178,6 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"dA" = (
-/turf/open/indestructible/sound/pool/end,
-/area/shuttle/escape)
 "dD" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -222,7 +212,9 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/glass_large,
+/obj/machinery/door/airlock/glass_large{
+	name = "Ambulance Shuttle"
+	},
 /obj/effect/turf_decal/stripes/full,
 /obj/effect/turf_decal/ramp_middle{
 	dir = 1
@@ -252,6 +244,12 @@
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -32
+	},
+/obj/machinery/button/door{
+	id = "fleetsupshutters";
+	name = "Shutters Control";
+	pixel_x = -22;
+	pixel_y = 12
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
@@ -286,6 +284,10 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "eG" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/shuttle/escape)
+"eN" = (
 /obj/structure/sign/directions/evac{
 	dir = 2;
 	pixel_y = 13
@@ -294,7 +296,8 @@
 	mech_sized = 1;
 	portal_id = "fleetpod2";
 	linked_to = "fleetesc2pod2";
-	name = "Portal to Escape Lounge Shuttle"
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
 	},
 /turf/open/floor/light,
 /area/shuttle/escape)
@@ -309,14 +312,7 @@
 /turf/open/indestructible/sound/pool/end,
 /area/shuttle/escape)
 "fd" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/window{
-	dir = 4
-	},
-/obj/structure/window{
-	dir = 1
-	},
-/turf/open/floor/grass,
+/turf/open/indestructible/sound/pool/end,
 /area/shuttle/escape)
 "fg" = (
 /obj/machinery/modular_computer/console/preset/engineering,
@@ -332,6 +328,23 @@
 	pixel_x = -12
 	},
 /turf/open/floor/carpet/royalblack,
+/area/shuttle/escape)
+"fs" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetesc2pod1";
+	linked_to = "fleetpod1";
+	name = "Portal to Escape Pod 1";
+	color = null
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "fw" = (
 /obj/effect/turf_decal/tile/brown/full,
@@ -412,17 +425,14 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "ga" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/window{
+	dir = 4
 	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetcom2toi";
-	linked_to = "fleettoi";
-	name = "Portal to Luxury Restroom Pod"
+/obj/structure/window{
+	dir = 1
 	},
-/turf/open/floor/light,
+/turf/open/floor/grass,
 /area/shuttle/escape)
 "gz" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -519,10 +529,52 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/noslip,
 /area/shuttle/escape)
+"hu" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleeteng";
+	linked_to = "fleetesc2eng";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
 "hv" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
+/area/shuttle/escape)
+"hw" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetesc2pod2";
+	linked_to = "fleetpod2";
+	name = "Portal to Escape Pod 2";
+	color = null
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
+"hO" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetsci";
+	linked_to = "fleetesc2sci";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "hR" = (
 /obj/machinery/telecomms/relay/preset/telecomms{
@@ -534,6 +586,20 @@
 	dir = 4
 	},
 /turf/open/floor/circuit/telecomms/server,
+/area/shuttle/escape)
+"hS" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetcom";
+	linked_to = "fleetesc2com";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "ie" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -549,7 +615,7 @@
 	dir = 1
 	},
 /obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
+	name = "Escape Pod 3"
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -578,7 +644,8 @@
 	mech_sized = 1;
 	portal_id = "fleetesc2sci";
 	linked_to = "fleetsci";
-	name = "Portal to Experiment Transport Shuttle"
+	name = "Portal to Experiment Transport Shuttle";
+	color = null
 	},
 /turf/open/floor/light,
 /area/shuttle/escape)
@@ -591,6 +658,16 @@
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
+"iB" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod 3"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
@@ -884,6 +961,10 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
+"lF" = (
+/obj/machinery/suit_storage_unit/command,
+/turf/open/indestructible/carpet/blue,
+/area/shuttle/escape)
 "lO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/reagent_dispensers/fueltank,
@@ -910,23 +991,24 @@
 	},
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
-"md" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/closet/secure_closet{
-	name = "Plasmaman Supplies Locker";
-	req_access_txt = "5"
-	},
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/tank/internals/plasmaman,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
 "mf" = (
 /obj/structure/closet/wardrobe/white,
 /turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"mh" = (
+/obj/effect/turf_decal{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "fleetengshutters2";
+	name = "Shutters Control";
+	pixel_x = 24;
+	pixel_y = -22
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "mx" = (
 /obj/structure/window/reinforced{
@@ -940,6 +1022,9 @@
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "fleetcomshutters"
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -1105,16 +1190,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
-"nV" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/window{
-	dir = 8
-	},
-/obj/structure/window{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/shuttle/escape)
 "nY" = (
 /mob/living/simple_animal/hostile/retaliate/clown/honkling,
 /obj/machinery/door/window/northleft{
@@ -1132,10 +1207,6 @@
 	},
 /obj/machinery/modular_computer/console/preset/research,
 /turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"oo" = (
-/obj/item/pool/rubber_ring,
-/turf/open/indestructible/sound/pool/end,
 /area/shuttle/escape)
 "ot" = (
 /obj/structure/shuttle/engine/heater,
@@ -1155,9 +1226,26 @@
 	},
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
+"oJ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod 1"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "oK" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating/airless,
+/area/shuttle/escape)
+"oL" = (
+/obj/machinery/suit_storage_unit/command,
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "pa" = (
 /obj/structure/chair/comfy/shuttle{
@@ -1187,9 +1275,10 @@
 	},
 /obj/effect/custom_portal{
 	mech_sized = 1;
-	portal_id = "fleetpod3";
-	linked_to = "fleetesc2pod3";
-	name = "Portal to Escape Lounge Shuttle"
+	portal_id = "fleetesc2pod3";
+	linked_to = "fleetpod3";
+	name = "Portal to Escape Pod 3";
+	color = null
 	},
 /turf/open/floor/light,
 /area/shuttle/escape)
@@ -1387,7 +1476,8 @@
 	mech_sized = 1;
 	portal_id = "fleetesc2sec";
 	linked_to = "fleetsec";
-	name = "Portal to Prisoner Transfer Shuttle"
+	name = "Portal to Prisoner Transfer Shuttle";
+	color = null
 	},
 /turf/open/floor/light,
 /area/shuttle/escape)
@@ -1449,19 +1539,6 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"sY" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetcom";
-	linked_to = "fleetesc2com";
-	name = "Portal to Escape Lounge Shuttle"
-	},
-/turf/open/floor/light,
-/area/shuttle/escape)
 "sZ" = (
 /obj/machinery/computer/security,
 /turf/open/indestructible/carpet/blue,
@@ -1482,7 +1559,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/door/airlock/security,
+/obj/machinery/door/airlock/security{
+	name = "Prisoner Transfer Shuttle"
+	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "tk" = (
@@ -1499,22 +1578,6 @@
 	list_reagents = list(/datum/reagent/consumable/wine = 50)
 	},
 /turf/open/floor/plasteel/white,
-/area/shuttle/escape)
-"tG" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetesc2pod1";
-	linked_to = "fleetpod1";
-	name = "Portal to Escape Pod One"
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/turf/open/floor/light,
 /area/shuttle/escape)
 "tI" = (
 /obj/structure/table/reinforced,
@@ -1565,7 +1628,9 @@
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
 "tP" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass{
+	name = "Pod Repair Bay"
+	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "tV" = (
@@ -1604,7 +1669,7 @@
 /area/shuttle/escape)
 "ug" = (
 /obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
+	name = "Emergency Shuttle Lounges"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -1679,15 +1744,14 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "uE" = (
-/obj/structure/table/reinforced,
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)"
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "fleetcomshutters"
 	},
-/turf/open/floor/mineral/titanium/yellow,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "uF" = (
 /turf/open/floor/carpet/royalblack,
@@ -1698,10 +1762,18 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "va" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/closet/secure_closet{
+	name = "Plasmaman Supplies Locker";
+	req_access_txt = "5"
 	},
-/turf/open/floor/carpet/royalblack,
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/tank/internals/plasmaman,
+/obj/machinery/status_display/evac{
+	pixel_y = -32
+	},
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "vl" = (
 /obj/structure/shuttle/engine/heater,
@@ -1713,7 +1785,9 @@
 /area/shuttle/escape)
 "vv" = (
 /obj/structure/fans/tiny,
-/obj/machinery/door/poddoor/shutters/window,
+/obj/machinery/door/poddoor/shutters/window{
+	id = "fleetsupshutters"
+	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "vG" = (
@@ -1828,7 +1902,8 @@
 	mech_sized = 1;
 	portal_id = "fleetesc2med";
 	linked_to = "fleetmed";
-	name = "Portal to Ambulance Shuttle"
+	name = "Portal to Ambulance Shuttle";
+	color = s
 	},
 /turf/open/floor/light,
 /area/shuttle/escape)
@@ -1989,9 +2064,10 @@
 	},
 /obj/effect/custom_portal{
 	mech_sized = 1;
-	portal_id = "fleetesc2pod3";
-	linked_to = "fleetpod3";
-	name = "Portal to Escape Pod Three"
+	portal_id = "fleetcom2toi";
+	linked_to = "fleettoi";
+	name = "Portal to Luxury Restroom Pod";
+	color = null
 	},
 /turf/open/floor/light,
 /area/shuttle/escape)
@@ -2063,26 +2139,35 @@
 	mech_sized = 1;
 	portal_id = "fleetesc2eng";
 	linked_to = "fleeteng";
-	name = "Portal to Pod Repair Shuttle"
+	name = "Portal to Pod Repair Shuttle";
+	color = null
 	},
 /turf/open/floor/light,
 /area/shuttle/escape)
 "zR" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleeteng";
-	linked_to = "fleetesc2eng";
-	name = "Portal to Escape Lounge Shuttle"
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/mapping_helpers/airlock/access/all/security/basic,
+/obj/machinery/door/airlock/security/glass{
+	name = "Cell 2"
 	},
-/turf/open/floor/light,
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "Ak" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"Ap" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod 2"
+	},
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "Ar" = (
 /obj/effect/spawner/structure/window/shuttle,
@@ -2129,6 +2214,20 @@
 	},
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
+"AY" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetpod3";
+	linked_to = "fleetesc2pod3";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
 "Bb" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -2142,6 +2241,20 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Be" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetsup";
+	linked_to = "fleetesc2sup";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "Bp" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -2188,7 +2301,9 @@
 /obj/effect/turf_decal{
 	dir = 8
 	},
-/obj/machinery/door/poddoor/shutters/window,
+/obj/machinery/door/poddoor/shutters/window{
+	id = "fleetengshutters1"
+	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Ca" = (
@@ -2262,6 +2377,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
+"CO" = (
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/royalblack,
+/area/shuttle/escape)
 "CS" = (
 /obj/effect/turf_decal/tile/darkblue{
 	dir = 8
@@ -2304,7 +2425,9 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/mapping_helpers/airlock/access/all/security/basic,
-/obj/machinery/door/airlock/security/glass,
+/obj/machinery/door/airlock/security/glass{
+	name = "Cell 1"
+	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "Dh" = (
@@ -2332,7 +2455,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
+	name = "Escape Pod 1"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
@@ -2372,19 +2495,6 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"Ec" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetpod1";
-	linked_to = "fleetesc2pod1";
-	name = "Portal to Escape Lounge Shuttle"
-	},
-/turf/open/floor/light,
-/area/shuttle/escape)
 "Ej" = (
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/mineral/titanium/blue,
@@ -2394,21 +2504,20 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/glass_large,
+/obj/machinery/door/airlock/glass_large{
+	name = "Experiment Transport Shuttle"
+	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Eq" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetmed";
-	linked_to = "fleetesc2med";
-	name = "Portal to Escape Lounge Shuttle"
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "fleetcomshutters"
 	},
-/turf/open/floor/light,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "Er" = (
 /obj/structure/chair/comfy/shuttle{
@@ -2445,7 +2554,9 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/door/airlock/titanium/glass,
+/obj/machinery/door/airlock/titanium/glass{
+	name = "Clown Specimens"
+	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "EA" = (
@@ -2460,7 +2571,9 @@
 /turf/open/indestructible/grass/jungle,
 /area/shuttle/escape)
 "ED" = (
-/obj/machinery/door/airlock/external/glass,
+/obj/machinery/door/airlock/external/glass{
+	name = "Pod Repair Bay"
+	},
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -2480,7 +2593,8 @@
 	mech_sized = 1;
 	portal_id = "fleetsec";
 	linked_to = "fleetesc2sec";
-	name = "Portal to Escape Lounge Shuttle"
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
 	},
 /turf/open/floor/light,
 /area/shuttle/escape)
@@ -2501,24 +2615,21 @@
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"Ff" = (
-/obj/machinery/suit_storage_unit/command,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/turf/open/indestructible/carpet/blue,
-/area/shuttle/escape)
 "Fp" = (
-/obj/structure/sign/directions/command{
-	pixel_y = 13
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
 	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleettoi";
-	linked_to = "fleetcom2toi";
-	name = "Portal to Luxury Command Shuttle"
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/turf/open/floor/light,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/titanium/glass{
+	name = "Goat Specimens"
+	},
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "FF" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -2703,12 +2814,39 @@
 	},
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
+"Hk" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Cargo Shuttle"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "Hu" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Hw" = (
+/obj/effect/turf_decal{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "fleetengshutters1";
+	name = "Shutters Control";
+	pixel_x = -24;
+	pixel_y = -22
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "Hy" = (
 /obj/structure/table/reinforced,
@@ -2723,6 +2861,13 @@
 /obj/structure/window{
 	dir = 4;
 	pixel_x = 3
+	},
+/obj/machinery/button/door{
+	id = "fleetsupshutters";
+	name = "Shutters Control";
+	pixel_y = 25;
+	layer = 3.3;
+	pixel_x = -6
 	},
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
@@ -2753,6 +2898,18 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"Ij" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/titanium{
+	name = "Cargo Shuttle"
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "IF" = (
 /obj/structure/statue/diamond/captain,
@@ -2789,14 +2946,16 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"Ja" = (
-/obj/machinery/suit_storage_unit/command,
-/turf/open/indestructible/carpet/blue,
-/area/shuttle/escape)
 "Jc" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal{
 	dir = 4
+	},
+/obj/effect/turf_decal{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/window{
+	id = "fleetengshutters2"
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -2811,25 +2970,22 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"Jm" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetsup";
-	linked_to = "fleetesc2sup";
-	name = "Portal to Escape Lounge Shuttle"
-	},
-/turf/open/floor/light,
-/area/shuttle/escape)
 "Jp" = (
 /obj/effect/turf_decal/trimline/blue/filled/warning,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Js" = (
 /turf/open/indestructible/carpet/blue,
+/area/shuttle/escape)
+"Jt" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod 2"
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "JA" = (
 /obj/structure/table/reinforced,
@@ -2878,7 +3034,9 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/shuttle,
+/obj/machinery/door/airlock/shuttle{
+	name = "Command Room"
+	},
 /obj/effect/mapping_helpers/airlock/access/all/command/general,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
@@ -2984,7 +3142,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Airlock"
+	name = "Cargo Bay"
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
@@ -3017,15 +3175,15 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "MX" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
+/obj/structure/sign/directions/command{
 	pixel_y = 13
 	},
 /obj/effect/custom_portal{
 	mech_sized = 1;
-	portal_id = "fleetesc2pod2";
-	linked_to = "fleetpod2";
-	name = "Portal to Escape Pod Two"
+	portal_id = "fleettoi";
+	linked_to = "fleetcom2toi";
+	name = "Portal to Luxury Command Shuttle";
+	color = null
 	},
 /turf/open/floor/light,
 /area/shuttle/escape)
@@ -3073,7 +3231,8 @@
 /obj/effect/custom_portal{
 	mech_sized = 1;
 	portal_id = "fleetesc2sup";
-	linked_to = "fleetsup"
+	linked_to = "fleetsup";
+	color = null
 	},
 /turf/open/floor/light,
 /area/shuttle/escape)
@@ -3165,6 +3324,20 @@
 "OM" = (
 /obj/machinery/vending/security,
 /turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"OR" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetmed";
+	linked_to = "fleetesc2med";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "OV" = (
 /obj/machinery/door/firedoor/border_only{
@@ -3302,6 +3475,17 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"Qj" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)"
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
 "QB" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -3402,6 +3586,18 @@
 	},
 /turf/open/floor/mineral/silver,
 /area/shuttle/escape)
+"Ru" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Emergency Lounge Shuttle"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "Rx" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/window{
@@ -3467,6 +3663,18 @@
 	},
 /obj/machinery/computer/emergency_shuttle,
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"Sr" = (
+/obj/machinery/door/airlock/titanium{
+	name = s
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "Sy" = (
 /obj/effect/turf_decal/box/white/corners{
@@ -3617,6 +3825,28 @@
 /obj/structure/closet/crate/secure/owned/gear,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
+"Ui" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Pod Repair Shuttle"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Un" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/shuttle/escape)
 "Uo" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -3650,22 +3880,23 @@
 /obj/machinery/suit_storage_unit/ce,
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
-"UQ" = (
+"Va" = (
+/obj/structure/closet/crate/secure/plasma,
+/turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Ve" = (
 /obj/structure/sign/directions/evac{
 	dir = 2;
 	pixel_y = 13
 	},
 /obj/effect/custom_portal{
 	mech_sized = 1;
-	portal_id = "fleetsci";
-	linked_to = "fleetesc2sci";
-	name = "Portal to Escape Lounge Shuttle"
+	portal_id = "fleetpod1";
+	linked_to = "fleetesc2pod1";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
 	},
 /turf/open/floor/light,
-/area/shuttle/escape)
-"Va" = (
-/obj/structure/closet/crate/secure/plasma,
-/turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "Vn" = (
 /obj/structure/mopbucket,
@@ -3804,6 +4035,12 @@
 	},
 /obj/structure/closet/wardrobe/pjs,
 /turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Xr" = (
+/obj/machinery/door/airlock/external/glass{
+	name = s
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "Xt" = (
 /obj/effect/turf_decal/tile/brown/full,
@@ -3958,7 +4195,7 @@ YQ
 RE
 ug
 cr
-ug
+Ru
 cr
 cr
 cr
@@ -3985,8 +4222,8 @@ Rn
 Er
 TX
 Ds
-Ec
-ii
+Ve
+oJ
 YQ
 qN
 RL
@@ -4229,14 +4466,14 @@ YQ
 cr
 Wy
 wb
-Fp
+MX
 hv
 YQ
 YQ
 px
 Gm
 Qb
-Dg
+zR
 tY
 tY
 tY
@@ -4257,7 +4494,7 @@ GK
 Uv
 Ox
 tb
-dA
+fd
 Ri
 Ri
 lb
@@ -4270,13 +4507,13 @@ gz
 nv
 IW
 Hu
-Eq
+OR
 Lk
 YQ
 "}
 (8,1,1) = {"
 cr
-va
+CO
 BN
 xo
 Nj
@@ -4404,7 +4641,7 @@ Nh
 Uv
 Ox
 tb
-dA
+fd
 Ri
 KL
 Ri
@@ -4426,11 +4663,11 @@ YQ
 RE
 cr
 hi
-cZ
+Ij
 cr
 cr
 hi
-ug
+Hk
 cr
 cr
 cr
@@ -4446,14 +4683,14 @@ YH
 YQ
 RE
 cr
-tG
-MX
-yi
+fs
+hw
+pi
 bZ
 Uv
 wp
 EQ
-oo
+cP
 Ri
 Ri
 Ri
@@ -4478,7 +4715,7 @@ cT
 VB
 fw
 cr
-Jm
+Be
 Lw
 lO
 KG
@@ -4514,7 +4751,7 @@ cr
 cg
 Yz
 Yz
-md
+va
 cr
 YQ
 YQ
@@ -4701,7 +4938,7 @@ YQ
 YQ
 RE
 ZM
-ug
+Sr
 cr
 RE
 YQ
@@ -4801,7 +5038,7 @@ hR
 vU
 vU
 Lv
-zR
+hu
 vl
 ep
 YH
@@ -4858,9 +5095,9 @@ YQ
 Rn
 Er
 TX
-Ds
-eG
-ii
+Ap
+eN
+Jt
 "}
 (20,1,1) = {"
 YQ
@@ -4962,9 +5199,9 @@ YQ
 "}
 (22,1,1) = {"
 RE
-cr
-Ja
-fd
+eG
+lF
+ga
 Rx
 Rx
 Rx
@@ -4976,7 +5213,7 @@ Rx
 Rx
 Rx
 Rx
-cr
+eG
 cr
 YQ
 YQ
@@ -5010,7 +5247,7 @@ cr
 RE
 "}
 (23,1,1) = {"
-Rn
+uE
 UA
 Js
 Yz
@@ -5047,19 +5284,19 @@ vU
 vU
 vU
 vU
-tP
+Xr
 ch
 ED
 WO
 Zx
 Zx
 Zx
-lw
+Hw
 RV
 cr
 "}
 (24,1,1) = {"
-Rn
+uE
 JB
 Js
 Yz
@@ -5086,7 +5323,7 @@ Bb
 MF
 fV
 dt
-UQ
+hO
 cr
 YQ
 RE
@@ -5108,7 +5345,7 @@ qo
 cr
 "}
 (25,1,1) = {"
-Rn
+uE
 WY
 PA
 Yz
@@ -5123,7 +5360,7 @@ PF
 zu
 IF
 ll
-ga
+yi
 uL
 ep
 ep
@@ -5145,7 +5382,7 @@ vU
 vU
 vU
 lW
-jh
+If
 kt
 Vn
 WO
@@ -5157,7 +5394,7 @@ hh
 hv
 "}
 (26,1,1) = {"
-Rn
+uE
 mX
 AV
 pO
@@ -5194,7 +5431,7 @@ vU
 cG
 vU
 lW
-Ky
+Oo
 kt
 SO
 WO
@@ -5206,7 +5443,7 @@ Hy
 hv
 "}
 (27,1,1) = {"
-Rn
+uE
 sZ
 AV
 Yz
@@ -5243,7 +5480,7 @@ vU
 vU
 vU
 lW
-Oo
+Ky
 kt
 XH
 WO
@@ -5255,7 +5492,7 @@ TN
 hv
 "}
 (28,1,1) = {"
-Rn
+uE
 Yg
 jZ
 Yz
@@ -5280,7 +5517,7 @@ RE
 cr
 cr
 kt
-Ew
+Fp
 kt
 cr
 cr
@@ -5292,7 +5529,7 @@ vU
 vU
 vU
 lW
-If
+jh
 kt
 qM
 WO
@@ -5304,7 +5541,7 @@ hh
 hv
 "}
 (29,1,1) = {"
-Rn
+uE
 gB
 xS
 pO
@@ -5322,7 +5559,7 @@ pO
 Yz
 Kl
 Ej
-sY
+hS
 iN
 YQ
 YQ
@@ -5336,7 +5573,7 @@ cr
 YQ
 RE
 cr
-uE
+Qj
 vU
 vU
 vU
@@ -5353,7 +5590,7 @@ tI
 cr
 "}
 (30,1,1) = {"
-Rn
+uE
 HB
 Gx
 Yz
@@ -5397,12 +5634,12 @@ WO
 Zx
 Zx
 Zx
-lw
+mh
 EF
 cr
 "}
 (31,1,1) = {"
-Rn
+uE
 tL
 AV
 Yz
@@ -5442,16 +5679,16 @@ cr
 cr
 cr
 cr
-BP
-BP
-BP
-BP
-BP
+Jc
+Jc
+Jc
+Jc
+Jc
 cr
 RE
 "}
 (32,1,1) = {"
-Rn
+uE
 Hg
 AV
 pO
@@ -5500,7 +5737,7 @@ YQ
 YQ
 "}
 (33,1,1) = {"
-Rn
+uE
 Ps
 no
 Yz
@@ -5549,7 +5786,7 @@ Nj
 oK
 "}
 (34,1,1) = {"
-Rn
+uE
 UJ
 Js
 Yz
@@ -5593,12 +5830,12 @@ YQ
 Rn
 Er
 TX
-Ds
-pi
+iB
+AY
 ii
 "}
 (35,1,1) = {"
-Rn
+uE
 oz
 Js
 Yz
@@ -5649,8 +5886,8 @@ oK
 (36,1,1) = {"
 RE
 cr
-Ff
-nV
+oL
+Un
 PM
 PM
 PM
@@ -5662,7 +5899,7 @@ PM
 PM
 PM
 PM
-cr
+eG
 cr
 YQ
 YQ
@@ -5698,19 +5935,19 @@ YQ
 (37,1,1) = {"
 YQ
 RE
-Jc
-Jc
-Jc
-Jc
-Jc
-Jc
-Jc
-Jc
-Jc
-Jc
-Jc
-Jc
-Jc
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
 RE
 YQ
 YQ
@@ -5730,7 +5967,7 @@ YQ
 YQ
 RE
 ZM
-ug
+Ui
 cr
 RE
 YQ

--- a/_maps/shuttles/emergency_fleet.dmm
+++ b/_maps/shuttles/emergency_fleet.dmm
@@ -21,9 +21,9 @@
 	},
 /obj/effect/custom_portal{
 	mech_sized = 1;
-	portal_id = "fleetesc2com";
-	linked_to = "fleetcom";
-	name = "Portal to Cargo Shuttle";
+	portal_id = "fleettoi";
+	linked_to = "fleetcom2toi";
+	name = "Portal to Luxury Command Shuttle";
 	color = null
 	},
 /turf/open/floor/light,
@@ -54,6 +54,18 @@
 /obj/structure/mopbucket,
 /obj/item/mop,
 /turf/open/floor/plasteel/freezer,
+/area/shuttle/escape)
+"bs" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Pod Repair Shuttle"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "bJ" = (
 /obj/effect/turf_decal/box/white/corners{
@@ -106,10 +118,6 @@
 "cG" = (
 /obj/machinery/shuttle_manipulator,
 /turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/escape)
-"cP" = (
-/obj/item/pool/rubber_ring,
-/turf/open/indestructible/sound/pool/end,
 /area/shuttle/escape)
 "cT" = (
 /obj/effect/turf_decal/tile/brown/full,
@@ -239,6 +247,16 @@
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
+"ej" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod 3"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
 "el" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/reagent_dispensers/watertank,
@@ -283,23 +301,25 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"eG" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall/mineral/titanium/nodiagonal,
+"eE" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/closet/secure_closet{
+	name = "Plasmaman Supplies Locker";
+	req_access_txt = "5"
+	},
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/tank/internals/plasmaman,
+/obj/machinery/status_display/evac{
+	pixel_y = -32
+	},
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"eN" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
+"eG" = (
+/obj/machinery/status_display/evac{
+	pixel_y = -32
 	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetpod2";
-	linked_to = "fleetesc2pod2";
-	name = "Portal to Escape Lounge Shuttle";
-	color = null
-	},
-/turf/open/floor/light,
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "eX" = (
 /obj/machinery/door/firedoor/border_only{
@@ -312,7 +332,10 @@
 /turf/open/indestructible/sound/pool/end,
 /area/shuttle/escape)
 "fd" = (
-/turf/open/indestructible/sound/pool/end,
+/obj/machinery/door/airlock/external/glass{
+	name = s
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "fg" = (
 /obj/machinery/modular_computer/console/preset/engineering,
@@ -328,23 +351,6 @@
 	pixel_x = -12
 	},
 /turf/open/floor/carpet/royalblack,
-/area/shuttle/escape)
-"fs" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetesc2pod1";
-	linked_to = "fleetpod1";
-	name = "Portal to Escape Pod 1";
-	color = null
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/turf/open/floor/light,
 /area/shuttle/escape)
 "fw" = (
 /obj/effect/turf_decal/tile/brown/full,
@@ -423,16 +429,6 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"ga" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/window{
-	dir = 4
-	},
-/obj/structure/window{
-	dir = 1
-	},
-/turf/open/floor/grass,
 /area/shuttle/escape)
 "gz" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
@@ -529,48 +525,20 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/noslip,
 /area/shuttle/escape)
-"hu" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleeteng";
-	linked_to = "fleetesc2eng";
-	name = "Portal to Escape Lounge Shuttle";
-	color = null
-	},
-/turf/open/floor/light,
-/area/shuttle/escape)
 "hv" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"hw" = (
+"hx" = (
 /obj/structure/sign/directions/evac{
 	dir = 2;
 	pixel_y = 13
 	},
 /obj/effect/custom_portal{
 	mech_sized = 1;
-	portal_id = "fleetesc2pod2";
-	linked_to = "fleetpod2";
-	name = "Portal to Escape Pod 2";
-	color = null
-	},
-/turf/open/floor/light,
-/area/shuttle/escape)
-"hO" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetsci";
-	linked_to = "fleetesc2sci";
+	portal_id = "fleetmed";
+	linked_to = "fleetesc2med";
 	name = "Portal to Escape Lounge Shuttle";
 	color = null
 	},
@@ -586,20 +554,6 @@
 	dir = 4
 	},
 /turf/open/floor/circuit/telecomms/server,
-/area/shuttle/escape)
-"hS" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetcom";
-	linked_to = "fleetesc2com";
-	name = "Portal to Escape Lounge Shuttle";
-	color = null
-	},
-/turf/open/floor/light,
 /area/shuttle/escape)
 "ie" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -661,16 +615,6 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"iB" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/titanium{
-	name = "Escape Pod 3"
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/shuttle/escape)
 "iF" = (
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/stairs/goon/white_stairs_middle{
@@ -726,6 +670,16 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
+"jj" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod 2"
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "js" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -784,6 +738,18 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"jS" = (
+/obj/machinery/door/airlock/titanium{
+	name = "Cargo Shuttle"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "jW" = (
 /obj/effect/turf_decal/box/white/corners,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -796,6 +762,16 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/indestructible/carpet/blue,
+/area/shuttle/escape)
+"ke" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod 1"
+	},
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "ki" = (
 /obj/effect/turf_decal/tile/darkblue{
@@ -831,9 +807,37 @@
 /obj/machinery/light/floor,
 /turf/open/floor/plasteel/white,
 /area/shuttle/escape)
+"kp" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleeteng";
+	linked_to = "fleetesc2eng";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
 "kt" = (
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
+/area/shuttle/escape)
+"ky" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetpod3";
+	linked_to = "fleetesc2pod3";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "kC" = (
 /obj/machinery/light,
@@ -934,9 +938,37 @@
 /obj/item/pool/rubber_ring,
 /turf/open/indestructible/sound/pool,
 /area/shuttle/escape)
+"lh" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetcom";
+	linked_to = "fleetesc2com";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
 "ll" = (
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"lm" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetsup";
+	linked_to = "fleetesc2sup";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "lp" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -961,10 +993,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"lF" = (
-/obj/machinery/suit_storage_unit/command,
-/turf/open/indestructible/carpet/blue,
-/area/shuttle/escape)
 "lO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/reagent_dispensers/fueltank,
@@ -972,6 +1000,19 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"lU" = (
+/obj/structure/sign/directions/command{
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetesc2com";
+	linked_to = "fleetcom";
+	name = "Portal to Luxury Command Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "lW" = (
 /obj/structure/chair/comfy/shuttle,
@@ -995,20 +1036,22 @@
 /obj/structure/closet/wardrobe/white,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"mh" = (
-/obj/effect/turf_decal{
-	dir = 1
+"mp" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetesc2pod1";
+	linked_to = "fleetpod1";
+	name = "Portal to Escape Pod 1";
+	color = null
 	},
-/obj/machinery/button/door{
-	id = "fleetengshutters2";
-	name = "Shutters Control";
-	pixel_x = 24;
-	pixel_y = -22
+/obj/machinery/status_display/evac{
+	pixel_y = 32
 	},
-/turf/open/floor/plating,
+/turf/open/floor/light,
 /area/shuttle/escape)
 "mx" = (
 /obj/structure/window/reinforced{
@@ -1078,6 +1121,17 @@
 	dir = 1
 	},
 /turf/open/indestructible/grass/jungle,
+/area/shuttle/escape)
+"mP" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)"
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "mX" = (
 /obj/machinery/computer/station_alert,
@@ -1226,26 +1280,9 @@
 	},
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
-"oJ" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/titanium{
-	name = "Escape Pod 1"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "oK" = (
 /obj/structure/shuttle/engine/propulsion,
 /turf/open/floor/plating/airless,
-/area/shuttle/escape)
-"oL" = (
-/obj/machinery/suit_storage_unit/command,
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "pa" = (
 /obj/structure/chair/comfy/shuttle{
@@ -1269,18 +1306,8 @@
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "pi" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetesc2pod3";
-	linked_to = "fleetpod3";
-	name = "Portal to Escape Pod 3";
-	color = null
-	},
-/turf/open/floor/light,
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "pn" = (
 /obj/effect/turf_decal/tile/brown/full,
@@ -1300,6 +1327,18 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/white,
+/area/shuttle/escape)
+"pK" = (
+/obj/machinery/door/airlock/titanium{
+	name = s
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "pM" = (
 /turf/closed/wall/mineral/plastitanium,
@@ -1669,7 +1708,7 @@
 /area/shuttle/escape)
 "ug" = (
 /obj/machinery/door/airlock/titanium{
-	name = "Emergency Shuttle Lounges"
+	name = "Escape Lounge Shuttle"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -1762,18 +1801,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "va" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/closet/secure_closet{
-	name = "Plasmaman Supplies Locker";
-	req_access_txt = "5"
-	},
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/tank/internals/plasmaman,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
-	},
-/turf/open/floor/mineral/titanium/white,
+/turf/open/indestructible/sound/pool/end,
 /area/shuttle/escape)
 "vl" = (
 /obj/structure/shuttle/engine/heater,
@@ -2144,30 +2172,9 @@
 	},
 /turf/open/floor/light,
 /area/shuttle/escape)
-"zR" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/mapping_helpers/airlock/access/all/security/basic,
-/obj/machinery/door/airlock/security/glass{
-	name = "Cell 2"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
 "Ak" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/mineral/plastitanium/red/brig,
-/area/shuttle/escape)
-"Ap" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/titanium{
-	name = "Escape Pod 2"
-	},
-/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "Ar" = (
 /obj/effect/spawner/structure/window/shuttle,
@@ -2214,19 +2221,9 @@
 	},
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
-"AY" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetpod3";
-	linked_to = "fleetesc2pod3";
-	name = "Portal to Escape Lounge Shuttle";
-	color = null
-	},
-/turf/open/floor/light,
+"AZ" = (
+/obj/item/pool/rubber_ring,
+/turf/open/indestructible/sound/pool/end,
 /area/shuttle/escape)
 "Bb" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -2242,19 +2239,25 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"Be" = (
+"Bc" = (
 /obj/structure/sign/directions/evac{
 	dir = 2;
 	pixel_y = 13
 	},
 /obj/effect/custom_portal{
 	mech_sized = 1;
-	portal_id = "fleetsup";
-	linked_to = "fleetesc2sup";
+	portal_id = "fleetpod2";
+	linked_to = "fleetesc2pod2";
 	name = "Portal to Escape Lounge Shuttle";
 	color = null
 	},
 /turf/open/floor/light,
+/area/shuttle/escape)
+"Bn" = (
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/royalblack,
 /area/shuttle/escape)
 "Bp" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -2302,7 +2305,7 @@
 	dir = 8
 	},
 /obj/machinery/door/poddoor/shutters/window{
-	id = "fleetengshutters1"
+	id = "fleetengshutters2"
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -2377,12 +2380,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"CO" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/royalblack,
-/area/shuttle/escape)
 "CS" = (
 /obj/effect/turf_decal/tile/darkblue{
 	dir = 8
@@ -2426,7 +2423,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/mapping_helpers/airlock/access/all/security/basic,
 /obj/machinery/door/airlock/security/glass{
-	name = "Cell 1"
+	name = "Cell 2"
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
@@ -2455,7 +2452,7 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/titanium{
-	name = "Escape Pod 1"
+	name = "Escape Pod 2"
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
@@ -2555,7 +2552,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/titanium/glass{
-	name = "Clown Specimens"
+	name = "Goat Specimens"
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
@@ -2616,20 +2613,19 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "Fp" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/effect/turf_decal{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/door/firedoor/border_only{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
+/obj/machinery/button/door{
+	id = "fleetengshutters1";
+	name = "Shutters Control";
+	pixel_x = -24;
+	pixel_y = -22
 	},
-/obj/machinery/door/airlock/titanium/glass{
-	name = "Goat Specimens"
-	},
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "FF" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -2814,39 +2810,12 @@
 	},
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
-"Hk" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Cargo Shuttle"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "Hu" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
 	},
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"Hw" = (
-/obj/effect/turf_decal{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	id = "fleetengshutters1";
-	name = "Shutters Control";
-	pixel_x = -24;
-	pixel_y = -22
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "Hy" = (
 /obj/structure/table/reinforced,
@@ -2899,18 +2868,6 @@
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
-"Ij" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/titanium{
-	name = "Cargo Shuttle"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "IF" = (
 /obj/structure/statue/diamond/captain,
 /obj/machinery/light/floor,
@@ -2942,22 +2899,37 @@
 /obj/structure/closet/athletic_mixed,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
+"IU" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetpod1";
+	linked_to = "fleetesc2pod1";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
 "IW" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Jc" = (
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal{
-	dir = 4
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
 	},
-/obj/effect/turf_decal{
-	dir = 8
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetsci";
+	linked_to = "fleetesc2sci";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
 	},
-/obj/machinery/door/poddoor/shutters/window{
-	id = "fleetengshutters2"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/light,
 /area/shuttle/escape)
 "Je" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -2976,16 +2948,6 @@
 /area/shuttle/escape)
 "Js" = (
 /turf/open/indestructible/carpet/blue,
-/area/shuttle/escape)
-"Jt" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/titanium{
-	name = "Escape Pod 2"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "JA" = (
 /obj/structure/table/reinforced,
@@ -3146,6 +3108,20 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"Mj" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetesc2pod3";
+	linked_to = "fleetpod3";
+	name = "Portal to Escape Pod 3";
+	color = null
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
 "Ms" = (
 /obj/effect/turf_decal/tile/brown/full,
 /obj/machinery/computer/shuttle/mining,
@@ -3154,6 +3130,16 @@
 "Mu" = (
 /obj/structure/closet/crate/solarpanel_small,
 /turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Mv" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/grass,
 /area/shuttle/escape)
 "MC" = (
 /obj/machinery/computer/emergency_shuttle,
@@ -3174,18 +3160,24 @@
 /obj/machinery/door/airlock/vault,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
+"MP" = (
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
 "MX" = (
-/obj/structure/sign/directions/command{
-	pixel_y = 13
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal{
+	dir = 4
 	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleettoi";
-	linked_to = "fleetcom2toi";
-	name = "Portal to Luxury Command Shuttle";
-	color = null
+/obj/effect/turf_decal{
+	dir = 8
 	},
-/turf/open/floor/light,
+/obj/machinery/door/poddoor/shutters/window{
+	id = "fleetengshutters1"
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "MZ" = (
 /obj/effect/turf_decal/tile/brown/full,
@@ -3232,7 +3224,8 @@
 	mech_sized = 1;
 	portal_id = "fleetesc2sup";
 	linked_to = "fleetsup";
-	color = null
+	color = null;
+	name = "Portal to Cargo Shuttle"
 	},
 /turf/open/floor/light,
 /area/shuttle/escape)
@@ -3325,20 +3318,6 @@
 /obj/machinery/vending/security,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
-"OR" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetmed";
-	linked_to = "fleetesc2med";
-	name = "Portal to Escape Lounge Shuttle";
-	color = null
-	},
-/turf/open/floor/light,
-/area/shuttle/escape)
 "OV" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -3427,6 +3406,17 @@
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
+"PK" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/mapping_helpers/airlock/access/all/security/basic,
+/obj/machinery/door/airlock/security/glass{
+	name = "Cell 1"
+	},
+/turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
 "PM" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/window{
@@ -3474,17 +3464,6 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"Qj" = (
-/obj/structure/table/reinforced,
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)"
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "QB" = (
 /obj/structure/chair/comfy/shuttle{
@@ -3554,6 +3533,20 @@
 /obj/structure/closet/wardrobe/mixed,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
+"Rm" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetesc2pod2";
+	linked_to = "fleetpod2";
+	name = "Portal to Escape Pod 2";
+	color = null
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
 "Rn" = (
 /obj/effect/spawner/structure/window/shuttle,
 /obj/machinery/door/firedoor/border_only{
@@ -3585,18 +3578,6 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/silver,
-/area/shuttle/escape)
-"Ru" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Emergency Lounge Shuttle"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "Rx" = (
 /obj/structure/flora/ausbushes/brflowers,
@@ -3663,18 +3644,6 @@
 	},
 /obj/machinery/computer/emergency_shuttle,
 /turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"Sr" = (
-/obj/machinery/door/airlock/titanium{
-	name = s
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "Sy" = (
 /obj/effect/turf_decal/box/white/corners{
@@ -3802,6 +3771,16 @@
 /obj/item/stack/sheet/cardboard/fifty,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
+"TT" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/grass,
+/area/shuttle/escape)
 "TX" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 1
@@ -3825,28 +3804,6 @@
 /obj/structure/closet/crate/secure/owned/gear,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"Ui" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Pod Repair Shuttle"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
-"Un" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/window{
-	dir = 8
-	},
-/obj/structure/window{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/shuttle/escape)
 "Uo" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -3867,6 +3824,10 @@
 	},
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
+"UD" = (
+/obj/machinery/suit_storage_unit/command,
+/turf/open/indestructible/carpet/blue,
+/area/shuttle/escape)
 "UI" = (
 /obj/machinery/stasis{
 	dir = 8
@@ -3880,23 +3841,24 @@
 /obj/machinery/suit_storage_unit/ce,
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
+"UN" = (
+/obj/effect/turf_decal{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "fleetengshutters2";
+	name = "Shutters Control";
+	pixel_x = 24;
+	pixel_y = -22
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "Va" = (
 /obj/structure/closet/crate/secure/plasma,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
-"Ve" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetpod1";
-	linked_to = "fleetesc2pod1";
-	name = "Portal to Escape Lounge Shuttle";
-	color = null
-	},
-/turf/open/floor/light,
 /area/shuttle/escape)
 "Vn" = (
 /obj/structure/mopbucket,
@@ -4036,12 +3998,6 @@
 /obj/structure/closet/wardrobe/pjs,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"Xr" = (
-/obj/machinery/door/airlock/external/glass{
-	name = s
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "Xt" = (
 /obj/effect/turf_decal/tile/brown/full,
 /obj/machinery/computer/security/qm,
@@ -4067,6 +4023,18 @@
 /obj/item/book/manual/wiki/security_space_law,
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
+"XS" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/titanium{
+	name = "Cargo Shuttle"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "Yg" = (
 /obj/structure/window{
 	dir = 8;
@@ -4075,12 +4043,38 @@
 /obj/machinery/computer/card,
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
+"Yj" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod 1"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "Yo" = (
 /obj/effect/spawner/structure/window/plastitanium,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
 	},
 /turf/open/floor/plating,
+/area/shuttle/escape)
+"Yt" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/titanium/glass{
+	name = "Clown Specimens"
+	},
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Yz" = (
 /turf/open/floor/mineral/titanium/white,
@@ -4195,7 +4189,7 @@ YQ
 RE
 ug
 cr
-Ru
+ug
 cr
 cr
 cr
@@ -4221,9 +4215,9 @@ YQ
 Rn
 Er
 TX
-Ds
-Ve
-oJ
+ke
+IU
+Yj
 YQ
 qN
 RL
@@ -4277,7 +4271,7 @@ YQ
 px
 Gm
 Qb
-Dg
+PK
 tY
 tY
 tY
@@ -4466,14 +4460,14 @@ YQ
 cr
 Wy
 wb
-MX
+ap
 hv
 YQ
 YQ
 px
 Gm
 Qb
-zR
+Dg
 tY
 tY
 tY
@@ -4494,7 +4488,7 @@ GK
 Uv
 Ox
 tb
-fd
+va
 Ri
 Ri
 lb
@@ -4507,13 +4501,13 @@ gz
 nv
 IW
 Hu
-OR
+hx
 Lk
 YQ
 "}
 (8,1,1) = {"
 cr
-CO
+Bn
 BN
 xo
 Nj
@@ -4584,7 +4578,7 @@ ot
 oK
 YQ
 Rn
-ap
+lU
 rH
 Uv
 Uv
@@ -4641,7 +4635,7 @@ Nh
 Uv
 Ox
 tb
-fd
+va
 Ri
 KL
 Ri
@@ -4663,11 +4657,11 @@ YQ
 RE
 cr
 hi
-Ij
+XS
 cr
 cr
 hi
-Hk
+jS
 cr
 cr
 cr
@@ -4683,14 +4677,14 @@ YH
 YQ
 RE
 cr
-fs
-hw
-pi
+mp
+Rm
+Mj
 bZ
 Uv
 wp
 EQ
-cP
+AZ
 Ri
 Ri
 Ri
@@ -4715,7 +4709,7 @@ cT
 VB
 fw
 cr
-Be
+lm
 Lw
 lO
 KG
@@ -4751,7 +4745,7 @@ cr
 cg
 Yz
 Yz
-va
+eE
 cr
 YQ
 YQ
@@ -4938,7 +4932,7 @@ YQ
 YQ
 RE
 ZM
-Sr
+pK
 cr
 RE
 YQ
@@ -5038,7 +5032,7 @@ hR
 vU
 vU
 Lv
-hu
+kp
 vl
 ep
 YH
@@ -5095,9 +5089,9 @@ YQ
 Rn
 Er
 TX
-Ap
-eN
-Jt
+Ds
+Bc
+jj
 "}
 (20,1,1) = {"
 YQ
@@ -5199,9 +5193,9 @@ YQ
 "}
 (22,1,1) = {"
 RE
-eG
-lF
-ga
+pi
+UD
+Mv
 Rx
 Rx
 Rx
@@ -5213,7 +5207,7 @@ Rx
 Rx
 Rx
 Rx
-eG
+pi
 cr
 YQ
 YQ
@@ -5238,11 +5232,11 @@ cr
 cr
 cr
 cr
-BP
-BP
-BP
-BP
-BP
+MX
+MX
+MX
+MX
+MX
 cr
 RE
 "}
@@ -5272,7 +5266,7 @@ RE
 cr
 cr
 kt
-Ew
+Yt
 kt
 cr
 cr
@@ -5284,14 +5278,14 @@ vU
 vU
 vU
 vU
-Xr
+fd
 ch
 ED
 WO
 Zx
 Zx
 Zx
-Hw
+Fp
 RV
 cr
 "}
@@ -5323,7 +5317,7 @@ Bb
 MF
 fV
 dt
-hO
+Jc
 cr
 YQ
 RE
@@ -5507,7 +5501,7 @@ kO
 iF
 Yz
 Yz
-Yz
+eG
 cr
 yv
 KY
@@ -5517,7 +5511,7 @@ RE
 cr
 cr
 kt
-Fp
+Ew
 kt
 cr
 cr
@@ -5559,7 +5553,7 @@ pO
 Yz
 Kl
 Ej
-hS
+lh
 iN
 YQ
 YQ
@@ -5573,7 +5567,7 @@ cr
 YQ
 RE
 cr
-Qj
+mP
 vU
 vU
 vU
@@ -5607,7 +5601,7 @@ Yz
 Yz
 Yz
 cr
-yv
+MP
 Ke
 iN
 YQ
@@ -5634,7 +5628,7 @@ WO
 Zx
 Zx
 Zx
-mh
+UN
 EF
 cr
 "}
@@ -5679,11 +5673,11 @@ cr
 cr
 cr
 cr
-Jc
-Jc
-Jc
-Jc
-Jc
+BP
+BP
+BP
+BP
+BP
 cr
 RE
 "}
@@ -5830,8 +5824,8 @@ YQ
 Rn
 Er
 TX
-iB
-AY
+ej
+ky
 ii
 "}
 (35,1,1) = {"
@@ -5885,9 +5879,9 @@ oK
 "}
 (36,1,1) = {"
 RE
-cr
-oL
-Un
+pi
+UD
+TT
 PM
 PM
 PM
@@ -5899,7 +5893,7 @@ PM
 PM
 PM
 PM
-eG
+pi
 cr
 YQ
 YQ
@@ -5967,7 +5961,7 @@ YQ
 YQ
 RE
 ZM
-Ui
+bs
 cr
 RE
 YQ

--- a/_maps/shuttles/emergency_fleet.dmm
+++ b/_maps/shuttles/emergency_fleet.dmm
@@ -44,12 +44,6 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"ba" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/turf/open/floor/carpet/royalblack,
-/area/shuttle/escape)
 "bl" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 4
@@ -60,6 +54,12 @@
 /obj/structure/mopbucket,
 /obj/item/mop,
 /turf/open/floor/plasteel/freezer,
+/area/shuttle/escape)
+"bE" = (
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/royalblack,
 /area/shuttle/escape)
 "bJ" = (
 /obj/effect/turf_decal/box/white/corners{
@@ -109,16 +109,6 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"cD" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/titanium{
-	name = "Escape Pod 3"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "cG" = (
 /obj/machinery/shuttle_manipulator,
 /turf/open/floor/mineral/titanium/yellow,
@@ -142,21 +132,6 @@
 	},
 /turf/open/indestructible/grass/jungle,
 /area/shuttle/escape)
-"dc" = (
-/obj/effect/turf_decal{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	id = "fleetengshutters1";
-	name = "Shutters Control";
-	pixel_x = -24;
-	pixel_y = -22
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "dh" = (
 /obj/structure/window/reinforced{
 	pixel_y = -3
@@ -173,18 +148,6 @@
 	dir = 8
 	},
 /turf/open/indestructible/grass/jungle,
-/area/shuttle/escape)
-"dj" = (
-/obj/machinery/door/airlock/titanium{
-	name = s
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "ds" = (
 /obj/machinery/light{
@@ -332,20 +295,6 @@
 	pixel_y = -32
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"eW" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetesc2pod2";
-	linked_to = "fleetpod2";
-	name = "Portal to Escape Pod 2";
-	color = null
-	},
-/turf/open/floor/light,
 /area/shuttle/escape)
 "eX" = (
 /obj/machinery/door/firedoor/border_only{
@@ -562,15 +511,15 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/shuttle/escape)
-"hz" = (
+"hP" = (
 /obj/structure/sign/directions/evac{
 	dir = 2;
 	pixel_y = 13
 	},
 /obj/effect/custom_portal{
 	mech_sized = 1;
-	portal_id = "fleetmed";
-	linked_to = "fleetesc2med";
+	portal_id = "fleetpod3";
+	linked_to = "fleetesc2pod3";
 	name = "Portal to Escape Lounge Shuttle";
 	color = null
 	},
@@ -703,16 +652,6 @@
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
-"jo" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/window{
-	dir = 8
-	},
-/obj/structure/window{
-	dir = 1
-	},
-/turf/open/floor/grass,
-/area/shuttle/escape)
 "js" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/closet/emcloset,
@@ -742,20 +681,6 @@
 	name = "Station Intercom (General)"
 	},
 /turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"jE" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetesc2pod3";
-	linked_to = "fleetpod3";
-	name = "Portal to Escape Pod 3";
-	color = null
-	},
-/turf/open/floor/light,
 /area/shuttle/escape)
 "jK" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -907,6 +832,20 @@
 /obj/item/wrench/medical,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
+"kT" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetcom";
+	linked_to = "fleetesc2com";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
 "kU" = (
 /obj/machinery/shuttle_manipulator{
 	layer = 3.3;
@@ -917,6 +856,20 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"kX" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetsci";
+	linked_to = "fleetesc2sci";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "kY" = (
 /obj/structure/window/reinforced{
@@ -937,6 +890,17 @@
 "lb" = (
 /obj/item/pool/rubber_ring,
 /turf/open/indestructible/sound/pool,
+/area/shuttle/escape)
+"lk" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/mapping_helpers/airlock/access/all/security/basic,
+/obj/machinery/door/airlock/security/glass{
+	name = "Cell 1"
+	},
+/turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
 "ll" = (
 /obj/machinery/door/firedoor/border_only,
@@ -981,18 +945,6 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
-"lX" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Cargo Shuttle"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "ma" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -1013,6 +965,12 @@
 /obj/structure/closet/wardrobe/white,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
+"mu" = (
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
 "mx" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -1022,20 +980,18 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "mE" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
 	},
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetesc2pod2";
+	linked_to = "fleetpod2";
+	name = "Portal to Escape Pod 2";
+	color = null
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/titanium/glass{
-	name = "Goat Specimens"
-	},
-/turf/open/floor/mineral/titanium/white,
+/turf/open/floor/light,
 /area/shuttle/escape)
 "mG" = (
 /obj/effect/turf_decal/tile/darkblue{
@@ -1072,21 +1028,6 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
-/area/shuttle/escape)
-"mJ" = (
-/turf/open/indestructible/sound/pool/end,
-/area/shuttle/escape)
-"mL" = (
-/obj/machinery/door/airlock/titanium{
-	name = "Pod Repair Shuttle"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "mO" = (
 /obj/structure/window/reinforced{
@@ -1286,14 +1227,16 @@
 /turf/open/floor/plasteel/freezer,
 /area/shuttle/escape)
 "pi" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/airlock/titanium{
-	name = "Escape Pod 1"
+	name = "Pod Repair Shuttle"
 	},
-/turf/open/floor/mineral/titanium/blue,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "pn" = (
 /obj/effect/turf_decal/tile/brown/full,
@@ -1376,6 +1319,10 @@
 	},
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
+"qI" = (
+/obj/item/pool/rubber_ring,
+/turf/open/indestructible/sound/pool/end,
+/area/shuttle/escape)
 "qM" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -1402,6 +1349,16 @@
 	},
 /turf/open/floor/mineral/bananium,
 /area/shuttle/escape)
+"qW" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod 3"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "qZ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -1417,6 +1374,22 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/plastitanium/red/brig,
+/area/shuttle/escape)
+"ri" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/airlock/titanium/glass{
+	name = "Clown Specimens"
+	},
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "rn" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -1449,12 +1422,6 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"rs" = (
-/obj/machinery/door/airlock/external/glass{
-	name = "Pod Repair Bay"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "ru" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 6
@@ -1470,20 +1437,6 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium,
-/area/shuttle/escape)
-"rD" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetcom2toi";
-	linked_to = "fleettoi";
-	name = "Portal to Luxury Restroom Pod";
-	color = null
-	},
-/turf/open/floor/light,
 /area/shuttle/escape)
 "rE" = (
 /obj/structure/extinguisher_cabinet{
@@ -1544,20 +1497,6 @@
 "sC" = (
 /obj/structure/closet/firecloset/full,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
-"sH" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleeteng";
-	linked_to = "fleetesc2eng";
-	name = "Portal to Escape Lounge Shuttle";
-	color = null
-	},
-/turf/open/floor/light,
 /area/shuttle/escape)
 "sL" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -1621,18 +1560,15 @@
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
-"ty" = (
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal{
-	dir = 4
+"to" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
-/obj/effect/turf_decal{
-	dir = 8
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod 1"
 	},
-/obj/machinery/door/poddoor/shutters/window{
-	id = "fleetengshutters2"
-	},
-/turf/open/floor/plating,
+/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "tz" = (
 /obj/structure/table/glass,
@@ -1696,16 +1632,6 @@
 	name = s
 	},
 /turf/open/floor/plating,
-/area/shuttle/escape)
-"tR" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/window{
-	dir = 4
-	},
-/obj/structure/window{
-	dir = 1
-	},
-/turf/open/floor/grass,
 /area/shuttle/escape)
 "tV" = (
 /obj/machinery/computer/security{
@@ -1819,19 +1745,18 @@
 /turf/open/floor/mineral/plastitanium/red/brig,
 /area/shuttle/escape)
 "uA" = (
-/obj/effect/turf_decal{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/structure/closet/secure_closet{
+	name = "Plasmaman Supplies Locker";
+	req_access_txt = "5"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+/obj/item/clothing/under/plasmaman,
+/obj/item/clothing/head/helmet/space/plasmaman,
+/obj/item/tank/internals/plasmaman,
+/obj/machinery/status_display/evac{
+	pixel_y = -32
 	},
-/obj/machinery/button/door{
-	id = "fleetengshutters2";
-	name = "Shutters Control";
-	pixel_x = 24;
-	pixel_y = -22
-	},
-/turf/open/floor/plating,
+/turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "uE" = (
 /obj/effect/spawner/structure/window/shuttle,
@@ -1852,32 +1777,16 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "va" = (
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/closet/secure_closet{
-	name = "Plasmaman Supplies Locker";
-	req_access_txt = "5"
+/obj/machinery/door/airlock/titanium{
+	name = "Cargo Shuttle"
 	},
-/obj/item/clothing/under/plasmaman,
-/obj/item/clothing/head/helmet/space/plasmaman,
-/obj/item/tank/internals/plasmaman,
-/obj/machinery/status_display/evac{
-	pixel_y = -32
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"vh" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetpod3";
-	linked_to = "fleetesc2pod3";
-	name = "Portal to Escape Lounge Shuttle";
-	color = null
-	},
-/turf/open/floor/light,
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "vl" = (
 /obj/structure/shuttle/engine/heater,
@@ -1898,6 +1807,10 @@
 /obj/effect/spawner/lootdrop/three_course_meal,
 /obj/structure/table/glass,
 /turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"vI" = (
+/obj/machinery/suit_storage_unit/command,
+/turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "vM" = (
 /obj/structure/sink{
@@ -2044,6 +1957,20 @@
 /obj/machinery/computer/atmos_alert,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
+"wQ" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetpod1";
+	linked_to = "fleetesc2pod1";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
 "wX" = (
 /obj/machinery/light,
 /obj/machinery/portable_atmospherics/pump,
@@ -2072,6 +1999,20 @@
 	},
 /obj/machinery/light/floor,
 /turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"xm" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleeteng";
+	linked_to = "fleetesc2eng";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "xo" = (
 /obj/machinery/door/firedoor/border_only{
@@ -2152,7 +2093,6 @@
 "xT" = (
 /obj/structure/table/reinforced,
 /obj/item/pet_carrier,
-/obj/item/bodybag/bluespace,
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "yc" = (
@@ -2173,9 +2113,9 @@
 	},
 /obj/effect/custom_portal{
 	mech_sized = 1;
-	portal_id = "fleetcom";
-	linked_to = "fleetesc2com";
-	name = "Portal to Escape Lounge Shuttle";
+	portal_id = "fleetesc2pod3";
+	linked_to = "fleetpod3";
+	name = "Portal to Escape Pod 3";
 	color = null
 	},
 /turf/open/floor/light,
@@ -2210,6 +2150,20 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"yR" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetpod2";
+	linked_to = "fleetesc2pod2";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
 "yS" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
@@ -2239,6 +2193,20 @@
 	},
 /obj/structure/closet/emcloset,
 /turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"zJ" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetcom2toi";
+	linked_to = "fleettoi";
+	name = "Portal to Luxury Restroom Pod";
+	color = null
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "zM" = (
 /obj/structure/sign/directions/engineering{
@@ -2359,7 +2327,7 @@
 	dir = 8
 	},
 /obj/machinery/door/poddoor/shutters/window{
-	id = "fleetengshutters1"
+	id = "fleetengshutters2"
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -2434,6 +2402,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
+"CG" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)"
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/escape)
 "CS" = (
 /obj/effect/turf_decal/tile/darkblue{
 	dir = 8
@@ -2477,7 +2456,7 @@
 /obj/machinery/door/firedoor/border_only,
 /obj/effect/mapping_helpers/airlock/access/all/security/basic,
 /obj/machinery/door/airlock/security/glass{
-	name = "Cell 1"
+	name = "Cell 2"
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
@@ -2544,6 +2523,19 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
+"DV" = (
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal{
+	dir = 4
+	},
+/obj/effect/turf_decal{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters/window{
+	id = "fleetengshutters1"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "Ej" = (
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/mineral/titanium/blue,
@@ -2559,8 +2551,14 @@
 /turf/open/floor/plating,
 /area/shuttle/escape)
 "Eq" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/obj/effect/spawner/structure/window/shuttle,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "fleetcomshutters"
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "Er" = (
 /obj/structure/chair/comfy/shuttle{
@@ -2575,6 +2573,21 @@
 	dir = 4
 	},
 /turf/open/floor/carpet/blue,
+/area/shuttle/escape)
+"Et" = (
+/obj/effect/turf_decal{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "fleetengshutters2";
+	name = "Shutters Control";
+	pixel_x = 24;
+	pixel_y = -22
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "Ev" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -2598,7 +2611,7 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/titanium/glass{
-	name = "Clown Specimens"
+	name = "Goat Specimens"
 	},
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
@@ -2661,14 +2674,14 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "Fp" = (
-/obj/machinery/door/firedoor/border_only{
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/window{
+	dir = 4
+	},
+/obj/structure/window{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/airlock/titanium{
-	name = "Escape Pod 2"
-	},
-/turf/open/floor/mineral/titanium/blue,
+/turf/open/floor/grass,
 /area/shuttle/escape)
 "FF" = (
 /obj/structure/flora/ausbushes/fullgrass,
@@ -2849,17 +2862,6 @@
 /obj/structure/chair/comfy/shuttle,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"He" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/mapping_helpers/airlock/access/all/security/basic,
-/obj/machinery/door/airlock/security/glass{
-	name = "Cell 2"
-	},
-/turf/open/floor/mineral/plastitanium,
-/area/shuttle/escape)
 "Hg" = (
 /obj/machinery/computer/secure_data,
 /obj/item/radio/intercom{
@@ -2867,10 +2869,6 @@
 	name = "Station Intercom (General)";
 	pixel_y = 25
 	},
-/turf/open/indestructible/carpet/blue,
-/area/shuttle/escape)
-"Hm" = (
-/obj/machinery/suit_storage_unit/command,
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
 "Hu" = (
@@ -2908,9 +2906,22 @@
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
+"HD" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod 1"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "HQ" = (
 /obj/effect/turf_decal/ramp_middle,
 /turf/open/floor/mineral/silver,
+/area/shuttle/escape)
+"HS" = (
+/turf/open/indestructible/sound/pool/end,
 /area/shuttle/escape)
 "HX" = (
 /obj/structure/mirror{
@@ -2924,20 +2935,6 @@
 "HZ" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/mineral/titanium/white,
-/area/shuttle/escape)
-"Ie" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetpod2";
-	linked_to = "fleetesc2pod2";
-	name = "Portal to Escape Lounge Shuttle";
-	color = null
-	},
-/turf/open/floor/light,
 /area/shuttle/escape)
 "If" = (
 /obj/machinery/modular_computer/console/preset/engineering{
@@ -2981,14 +2978,18 @@
 /turf/open/floor/mineral/titanium/white,
 /area/shuttle/escape)
 "Jc" = (
-/obj/effect/spawner/structure/window/shuttle,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "fleetcomshutters"
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetmed";
+	linked_to = "fleetesc2med";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
 	},
-/turf/open/floor/plating,
+/turf/open/floor/light,
 /area/shuttle/escape)
 "Je" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -3136,37 +3137,9 @@
 /obj/item/kirbyplants/photosynthetic,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
-"Lg" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetsup";
-	linked_to = "fleetesc2sup";
-	name = "Portal to Escape Lounge Shuttle";
-	color = null
-	},
-/turf/open/floor/light,
-/area/shuttle/escape)
 "Lk" = (
 /obj/structure/sign/warning/nosmoking,
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/shuttle/escape)
-"Lo" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetpod1";
-	linked_to = "fleetesc2pod1";
-	name = "Portal to Escape Lounge Shuttle";
-	color = null
-	},
-/turf/open/floor/light,
 /area/shuttle/escape)
 "Lr" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -3190,19 +3163,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
-"LF" = (
-/obj/structure/sign/directions/command{
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetesc2com";
-	linked_to = "fleetcom";
-	name = "Portal to Luxury Command Shuttle";
-	color = null
-	},
-/turf/open/floor/light,
-/area/shuttle/escape)
 "LO" = (
 /obj/effect/turf_decal/tile/brown/full,
 /obj/machinery/door/firedoor/border_only{
@@ -3214,19 +3174,17 @@
 	},
 /turf/open/floor/mineral/titanium,
 /area/shuttle/escape)
-"Ma" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
+"Mj" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetsci";
-	linked_to = "fleetesc2sci";
-	name = "Portal to Escape Lounge Shuttle";
-	color = null
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
-/turf/open/floor/light,
+/obj/machinery/door/airlock/titanium{
+	name = "Cargo Shuttle"
+	},
+/turf/open/floor/plating,
 /area/shuttle/escape)
 "Ms" = (
 /obj/effect/turf_decal/tile/brown/full,
@@ -3236,17 +3194,6 @@
 "Mu" = (
 /obj/structure/closet/crate/solarpanel_small,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
-"Mw" = (
-/obj/structure/table/reinforced,
-/obj/item/radio/intercom{
-	dir = 4;
-	name = "Station Intercom (General)"
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "MC" = (
 /obj/machinery/computer/emergency_shuttle,
@@ -3267,34 +3214,9 @@
 /obj/machinery/door/airlock/vault,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/escape)
-"MU" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/airlock/titanium{
-	name = "Cargo Shuttle"
-	},
-/turf/open/floor/plating,
-/area/shuttle/escape)
 "MX" = (
-/obj/structure/sign/directions/evac{
-	dir = 2;
-	pixel_y = 13
-	},
-/obj/effect/custom_portal{
-	mech_sized = 1;
-	portal_id = "fleetesc2pod1";
-	linked_to = "fleetpod1";
-	name = "Portal to Escape Pod 1";
-	color = null
-	},
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/turf/open/floor/light,
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
 "MZ" = (
 /obj/effect/turf_decal/tile/brown/full,
@@ -3367,10 +3289,6 @@
 /obj/machinery/light/floor,
 /turf/open/floor/carpet/blue,
 /area/shuttle/escape)
-"NY" = (
-/obj/item/pool/rubber_ring,
-/turf/open/indestructible/sound/pool/end,
-/area/shuttle/escape)
 "NZ" = (
 /obj/item/reagent_containers/food/snacks/burger/clown{
 	desc = "They turned a clown into a burger. Funniest shit you've ever seen."
@@ -3435,6 +3353,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
+"OH" = (
+/obj/structure/sign/directions/command{
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetesc2com";
+	linked_to = "fleetcom";
+	name = "Portal to Luxury Command Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
 "OM" = (
 /obj/machinery/vending/security,
 /turf/open/floor/mineral/plastitanium/red/brig,
@@ -3496,12 +3427,6 @@
 	pixel_x = -3
 	},
 /turf/open/indestructible/carpet/blue,
-/area/shuttle/escape)
-"PC" = (
-/obj/machinery/status_display/evac{
-	pixel_y = 32
-	},
-/turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "PF" = (
 /obj/machinery/shuttle_manipulator{
@@ -3788,6 +3713,20 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
+"SW" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetsup";
+	linked_to = "fleetesc2sup";
+	name = "Portal to Escape Lounge Shuttle";
+	color = null
+	},
+/turf/open/floor/light,
+/area/shuttle/escape)
 "SX" = (
 /obj/structure/mirror{
 	pixel_y = 34
@@ -3799,6 +3738,16 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
+/area/shuttle/escape)
+"SZ" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/grass,
 /area/shuttle/escape)
 "Th" = (
 /obj/effect/turf_decal/tile/darkblue{
@@ -3935,9 +3884,36 @@
 /obj/machinery/suit_storage_unit/ce,
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
+"UL" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/titanium{
+	name = "Escape Pod 2"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/shuttle/escape)
 "Va" = (
 /obj/structure/closet/crate/secure/plasma,
 /turf/open/floor/plasteel/dark,
+/area/shuttle/escape)
+"Vd" = (
+/obj/structure/sign/directions/evac{
+	dir = 2;
+	pixel_y = 13
+	},
+/obj/effect/custom_portal{
+	mech_sized = 1;
+	portal_id = "fleetesc2pod1";
+	linked_to = "fleetpod1";
+	name = "Portal to Escape Pod 1";
+	color = null
+	},
+/obj/machinery/status_display/evac{
+	pixel_y = 32
+	},
+/turf/open/floor/light,
 /area/shuttle/escape)
 "Vn" = (
 /obj/structure/mopbucket,
@@ -3982,16 +3958,6 @@
 	dir = 1
 	},
 /turf/open/floor/mineral/silver,
-/area/shuttle/escape)
-"Wh" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/titanium{
-	name = "Escape Pod 1"
-	},
-/turf/open/floor/plating,
 /area/shuttle/escape)
 "Wl" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -4082,6 +4048,21 @@
 /obj/machinery/computer/aifixer,
 /turf/open/indestructible/carpet/blue,
 /area/shuttle/escape)
+"Xd" = (
+/obj/effect/turf_decal{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "fleetengshutters1";
+	name = "Shutters Control";
+	pixel_x = -24;
+	pixel_y = -22
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 "Xf" = (
 /obj/effect/turf_decal/box/white/corners{
 	dir = 4
@@ -4126,6 +4107,18 @@
 /obj/effect/spawner/structure/window/plastitanium,
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
+"Yr" = (
+/obj/machinery/door/airlock/titanium{
+	name = s
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/shuttle/escape)
@@ -4216,6 +4209,12 @@
 /obj/structure/sign/departments/minsky/engineering/engineering,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/escape)
+"ZW" = (
+/obj/machinery/door/airlock/external/glass{
+	name = "Pod Repair Bay"
+	},
+/turf/open/floor/plating,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 RE
@@ -4270,9 +4269,9 @@ YQ
 Rn
 Er
 TX
-pi
-Lo
-Wh
+to
+wQ
+HD
 YQ
 qN
 RL
@@ -4326,7 +4325,7 @@ YQ
 px
 Gm
 Qb
-Dg
+lk
 tY
 tY
 tY
@@ -4522,7 +4521,7 @@ YQ
 px
 Gm
 Qb
-He
+Dg
 tY
 tY
 tY
@@ -4543,7 +4542,7 @@ GK
 Uv
 Ox
 tb
-mJ
+HS
 Ri
 Ri
 lb
@@ -4556,13 +4555,13 @@ gz
 nv
 IW
 Hu
-hz
+Jc
 Lk
 YQ
 "}
 (8,1,1) = {"
 cr
-ba
+bE
 BN
 xo
 Nj
@@ -4633,7 +4632,7 @@ ot
 oK
 YQ
 Rn
-LF
+OH
 rH
 Uv
 Uv
@@ -4690,7 +4689,7 @@ Nh
 Uv
 Ox
 tb
-mJ
+HS
 Ri
 KL
 Ri
@@ -4712,11 +4711,11 @@ YQ
 RE
 cr
 hi
-MU
+Mj
 cr
 cr
 hi
-lX
+va
 cr
 cr
 cr
@@ -4732,14 +4731,14 @@ YH
 YQ
 RE
 cr
-MX
-eW
-jE
+Vd
+mE
+yi
 bZ
 Uv
 wp
 EQ
-NY
+qI
 Ri
 Ri
 Ri
@@ -4764,7 +4763,7 @@ cT
 VB
 fw
 cr
-Lg
+SW
 Lw
 lO
 KG
@@ -4800,7 +4799,7 @@ cr
 cg
 Yz
 Yz
-va
+uA
 cr
 YQ
 YQ
@@ -4987,7 +4986,7 @@ YQ
 YQ
 RE
 ZM
-dj
+Yr
 cr
 RE
 YQ
@@ -5087,7 +5086,7 @@ hR
 vU
 vU
 Lv
-sH
+xm
 vl
 ep
 YH
@@ -5144,8 +5143,8 @@ YQ
 Rn
 Er
 TX
-Fp
-Ie
+UL
+yR
 ii
 "}
 (20,1,1) = {"
@@ -5248,9 +5247,9 @@ YQ
 "}
 (22,1,1) = {"
 RE
-Eq
-Hm
-tR
+MX
+vI
+Fp
 Rx
 Rx
 Rx
@@ -5262,7 +5261,7 @@ Rx
 Rx
 Rx
 Rx
-Eq
+MX
 cr
 YQ
 YQ
@@ -5287,11 +5286,11 @@ cr
 cr
 cr
 cr
-BP
-BP
-BP
-BP
-BP
+DV
+DV
+DV
+DV
+DV
 cr
 RE
 "}
@@ -5321,7 +5320,7 @@ RE
 cr
 cr
 kt
-Ew
+ri
 kt
 cr
 cr
@@ -5340,7 +5339,7 @@ WO
 Zx
 Zx
 Zx
-dc
+Xd
 RV
 cr
 "}
@@ -5372,7 +5371,7 @@ Bb
 MF
 fV
 dt
-Ma
+kX
 cr
 YQ
 RE
@@ -5409,7 +5408,7 @@ PF
 zu
 IF
 ll
-rD
+zJ
 uL
 ep
 ep
@@ -5566,7 +5565,7 @@ RE
 cr
 cr
 kt
-mE
+Ew
 kt
 cr
 cr
@@ -5608,7 +5607,7 @@ pO
 Yz
 Kl
 Ej
-yi
+kT
 iN
 YQ
 YQ
@@ -5622,7 +5621,7 @@ cr
 YQ
 RE
 cr
-Mw
+CG
 vU
 vU
 vU
@@ -5656,7 +5655,7 @@ Yz
 Yz
 Yz
 cr
-PC
+mu
 Ke
 iN
 YQ
@@ -5676,14 +5675,14 @@ vU
 vU
 vU
 vU
-rs
+ZW
 ch
 ED
 WO
 Zx
 Zx
 Zx
-uA
+Et
 EF
 cr
 "}
@@ -5728,11 +5727,11 @@ cr
 cr
 cr
 cr
-ty
-ty
-ty
-ty
-ty
+BP
+BP
+BP
+BP
+BP
 cr
 RE
 "}
@@ -5880,8 +5879,8 @@ Rn
 Er
 TX
 Ds
-vh
-cD
+hP
+qW
 "}
 (35,1,1) = {"
 uE
@@ -5934,9 +5933,9 @@ oK
 "}
 (36,1,1) = {"
 RE
-Eq
-Hm
-jo
+MX
+vI
+SZ
 PM
 PM
 PM
@@ -5948,7 +5947,7 @@ PM
 PM
 PM
 PM
-Eq
+MX
 cr
 YQ
 YQ
@@ -5984,19 +5983,19 @@ YQ
 (37,1,1) = {"
 YQ
 RE
-Jc
-Jc
-Jc
-Jc
-Jc
-Jc
-Jc
-Jc
-Jc
-Jc
-Jc
-Jc
-Jc
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
+Eq
 RE
 YQ
 YQ
@@ -6016,7 +6015,7 @@ YQ
 YQ
 RE
 ZM
-mL
+pi
 cr
 RE
 YQ

--- a/code/datums/shuttles/emergency.dm
+++ b/code/datums/shuttles/emergency.dm
@@ -270,6 +270,15 @@
 	admin_notes = "The emergency shuttled created during Round 48641. "
 	credit_cost = 7000
 
+/datum/map_template/shuttle/emergency/fleet
+	suffix = "fleet"
+	name = "Departmental Fleet"
+	description = "This fleet of departmental shuttles employed by Nanotrasen are linked together with a state-of-the-art quantum teleporter network. \
+		It consists of: a lounge/teleporter hub emergency shuttle, a top-security brig shuttle, an ambulance shuttle, a fully stocked cargo shuttle, \
+		an experimental specimin transfer shuttle, a pod mechanic shuttle, three private escape pods, and a luxury command shuttle with its own luxury restroom pod."
+	admin_notes = "Security shuttle comes with turrets that will target anything without the neutral faction (nuke ops, xenos etc, but not pets). Science shuttle is full of retaliative mobs. Emergency shuttle console is accessible without access on multiple shuttles."
+	credit_cost = 100000
+
 /datum/map_template/shuttle/emergency/mafia
 	suffix = "mafia"
 	name = "Droni Fedora"

--- a/code/datums/shuttles/emergency.dm
+++ b/code/datums/shuttles/emergency.dm
@@ -276,7 +276,7 @@
 	description = "This fleet of departmental shuttles employed by Nanotrasen are linked together with a state-of-the-art quantum teleporter network. \
 		It consists of: a lounge/teleporter hub emergency shuttle, a top-security brig shuttle, an ambulance shuttle, a fully stocked cargo shuttle, \
 		an experimental specimin transfer shuttle, a pod mechanic shuttle, three private escape pods, and a luxury command shuttle with its own luxury restroom pod."
-	admin_notes = "Security shuttle comes with turrets that will target anything without the neutral faction (nuke ops, xenos etc, but not pets). Science shuttle is full of retaliative mobs. Emergency shuttle console is accessible without access on multiple shuttles."
+	admin_notes = "Security shuttle comes with turrets that will target anything without the neutral faction (nuke ops, xenos etc, but not pets). Science shuttle is full of retaliative mobs. Emergency shuttle console is publicly accessible on multiple shuttles."
 	credit_cost = 100000
 
 /datum/map_template/shuttle/emergency/mafia

--- a/code/datums/shuttles/emergency.dm
+++ b/code/datums/shuttles/emergency.dm
@@ -274,8 +274,8 @@
 	suffix = "fleet"
 	name = "Departmental Fleet"
 	description = "This fleet of departmental shuttles employed by Nanotrasen are linked together with a state-of-the-art portal network. \
-		It consists of: a lounge emergency shuttle, a prisoner transport shuttle, an ambulance shuttle, a cargo shuttle, \
-		an experiment transfer shuttle, a pod repair shuttle, three escape pods, and a luxury command shuttle with its own luxury restroom pod."
+		It consists of: a escape lounge shuttle, a prisoner transfer shuttle, an ambulance shuttle, a cargo shuttle, \
+		an experiment transport shuttle, a pod repair shuttle, three escape pods, and a luxury command shuttle with its own luxury restroom pod."
 	admin_notes = "Security shuttle comes with turrets that will target anything without the neutral faction (nuke ops, xenos etc, but not pets). Science shuttle is full of retaliative mobs. Emergency shuttle console is publicly accessible on multiple shuttles."
 	credit_cost = 100000
 

--- a/code/datums/shuttles/emergency.dm
+++ b/code/datums/shuttles/emergency.dm
@@ -273,9 +273,9 @@
 /datum/map_template/shuttle/emergency/fleet
 	suffix = "fleet"
 	name = "Departmental Fleet"
-	description = "This fleet of departmental shuttles employed by Nanotrasen are linked together with a state-of-the-art quantum teleporter network. \
-		It consists of: a lounge/teleporter hub emergency shuttle, a top-security brig shuttle, an ambulance shuttle, a fully stocked cargo shuttle, \
-		an experimental specimin transfer shuttle, a pod mechanic shuttle, three private escape pods, and a luxury command shuttle with its own luxury restroom pod."
+	description = "This fleet of departmental shuttles employed by Nanotrasen are linked together with a state-of-the-art portal network. \
+		It consists of: a lounge emergency shuttle, a prisoner transport shuttle, an ambulance shuttle, a cargo shuttle, \
+		an experiment transfer shuttle, a pod repair shuttle, three escape pods, and a luxury command shuttle with its own luxury restroom pod."
 	admin_notes = "Security shuttle comes with turrets that will target anything without the neutral faction (nuke ops, xenos etc, but not pets). Science shuttle is full of retaliative mobs. Emergency shuttle console is publicly accessible on multiple shuttles."
 	credit_cost = 100000
 


### PR DESCRIPTION
# Document the changes in your pull request

(My first PR) Adds massive new "shuttle"/collection of shuttles, each representing a department, that are connected via quantum pads. Includes a brig and medical shuttle.

![image](https://github.com/user-attachments/assets/421fd11d-08a1-44a5-80b4-aec5c4ca7326)

# Why is this good for the game?

Adds a fun, high-end shuttle option. Alternative to the Luxury Shuttle that isn't ugly.

# Testing

Tested. It fits.

![image](https://github.com/user-attachments/assets/89b6e31a-bda3-4c87-9aa8-d86eddc42142)

![image](https://github.com/user-attachments/assets/9e5c907f-a6c3-4ef6-ad7a-abbd3790f881)

# Changelog

:cl:

rscadd: Added new emergency shuttle: The Fleet

/:cl: