### PR TITLE
Reworked Plasmamen's explosive fist

### DIFF
--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -197,6 +197,8 @@
 
 #define STATUS_EFFECT_MASQUERADE /datum/status_effect/masquerade
 
+#define STATUS_EFFECT_EXPLOSION_PRIME /datum/status_effect/explosion_prime
+
 /////////////
 //  SLIME  //
 /////////////

--- a/yogstation/code/datums/martial/explosive_fist.dm
+++ b/yogstation/code/datums/martial/explosive_fist.dm
@@ -10,7 +10,7 @@
 	id =  MARTIALART_EXPLOSIVEFIST
 	help_verb = /mob/living/carbon/human/proc/explosive_fist_help
 	martial_traits = list(TRAIT_RESISTHEAT, TRAIT_IGNOREDAMAGESLOWDOWN)
-	var/succ_damage = 4	//Our life suck damage. Increases the longer it's held.
+	var/succ_damage = 2	//Our life suck damage. Increases the longer it's held.
 
 /datum/martial_art/explosive_fist/can_use(mob/living/carbon/human/H)
 	if(!H.combat_mode) //gotta be combat mode
@@ -85,10 +85,10 @@
 	var/zone_selected = A.zone_selected
 	var/punch_damage = A.get_punchdamagehigh()
 	damage(D, (punch_damage * 2), 0, 0, zone_selected) //14 burn damage
-	D.Knockdown(((punch_damage * 4)/10) SECONDS)	//3.5 seconds (baseline (7*5)/10 seconds)
+	D.Knockdown(((punch_damage * 4)/10) SECONDS)	//2.8 seconds (baseline (7*4)/10 seconds)
 
 	playsound(D, get_sfx(SFX_EXPLOSION), 50, TRUE, -1)
-	A.do_attack_animation(D, ATTACK_EFFECT_DISARM)
+	A.do_attack_animation(D, ATTACK_EFFECT_MECHFIRE)
 	log_combat(A, D, "blasts(Explosive Fist)")
 	D.visible_message(span_danger("[A] blasts [D]!"), span_userdanger("[A] blasts you!"))
 
@@ -111,7 +111,7 @@
 	var/level = status.level
 	qdel(status) //we're done with it now, get rid of it so they can't use it again
 
-	A.do_attack_animation(D, ATTACK_EFFECT_SMASH)
+	A.do_attack_animation(D, ATTACK_EFFECT_MECHFIRE)
 	var/punch_damage = A.get_punchdamagehigh() + level
 
 	var/turf/center = get_turf(D)
@@ -175,6 +175,7 @@
 			D.grabbedby(A, 1)
 		D.visible_message(span_danger("[A] violently grabs [D]'s neck!"), span_userdanger("[A] violently grabs your neck!"))
 		log_combat(A, D, "grabs by the neck(Explosive Fist)")
+		playsound(get_turf(D), 'sound/weapons/cqchit1.ogg', 50, TRUE, -1)
 		playsound(get_turf(D), 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
 		A.adjust_fire_stacks(3)
 		D.adjust_fire_stacks(3)
@@ -191,6 +192,7 @@
 		return
 	if(!can_suck_life(A, D))
 		return
+
 	if(prob(35))
 		var/message = pick(
 			"You feel your life force being drained!", 
@@ -201,11 +203,15 @@
 		to_chat(D, span_userdanger(message))
 	if(prob(25))
 		D.emote("scream")
+
+	playsound(get_turf(D), 'yogstation/sound/magic/devour_will_form.ogg', 10, TRUE)
+	to_chat(A, span_notice("You drain lifeforce from [D]"))
+
 	D.apply_status_effect(STATUS_EFFECT_EXPLOSION_PRIME) //prime them for big boom
 	D.adjustFireLoss(succ_damage / 2) //doesn't do much damage, more of a healing tool
-	D.adjustStaminaLoss(succ_damage * 2)		//YOU ARE HELPLESS TO RESIST THE SPOOKY SKELETON
+	D.adjustStaminaLoss(succ_damage * 2) //YOU ARE HELPLESS TO RESIST THE SPOOKY SKELETON
+
 	A.heal_ordered_damage(succ_damage, list(BURN, BRUTE, STAMINA, OXY), BODYPART_ANY)
-	to_chat(A, span_notice("You drain lifeforce from [D]"))
 	succ_damage *= 1.5	//50% increased damage per succ
 	proceed_lifeforce_trade(A, D)
 

--- a/yogstation/code/datums/martial/explosive_fist.dm
+++ b/yogstation/code/datums/martial/explosive_fist.dm
@@ -233,7 +233,7 @@
 	combined_msg += span_notice("<b>All Intents</b> Will <b>prime</b> the target with explosive plasma.")
 	combined_msg += span_notice("<b>Harm Intent</b> Will detonate the plasma, creating a fire explosion scaling with how many times the target was <b>primed</b>.")
 
-	combined_msg += "[span_notice("Explosive disarm")]: Disarm Disarm. Deals damage to your target and applies an additional stack of <b>primed</b>. Also throws your target away and knocking them down for a short duration."
+	combined_msg += "[span_notice("Explosive disarm")]: Disarm Disarm. Deals damage to your target and applies an additional stack of <b>primed</b>. Also throws your target away and knocks them down for a short duration."
 	combined_msg += "[span_notice("Life force trade")]: Grab Harm. If wearing headwear, you deal considerable brute and stamina damage to the target. If not wearing headwear, you will instantly grab the target by the neck and start draining life from them."
 	
 	to_chat(usr, examine_block(combined_msg.Join("\n")))

--- a/yogstation/code/datums/martial/explosive_fist.dm
+++ b/yogstation/code/datums/martial/explosive_fist.dm
@@ -248,7 +248,7 @@
 /atom/movable/screen/alert/status_effect/explosion_prime
 	name = "Primed"
 	desc = "You've been primed to explode."
-	icon_state = "slime_clonedecay"
+	icon_state = "overheating"
 
 /datum/status_effect/explosion_prime
 	status_type = STATUS_EFFECT_REFRESH

--- a/yogstation/code/datums/martial/explosive_fist.dm
+++ b/yogstation/code/datums/martial/explosive_fist.dm
@@ -1,19 +1,10 @@
 #define EXPLOSIVE_DISARM_COMBO "DD"
+#define LIFEFORCE_TRADE_COMBO "GH"
 
-#define DETONATE_COMBO "QH"
-#define ALMOST_DETONATE_COMBO "PD" 	//Sets streak to "Q"
-#define PRE_DETONATE_COMBO "HH" 	//Sets streak to "P"
-
-#define LIFEFORCE_TRADE_COMBO "MG"
-#define ALMOST_LIFEFORCE_TRADE_COMBO "LD" 	//Sets streak to "M"
-#define PRE_LIFEFORCE_TRADE_COMBO "DG" 		//Sets streak to "L"
-
-#define IMMOLATE_COMBO "JG"
-#define ALMOST_IMMOLATE_COMBO "ID"	//Sets streak to "J"
-#define PRE_IMMOLATE_COMBO "DH"  	//Sets strak to "I"
+#define PRIME_EFFECT_DURATION (10 SECONDS)
+#define MAX_PRIME_LEVEL 7
 
 //Important note: Plasma man max punch damage is 7, values are based off of this number.
-
 /datum/martial_art/explosive_fist
 	name = "Explosive Fist"
 	id =  MARTIALART_EXPLOSIVEFIST
@@ -22,49 +13,45 @@
 	var/succ_damage = 4	//Our life suck damage. Increases the longer it's held.
 
 /datum/martial_art/explosive_fist/can_use(mob/living/carbon/human/H)
-	return isplasmaman(H)
+	if(!H.combat_mode) //gotta be combat mode
+		return FALSE
+	if(!isplasmaman(H)) //gotta be plasmeme
+		return FALSE
+	return ..()
 
 /datum/martial_art/explosive_fist/disarm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!can_use(A))
 		return FALSE
+	if(A == D)
+		return FALSE
+	D.apply_status_effect(STATUS_EFFECT_EXPLOSION_PRIME)
 	add_to_streak("D",D)
 	if(check_streak(A,D))
 		return TRUE
 	return FALSE  
 
 /datum/martial_art/explosive_fist/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	if(A.combat_mode && A!=D && (can_use(A))) // A!=D prevents grabbing yourself
-		add_to_streak("G",D)
-		if(check_streak(A,D)) //if a combo is made no grab upgrade is done
-			return TRUE
+	if(!can_use(A))
 		return FALSE
-	else
+	if(A == D)
 		return FALSE
+	D.apply_status_effect(STATUS_EFFECT_EXPLOSION_PRIME)
+	add_to_streak("G",D)
+	if(check_streak(A,D)) //if a combo is made no grab upgrade is done
+		return TRUE
+	return FALSE
 
 /datum/martial_art/explosive_fist/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!can_use(A))
 		return FALSE
+	if(A == D)
+		return FALSE
+	D.apply_status_effect(STATUS_EFFECT_EXPLOSION_PRIME)
 	add_to_streak("H",D)
 	if(check_streak(A,D))
 		return TRUE
-	var/selected_zone = A.zone_selected
-	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
-	var/brute_block = D.run_armor_check(affecting, MELEE, 0)
-	var/burn_block = D.run_armor_check(affecting, BOMB, 0)
-	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
-	playsound(get_turf(D), get_sfx(SFX_EXPLOSION), 50, TRUE, -1)
-	
-	if(isopenturf(get_turf(D)))
-		var/turf/open/flashy = get_turf(D)
-		flashy.ignite_turf(rand(5, 10)) //for the flashy
-
-	D.ignite_mob()
-	D.apply_damage(A.get_punchdamagehigh() + 3, BRUTE, selected_zone, brute_block) 	//10 brute
-	D.apply_damage(A.get_punchdamagehigh() + 3, BURN, selected_zone, burn_block) 	//10 burn (vs bomb armor)
-	var/atk_verb = pick(A.dna.species.attack_verbs)
-	D.visible_message(span_danger("[A] [atk_verb]s [D]!"), \
-					  span_userdanger("[A] [atk_verb]s you!"))
-	log_combat(A, D, "[atk_verb]s(Explosive Fist)")
+	streak = ""
+	return detonate(A, D)
 
 /datum/martial_art/explosive_fist/proc/check_streak(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!can_use(A))
@@ -73,121 +60,77 @@
 		streak = ""
 		explosive_disarm(A,D)
 		return TRUE
-	if(findtext(streak, DETONATE_COMBO))	// End Detonate Chain
-		streak = ""
-		detonate(A,D)
-		return TRUE
-	if(findtext(streak, ALMOST_DETONATE_COMBO))
-		streak = "Q"	//Q comes after P
-		almost_detonate(A,D)
-		return TRUE
-	if(findtext(streak, PRE_DETONATE_COMBO))	//Start detonate chain
-		streak = "P"
-		pre_detonate(A,D)
-		return TRUE
 	if(findtext(streak, LIFEFORCE_TRADE_COMBO))	//End life force drain chain
 		streak = ""
 		lifeforce_trade(A,D)
 		return TRUE
-	if(findtext(streak, ALMOST_LIFEFORCE_TRADE_COMBO))
-		streak = "M"	//M comes after L
-		almost_lifeforce_trade(A,D)
-		return TRUE
-	if(findtext(streak, PRE_LIFEFORCE_TRADE_COMBO))	//Start life force drain chain
-		streak = "L"
-		pre_lifeforce_trade(A,D)
-		return TRUE
-	if(findtext(streak,IMMOLATE_COMBO))	//End immolate chain
-		streak = ""
-		immolate(A,D)
-		return TRUE
-	if(findtext(streak,ALMOST_IMMOLATE_COMBO))
-		streak = "J"	//J comes after I
-		almost_immolate(A,D)
-		return TRUE
-	if(findtext(streak,PRE_IMMOLATE_COMBO))	//Start immolate chain
-		streak = "I"
-		pre_immolate(A,D)
-		return TRUE
-	//I have come to realize maybe this martial art is too complicated - Mqiib
-	
-/datum/martial_art/explosive_fist/proc/remove_stagger(mob/living/carbon/human/D)
-	D.dna.species.aiminginaccuracy -= 25
 
+/datum/martial_art/explosive_fist/proc/damage(mob/living/carbon/human/target, burn_damage = 0, brute_damage = 0, stamina_damage = 0, zone_selected = BODY_ZONE_CHEST)
+	if(!target)
+		return
+	var/melee_block = target.run_armor_check(zone_selected, MELEE, 0)
+	var/burn_block = target.run_armor_check(zone_selected, BOMB, 0)
+
+	target.apply_damage(brute_damage, STAMINA, zone_selected, melee_block)
+	target.apply_damage(stamina_damage, STAMINA, zone_selected, melee_block)
+	target.apply_damage(burn_damage, BURN, zone_selected, burn_block)
 /*---------------------------------------------------------------
 	start of disarm section
 ---------------------------------------------------------------*/
 /datum/martial_art/explosive_fist/proc/explosive_disarm(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!can_use(A))
 		return
-	var/selected_zone = A.zone_selected
-	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
-	var/armor_block = D.run_armor_check(affecting, BOMB, 0)
-	D.apply_damage(A.get_punchdamagehigh() * 2 + 4, BURN, selected_zone, armor_block)	//18 burn (vs bomb armor)
-	D.Knockdown((A.get_punchdamagehigh() * 4/10 + 0.2) SECONDS)	//3 seconds (baseline (7*4)/10 + 0.2 seconds)
+	var/zone_selected = A.zone_selected
+	var/punch_damage = A.get_punchdamagehigh()
+	damage(D, (punch_damage * 3), 0, 0, zone_selected) //21 burn damage
+	D.Knockdown(((punch_damage * 5)/10) SECONDS)	//3.5 seconds (baseline (7*5)/10 seconds)
+
 	playsound(D, get_sfx(SFX_EXPLOSION), 50, TRUE, -1)
 	A.do_attack_animation(D, ATTACK_EFFECT_DISARM)
 	log_combat(A, D, "blasts(Explosive Fist)")
-	D.visible_message(span_danger("[A] blasts [D]!"), \
-				span_userdanger("[A] blasts you!"))
+	D.visible_message(span_danger("[A] blasts [D]!"), span_userdanger("[A] blasts you!"))
+
 	var/atom/throw_target = get_edge_target_turf(D, get_dir(A,D))
-	D.throw_at(throw_target, rand(1,2), 7, A)
-	streak = ""
+	D.throw_at(throw_target, 2, 7, A)
+
 /*---------------------------------------------------------------
 	end of Explosive disarm section
 ---------------------------------------------------------------*/
 /*---------------------------------------------------------------
 	start of Detonate section
 ---------------------------------------------------------------*/
-/datum/martial_art/explosive_fist/proc/pre_detonate(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	if(!can_use(A))
-		return
-	var/selected_zone = A.zone_selected
-	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
-	var/brute_block = D.run_armor_check(affecting, MELEE, 0)
-	var/burn_block = D.run_armor_check(affecting, BOMB, 0)
-	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
-	playsound(D, get_sfx(SFX_EXPLOSION), 50, TRUE, -1)
-	D.apply_damage(A.get_punchdamagehigh() + 5, BRUTE, selected_zone, brute_block) 	//12 brute
-	D.apply_damage(A.get_punchdamagehigh() + 5, BURN, selected_zone, burn_block) 	//12 burn (vs bomb armor)
-	D.adjust_fire_stacks(2)
-	D.visible_message(span_danger("[A] primes [D]!"), \
-					span_userdanger("[A] primes you!"))		
-	log_combat(A, D, "primes(Explosive Fist)")
-
-/datum/martial_art/explosive_fist/proc/almost_detonate(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	if(!can_use(A))
-		return
-	var/selected_zone = A.zone_selected
-	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
-	var/armor_block = D.run_armor_check(affecting, MELEE, 0)
-	A.do_attack_animation(D, ATTACK_EFFECT_DISARM)
-	playsound(D, 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
-
-	var/current_stamina_damage = D.getStaminaLoss()
-	var/damage_to_deal = clamp(0, 55 - current_stamina_damage, 45)	//Tries to get their total stamina damage to 55
-	D.apply_damage(damage_to_deal + 10, STAMINA, selected_zone, armor_block) 	//Always does at least 10
-
-	D.visible_message(span_danger("[A] activates [D]!"), \
-					span_userdanger("[A] activates you!"))
-	log_combat(A, D, "activates(Explosive Fist)")
-	D.adjust_fire_stacks(4)
-
 /datum/martial_art/explosive_fist/proc/detonate(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!can_use(A))
-		return
+		return FALSE
+
+	var/datum/status_effect/explosion_prime/status = D.has_status_effect(/datum/status_effect/explosion_prime)
+	if(!status)
+		return FALSE
+	var/level = status.level
+	qdel(status) //we're done with it now, get rid of it so they can't use it again
+
 	A.do_attack_animation(D, ATTACK_EFFECT_SMASH)
+	var/punch_damage = A.get_punchdamagehigh() + level
+
+	var/turf/center = get_turf(D)
+	var/range = round(level/2)
+	explosion(center, -1, -1, -1, flame_range = (range + 1)) //only fire explosion
+	for(var/mob/living/target in view(center, range))
+		if(target == A) //no self damage
+			continue
+		target.adjust_fire_stacks(level)
+		target.ignite_mob()
+		damage(target, punch_damage) //burn to everyone nearby
+	for(var/turf/open/flashy in view(center, range))
+		flashy.ignite_turf(level * 5)
+
+	damage(D, 0, punch_damage, punch_damage * 2) //extra brute and stamina damage for the main target
 	log_combat(A, D, "detonates(Explosive Fist)")
-	D.visible_message(span_danger("[A] detonates [D]!"), \
-				span_userdanger("[A] detonates you!"))
-	explosion(get_turf(D), -1, 0, 2, flame_range = 3)
-	D.ignite_mob()
-	playsound(D, get_sfx(SFX_EXPLOSION), 50, TRUE, -1)
+	D.visible_message(span_danger("[A] detonates [D]!"), span_userdanger("[A] detonates you!"))
 	
-	var/obj/item/bodypart/affecting = D.get_bodypart(BODY_ZONE_CHEST)
-	var/armor_block = D.run_armor_check(affecting, BOMB)
-	D.apply_damage(A.get_punchdamagehigh() * 1.5 + 4.5, BRUTE, BODY_ZONE_CHEST, armor_block) 	//15 brute (vs bomb)
 	streak = ""
+	return TRUE
+
 /*---------------------------------------------------------------
 	end of Detonate section
 ---------------------------------------------------------------*/
@@ -205,91 +148,39 @@
 		return FALSE
 	if(A.grab_state < GRAB_NECK)
 		return FALSE
-	if(A.stat == DEAD || A.stat == UNCONSCIOUS)
+	if(A.stat == DEAD || A.stat == UNCONSCIOUS) //if we're dead or knocked out
 		return FALSE
-	if(D.stat == DEAD)
+	if(D.stat == DEAD) //if they're dead
 		return FALSE
 	return TRUE
-
-/datum/martial_art/explosive_fist/proc/pre_lifeforce_trade(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	if(!can_use(A))
-		return
-
-	A.do_attack_animation(D, ATTACK_EFFECT_DISARM)
-
-	var/selected_zone = A.zone_selected
-	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
-	var/armor_block = D.run_armor_check(affecting, BOMB, 0)
-	D.apply_damage(A.get_punchdamagehigh() * 2 + 6, BURN, selected_zone, armor_block)	//20 burn (vs bomb armor)
-
-	D.visible_message(span_danger("[A] burns [D]!"), \
-					span_userdanger("[A] burns you!"))		
-	log_combat(A, D, "burns(Explosive Fist)")
-
-/datum/martial_art/explosive_fist/proc/almost_lifeforce_trade(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	if(!can_use(A))
-		return
-	A.do_attack_animation(D, ATTACK_EFFECT_DISARM)			
-	playsound(get_turf(D), 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
-
-	D.visible_message(span_danger("[A] staggers [D]!"), \
-					span_userdanger("[A] staggers you!"))		
-	log_combat(A, D, "staggers(Explosive Fist)")
-
-	var/selected_zone = A.zone_selected
-	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(selected_zone))
-	var/stamina_block = D.run_armor_check(affecting, MELEE, 0)
-	var/burn_block = D.run_armor_check(affecting, BOMB, 0)
-	D.apply_damage(A.get_punchdamagehigh() * 2 + 6, STAMINA, selected_zone, stamina_block) 	//20 stamina
-	D.apply_damage(A.get_punchdamagehigh() - 2, BURN, selected_zone, burn_block) 			//5 burn (vs bomb armor)
-
-	if(!D.has_movespeed_modifier(MOVESPEED_ID_SHOVE)) /// We apply a more long shove slowdown if our target doesn't already have one
-		D.add_movespeed_modifier(MOVESPEED_ID_SHOVE, multiplicative_slowdown = SHOVE_SLOWDOWN_STRENGTH)
-		addtimer(CALLBACK(D, TYPE_PROC_REF(/mob/living/carbon/human, clear_shove_slowdown)), 4 SECONDS)
-
-	D.dna.species.aiminginaccuracy += 25
-	addtimer(CALLBACK(src, PROC_REF(remove_stagger), D), 2 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
 
 /datum/martial_art/explosive_fist/proc/lifeforce_trade(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!can_use(A))
 		return
-	if(A.get_item_by_slot(ITEM_SLOT_HEAD))
+	if(A.get_item_by_slot(ITEM_SLOT_HEAD)) //Helmet on, head go bonk
 		A.do_attack_animation(D, ATTACK_EFFECT_SMASH)			//BONK
-		playsound(get_turf(D), 'sound/weapons/cqchit2.ogg', 50, 1, -1)
-
+		playsound(get_turf(D), 'sound/weapons/punch1.ogg', 50, TRUE, -1)
 		var/selected_zone = A.zone_selected
-		var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
-		var/brute_block = D.run_armor_check(affecting, MELEE, 0)
-		var/burn_block = D.run_armor_check(affecting, BOMB, 0)
-		D.apply_damage(A.get_punchdamagehigh() * 2.5 +  7.5, BRUTE, selected_zone, brute_block) 	//25 brute
-		D.apply_damage(A.get_punchdamagehigh() * 2.5 +  7.5, BURN, selected_zone, burn_block) 		//25 burn (vs bomb armor)
+		var/punch_damage = (A.get_punchdamagehigh() * 2.5) +  7.5
+		damage(D, 0, punch_damage, punch_damage * 2, selected_zone)
 
-		var/obj/item/bodypart/affecting_p = A.get_bodypart(BODY_ZONE_HEAD)
-		var/brute_block_p = A.run_armor_check(affecting_p, MELEE)
-		var/burn_block_p = A.run_armor_check(affecting_p, BOMB)
-		A.apply_damage(5, BRUTE, BODY_ZONE_HEAD, brute_block_p)
-		A.apply_damage(5, BURN, BODY_ZONE_HEAD, burn_block_p)
-
-		D.visible_message(span_danger("[A] headbutts [D]!"), \
-						span_userdanger("[A] headbutts you!"))
+		D.visible_message(span_danger("[A] headbutts [D]!"), span_userdanger("[A] headbutts you!"))
 		log_combat(A, D, "headbutts(Explosive Fist)")
-		streak = ""
 	else
 		if(A.grab_state < GRAB_NECK)
 			A.grab_state = GRAB_NECK
 		if(!(A.pulling == D))
 			D.grabbedby(A, 1)
-		D.visible_message(span_danger("[A] violently grabs [D]'s neck!"), \
-						span_userdanger("[A] violently grabs your neck!"))
+		D.visible_message(span_danger("[A] violently grabs [D]'s neck!"), span_userdanger("[A] violently grabs your neck!"))
 		log_combat(A, D, "grabs by the neck(Explosive Fist)")
-		playsound(get_turf(D), 'sound/weapons/punch1.ogg', 50, TRUE, -1)
-		streak = ""
+		playsound(get_turf(D), 'sound/weapons/cqchit2.ogg', 50, 1, -1)
 		A.adjust_fire_stacks(3)
 		D.adjust_fire_stacks(3)
 		A.ignite_mob()
 		D.ignite_mob()
 		succ_damage = initial(succ_damage)	//Reset our succ damage on start
 		proceed_lifeforce_trade(A, D)
+		streak = ""
 
 /datum/martial_art/explosive_fist/proc/proceed_lifeforce_trade(mob/living/carbon/human/A, mob/living/carbon/human/D)//lifeforce trade loop
 	if(!can_suck_life(A, D))
@@ -303,80 +194,16 @@
 		to_chat(D, span_userdanger(message))
 	if(prob(25))
 		D.emote("scream")
-	D.adjustFireLoss(succ_damage)
+	D.apply_status_effect(STATUS_EFFECT_EXPLOSION_PRIME) //prime them for big boom
+	D.adjustFireLoss(succ_damage / 2) //doesn't do much damage, more of a healing tool
 	D.adjustStaminaLoss(succ_damage * 2)		//YOU ARE HELPLESS TO RESIST THE SPOOKY SKELETON
-	A.heal_overall_damage(succ_damage/2, succ_damage/2, 0, CONSCIOUS, TRUE)
+	A.heal_ordered_damage(succ_damage, list(BURN, BRUTE, STAMINA, OXY), BODYPART_ANY)
 	to_chat(A, span_notice("You drain lifeforce from [D]"))
 	succ_damage *= 1.5	//50% increased damage per succ
 	proceed_lifeforce_trade(A, D)
+
 /*---------------------------------------------------------------
 	end of Life force trade section
----------------------------------------------------------------*/
-/*---------------------------------------------------------------
-	start of immolate section
----------------------------------------------------------------*/
-/datum/martial_art/explosive_fist/proc/pre_immolate(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	if(!can_use(A))
-		return
-	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
-	playsound(get_turf(D), 'sound/weapons/punch1.ogg', 50, 1, -1)
-
-	var/selected_zone = A.zone_selected
-	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
-	var/armor_block = D.run_armor_check(affecting, BOMB, 0)
-	D.apply_damage(A.get_punchdamagehigh() * 2 + 6, BURN, selected_zone, armor_block)	//20 burn (vs bomb armor)
-
-	D.visible_message(span_danger("[A] burns [D]!"), \
-					span_userdanger("[A] burns you!"))
-	log_combat(A, D, "burns(Explosive Fist)")
-
-	return TRUE
-
-/datum/martial_art/explosive_fist/proc/almost_immolate(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	if(!can_use(A))
-		return
-	for(var/mob/living/target in view_or_range(2, A, "range"))
-		target.adjust_fire_stacks(5)
-		var/selected_zone = A.zone_selected
-		var/obj/item/bodypart/affecting = target.get_bodypart(ran_zone(A.zone_selected))
-		var/burn_block = target.run_armor_check(affecting, BOMB, 0)
-		var/brute_block = target.run_armor_check(affecting, MELEE, 0)
-		target.apply_damage(A.get_punchdamagehigh() + 3, BURN, selected_zone, burn_block)	//10 brute
-		target.apply_damage(A.get_punchdamagehigh() - 2, BRUTE, selected_zone, brute_block)	//5 burn (vs bomb armor)
-	D.visible_message(span_danger("[A] primes [D]!"), \
-				span_userdanger("[A] primes you!"))
-	log_combat(A, D, "primes(Explosive Fist)")	
-	playsound(get_turf(D), get_sfx(SFX_EXPLOSION), 50, TRUE, -1)
-
-/datum/martial_art/explosive_fist/proc/immolate(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	if(!can_use(A))
-		return
-
-	if(A.get_item_by_slot(ITEM_SLOT_HEAD))   //No helmets???
-		streak = ""
-		return FALSE
-	else
-		for(var/mob/living/target in view_or_range(2, A, "range"))
-			if(target == A)
-				continue
-			target.adjustFireLoss(30)
-			target.ignite_mob() 	
-		for(var/turf/open/flashy in view_or_range(2, A, "range"))
-			flashy.ignite_turf(15)
-
-		var/obj/item/bodypart/hed = D.get_bodypart(BODY_ZONE_HEAD)
-		var/armor_block = D.run_armor_check(hed, BOMB)
-		D.apply_damage(A.get_punchdamagehigh() + 3, BURN, BODY_ZONE_HEAD, armor_block) 		//10 burn (vs bomb armor)
-		D.emote("scream")
-		D.adjust_eye_blur(4)
-
-		A.apply_damage(10, BURN, BODY_ZONE_CHEST, 0) 	//Take some unblockable damage since you're using your inner flame or something
-
-		A.visible_message(span_danger("[A] explodes violently!"), \
-					span_userdanger("You unleash the flames from yourself!"))
-		log_combat(A, D, "immolates(Explosive Fist)")	
-/*---------------------------------------------------------------
-	end of immolate section
 ---------------------------------------------------------------*/
 /*---------------------------------------------------------------
 	start of learn section
@@ -385,29 +212,60 @@
 	set name = "Remember the basics"
 	set desc = "You try to remember some basic actions from the explosive fist art."
 	set category = "Explosive Fist"
-	to_chat(usr, "<b><i>You try to remember some basic actions from the explosive fist art.</i></b>")
 
-	to_chat(usr, span_notice("<b>Harm Intent</b> Will deal 10 burn and 10 brute damage to people who you hit."))
+	var/list/combined_msg = list()
 
-	to_chat(usr, "[span_notice("Explosive disarm")]: Disarm Disarm. Finishing this combo will deal 10 damage to you and 18 to your target, as well as throwing your target away and knocking down for three seconds.")
-	to_chat(usr, "[span_notice("Detonate")]: Harm Harm Disarm Harm. Second strike will deal 12/12 brute/burn and apply 2 fire stacks to the target. Third strike will apply 4 fire stacks and deal some stamina damage if the target has less then 50 stamina damage. The final strike will ignite the target, make a light explosion and deal 15 damage to you.")
-	to_chat(usr, "[span_notice("Life force trade")]: Disarm Grab Disarm Grab. Second strike will deal 20 damage to the target and 5 damage to you. Third strike will deal 20 stamina and 5 burn damage to the target, and will make it unable to use ranged weapons for 2 second as well as a more long shove slowdown. Finishing the combo with a headwear on will just deal 25/25 brute/burn damage to the target, and if you don't wear a helmet, you will instantly grab the target by a neck, as well as start to drain life from them.")
-	to_chat(usr, "[span_notice("Immolate")]: Disarm Harm Disarm Grab. Second strike will deal 25 burn damage to the target and 5 burn damage to you. Third strike will apply 5 fire stacks to EVERYONE in the range of 2 tiles. Finishing the combo will, if you don't wear any headwear, will deal 30 burn damage to anyone except you in the range of 2 tiles, or ignite them if they are close enough to you. You target will get additional 10 burn damage and get blurry vision.")
+	combined_msg += "<b><i>You try to remember some basic actions from the explosive fist art.</i></b>"
+
+	combined_msg += span_notice("<b>All Intents</b> Will prime the target with explosive plasma.")
+	combined_msg += span_notice("<b>Harm Intent</b> Will detonate the plasma, creating a fire explosion scaling with how many times the target was primed.")
+
+	combined_msg += "[span_notice("Explosive disarm")]: Disarm Disarm. Deals damage to your target. Also throws your target away and knocking them down for a short duration."
+	combined_msg += "[span_notice("Life force trade")]: Grab Harm. If wearing headwear, you deal considerable brute and stamina damage to the target. If not wearing headwear, you will instantly grab the target by the neck and start draining life from them."
+	
+	to_chat(usr, examine_block(combined_msg.Join("\n")))
 
 /*---------------------------------------------------------------
 	end of learn section
 ---------------------------------------------------------------*/
 //these aren't needed elsewhere
 #undef EXPLOSIVE_DISARM_COMBO
-
-#undef DETONATE_COMBO
-#undef ALMOST_DETONATE_COMBO
-#undef PRE_DETONATE_COMBO
-
 #undef LIFEFORCE_TRADE_COMBO
-#undef ALMOST_LIFEFORCE_TRADE_COMBO
-#undef PRE_LIFEFORCE_TRADE_COMBO
 
-#undef IMMOLATE_COMBO
-#undef ALMOST_IMMOLATE_COMBO
-#undef PRE_IMMOLATE_COMBO
+/atom/movable/screen/alert/status_effect/explosion_prime
+	name = "Primed"
+	desc = "You've been primed to explode."
+	icon_state = "slime_clonedecay"
+
+/datum/status_effect/explosion_prime
+	status_type = STATUS_EFFECT_REFRESH
+	duration = PRIME_EFFECT_DURATION
+	alert_type = /atom/movable/screen/alert/status_effect/explosion_prime
+	/// How potent this effect is
+	var/level = 0
+
+/datum/status_effect/explosion_prime/initialize()
+	. = ..()
+	increase_level()
+
+/datum/status_effect/explosion_prime/refresh(effect, ...) //when it gets re-applied, make it stronger
+	. = ..()
+	increase_level()
+	
+/datum/status_effect/explosion_prime/proc/increase_level()
+	var/new_level = clamp(level + 1, 0, MAX_PRIME_LEVEL)
+	set_level(new_level)
+
+/datum/status_effect/explosion_prime/proc/set_level(amount)
+	if(amount == level)
+		return
+	level = amount
+	update_particles()
+
+/datum/status_effect/explosion_prime/update_particles()
+	if(!particle_effect)
+		particle_effect = new(owner, /particles/drill_sparks)
+	particle_effect.particles.spawning = level
+
+#undef PRIME_EFFECT_DURATION
+#undef MAX_PRIME_LEVEL 

--- a/yogstation/code/datums/martial/explosive_fist.dm
+++ b/yogstation/code/datums/martial/explosive_fist.dm
@@ -194,13 +194,13 @@
 		return
 
 	if(prob(35))
-		var/message = pick(
+		var/list/messages = list(
 			"You feel your life force being drained!", 
 			"It hurts!", 
 			"AAAAAAAAAAAAAAAAAAAAAAAAAAA",
 			"You stare into [A]'s expressionless skull and see only fire and death."
 			)
-		to_chat(D, span_userdanger(message))
+		to_chat(D, span_userdanger(pick(message)))
 	if(prob(25))
 		D.emote("scream")
 

--- a/yogstation/code/datums/martial/explosive_fist.dm
+++ b/yogstation/code/datums/martial/explosive_fist.dm
@@ -233,7 +233,7 @@
 	combined_msg += span_notice("<b>All Intents</b> Will <b>prime</b> the target with explosive plasma.")
 	combined_msg += span_notice("<b>Harm Intent</b> Will detonate the plasma, creating a fire explosion scaling with how many times the target was <b>primed</b>.")
 
-	combined_msg += "[span_notice("Explosive disarm")]: Disarm Disarm. Deals damage to your target and applies a stack of <b>primed</b>. Also throws your target away and knocking them down for a short duration."
+	combined_msg += "[span_notice("Explosive disarm")]: Disarm Disarm. Deals damage to your target and applies an additional stack of <b>primed</b>. Also throws your target away and knocking them down for a short duration."
 	combined_msg += "[span_notice("Life force trade")]: Grab Harm. If wearing headwear, you deal considerable brute and stamina damage to the target. If not wearing headwear, you will instantly grab the target by the neck and start draining life from them."
 	
 	to_chat(usr, examine_block(combined_msg.Join("\n")))

--- a/yogstation/code/datums/martial/explosive_fist.dm
+++ b/yogstation/code/datums/martial/explosive_fist.dm
@@ -80,10 +80,12 @@
 /datum/martial_art/explosive_fist/proc/explosive_disarm(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(!can_use(A))
 		return
+	D.apply_status_effect(STATUS_EFFECT_EXPLOSION_PRIME)
+
 	var/zone_selected = A.zone_selected
 	var/punch_damage = A.get_punchdamagehigh()
-	damage(D, (punch_damage * 3), 0, 0, zone_selected) //21 burn damage
-	D.Knockdown(((punch_damage * 5)/10) SECONDS)	//3.5 seconds (baseline (7*5)/10 seconds)
+	damage(D, (punch_damage * 2), 0, 0, zone_selected) //14 burn damage
+	D.Knockdown(((punch_damage * 4)/10) SECONDS)	//3.5 seconds (baseline (7*5)/10 seconds)
 
 	playsound(D, get_sfx(SFX_EXPLOSION), 50, TRUE, -1)
 	A.do_attack_animation(D, ATTACK_EFFECT_DISARM)
@@ -159,7 +161,7 @@
 		return
 	if(A.get_item_by_slot(ITEM_SLOT_HEAD)) //Helmet on, head go bonk
 		A.do_attack_animation(D, ATTACK_EFFECT_SMASH)			//BONK
-		playsound(get_turf(D), 'sound/weapons/punch1.ogg', 50, TRUE, -1)
+		playsound(get_turf(D), 'sound/weapons/cqchit2.ogg', 50, 1, -1)
 		var/selected_zone = A.zone_selected
 		var/punch_damage = (A.get_punchdamagehigh() * 2.5) +  7.5
 		damage(D, 0, punch_damage, punch_damage * 2, selected_zone)
@@ -173,7 +175,7 @@
 			D.grabbedby(A, 1)
 		D.visible_message(span_danger("[A] violently grabs [D]'s neck!"), span_userdanger("[A] violently grabs your neck!"))
 		log_combat(A, D, "grabs by the neck(Explosive Fist)")
-		playsound(get_turf(D), 'sound/weapons/cqchit2.ogg', 50, 1, -1)
+		playsound(get_turf(D), 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
 		A.adjust_fire_stacks(3)
 		D.adjust_fire_stacks(3)
 		A.ignite_mob()
@@ -190,7 +192,12 @@
 	if(!can_suck_life(A, D))
 		return
 	if(prob(35))
-		var/message = pick("You feel your life force being drained!", "It hurts!", "You stare into [A]'s expressionless skull and see only fire and death.")
+		var/message = pick(
+			"You feel your life force being drained!", 
+			"It hurts!", 
+			"AAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"You stare into [A]'s expressionless skull and see only fire and death."
+			)
 		to_chat(D, span_userdanger(message))
 	if(prob(25))
 		D.emote("scream")
@@ -217,10 +224,10 @@
 
 	combined_msg += "<b><i>You try to remember some basic actions from the explosive fist art.</i></b>"
 
-	combined_msg += span_notice("<b>All Intents</b> Will prime the target with explosive plasma.")
-	combined_msg += span_notice("<b>Harm Intent</b> Will detonate the plasma, creating a fire explosion scaling with how many times the target was primed.")
+	combined_msg += span_notice("<b>All Intents</b> Will <b>prime</b> the target with explosive plasma.")
+	combined_msg += span_notice("<b>Harm Intent</b> Will detonate the plasma, creating a fire explosion scaling with how many times the target was <b>primed</b>.")
 
-	combined_msg += "[span_notice("Explosive disarm")]: Disarm Disarm. Deals damage to your target. Also throws your target away and knocking them down for a short duration."
+	combined_msg += "[span_notice("Explosive disarm")]: Disarm Disarm. Deals damage to your target and applies a stack of <b>primed</b>. Also throws your target away and knocking them down for a short duration."
 	combined_msg += "[span_notice("Life force trade")]: Grab Harm. If wearing headwear, you deal considerable brute and stamina damage to the target. If not wearing headwear, you will instantly grab the target by the neck and start draining life from them."
 	
 	to_chat(usr, examine_block(combined_msg.Join("\n")))
@@ -244,7 +251,7 @@
 	/// How potent this effect is
 	var/level = 0
 
-/datum/status_effect/explosion_prime/initialize()
+/datum/status_effect/explosion_prime/New(list/arguments)
 	. = ..()
 	increase_level()
 

--- a/yogstation/code/datums/martial/explosive_fist.dm
+++ b/yogstation/code/datums/martial/explosive_fist.dm
@@ -200,7 +200,7 @@
 			"AAAAAAAAAAAAAAAAAAAAAAAAAAA",
 			"You stare into [A]'s expressionless skull and see only fire and death."
 			)
-		to_chat(D, span_userdanger(pick(message)))
+		to_chat(D, span_userdanger(pick(messages)))
 	if(prob(25))
 		D.emote("scream")
 


### PR DESCRIPTION
Deleted pretty much every combo
No more self damage
New system

All Intents will **prime** the target with explosive plasma
Harm Intent will detonate the plasma, creating a fire explosion scaling with how many times the target was **primed**

**Explosive disarm:** Disarm Disarm. Deals damage to your target and applies an additional stack of **primed**. Also throws your target away and knocks them down for a short duration.
**Life force trade:** Grab Harm. If wearing headwear, you deal considerable brute and stamina damage to the target. If not wearing headwear, you will instantly grab the target by the neck and start draining life from them.

# Why is this good for the game?
It was already a clunky martial art, and when combat mode was added it just became even more obvious

# Testing
gonna need to do a video or something to showcase it i guess

:cl:
rscadd: New explosive fist
rscdel: Old explosive fist
/:cl:
