### PR TITLE
actually adds .38 rubber ammo box to autolathe

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -1119,7 +1119,7 @@
 	name = "Ammo Box (.38 Rubber)"
 	id = "box_a38_rubber"
 	build_path = /obj/item/ammo_box/no_direct/a38/rubber
-	category = list("Security")
+	category = list("initial", "Security")
 
 /datum/design/cleaver
 	name = "Butcher's Cleaver"


### PR DESCRIPTION
# Document the changes in your pull request

missing initial

# Testing
Not hacked:
![image](https://github.com/user-attachments/assets/ed51382b-0e4d-4592-a1a3-4f02c772ca1f)

Hacked:

![image](https://github.com/user-attachments/assets/f2b0f5c2-508a-46fa-b7b3-76ccda9893de)


# Changelog

:cl:
bugfix: .38 rubber ammo box is actually available in autolathe
/:cl:
