### PR TITLE
Silicon Admins Get Regular Law Manager

### DIFF
--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -539,7 +539,7 @@
 	// This usually gives the power to add/delete/edit the laws. Some exceptions apply (like being a pAI)!
 	data["admin"] = is_admin(user)
 
-	// Causes admins (who are not deadmined) and are also the owner to not view the admin version of the Law Manager.
+	// Causes admins (who are not deadmined and) are also the owner to not view the admin version of the Law Manager.
 	if(is_admin(user) && owner == user)
 		data["admin"] = FALSE
 

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -539,7 +539,7 @@
 	// This usually gives the power to add/delete/edit the laws. Some exceptions apply (like being a pAI)!
 	data["admin"] = is_admin(user)
 
-	// Causes admins (who are not deadmined and) are also the owner to not view the admin version of the Law Manager.
+	// Causes admins who (are not deadmined and) are also the owner to not view the admin version of the Law Manager.
 	if(is_admin(user) && owner == user)
 		data["admin"] = FALSE
 

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -539,6 +539,10 @@
 	// This usually gives the power to add/delete/edit the laws. Some exceptions apply (like being a pAI)!
 	data["admin"] = is_admin(user)
 
+	// Causes admins (who are not deadmined) and are also the owner to not view the admin version of the Law Manager.
+	if(is_admin(user) && owner == user)
+		data["admin"] = FALSE
+
 	handle_laws(data, owner.laws)
 	handle_channels(data)
 	data["zeroth_law"] = zeroth_law


### PR DESCRIPTION
# Document the changes in your pull request
Admins who (decline to deadmin and) are actively inside of a silicon will have Law Manager appear as if they were not an admin.

# Why is this good for the game?
Baimou's request.

# Testing
Ghosted.  Used 'Manage Silicon Laws' (admin) on any Silicon and showed Admin version of Law Manager.
Entered said Silicon. Used 'Law Manager' (robot commands). Showed regular version of Law Manager.

# Changelog
:cl:
rscadd: Admins who are currently controlling a silicon will have Law Manager appear as if they were not an admin.
/:cl:
