### PR TITLE
Re-adds the TEG cause I'm an idiot

### DIFF
--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -110,7 +110,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	return TRUE
 
 /obj/effect/landmark/stationroom/box/engine
-	template_names = list("Engine SM" = 50, "Engine Singulo And Tesla" = 25, "Engine Nuclear Reactor" = 25)
+	template_names = list("Engine SM" = 25, "Engine Singulo And Tesla" = 25, "Engine Nuclear Reactor" = 25, "Engine TEG" = 25,)
 
 /obj/effect/landmark/stationroom/box/engine/choose()
 	. = ..()
@@ -151,7 +151,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	return TRUE
 
 /obj/effect/landmark/stationroom/meta/engine
-	template_names = list("Meta SM" = 50, "Meta Nuclear Reactor" = 50) // tesla is loud as fuck and singulo doesn't make sense, so SM/reactor only
+	template_names = list("Meta SM" = 50, "Meta Nuclear Reactor" = 25, "Meta TEG" = 25) // tesla is loud as fuck and singulo doesn't make sense, so SM/reactor only
 
 /obj/effect/landmark/stationroom/meta/engine/choose()
 	. = ..()

--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -110,7 +110,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	return TRUE
 
 /obj/effect/landmark/stationroom/box/engine
-	template_names = list("Engine SM" = 25, "Engine Singulo And Tesla" = 25, "Engine Nuclear Reactor" = 25, "Engine TEG" = 25,)
+	template_names = list("Engine SM" = 25, "Engine Singulo And Tesla" = 25, "Engine Nuclear Reactor" = 25, "Engine TEG" = 25)
 
 /obj/effect/landmark/stationroom/box/engine/choose()
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

Was a mistake reverting it, didn't know the guide was fixed so I jumped the gun on it.

Readds the TEG rotation, every engine on box now has an equal chance to trigger, while SM triggers 50% of the time on icemeta and the reactor/teg trigger 25% now.

# Why is this good for the game?
TEG guide has been tweaked and is now really good and comparable to the SM guide, which makes me think that the TEG can 100% be used now as what always put me off of it was difficulty to setup. Also, the fact that it never should've been removed cause I'm an idiot


<!-- Describe what testing you did with this PR. Try to be thorough, especially if this is a larger project. -->

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

Guide is all there, unless someone documented that it's out of rotation but i don't see that

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
rscadd: returns the teg to roundstart engine rotation
/:cl:
