### PR TITLE
Nerfs the caltrop component to only slow at low damage values

### DIFF
--- a/code/datums/components/caltrop.dm
+++ b/code/datums/components/caltrop.dm
@@ -94,6 +94,9 @@
 	if(HAS_TRAIT(digitigrade_fan, TRAIT_LIGHT_STEP))
 		damage *= 0.75
 	
+	if(HAS_TRAIT(digitigrade_fan, TRAIT_DIGITIGRADE))	//They're used to it
+		damage *= 0.75
+
 	digitigrade_fan.apply_damage(damage, BRUTE, picked_def_zone, wound_bonus = CANT_WOUND)
 
 	if(cooldown < world.time - 10) //cooldown to avoid message spam.
@@ -105,7 +108,13 @@
 					span_userdanger("You slide on [parent]!"))
 
 		cooldown = world.time
-	digitigrade_fan.Paralyze(paralyze_duration)
+
+	if(damage >= 5)	//If you have any resistance to caltrops you won't eat shit stepping on a glass shard. Punji sticks hurt enough that they don't care.
+		digitigrade_fan.Paralyze(paralyze_duration)
+	else
+		digitigrade_fan.add_movespeed_modifier("caltrop", update=TRUE, priority=100, multiplicative_slowdown=1)	//ow fuck that still hurt
+		addtimer(CALLBACK(digitigrade_fan, TYPE_PROC_REF(/mob, remove_movespeed_modifier), "caltrop"), paralyze_duration, TIMER_UNIQUE|TIMER_OVERRIDE)
+
 	if(!soundfile)
 		return
 	playsound(digitigrade_fan, soundfile, 15, TRUE, -3)


### PR DESCRIPTION
Ok lizards are just worse than humans now, plus glass shards are just really annoying. This significantly reduces the effects of stepping on glass shards if you are either a digitigrade fan or have light step. Notably, this will not affect anything that has REAL caltrop damage like punji sticks or idk actual caltrops if someone decided to make those a thing.


# Document the changes in your pull request

Caltrops now work SLIGHTLY differently at low damage values.
1: Digitigrade users take 75% damage from caltrops because they don't really wear shoes anyways
2: If the caltrops do less than 5 damage, the stepper will be slowed (1.0 slowdown) for the stun duration rather than paralyzed

This means that if you are either a lizard/polys/weirdo with funny legs for some reason OR if you have light step, you won't get stunned. Everything else is otherwise unchanged.

# Why is this good for the game?

Lizards and polys no longer just straight up die because of a random shard/lightbulb hidden in a giant pile of junk. Alternatively, if you're a human/moth/plant/whatever player with light step it now is ACTUALLY USEFUL because you wont get stunned from shards if you're not wearing shoes. Everyone else still falls over dramatically because they weren't watching where they were going.

# Testing
Punji Sticks (with digitigrade + light step)
![image](https://github.com/user-attachments/assets/1891f347-235f-4034-a884-0164360fd904)
![image](https://github.com/user-attachments/assets/9c0afc88-5b63-4b17-9bc2-0bf8cf6bd2fb)

Glass shard:
Digitigrade
![image](https://github.com/user-attachments/assets/2b3e65a2-058c-4e3c-96fb-3ed2fe065fa4)

Digitigrade + light step
![image](https://github.com/user-attachments/assets/8111558e-05e6-4cd0-8726-832aedbc750c)
![image](https://github.com/user-attachments/assets/79bc4e61-a0f5-40a4-adc1-96babc1c2d78)

Light step
![image](https://github.com/user-attachments/assets/90b849f4-8a02-4a49-993a-bc5e3d0ef773)
![image](https://github.com/user-attachments/assets/48af01ee-6828-49c3-986c-8603053d2660)

Nothing
![image](https://github.com/user-attachments/assets/a7f122ac-21db-40e1-aa6b-45de2e23746d)
![image](https://github.com/user-attachments/assets/1f6ddc46-18b7-404e-b2ed-c945c84a7fed)


# Wiki Documentation

Lizards and polys are slightly resistant to stepping on shards and other caltrops.

# Changelog

:cl:

tweak: Caltrops now only slow if the damage is below 5
tweak: Digitigrade legs are slightly more resistant to caltrops (75%)

/:cl:
