### PR TITLE
Removes duplicate item handling in /proc/pickpocket_storage_item

### DIFF
--- a/code/datums/elements/strippable.dm
+++ b/code/datums/elements/strippable.dm
@@ -564,6 +564,4 @@
 	user.log_message(log_message_success, LOG_ATTACK, color="red", log_globally=FALSE)
 	loot.add_fingerprint(user)
 
-	living_source.dropItemToGround(loot)
-
 	finish_unequip_mob(loot, living_source, user, TRUE)


### PR DESCRIPTION
# Document changes

The item was being dropped, then the actual item transfer handling proc is called. The item drop call is now removed as it is unnecessary and caused drop sounds to play when the item was never being "dropped".

# Testing
![image](https://github.com/user-attachments/assets/02a6a40a-3535-4e08-a670-cb46f9bdb935)


# Changelog

:cl:
bugfix: Fixed pickpocketing storage items making noise
/:cl:
