### PR TITLE
Fix changelog being long

### DIFF
--- a/html/changelog.css
+++ b/html/changelog.css
@@ -8,6 +8,7 @@ a img {border:none;}
 	border:1px solid #ddd;
 	border-left:4px solid #999;
 	margin-bottom:2px;
+	word-break: break-word;
 }
 .bugfix {background-image:url(bug-minus.png)}
 .wip {background-image:url(hard-hat-exclamation.png)}
@@ -30,7 +31,7 @@ a img {border:none;}
 .sansserif {font-family:Tahoma,sans-serif;font-size:12px;}
 .commit {margin-bottom:20px;font-size:100%;font-weight:normal;}
 .changes {list-style:none;margin:5px 0;padding:0 0 0 25px;font-size:0.8em;}
-.date {margin:10px 0;color:blue;border-bottom:2px solid #00f;width:60%;padding:2px 0;font-size:1em;font-weight:bold;}	
+.date {margin:10px 0;color:blue;border-bottom:2px solid #00f;width:60%;padding:2px 0;font-size:1em;font-weight:bold;}
 .author {padding-left:10px;margin:0;font-weight:bold;font-size:0.9em;}
 .drop {cursor:pointer;border:1px solid #999;display:inline;font-size:0.9em;padding:1px 20px 1px 5px;line-height:16px;}
 .hidden {display:none;}


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Added word wrapping to list items `<li>`

# Testing
<!-- Describe what testing you did with this PR. Try to be thorough, especially if this is a larger project. -->
![image](https://github.com/user-attachments/assets/1833a024-5f7b-4ea7-8202-a3900920f93e)


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl: 
bugfix: Fixed changelog changes not word wrapping, which made the window horizontally cut off
/:cl:
