### PR TITLE
Makes Admin Cryo verb better

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -208,7 +208,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 
 	return control_computer != null
 
-/obj/machinery/cryopod/close_machine(mob/user, waking = FALSE)
+/obj/machinery/cryopod/close_machine(mob/user, waking = FALSE, admin_forced = FALSE)
 	if(!control_computer)
 		find_control_computer(TRUE)
 	if((isnull(user) || istype(user)) && state_open && !panel_open)
@@ -223,7 +223,7 @@ GLOBAL_LIST_EMPTY(cryopod_computers)
 			to_chat(occupant, span_boldnotice("You feel cool air surround you. You go numb as your senses turn inward."))
 		if(!occupant) //Check they still exist
 			return
-		if(mob_occupant.client)//if they're logged in
+		if(mob_occupant.client && !admin_forced) //if they're logged in, admin forcing will handle this stuff anyway
 			despawn_timer = addtimer(VARSET_CALLBACK(src, ready, TRUE), time_till_despawn_online, TIMER_STOPPABLE)
 			if(tgui_alert(mob_occupant, "Do you want to offer yourself to ghosts?", "Ghost Offer", list("Yes", "No")) != "No")
 				deltimer(despawn_timer) //Player wants to offer, cancel the timer

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1505,9 +1505,10 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	set name = "Admin Cryo"
 	if(!check_rights(R_ADMIN))
 		return
-	var/confirm = alert(usr, "Are you Sure you want to offer them?", "Are you Sure", "Yes", "No")
+	var/confirm = alert(usr, "Are you Sure you want to cryo them?", "Are you Sure", "Yes", "No")
 	if(confirm == "No")
 		return
+	var/offer = alert(usr, "Do you want to offer control of their mob to ghosts?", "Offer Control", "Yes", "No")
 	for(var/obj/machinery/cryopod/cryopod in GLOB.cryopods)
 		if(cryopod.occupant)
 			continue
@@ -1519,7 +1520,11 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		message_admins(msg)
 		log_admin(msg)
 		new /obj/effect/particle_effect/sparks/quantum(get_turf(target))
-		cryopod.close_machine(target)
+		if(offer == "Yes")
+			cryopod.close_machine(target, admin_forced = TRUE)
+			offer_control(target)
+		else
+			cryopod.close_machine(target)
 		return
 
 /datum/admins/proc/cmd_create_centcom()

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1505,7 +1505,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	set name = "Admin Cryo"
 	if(!check_rights(R_ADMIN))
 		return
-	var/confirm = alert(usr, "Are you Sure you want to cryo them?", "Are you Sure", "Yes", "No")
+	var/confirm = alert(usr, "Are you sure you want to cryo them?", "Admin Cryo", "Yes", "No")
 	if(confirm == "No")
 		return
 	var/offer = alert(usr, "Do you want to offer control of their mob to ghosts?", "Offer Control", "Yes", "No")


### PR DESCRIPTION
# Document the changes in your pull request

Admin cryo would ask "Are you Sure you want to offer them?" which is WRONG because it doesnt OFFER them anyway, the confirmation is if you want to CRYO them

adds a second prompt for offering to ghosts

# Why is this good for the game?
now admin cryo'd people can actually be offered to ghosts


# Changelog


:cl:
rscadd: Admin Cryo verb functions more clearly and actually lets admins offer control of the mob
/:cl:
