### PR TITLE
[BOX] Actually fixes door over tech storage needing maint access

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -41310,7 +41310,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "lUW" = (
@@ -73826,7 +73826,7 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "xML" = (


### PR DESCRIPTION
# Document the changes in your pull request
aaaaaa I did the wrong door mb
this actually fixes the problem (plus my fuckup)
![image](https://github.com/user-attachments/assets/2d723666-cb3b-4d78-a4df-b844e53b63a9)



# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
mapping: Fixed the maint door over tech storage on Box needing engie access instead of maint access
/:cl:
