### PR TITLE
Fixes lavaland artillery mainframe access

### DIFF
--- a/code/game/machinery/sci_bombardment.dm
+++ b/code/game/machinery/sci_bombardment.dm
@@ -195,7 +195,7 @@
 			else
 				var/mob/M = usr
 				var/obj/item/card/id/I = M.get_idcard(TRUE)
-				if(check_access(I) && (30 in I.access))
+				if(check_access(I) && ("rd" in I.access))
 					locked = !locked
 					radio.talk_into(src, "Controls [locked ? "locked" : "unlocked"] by [I.registered_name].",)
 				else


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Changes access in the lavaland artillery mainframe to follow the new access format.

# Testing
![image](https://github.com/user-attachments/assets/83a229aa-8211-49ce-983d-b45fb7fca44e)


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:

bugfix: Fixed RD not being able to unlock the lavaland artillery mainframe 
/:cl:
