### PR TITLE
Reduces asclepius snake bite damage

### DIFF
--- a/code/datums/status_effects/buffs/buffs.dm
+++ b/code/datums/status_effects/buffs/buffs.dm
@@ -421,6 +421,8 @@
 			var/mob/living/simple_animal/hostile/retaliate/poison/snake/healSnake = new(owner.loc)
 			healSnake.poison_type = /datum/reagent/medicine/omnizine/godblood
 			healSnake.poison_per_bite = 5
+			healSnake.melee_damage_upper = 2
+			healSnake.melee_damage_lower = 1	//It's not supposed to hurt that much
 			healSnake.name = "Asclepius's Snake"
 			healSnake.real_name = "Asclepius's Snake"
 			healSnake.desc = "A mystical snake previously trapped upon the Rod of Asclepius, now freed of its burden. Unlike the average snake, its bites contain chemicals with minor healing properties."


### PR DESCRIPTION
It's a GOOD snake it's not supposed to be able to kill you!!!

# Document the changes in your pull request

Bite damage reduced from 5-6 (normal snake) to 1-2.

# Why is this good for the game?

Healy snake no kill

# Testing

Variable change

# Changelog

:cl:

tweak: Rod of Asclepius snake bite damage reduced (5-6 -> 1-2)

/:cl:
