### PR TITLE
Reopens #22621, the TEG has been added back to rotation 

### DIFF
--- a/yogstation/code/game/objects/effects/landmarks.dm
+++ b/yogstation/code/game/objects/effects/landmarks.dm
@@ -110,7 +110,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	return TRUE
 
 /obj/effect/landmark/stationroom/box/engine
-	template_names = list("Engine SM" = 50, "Engine Singulo And Tesla" = 25, "Engine Nuclear Reactor" = 25)
+	template_names = list("Engine SM" = 25, "Engine Singulo And Tesla" = 25, "Engine Nuclear Reactor" = 25, "Engine TEG" = 25)
 
 /obj/effect/landmark/stationroom/box/engine/choose()
 	. = ..()
@@ -151,7 +151,7 @@ GLOBAL_LIST_EMPTY(chosen_station_templates)
 	return TRUE
 
 /obj/effect/landmark/stationroom/meta/engine
-	template_names = list("Meta SM" = 50, "Meta Nuclear Reactor" = 50) // tesla is loud as fuck and singulo doesn't make sense, so SM/reactor only
+	template_names = list("Meta SM" = 35, "Meta Nuclear Reactor" = 35, "Meta TEG" = 30) // tesla is loud as fuck and singulo doesn't make sense, so SM/reactor/TEG only
 
 /obj/effect/landmark/stationroom/meta/engine/choose()
 	. = ..()


### PR DESCRIPTION

# Document the changes in your pull request

the Thermo Electric Generator has been readded as a roundstart engine. 

spawn chances of the engines on meta are
Meta SM = 35, Meta Reactor = 35, Meta TEG = 30

spawn chances on box are 
SM = 25, reactor = 25, TEG = 25, singulo/tesla = 25
# Why is this good for the game?
in #22621 its been mentioned that the lovely @missatessatessy redid my edit on the wiki to actually make it on par with setting up other engines. reason it got pulled from rotation was a miscommunication on our part and it was merged.

# Testing
just a number change to spawn chance. unless we want to test chaos theory then go ahead

# Changelog


:cl: missatessatessy because people should look at the wiki page they did  
rscadd: readds the TEG back to engine rotation 

/:cl:
