### PR TITLE
Lizards now make clawprints instead of normal footprints

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -124,6 +124,9 @@
 		tail.Insert(H, TRUE)
 		H.visible_message("[H]'s tail regrows.","You feel your tail regrow.")
 
+/datum/species/lizard/get_footprint_sprite()
+	return FOOTPRINT_SPRITE_CLAWS
+
 /datum/species/lizard/get_species_description()
 	return "The first sentient beings encountered by the SIC outside of the Sol system, vuulen are the most \
 		commonly encountered non-human species in SIC space. Despite being one of the most integrated species in the SIC, they \


### PR DESCRIPTION
Doesn't make much sense for lizards to be making normal footprints

![image](https://github.com/user-attachments/assets/402815f8-78d7-4774-8f51-f3560d7ae03d)

:cl:
tweak: Lizards now make clawprints instead of normal footprints
/:cl:
