### PR TITLE
Assorted stripping fixes

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_object.dm
+++ b/code/__DEFINES/dcs/signals/signals_object.dm
@@ -130,7 +130,7 @@
 #define COMSIG_ITEM_DROPPED "item_drop"
 ///from base of mob/dropItemToGround(): (mob/user)
 #define COMSIG_ITEM_PREDROPPED "item_predrop"
-///from base of /mob/living/stripPanelUnequip(): (obj/item/what, mob/who, where)
+///from base of /start_unequip_mob(): (obj/item/what, mob/who, where)
 #define COMSIG_ITEM_PRESTRIP "item_prestrip"
 
 ///from base of obj/item/pickup(): (/mob/taker)
@@ -144,25 +144,25 @@
 ///from base of mob/living/carbon/attacked_by(): (mob/living/carbon/target, mob/living/user, hit_zone)
 #define COMSIG_ITEM_ATTACK_ZONE "item_attack_zone"
 
-/// from /datum/component/cleave_attack/perform_sweep(): (atom/target, obj/item/item, mob/living/user, params) 
+/// from /datum/component/cleave_attack/perform_sweep(): (atom/target, obj/item/item, mob/living/user, params)
 #define COMSIG_ATOM_CLEAVE_ATTACK "atom_cleave_attack"
 	// allows cleave attack to hit things it normally wouldn't
 	#define ATOM_ALLOW_CLEAVE_ATTACK (1<<0)
 
 /// Called before an item is embedded (mob/living/carbon/target = carbon that it is getting embedded into)
-#define COMSIG_ITEM_EMBEDDED "mob_carbon_embedded" 
+#define COMSIG_ITEM_EMBEDDED "mob_carbon_embedded"
 	// Prevents the embed
 	#define COMSIG_ITEM_BLOCK_EMBED (1 << 0)
 
 /// Called before an item is removed from being embedded (mob/living/carbon/embedded = carbon that is currently embedded)
-#define COMSIG_ITEM_EMBED_REMOVAL "mob_carbon_embed_removal" 
+#define COMSIG_ITEM_EMBED_REMOVAL "mob_carbon_embed_removal"
 	// Prevents the removal of the embed
 	#define COMSIG_ITEM_BLOCK_EMBED_REMOVAL (1 << 0)
 	// Qdels the object when it is removed instead of droping it
 	#define COMSIG_ITEM_QDEL_EMBED_REMOVAL (1 << 1)
 
 /// Called every life tick for the embedded mob when the item is embedded (mob/living/carbon/embedded = carbon that is currently embedded)
-#define COMSIG_ITEM_EMBED_TICK "mob_carbon_embed_tick" 
+#define COMSIG_ITEM_EMBED_TICK "mob_carbon_embed_tick"
 	// Prevents the rest of the tick logic for the item from proccessing
 	#define COMSIG_ITEM_BLOCK_EMBED_TICK (1 << 0)
 

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -474,17 +474,16 @@
 /datum/strip_menu/ui_status(mob/user, datum/ui_state/state)
 	. = ..()
 
-	if (iscarbon(usr) || iscyborg(usr))
+	if (isliving(user))
 		var/mob/living/living_user = user
 
 		if (
-			user.stat == CONSCIOUS \
-			&& living_user.body_position != LYING_DOWN \
+			. == UI_UPDATE \
+			&& user.stat == CONSCIOUS \
+			&& living_user.body_position == LYING_DOWN \
 			&& user.Adjacent(owner)
 		)
 			return UI_INTERACTIVE
-
-	return min(., UI_UPDATE) // If ..() == UI_INTERACTIVE, return UI_UPDATE
 
 /// Creates an assoc list of keys to /datum/strippable_item
 /proc/create_strippable_list(types)

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -50,7 +50,7 @@
 	if (!isnull(should_strip_proc_path) && !call(source, should_strip_proc_path)(user))
 		return
 
-	var/datum/strip_menu/strip_menu
+	var/datum/strip_menu/strip_menu = LAZYACCESS(strip_menus, source)
 
 	if (isnull(strip_menu))
 		strip_menu = new(source, src)

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -474,16 +474,17 @@
 /datum/strip_menu/ui_status(mob/user, datum/ui_state/state)
 	. = ..()
 
-	if (isliving(user))
+	if (iscarbon(usr) || iscyborg(usr))
 		var/mob/living/living_user = user
 
 		if (
-			. == UI_UPDATE \
-			&& user.stat == CONSCIOUS \
-			&& living_user.body_position == LYING_DOWN \
+			user.stat == CONSCIOUS \
+			&& living_user.body_position != LYING_DOWN \
 			&& user.Adjacent(owner)
 		)
 			return UI_INTERACTIVE
+
+	return min(., UI_UPDATE) // If ..() == UI_INTERACTIVE, return UI_UPDATE
 
 /// Creates an assoc list of keys to /datum/strippable_item
 /proc/create_strippable_list(types)

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -268,6 +268,7 @@
 
 /// A utility function for `/datum/strippable_item`s to start unequipping an item from a mob.
 /proc/start_unequip_mob(obj/item/item, mob/source, mob/user, strip_delay)
+	SEND_SIGNAL(item, COMSIG_ITEM_PRESTRIP, user)
 	if (!do_after(user, strip_delay || item.strip_delay, source, interaction_key = REF(item)))
 		return FALSE
 

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -59,10 +59,3 @@
 /mob/living/carbon/alien/larva/start_pulling(atom/movable/AM, state, force = move_force, supress_message = FALSE)
 	return
 
-/mob/living/carbon/alien/larva/stripPanelUnequip(obj/item/what, mob/who)
-	to_chat(src, span_warning("You don't have the dexterity to do this!"))
-	return
-
-/mob/living/carbon/alien/larva/stripPanelEquip(obj/item/what, mob/who)
-	to_chat(src, span_warning("You don't have the dexterity to do this!"))
-	return

--- a/code/modules/mob/living/carbon/human/human_stripping.dm
+++ b/code/modules/mob/living/carbon/human/human_stripping.dm
@@ -165,11 +165,12 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 
 	var/mob/living/carbon/carbon_source = source
 
-	var/obj/item/clothing/mask = carbon_source.wear_mask
-	if (!istype(mask))
-		return
+	var/obj/item/clothing/head = carbon_source.head
+	if (istype(head) && (head.clothing_flags & HEADINTERNALS) && istype(item, /obj/item/tank))
+		return isnull(carbon_source.internal) ? "enable_internals" : "disable_internals"
 
-	if ((mask.clothing_flags & MASKINTERNALS) && istype(item, /obj/item/tank))
+	var/obj/item/clothing/mask = carbon_source.wear_mask
+	if (istype(mask) && (mask.clothing_flags & MASKINTERNALS) && istype(item, /obj/item/tank))
 		return isnull(carbon_source.internal) ? "enable_internals" : "disable_internals"
 
 /proc/strippable_alternate_action_internals(obj/item/item, atom/source, mob/user)

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -21,6 +21,17 @@
 	blood_volume = BLOOD_VOLUME_MONKEY // Yogs -- Makes monkeys/xenos have different amounts of blood from normal carbonbois
 	can_be_held = TRUE
 
+GLOBAL_LIST_INIT(strippable_monkey_items, create_strippable_list(list(
+	/datum/strippable_item/mob_item_slot/head,
+	/datum/strippable_item/mob_item_slot/back,
+	/datum/strippable_item/mob_item_slot/mask,
+	/datum/strippable_item/mob_item_slot/neck,
+	/datum/strippable_item/hand/left,
+	/datum/strippable_item/hand/right,
+	/datum/strippable_item/mob_item_slot/handcuffs,
+	/datum/strippable_item/mob_item_slot/legcuffs,
+)))
+
 /mob/living/carbon/monkey/Initialize(mapload, cubespawned=FALSE, mob/spawner)
 	add_verb(src, /mob/living/proc/mob_sleep)
 	add_verb(src, /mob/living/proc/lay_down)
@@ -46,6 +57,7 @@
 	create_dna(src)
 	dna.initialize_dna(random_blood_type())
 	AddComponent(/datum/component/bloodysoles/feet)
+	AddElement(/datum/element/strippable, GLOB.strippable_monkey_items)
 
 /mob/living/carbon/monkey/Destroy()
 	SSmobs.cubemonkeys -= src

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -877,58 +877,6 @@
 		animate(src, pixel_y = get_standard_pixel_y_offset(lying), time = 1 SECONDS)
 		setMovetype(movement_type & ~FLOATING)
 
-// The src mob is trying to strip an item from someone
-// Override if a certain type of mob should be behave differently when stripping items (can't, for example)
-/mob/living/stripPanelUnequip(obj/item/what, mob/who, where)
-	if(!what.canStrip(who))
-		to_chat(src, span_warning("You can't remove \the [what.name], it appears to be stuck!"))
-		return
-	who.visible_message(span_danger("[src] tries to remove [who]'s [what.name]."), \
-					span_userdanger("[src] tries to remove [who]'s [what.name]."))
-	what.add_fingerprint(src)
-	SEND_SIGNAL(what, COMSIG_ITEM_PRESTRIP)
-	if(do_after(src, what.strip_delay, who, interaction_key = REF(what)))
-		if(what && Adjacent(who))
-			if(islist(where))
-				var/list/L = where
-				if(what == who.get_item_for_held_index(L[2]))
-					if(what.doStrip(src, who))
-						log_combat(src, who, "stripped [what] off")
-			if(what == who.get_item_by_slot(where))
-				if(what.doStrip(src, who))
-					log_combat(src, who, "stripped [what] off")
-
-// The src mob is trying to place an item on someone
-// Override if a certain mob should be behave differently when placing items (can't, for example)
-/mob/living/stripPanelEquip(obj/item/what, mob/who, where)
-	what = src.get_active_held_item()
-	if(what && (HAS_TRAIT(what, TRAIT_NODROP)))
-		to_chat(src, span_warning("You can't put \the [what.name] on [who], it's stuck to your hand!"))
-		return
-	if(what)
-		var/list/where_list
-		var/final_where
-
-		if(islist(where))
-			where_list = where
-			final_where = where[1]
-		else
-			final_where = where
-
-		if(!what.mob_can_equip(who, src, final_where, TRUE, TRUE))
-			to_chat(src, span_warning("\The [what.name] doesn't fit in that place!"))
-			return
-
-		visible_message(span_notice("[src] tries to put [what] on [who]."))
-		if(do_after(src, what.equip_delay_other, who))
-			if(what && Adjacent(who) && what.mob_can_equip(who, src, final_where, TRUE, TRUE))
-				if(temporarilyRemoveItemFromInventory(what))
-					if(where_list)
-						if(!who.put_in_hand(what, where_list[2]))
-							what.forceMove(get_turf(who))
-					else
-						who.equip_to_slot(what, where, TRUE)
-
 /mob/living/singularity_pull(S, current_size)
 	..()
 	if(current_size >= STAGE_SIX) //your puny magboots/wings/whatever will not save you against supermatter singularity

--- a/code/modules/mob/living/silicon/pai/pai_defense.dm
+++ b/code/modules/mob/living/silicon/pai/pai_defense.dm
@@ -63,12 +63,6 @@
 		src.visible_message(span_warning("The electrically-charged projectile disrupts [src]'s holomatrix, forcing [src] to fold in!"))
 	. = ..(Proj)
 
-/mob/living/silicon/pai/stripPanelUnequip(obj/item/what, mob/who, where) //prevents stripping
-	to_chat(src, span_warning("Your holochassis stutters and warps intensely as you attempt to interact with the object, forcing you to cease lest the field fail."))
-
-/mob/living/silicon/pai/stripPanelEquip(obj/item/what, mob/who, where) //prevents stripping
-	to_chat(src, span_warning("Your holochassis stutters and warps intensely as you attempt to interact with the object, forcing you to cease lest the field fail."))
-
 /mob/living/silicon/pai/ignite_mob(mob/living/silicon/pai/P)
 	return FALSE //No we're not flammable
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -263,12 +263,6 @@
 /mob/living/silicon/put_in_hand_check() // This check is for borgs being able to receive items, not put them in others' hands.
 	return 0
 
-// The src mob is trying to place an item on someone
-// But the src mob is a silicon!!  Disable.
-/mob/living/silicon/stripPanelEquip(obj/item/what, mob/who, slot)
-	return 0
-
-
 /mob/living/silicon/assess_threat(judgement_criteria, lasercolor = "", datum/callback/weaponcheck=null) //Secbots won't hunt silicon units
 	return -10
 

--- a/code/modules/mob/living/simple_animal/friendly/dog.dm
+++ b/code/modules/mob/living/simple_animal/friendly/dog.dm
@@ -169,7 +169,7 @@ GLOBAL_LIST_INIT(strippable_corgi_items, create_strippable_list(list(
 
 	corgi_source.place_on_head(equipping, user)
 
-/datum/strippable_item/corgi_head/finish_unequip(atom/source, obj/item/equipping, mob/user)
+/datum/strippable_item/corgi_head/finish_unequip(atom/source, mob/user)
 	var/mob/living/simple_animal/pet/dog/corgi/corgi_source = source
 	if (!istype(corgi_source))
 		return

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -111,7 +111,7 @@
 	var/music_component = null
 	var/music_path = null
 
-	
+
 
 /mob/living/simple_animal/Initialize(mapload)
 	. = ..()
@@ -340,7 +340,7 @@
 		del_on_death = FALSE
 		qdel(src)
 		return
-	
+
 	health = 0
 	icon_state = icon_dead
 	if(flip_on_death)
@@ -426,18 +426,6 @@
 		to_chat(src, span_warning("You don't have the dexterity to do this!"))
 		return FALSE
 	return TRUE
-
-/mob/living/simple_animal/stripPanelUnequip(obj/item/what, mob/who, where)
-	if(!canUseTopic(who, BE_CLOSE))
-		return
-	else
-		..()
-
-/mob/living/simple_animal/stripPanelEquip(obj/item/what, mob/who, where)
-	if(!canUseTopic(who, BE_CLOSE))
-		return
-	else
-		..()
 
 /mob/living/simple_animal/update_mobility(value_otherwise = TRUE)
 	if(IsUnconscious() || IsParalyzed() || IsStun() || IsKnockdown() || IsParalyzed() || stat || resting)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -805,32 +805,6 @@
 		unset_machine()
 		src << browse(null, t1)
 
-
-	if(href_list["item"] && usr.canUseTopic(src, BE_CLOSE, NO_DEXTERITY))
-		var/slot = text2num(href_list["item"])
-		var/hand_index = text2num(href_list["hand_index"])
-		var/obj/item/what
-		if(hand_index)
-			what = get_item_for_held_index(hand_index)
-			slot = list(slot,hand_index)
-		else
-			what = get_item_by_slot(slot)
-		if(what)
-			if(!(what.item_flags & ABSTRACT))
-				usr.stripPanelUnequip(what,src,slot)
-		else
-			usr.stripPanelEquip(what,src,slot)
-
-// The src mob is trying to strip an item from someone
-// Defined in living.dm
-/mob/proc/stripPanelUnequip(obj/item/what, mob/who)
-	return
-
-// The src mob is trying to place an item on someone
-// Defined in living.dm
-/mob/proc/stripPanelEquip(obj/item/what, mob/who)
-	return
-
 /**
   * Controls if a mouse drop succeeds (return null if it doesnt)
   */


### PR DESCRIPTION
# Document the changes in your pull request

- Fixes #22331 
- Fixes #22350
- Fixes stripping windows duplicating
- Removes unused stripping href (and the proc that only it used) to prevent exploits
- Fixes being unable to enable internals on someone with a helmet that supports internals but no mask

# Testing

![image](https://github.com/user-attachments/assets/3bf90c91-c60c-4c5c-b473-c1076177c406)
![image](https://github.com/user-attachments/assets/efe36b1d-5d32-45a0-9628-4dd2cdbca55b)

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
bugfix: Fixed being unable to strip/put items on monkeys
bugfix: Fixed being unable to strip corgi's hats
bugfix: Fixed stripping TGUI windows duplicating
bugfix: Fixed being unable to enable internals on someone with a space helmet and no mask
/:cl:
