### PR TITLE
Fixes xenomorphs dying to acid rain

### DIFF
--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -9,6 +9,7 @@
 	verb_say = "hisses"
 	initial_language_holder = /datum/language_holder/alien
 	bubble_icon = BUBBLE_ALIEN
+	weather_immunities = WEATHER_STORM
 	type_of_meat = /obj/item/reagent_containers/food/snacks/meat/slab/xeno
 	blocks_emissive = EMISSIVE_BLOCK_UNIQUE
 

--- a/code/modules/mob/living/simple_animal/hostile/alien.dm
+++ b/code/modules/mob/living/simple_animal/hostile/alien.dm
@@ -31,6 +31,7 @@
 	faction = list(ROLE_ALIEN)
 	status_flags = CANPUSH
 	minbodytemp = 0
+	weather_immunities = WEATHER_STORM
 	// Going for a dark purple here
 	lighting_cutoff_red = 30
 	lighting_cutoff_green = 15


### PR DESCRIPTION
# Testing
probably need to, but been busy lately

:cl:
bugfix: Ruin spawned xenos no longer die to weather effects
/:cl:
