### PR TITLE
[BOX] Puts an intercom on the wall by the glass flower case outside of security so sentient butterflies may call for help on comms (and receive none as everyone ignores their pleas for rescue anyway)

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -3417,6 +3417,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
+"azw" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp/green{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 9
+	},
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "azx" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable{
@@ -25285,13 +25299,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
-"geQ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -31
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "gft" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/power/smes,
@@ -26879,14 +26886,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"gLV" = (
-/obj/machinery/camera{
-	c_tag = "Fore Primary Hallway Central";
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "gMD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -30106,17 +30105,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"hPV" = (
-/obj/structure/table,
-/obj/item/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "hPW" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
@@ -32423,6 +32411,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"iBM" = (
+/obj/machinery/camera{
+	c_tag = "Fore Primary Hallway Central";
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -31
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "iCk" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock"
@@ -103740,7 +103739,7 @@ rxB
 wXu
 tsu
 anz
-gLV
+iBM
 bNR
 cCR
 hGZ
@@ -104254,9 +104253,9 @@ cRY
 tDw
 tsu
 anz
-geQ
+kUv
 bNR
-hPV
+azw
 qEB
 qEB
 iNE


### PR DESCRIPTION
# Document the changes in your pull request

title

# Changelog

:cl: cark
mapping: adds an intercom by the butterfly case outside of sec on box
/:cl:
