### PR TITLE
fixes some mapping errors in maint ruins

### DIFF
--- a/_maps/RandomRuins/StationRuins/maint/10x10/10x10_halloween.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x10/10x10_halloween.dmm
@@ -46,7 +46,7 @@
 /obj/structure/railing,
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/ash/large,
-/obj/item/clothing/under/schoolgirl/orange,
+/obj/item/clothing/under/costume/schoolgirl/orange,
 /obj/item/clothing/head/kitty{
 	pixel_y = 8
 	},
@@ -60,7 +60,7 @@
 "j" = (
 /obj/effect/decal/remains/xeno,
 /obj/effect/decal/cleanable/ash/large,
-/obj/item/clothing/under/scratch{
+/obj/item/clothing/under/suit/scratch{
 	pixel_x = 2;
 	pixel_y = -2
 	},

--- a/_maps/RandomRuins/StationRuins/maint/10x10/10x10_halloween.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x10/10x10_halloween.dmm
@@ -151,7 +151,7 @@
 	pixel_x = -2;
 	pixel_y = 11
 	},
-/obj/item/clothing/under/redeveninggown,
+/obj/item/clothing/under/dress/redeveninggown,
 /obj/effect/decal/cleanable/glitter/pink,
 /turf/open/floor/light/colour_cycle/dancefloor_a,
 /area/template_noop)
@@ -307,7 +307,7 @@
 	},
 /obj/effect/decal/remains/human,
 /obj/effect/decal/cleanable/ash/large,
-/obj/item/clothing/under/soviet{
+/obj/item/clothing/under/costume/soviet{
 	pixel_x = 1;
 	pixel_y = -5
 	},

--- a/_maps/RandomRuins/StationRuins/maint/10x10/10x10_sixsectorsdown.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x10/10x10_sixsectorsdown.dmm
@@ -54,7 +54,7 @@
 	dir = 4
 	},
 /obj/item/stack/spacecash/c20,
-/obj/item/clothing/under/jabroni,
+/obj/item/clothing/under/costume/jabroni,
 /turf/open/floor/plasteel/showroomfloor,
 /area/template_noop)
 "hX" = (

--- a/_maps/RandomRuins/StationRuins/maint/10x5/10x5_commie.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x5/10x5_commie.dmm
@@ -105,7 +105,7 @@
 /area/template_noop)
 "Q" = (
 /obj/structure/table,
-/obj/item/clothing/under/soviet,
+/obj/item/clothing/under/costume/soviet,
 /obj/item/clothing/head/ushanka{
 	pixel_y = 10
 	},

--- a/_maps/RandomRuins/StationRuins/maint/10x5/10x5_medicalmaint.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x5/10x5_medicalmaint.dmm
@@ -55,7 +55,7 @@
 /turf/open/floor/plasteel/white,
 /area/template_noop)
 "h" = (
-/obj/effect/turf_decal/trimline/blue/corner/lower{
+/obj/effect/turf_decal/trimline/blue/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,

--- a/_maps/RandomRuins/StationRuins/maint/10x5/10x5_medicalmaint.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/10x5/10x5_medicalmaint.dmm
@@ -23,6 +23,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/template_noop)
+"c" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/template_noop)
 "d" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -52,13 +58,6 @@
 	pixel_x = -2;
 	pixel_y = -14
 	},
-/turf/open/floor/plasteel/white,
-/area/template_noop)
-"h" = (
-/obj/effect/turf_decal/trimline/blue/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/plasteel/white,
 /area/template_noop)
 "i" = (
@@ -157,6 +156,14 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/stump,
 /turf/open/floor/grass,
+/area/template_noop)
+"u" = (
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/item/broken_bottle{
+	pixel_x = 10;
+	pixel_y = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/template_noop)
 "v" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
@@ -307,17 +314,6 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/plating,
 /area/template_noop)
-"K" = (
-/obj/effect/turf_decal/trimline/blue/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/item/broken_bottle{
-	pixel_x = 10;
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/template_noop)
 "L" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -385,13 +381,6 @@
 /obj/structure/sign/painting{
 	persistence_id = "public";
 	pixel_y = -32
-	},
-/turf/open/floor/plasteel/white,
-/area/template_noop)
-"S" = (
-/obj/effect/turf_decal/trimline/blue/corner/lower,
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/template_noop)
@@ -469,11 +458,11 @@ m
 H
 "}
 (5,1,1) = {"
-S
+c
 W
 v
 P
-h
+l
 "}
 (6,1,1) = {"
 L
@@ -487,7 +476,7 @@ Y
 g
 y
 y
-K
+u
 "}
 (8,1,1) = {"
 B

--- a/_maps/RandomRuins/StationRuins/maint/3x3/3x3_biohazard.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x3/3x3_biohazard.dmm
@@ -8,7 +8,7 @@
 /turf/open/floor/plating,
 /area/template_noop)
 "e" = (
-/obj/effect/decal/cleanable/blood/xtracks,
+/obj/effect/decal/cleanable/xenoblood/xtracks,
 /turf/open/floor/plating,
 /area/template_noop)
 "f" = (
@@ -33,7 +33,7 @@
 /turf/open/floor/plating,
 /area/template_noop)
 "v" = (
-/obj/effect/decal/cleanable/blood/xtracks,
+/obj/effect/decal/cleanable/xenoblood/xtracks,
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},

--- a/_maps/RandomRuins/StationRuins/maint/3x3/3x3_naughtyroom.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x3/3x3_naughtyroom.dmm
@@ -22,7 +22,7 @@
 "q" = (
 /obj/structure/closet/crate/wooden,
 /obj/item/clothing/head/kitty,
-/obj/item/clothing/under/schoolgirl/red,
+/obj/item/clothing/under/costume/schoolgirl/red,
 /turf/open/floor/carpet/purple,
 /area/template_noop)
 "K" = (

--- a/_maps/RandomRuins/StationRuins/maint/3x3/3x3_owloffice.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x3/3x3_owloffice.dmm
@@ -54,7 +54,7 @@
 	dir = 1
 	},
 /obj/item/clothing/suit/toggle/owlwings,
-/obj/item/clothing/under/owl,
+/obj/item/clothing/under/costume/owl,
 /obj/item/clothing/mask/gas/owl_mask,
 /obj/structure/sign/poster/official/the_owl{
 	pixel_y = 32

--- a/_maps/RandomRuins/StationRuins/maint/3x3/3x3_pubbyartism.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x3/3x3_pubbyartism.dmm
@@ -50,9 +50,7 @@
 /turf/open/floor/plating,
 /area/template_noop)
 "G" = (
-/obj/structure/closet/l3closet/scientist{
-	opened = 1
-	},
+/obj/structure/closet/l3closet/scientist,
 /obj/item/book/manual/wiki/chemistry,
 /obj/machinery/light/small{
 	dir = 1

--- a/_maps/RandomRuins/StationRuins/maint/3x5/3x5_junkcloset.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/3x5/3x5_junkcloset.dmm
@@ -39,7 +39,7 @@
 /obj/item/clothing/head/mailman,
 /obj/structure/closet,
 /obj/effect/landmark/blobstart,
-/obj/item/clothing/under/rank/mailman,
+/obj/item/clothing/under/rank/cargo/mailman,
 /turf/open/floor/plating,
 /area/template_noop)
 "G" = (

--- a/_maps/RandomRuins/StationRuins/maint/5x3/5x3_chestburst.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/5x3/5x3_chestburst.dmm
@@ -12,7 +12,7 @@
 /area/template_noop)
 "e" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/xtracks{
+/obj/effect/decal/cleanable/xenoblood/xtracks{
 	dir = 9
 	},
 /turf/open/floor/plating,
@@ -43,7 +43,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/blood/xtracks{
+/obj/effect/decal/cleanable/xenoblood/xtracks{
 	dir = 5
 	},
 /turf/open/floor/plating,
@@ -61,7 +61,7 @@
 /area/template_noop)
 "H" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/xtracks{
+/obj/effect/decal/cleanable/xenoblood/xtracks{
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -71,13 +71,13 @@
 /turf/open/floor/plating,
 /area/template_noop)
 "N" = (
-/obj/effect/decal/cleanable/blood/xtracks{
+/obj/effect/decal/cleanable/xenoblood/xtracks{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/template_noop)
 "O" = (
-/obj/effect/decal/cleanable/blood/xtracks,
+/obj/effect/decal/cleanable/xenoblood/xtracks,
 /turf/open/floor/plating,
 /area/template_noop)
 

--- a/_maps/RandomRuins/StationRuins/maint/5x3/5x3_yogsmaintrpg.dmm
+++ b/_maps/RandomRuins/StationRuins/maint/5x3/5x3_yogsmaintrpg.dmm
@@ -19,7 +19,7 @@
 "y" = (
 /obj/structure/closet/crate/necropolis,
 /obj/item/clothing/head/helmet/gladiator,
-/obj/item/clothing/under/gladiator,
+/obj/item/clothing/under/costume/gladiator,
 /turf/open/floor/wood,
 /area/maintenance/aft)
 "z" = (


### PR DESCRIPTION
# Document the changes in your pull request

Mostly invisible clothing, some invisible decals, a closet that was open but blocked you until it was closed. Not tested beyond opening the map files, but it shouldn't need anything further.

:cl: ktlwjec
mapping: Invisible maint ruin clothing can now be seen.
/:cl: