### PR TITLE
Just removing an unused app for unused content don't mind me

### DIFF
--- a/code/modules/modular_computers/computers/item/phone/phone_presets.dm
+++ b/code/modules/modular_computers/computers/item/phone/phone_presets.dm
@@ -46,8 +46,7 @@
 
 /obj/item/modular_computer/tablet/phone/preset/advanced/command/Initialize(mapload)
 	starting_files |= list(
-		new /datum/computer_file/program/card_mod,
-		new /datum/computer_file/program/synth_requester
+		new /datum/computer_file/program/card_mod
 	)	
 	. = ..()
 


### PR DESCRIPTION
# Document the changes in your pull request
![clueless-aware](https://github.com/user-attachments/assets/85ff1ea1-8e8d-43d6-a649-070a065fb09a)

We took out the robots but we didn't remove the app 


# Why is this good for the game?
we removed them

# Testing
will do


# Changelog
:cl:
rscdel: Removed synth requester app from head of staff phones
/:cl:
