### PR TITLE
Now mentions divulging in the darkspawn antag info panel

### DIFF
--- a/tgui/packages/tgui/interfaces/AntagInfoDarkspawn.tsx
+++ b/tgui/packages/tgui/interfaces/AntagInfoDarkspawn.tsx
@@ -172,7 +172,7 @@ const FlavorSection = () => {
 
 const GuideSection = (props, context) => {
   const { data } = useBackend<Info>(context);
-  const { has_class } = data;
+  const { divulged, has_class } = data;
 
   return (
     <Stack vertical fontSize="16px">
@@ -182,6 +182,12 @@ const GuideSection = (props, context) => {
       {!has_class && (
       <Stack.Item>
         - Select a class in the selection tab to decide what kind of gameplay you want.
+      </Stack.Item>
+      )}
+      {!divulged && (
+      <Stack.Item>
+        - Once you are ready, retreat to a secluded location to divulge.
+        - Divulging removes your disguise while enabling you to learn new abilities via the research tab.
       </Stack.Item>
       )}
       <Stack.Item>


### PR DESCRIPTION
# Why is this good for the game?
because apparently people can't read chat or their abilities, lets put it in the one place where all info is supposed to be

# Testing


:cl:
tweak: Now mentions divulging in the darkspawn antag info panel
/:cl:
