### PR TITLE
poplock spontaneous brain trauma

### DIFF
--- a/code/modules/events/brain_trauma.dm
+++ b/code/modules/events/brain_trauma.dm
@@ -2,6 +2,7 @@
 	name = "Spontaneous Brain Trauma"
 	typepath = /datum/round_event/brain_trauma
 	weight = 25
+	min_players = 15
 
 /datum/round_event/brain_trauma
 	fakeable = FALSE


### PR DESCRIPTION
# Document the changes in your pull request
set minimum player requirement for spontaneous brain trauma to 15
# Why is this good for the game?
this event has no minimum player requirements and is usually a death sentence if you're the only one on server, 15 player poplock give you a decent chance at having medical players to fix you
# Testing
I don't know how you would test this, I hope it works

# Wiki Documentation
it'll have to mention this I guess
# Changelog
:cl:
tweak: set minimum player requirement for spontaneous brain trauma to 15
/:cl:
