### PR TITLE
Adds storage item (backpack) pickpocketing

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -531,7 +531,11 @@
 	if (!istype(living_source))
 		return
 
-	to_chat(user, span_notice("You try to pull something out of [living_source]'s [storage_item]."))
+	if (istype(storage_item, /obj/item/storage/backpack/duffelbag))
+		to_chat(user, span_notice("You try to unzip [living_source]'s [storage_item]. Hopefully they don't notice."))
+		playsound(living_source, 'sound/items/zip.ogg', 100, TRUE) // obnoxiously loud
+	else
+		to_chat(user, span_notice("You try to pull something out of [living_source]'s [storage_item]."))
 
 	var/log_message = "[key_name(living_source)] is being pickpocketed by [key_name(user)] ([storage_item])"
 	living_source.log_message(log_message, LOG_ATTACK, color="red")

--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -177,6 +177,31 @@
 	/// The ITEM_SLOT_* to equip to.
 	var/item_slot
 
+/datum/strippable_item/mob_item_slot/get_alternate_action(atom/source, mob/user)
+	SHOULD_CALL_PARENT(TRUE)
+	. = ..()
+	if (.)
+		return
+
+	var/obj/item/worn_thing = get_item(source)
+	if (!istype(worn_thing))
+		return null
+	return worn_thing.GetComponent(/datum/component/storage/concrete) ? "pickpocket_storage" : null
+
+/datum/strippable_item/mob_item_slot/alternate_action(atom/source, mob/user)
+	SHOULD_CALL_PARENT(TRUE)
+	. = ..()
+	if (.)
+		return
+
+	var/obj/item/worn_thing = get_item(source)
+	if (!istype(worn_thing))
+		return null
+	if (worn_thing.GetComponent(/datum/component/storage/concrete))
+		return pickpocket_storage_item(worn_thing, source, user)
+	else
+		return null
+
 /datum/strippable_item/mob_item_slot/get_item(atom/source)
 	if (!ismob(source))
 		return null
@@ -494,3 +519,42 @@
 		strippable_items[strippable_item.key] = strippable_item
 
 	return strippable_items
+
+/// Like pickpocketing pockets, but takes out a random item from a storage item
+/proc/pickpocket_storage_item(obj/item/storage_item, atom/source, mob/user)
+	. = TRUE // blocks children from using alternate actions
+	var/datum/component/storage/concrete/storage = storage_item.GetComponent(/datum/component/storage/concrete)
+	if (!istype(storage_item) || !storage)
+		return
+
+	var/mob/living/living_source = source
+	if (!istype(living_source))
+		return
+
+	to_chat(user, span_notice("You try to pull something out of [living_source]'s [storage_item]."))
+
+	var/log_message = "[key_name(living_source)] is being pickpocketed by [key_name(user)] ([storage_item])"
+	living_source.log_message(log_message, LOG_ATTACK, color="red")
+	user.log_message(log_message, LOG_ATTACK, color="red", log_globally=FALSE)
+	storage_item.add_fingerprint(user)
+
+	if (!do_after(user, POCKET_STRIP_DELAY, living_source, interaction_key = REF(storage_item)))
+		to_chat(living_source, span_warning("You feel your [storage_item] being fumbled with!"))
+		return
+
+	var/list/atom/lootables = storage.contents()
+	if (lootables.len == 0)
+		to_chat(user, span_notice("You couldn't find anything inside [living_source]'s [storage_item]."))
+		return
+
+	var/obj/item/loot = pick(lootables)
+	if (!istype(loot))
+		to_chat(user, span_notice("You found \a [loot] inside [living_source]'s [storage_item] but couldn't pull it out."))
+		return
+
+	var/log_message_success = "[key_name(living_source)]'s [loot] was successfully pickpocketed by [key_name(user)] ([storage_item])"
+	living_source.log_message(log_message_success, LOG_ATTACK, color="red")
+	user.log_message(log_message_success, LOG_ATTACK, color="red", log_globally=FALSE)
+	loot.add_fingerprint(user)
+
+	living_source.dropItemToGround(loot)

--- a/code/modules/mob/living/carbon/carbon_stripping.dm
+++ b/code/modules/mob/living/carbon/carbon_stripping.dm
@@ -7,7 +7,18 @@
 	item_slot = ITEM_SLOT_BACK
 
 /datum/strippable_item/mob_item_slot/back/get_alternate_action(atom/source, mob/user)
+	. = ..()
+	if (.)
+		return
+
 	return get_strippable_alternate_action_internals(get_item(source), source)
+
+/datum/strippable_item/mob_item_slot/back/alternate_action(atom/source, mob/user)
+	. = ..()
+	if (.)
+		return
+
+	return strippable_alternate_action_internals(get_item(source), source, user)
 
 /datum/strippable_item/mob_item_slot/mask
 	key = STRIPPABLE_ITEM_MASK

--- a/code/modules/mob/living/carbon/human/human_stripping.dm
+++ b/code/modules/mob/living/carbon/human/human_stripping.dm
@@ -46,12 +46,20 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 	item_slot = ITEM_SLOT_ICLOTHING
 
 /datum/strippable_item/mob_item_slot/jumpsuit/get_alternate_action(atom/source, mob/user)
+	. = ..()
+	if (.)
+		return
+
 	var/obj/item/clothing/under/jumpsuit = get_item(source)
 	if (!istype(jumpsuit))
 		return null
 	return jumpsuit?.can_adjust ? "adjust_jumpsuit" : null
 
 /datum/strippable_item/mob_item_slot/jumpsuit/alternate_action(atom/source, mob/user)
+	. = ..()
+	if (.)
+		return
+
 	var/obj/item/clothing/under/jumpsuit = get_item(source)
 	if (!istype(jumpsuit))
 		return null
@@ -81,9 +89,17 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 	item_slot = ITEM_SLOT_FEET
 
 /datum/strippable_item/mob_item_slot/feet/get_alternate_action(atom/source, mob/user)
+	. = ..()
+	if (.)
+		return
+
 	return null
 
 /datum/strippable_item/mob_item_slot/feet/alternate_action(atom/source, mob/user)
+	. = ..()
+	if (.)
+		return
+
 	return
 
 /datum/strippable_item/mob_item_slot/suit_storage
@@ -91,9 +107,17 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 	item_slot = ITEM_SLOT_SUITSTORE
 
 /datum/strippable_item/mob_item_slot/suit_storage/get_alternate_action(atom/source, mob/user)
+	. = ..()
+	if (.)
+		return
+
 	return get_strippable_alternate_action_internals(get_item(source), source)
 
 /datum/strippable_item/mob_item_slot/suit_storage/alternate_action(atom/source, mob/user)
+	. = ..()
+	if (.)
+		return
+
 	return strippable_alternate_action_internals(get_item(source), source, user)
 
 /datum/strippable_item/mob_item_slot/id
@@ -105,9 +129,17 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 	item_slot = ITEM_SLOT_BELT
 
 /datum/strippable_item/mob_item_slot/belt/get_alternate_action(atom/source, mob/user)
+	. = ..()
+	if (.)
+		return
+
 	return get_strippable_alternate_action_internals(get_item(source), source)
 
 /datum/strippable_item/mob_item_slot/belt/alternate_action(atom/source, mob/user)
+	. = ..()
+	if (.)
+		return
+
 	return strippable_alternate_action_internals(get_item(source), source, user)
 
 /datum/strippable_item/mob_item_slot/pocket
@@ -137,7 +169,7 @@ GLOBAL_LIST_INIT(strippable_human_items, create_strippable_list(list(
 	var/log_message = "[key_name(source)] is being pickpocketed of [item] by [key_name(user)] ([pocket_side])"
 	source.log_message(log_message, LOG_ATTACK, color="red")
 	user.log_message(log_message, LOG_ATTACK, color="red", log_globally=FALSE)
-	item.add_fingerprint(src)
+	item.add_fingerprint(user)
 
 	var/result = start_unequip_mob(item, source, user, POCKET_STRIP_DELAY)
 

--- a/tgui/packages/tgui/interfaces/StripMenu.tsx
+++ b/tgui/packages/tgui/interfaces/StripMenu.tsx
@@ -51,6 +51,11 @@ const ALTERNATE_ACTIONS: Record<string, AlternateAction> = {
     icon: "tshirt",
     text: "Adjust jumpsuit",
   },
+
+  pickpocket_storage: {
+    icon: "hand",
+    text: "Steal random item",
+  },
 };
 
 const SLOTS: Record<


### PR DESCRIPTION
# Document the changes in your pull request
Forces all `/datum/strippable_item/mob_item_slot` alternate_action procs to call parent, which checks if the item has a storage component and handles actions if so.

Added a missing proc at `/datum/strippable_item/mob_item_slot/back/alternate_action` which would prevent setting internals on back slot.

Changed pickpocketing to do `item.add_fingerprint(user)` instead of `item.add_fingerprint(src)`, as `src` is a datum there, not a mob.

Duffel bags will play zip.ogg at 100% volume which will make it very obvious.

# Why is this good for the game?
Pickpocketing is good for roleplay and stealthy opportunities

# Testing
![image](https://github.com/user-attachments/assets/25fb65d7-93f7-4a03-8a8b-49c283713984)
![image](https://github.com/user-attachments/assets/b951c5d9-9d0b-4643-ae8c-ce5d6eac6b50)

# Wiki Documentation
Pickpocketing takes 4 seconds, inherited from POCKET_STRIP_DELAY

Works nigh identically to pocket pickpocketing, you will only alarm the victim if the action is cancelled.

# Changelog

:cl:
rscadd: Added storage-item pickpocketing. You can now pickpocket backpacks and other storage items by clicking the hand in the stripping menu
rscadd: Duffel bags make obnoxiously loud zipping noises when someone tries to pickpocket them
bugfix: Fixed not being able to set internals on a back-slotted tank 
bugfix: Fixed pickpocketing not applying fingerprints correctly
/:cl:
