### PR TITLE
Fixes a runtime caused by the alarm display program

### DIFF
--- a/code/modules/modular_computers/file_system/programs/engineering/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/alarm.dm
@@ -47,11 +47,11 @@
 
 /datum/computer_file/program/alarm_monitor/New()
 	..()
-	GLOB.alarmdisplay += src
+	GLOB.alarmdisplay |= src
 
 /datum/computer_file/program/alarm_monitor/run_program(mob/user)
 	. = ..(user)
-	GLOB.alarmdisplay += src
+	GLOB.alarmdisplay |= src
 
 /datum/computer_file/program/alarm_monitor/kill_program(forced = FALSE)
 	GLOB.alarmdisplay -= src

--- a/code/modules/modular_computers/file_system/programs/engineering/alarm.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/alarm.dm
@@ -56,3 +56,7 @@
 /datum/computer_file/program/alarm_monitor/kill_program(forced = FALSE)
 	GLOB.alarmdisplay -= src
 	..()
+
+/datum/computer_file/program/alarm_monitor/Destroy()
+	GLOB.alarmdisplay -= src
+	. = ..()


### PR DESCRIPTION
it happens when the program gets deleted without being removed from the global list

# Testing
gotta

nothing player facing

:cl:
/:cl:
