### PR TITLE
Gives Bot Remote Controller program to QM's PDA at round start

### DIFF
--- a/code/modules/modular_computers/computers/item/pda/pda_presets.dm
+++ b/code/modules/modular_computers/computers/item/pda/pda_presets.dm
@@ -86,6 +86,12 @@
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#D6B328#6506CA#927444"
 
+/obj/item/modular_computer/tablet/pda/preset/cargo/quartermaster/Initialize(mapload)
+	starting_files |= list(
+			new /datum/computer_file/program/robocontrol,
+	)
+	return ..()
+
 /obj/item/modular_computer/tablet/pda/preset/shaft_miner
 	greyscale_config = /datum/greyscale_config/tablet/stripe_thick
 	greyscale_colors = "#927444#D6B328#6C3BA1"


### PR DESCRIPTION
# Document the changes in your pull request

I got really annoyed needing to download this to use the M.U.L.E. bots since it's actually pretty huge and takes forever to actually download. Yes this fits, but only barely, if someone wants to add something else they'll have to delete something but that's not hard to do.

# Why is this good for the game?

Lets QM conveniently access a core mechanic of their job, the M.U.L.E bots.

# Testing

![image](https://github.com/user-attachments/assets/bfa22252-17b7-4a57-8b4c-7f725b0ce48e)

# Changelog

:cl:
tweak: QM PDA comes with Bot Controller pre-installed
/:cl:
