### PR TITLE
[DONUT] Redoes all of Engineering and some areas around it

### DIFF
--- a/_maps/map_files/DonutStation/DonutStation.dmm
+++ b/_maps/map_files/DonutStation/DonutStation.dmm
@@ -59,17 +59,6 @@
 /obj/machinery/telecomms/bus/preset_four,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"abg" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 10
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "abn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -120,6 +109,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"aci" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/mail_sorting/engineering/general,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 2;
+	pixel_y = -1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "ack" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -171,6 +173,18 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"acV" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/power/grounding_rod,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Engine Containment West";
+	dir = 4;
+	network = list("ss13","Engine","Engineering")
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "acY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -244,6 +258,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/storage)
+"adN" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "adT" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -334,10 +358,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"afR" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/crew_quarters/heads/chief)
 "afT" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -460,13 +480,6 @@
 /obj/machinery/vending/tool,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"aiX" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/machinery/power/tesla_coil,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "ajm" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Biohazard";
@@ -591,6 +604,13 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/space/basic,
 /area/engine/atmos)
+"akY" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/power/tesla_coil,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "alg" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/chapel,
@@ -645,6 +665,13 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"alG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/nuke_storage)
 "alM" = (
 /obj/machinery/space_heater,
 /turf/open/floor/plating,
@@ -734,18 +761,6 @@
 	},
 /turf/open/floor/noslip,
 /area/medical/sleeper)
-"amY" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ana" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -877,6 +892,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"aoY" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/effect/landmark/start/station_engineer,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "aph" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -925,6 +950,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"apM" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "apO" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/oxygen_input{
 	dir = 1
@@ -962,10 +996,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/central)
-"arc" = (
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "arm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1019,18 +1049,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"asg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "asm" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
@@ -1073,13 +1091,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"atl" = (
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "atm" = (
 /obj/structure/ethernet_cable{
 	icon_state = "4-8"
@@ -1092,6 +1103,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"ats" = (
+/obj/machinery/advanced_airlock_controller{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "atB" = (
 /turf/closed/wall,
 /area/quartermaster/warehouse)
@@ -1129,20 +1155,6 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"aue" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/engine,
-/area/engine/gravity_generator)
 "auj" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1429,6 +1441,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"ayZ" = (
+/obj/structure/particle_accelerator/end_cap{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "azb" = (
 /turf/open/floor/plasteel,
 /area/security/courtroom)
@@ -1444,6 +1465,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"azM" = (
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "azX" = (
 /obj/structure/frame/computer{
 	anchored = 1;
@@ -1617,6 +1648,13 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"aEx" = (
+/obj/structure/closet/secure_closet/security/engine,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "aEB" = (
 /obj/machinery/atmospherics/pipe/manifold/purple/visible,
 /turf/open/floor/plasteel,
@@ -1668,16 +1706,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"aFW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "aGa" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -1686,19 +1714,6 @@
 "aGn" = (
 /turf/template_noop,
 /area/maintenance/aft)
-"aGt" = (
-/obj/machinery/power/apc/auto_name{
-	dir = 8;
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_smes)
 "aGu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1721,15 +1736,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"aGy" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "aGC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -1802,6 +1808,28 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"aID" = (
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "aIE" = (
 /obj/machinery/shower{
 	dir = 1
@@ -1900,6 +1928,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aJZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/engiyellow/warning/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aKc" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -1995,6 +2030,19 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"aLE" = (
+/obj/machinery/power/emitter/anchored{
+	dir = 8;
+	state = 2
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aLL" = (
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/plasteel/grimy,
@@ -2054,14 +2102,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"aNb" = (
-/obj/structure/rack,
-/mob/living/simple_animal/parrot/Poly,
-/obj/machinery/keycard_auth{
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "aNh" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
@@ -2334,35 +2374,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"aTL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/ramp_middle{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"aTV" = (
-/obj/machinery/nuclearbomb/selfdestruct,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "aTX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -2631,6 +2642,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"aYl" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "aYn" = (
 /obj/structure/cable/orange{
 	icon_state = "2-8"
@@ -2763,6 +2780,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
+"bbe" = (
+/obj/structure/table,
+/obj/item/stock_parts/cell/high/plus{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/pen/blue,
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "bbg" = (
 /turf/closed/wall,
 /area/medical/medbay/lobby)
@@ -2778,12 +2804,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
-"bbz" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "bbG" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -2820,6 +2840,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"bbY" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "bcj" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -2876,6 +2902,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bcP" = (
+/obj/structure/cable/orange{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "bda" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -2896,6 +2928,18 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/chapel_office,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"bdt" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bdC" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -3202,18 +3246,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
-"biT" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "bjl" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -3343,16 +3375,18 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"blR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"blT" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
+/obj/structure/table,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bmr" = (
@@ -3364,6 +3398,25 @@
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"bmD" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bmL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm{
@@ -3463,6 +3516,17 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"bpe" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "bpi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -3475,6 +3539,18 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
+"bpj" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bpo" = (
 /obj/machinery/atmospherics/components/binary/valve/layer2{
 	dir = 4
@@ -3604,6 +3680,19 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"brC" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "brU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -3644,15 +3733,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"bsG" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bsI" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -3780,19 +3860,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"bvA" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/engine/storage_shared";
-	dir = 8;
-	name = "Shared Engineering Storage APC";
-	pixel_x = -25
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "bvG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3836,6 +3903,13 @@
 /mob/living/simple_animal/pet/snail/gary,
 /turf/open/floor/carpet,
 /area/library)
+"bwn" = (
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+	dir = 8
+	},
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bwr" = (
 /obj/item/chair/stool,
 /turf/open/floor/plating,
@@ -3910,14 +3984,6 @@
 	},
 /turf/open/floor/wood,
 /area/tcommsat/computer)
-"bxM" = (
-/obj/machinery/power/emitter/anchored{
-	dir = 4;
-	state = 2
-	},
-/obj/structure/cable/orange,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "bxR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -4039,6 +4105,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"bAH" = (
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bBh" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -4125,18 +4198,6 @@
 "bDj" = (
 /turf/closed/wall,
 /area/hallway/primary/central)
-"bDl" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Engineer's Desk";
-	departmentType = 3;
-	name = "Chief Engineer RC";
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "bDo" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/small{
@@ -4208,16 +4269,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"bFy" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "bFM" = (
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -4288,6 +4339,18 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"bHp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bHL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
@@ -4389,21 +4452,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
-"bKe" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel/stairs/goon/stairs2_wide{
-	dir = 1
-	},
-/area/engine/engineering)
 "bKm" = (
 /obj/machinery/computer/communications{
 	dir = 8
@@ -4482,13 +4530,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bLM" = (
-/obj/structure/closet/secure_closet/engineering_chief,
-/obj/machinery/light{
-	dir = 1
+"bLw" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bLP" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating{
@@ -4515,6 +4563,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"bMq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "bMz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4545,12 +4603,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
-"bNn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "bNI" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
@@ -4648,43 +4700,6 @@
 /obj/machinery/vending/hydroseeds/weak,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
-"bOU" = (
-/obj/item/coin/silver{
-	pixel_x = 7;
-	pixel_y = 12
-	},
-/obj/item/coin/silver{
-	pixel_x = 12;
-	pixel_y = 7
-	},
-/obj/item/coin/silver{
-	pixel_x = 4;
-	pixel_y = 8
-	},
-/obj/item/coin/silver{
-	pixel_x = -6;
-	pixel_y = 5
-	},
-/obj/item/coin/silver{
-	pixel_x = 5;
-	pixel_y = -8
-	},
-/obj/structure/closet/crate{
-	name = "Silver Crate"
-	},
-/obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "bPj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -4747,21 +4762,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"bQl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "bQv" = (
 /obj/structure/chair{
 	dir = 8
@@ -4863,8 +4863,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bSP" = (
-/turf/closed/wall/r_wall,
+"bSD" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bSU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -5035,6 +5043,12 @@
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bWP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bWY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -5156,6 +5170,16 @@
 "bZW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
+/area/engine/engineering)
+"bZY" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/machinery/light{
+	light_color = "#c1caff"
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cad" = (
 /obj/machinery/door/airlock/research{
@@ -5484,16 +5508,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"cfa" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/machinery/light{
-	light_color = "#c1caff"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cfh" = (
 /obj/machinery/light_switch{
 	pixel_y = -24
@@ -5611,14 +5625,6 @@
 	icon_state = "damaged2"
 	},
 /area/space/nearstation)
-"chN" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/obj/effect/landmark/start/station_engineer,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "chU" = (
 /obj/structure/closet/crate/wooden/toy,
 /obj/item/grenade/chem_grenade/teargas/moustache,
@@ -5680,15 +5686,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
-"ciH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "ciL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -5751,15 +5748,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"cjR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/gravity_generator)
 "cjS" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -5867,6 +5855,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
+"cmN" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs2_wide{
+	dir = 1
+	},
+/area/engine/engineering)
 "cmQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -6005,24 +6008,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"crd" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "cre" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/engineering,
 /turf/open/floor/plating,
 /area/storage/tech)
-"crf" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "crg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -6123,6 +6113,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"cub" = (
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
 "cuh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -6171,6 +6165,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"cvc" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cve" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -6187,6 +6190,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"cvL" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cvV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6431,19 +6444,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"cAL" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_smes)
 "cAM" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -6482,6 +6482,12 @@
 "cCh" = (
 /turf/closed/wall/r_wall,
 /area/science/storage)
+"cCC" = (
+/obj/machinery/light_switch{
+	pixel_x = -28
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/nuke_storage)
 "cCL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -6864,6 +6870,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"cJb" = (
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "cJk" = (
 /turf/closed/wall/r_wall,
 /area/security/main)
@@ -6871,6 +6883,16 @@
 /obj/effect/turf_decal/trimline/green/filled/corner/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"cJA" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "cJF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/corner{
@@ -6908,6 +6930,18 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/experimentation,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"cKi" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cLs" = (
 /turf/closed/wall/r_wall,
 /area/science/explab)
@@ -7026,28 +7060,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"cMV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cNi" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cNq" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/wood,
@@ -7101,12 +7113,14 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"cOk" = (
+"cOm" = (
 /obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plating,
-/area/maintenance/central)
+/mob/living/simple_animal/parrot/Poly,
+/obj/machinery/keycard_auth{
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "cOt" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/disposal";
@@ -7140,22 +7154,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"cOH" = (
-/obj/structure/table/reinforced,
-/obj/item/paper/monitorkey{
-	pixel_x = 6;
-	pixel_y = -4
-	},
-/obj/item/stamp/ce{
-	pixel_x = -6;
-	pixel_y = 7
-	},
-/obj/item/storage/pencil_holder/crew/fancy{
-	pixel_x = 7;
-	pixel_y = 11
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "cOX" = (
 /obj/effect/spawner/lootdrop/donkpockets{
 	pixel_x = -6;
@@ -7172,21 +7170,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/tcommsat/computer)
-"cPf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "cPg" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -7564,12 +7547,12 @@
 /obj/item/healthanalyzer,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"cXI" = (
-/obj/machinery/computer/apc_control{
-	dir = 8
+"cXt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cXJ" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Monkey Pen"
@@ -7841,17 +7824,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"deo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 1
-	},
-/turf/open/floor/engine,
-/area/engine/gravity_generator)
 "dep" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/extinguisher_cabinet{
@@ -7894,18 +7866,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/science/lab)
-"dfB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "dfE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -8088,6 +8048,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"diQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "djm" = (
 /obj/item/screwdriver,
 /turf/open/floor/plasteel/airless{
@@ -8180,6 +8152,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"dlo" = (
+/obj/machinery/power/emitter/anchored{
+	dir = 4;
+	state = 2
+	},
+/obj/structure/cable/orange,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dlt" = (
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -8469,6 +8449,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"dry" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "drC" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -8613,18 +8601,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"duq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/ramp_middle{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "duu" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -8738,6 +8714,9 @@
 	},
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"dwy" = (
+/turf/closed/wall/r_wall,
 /area/hallway/primary/central)
 "dwG" = (
 /obj/structure/closet/secure_closet/detective,
@@ -8910,6 +8889,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"dBd" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "dBR" = (
 /obj/machinery/button/flasher{
 	id = "hopflash";
@@ -8957,6 +8948,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"dCk" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "dCn" = (
 /obj/structure/table,
 /obj/item/assembly/flash/handheld,
@@ -9064,6 +9061,10 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"dEM" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "dEX" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical,
@@ -9107,6 +9108,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"dGk" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "dGl" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -9203,12 +9222,6 @@
 "dHD" = (
 /turf/open/floor/plating/rust,
 /area/maintenance/starboard)
-"dHJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "dHQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9422,27 +9435,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
-"dLd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "dLi" = (
 /obj/machinery/status_display/ai{
 	pixel_y = -32
@@ -9564,11 +9556,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
-"dMP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "dMR" = (
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
@@ -9584,6 +9571,22 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"dNm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "dNw" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
@@ -9760,17 +9763,6 @@
 /obj/structure/sign/warning/vacuum,
 /turf/closed/wall/rust,
 /area/quartermaster/warehouse)
-"dRO" = (
-/obj/structure/table/glass,
-/obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "dSR" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
@@ -10295,15 +10287,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"egv" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "egB" = (
 /obj/structure/table,
 /obj/item/wallframe/airalarm,
@@ -10460,18 +10443,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"eiM" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "eiQ" = (
 /obj/structure/table,
 /obj/item/clothing/head/soft,
@@ -10759,18 +10730,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"epv" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "epS" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
@@ -10798,46 +10757,20 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "eqj" = (
-/obj/machinery/door/firedoor/border_only{
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
 	},
+/obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
-	dir = 4
+	dir = 1
 	},
-/obj/machinery/door/airlock/command{
-	name = "Chief Engineer's Office"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "eri" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/randomdrink,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"erm" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower,
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ero" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -11085,6 +11018,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"ewo" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/power/grounding_rod,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Engine Containment East";
+	dir = 8;
+	network = list("ss13","Engine","Engineering")
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "ewp" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 5
@@ -11171,6 +11116,42 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"eyx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -27;
+	pixel_y = -34
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/gravity_generator)
+"eyG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "eyK" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -11186,20 +11167,22 @@
 "eyR" = (
 /turf/closed/wall,
 /area/construction/mining/aux_base)
-"ezb" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ezc" = (
 /obj/effect/turf_decal/trimline/white/filled/corner/lower,
 /obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"ezp" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ezI" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -11207,6 +11190,17 @@
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"ezY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering Particle Accelerator";
+	dir = 4;
+	network = list("ss13","engine")
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "eAb" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms"
@@ -11222,6 +11216,17 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"eAq" = (
+/obj/machinery/vending/engivend,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "eAx" = (
 /obj/machinery/door/airlock/external{
 	name = "External Freight Airlock"
@@ -11297,21 +11302,6 @@
 /obj/machinery/vending/autodrobe/capdrobe,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"eBG" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/engineering";
-	dir = 8;
-	name = "Engineering Security APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "eBH" = (
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
@@ -11377,21 +11367,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"eCN" = (
-/obj/effect/turf_decal/bot_white/right,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "eCV" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -11434,18 +11409,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"eDD" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_smes)
 "eDH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -11463,21 +11426,6 @@
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
 /area/maintenance/aft)
-"eDN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "eEa" = (
 /obj/effect/landmark/start/clown,
 /obj/structure/disposalpipe/segment{
@@ -11545,21 +11493,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"eFM" = (
-/obj/structure/rack,
-/obj/item/airlock_painter{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/airlock_painter{
-	pixel_x = 3;
-	pixel_y = -6
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "eFO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -11649,6 +11582,35 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"eHx" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Desk"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "eIc" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -11681,12 +11643,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"eIA" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "eIB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -11708,26 +11664,17 @@
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
-"eIS" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=BOTTOMLEFT";
-	location = "BOTTOMMID";
-	name = "navigation beacon (BOTTOMMID)"
-	},
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 9
+"eIK" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/button/door{
+	id = "enginesecurestorage";
+	name = "Secure Storage Control";
+	pixel_x = -25;
+	pixel_y = -23;
+	req_access = list("engine_equip")
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/engine/engineering)
 "eJx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -11749,9 +11696,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"eKw" = (
-/turf/closed/wall/r_wall,
-/area/hydroponics)
 "eKB" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Office"
@@ -11779,6 +11723,19 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"eKS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "eLb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -11804,6 +11761,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"eLj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "eLl" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 6
@@ -11945,16 +11917,12 @@
 "eNH" = (
 /turf/closed/wall,
 /area/science/explab)
-"eNW" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
+"eOb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/engine/storage_shared)
 "eOt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -11967,15 +11935,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"eOx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "eOB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12026,6 +11985,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"ePu" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/engine,
+/area/engine/gravity_generator)
 "ePv" = (
 /obj/machinery/camera{
 	c_tag = "Security Post - Medbay";
@@ -12071,6 +12044,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"eQw" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "eQD" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/closet/secure_closet/personal,
@@ -12134,17 +12119,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/solars/port/fore)
-"eSk" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "eSw" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -12223,25 +12197,6 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"eUq" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/button/door{
-	id = "engsm";
-	name = "Radiation Shutters Control";
-	pixel_y = 24;
-	req_access = list("engineering")
-	},
-/obj/machinery/vending/wardrobe/engi_wardrobe,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "eUs" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hopqueue";
@@ -12393,16 +12348,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"eYF" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/nuke_storage)
 "eZg" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -12499,18 +12444,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"fbN" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/camera{
-	c_tag = "Security Post - Engineering";
-	dir = 8;
-	network = list("ss13","chpt")
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "fbR" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrig";
@@ -12549,6 +12482,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"fdd" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/effect/landmark/start/station_engineer,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "fdW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed,
@@ -12869,24 +12810,6 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
-"fiE" = (
-/mob/living/simple_animal/opossum/poppy,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8;
-	pixel_y = -1
-	},
-/obj/effect/mapping_helpers/mail_sorting/engineering/ce_office,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "fjk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -12912,21 +12835,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
-"fki" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "fkv" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -12976,6 +12884,15 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
+"fln" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "flE" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp,
@@ -13006,6 +12923,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"fnt" = (
+/obj/machinery/computer/station_alert{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "fnu" = (
 /obj/machinery/telecomms/message_server/preset,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -13014,6 +12937,19 @@
 /obj/item/wrench,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"fnT" = (
+/obj/machinery/suit_storage_unit/ce,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/computer/security/telescreen{
+	name = "Telecomms/Engineering Monitor";
+	network = list("Telecom","Engine","Engineering");
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "fnX" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -13025,20 +12961,6 @@
 /obj/effect/turf_decal/ramp_corner,
 /turf/open/floor/wood,
 /area/tcommsat/computer)
-"fof" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "foy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster{
@@ -13113,6 +13035,18 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/hydroponics,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"fqx" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "fqS" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -13262,9 +13196,6 @@
 	},
 /turf/open/floor/catwalk_floor/telecomms,
 /area/ai_monitored/turret_protected/ai)
-"fsU" = (
-/turf/closed/wall/r_wall,
-/area/engine/storage_shared)
 "ftc" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 4
@@ -13527,34 +13458,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"fyC" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fyF" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"fyM" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fyP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer2{
 	dir = 4
@@ -13565,12 +13472,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
-"fyQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fyX" = (
 /obj/structure/closet/crate,
 /obj/item/kitchen/fork,
@@ -13629,6 +13530,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"fAJ" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/donkpockets,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "fAQ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/open/floor/plating,
@@ -13829,20 +13741,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"fFq" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/stairs/goon/stairs_wide{
-	dir = 1
-	},
-/area/engine/engineering)
 "fFz" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -14241,12 +14139,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"fMB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fME" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -14638,13 +14530,6 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"fXg" = (
-/obj/structure/closet/secure_closet/security/engine,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "fXj" = (
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
@@ -14740,6 +14625,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"fZp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "fZy" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -14947,11 +14846,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"geA" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "geB" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -15053,6 +14947,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"ggN" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ghc" = (
 /obj/structure/chair{
 	dir = 4
@@ -15145,15 +15051,6 @@
 	},
 /turf/open/floor/catwalk_floor/telecomms,
 /area/ai_monitored/turret_protected/ai)
-"giy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "giY" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/medical,
@@ -15342,6 +15239,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"goq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "goz" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -15354,6 +15257,17 @@
 /obj/machinery/atmospherics/pipe/simple/dark/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"gpf" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "gpj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -15420,6 +15334,19 @@
 /obj/effect/turf_decal/sand/plating,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"grd" = (
+/obj/machinery/power/emitter/anchored{
+	dir = 4;
+	state = 2
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "gre" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
@@ -15466,16 +15393,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"grO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "grP" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Dorms"
@@ -15570,13 +15487,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"gto" = (
-/obj/machinery/disposal/bin/tagger,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "gtI" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -15775,6 +15685,20 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"gwr" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "gwu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/carbon_output{
 	dir = 8
@@ -15963,6 +15887,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/storage)
+"gCa" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/machinery/vending/wardrobe/law_wardrobe,
+/turf/open/floor/wood,
+/area/lawoffice)
 "gCh" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -16000,20 +15931,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"gDg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "gDt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16028,9 +15945,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"gDE" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
+"gDG" = (
+/obj/machinery/vending/tool,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "gDN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -16055,6 +15981,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"gDP" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "gDQ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -16144,7 +16091,7 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"gFv" = (
+"gEX" = (
 /obj/structure/sign/poster/official/pda_ad{
 	pixel_x = 32
 	},
@@ -16222,6 +16169,10 @@
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
+"gHG" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall,
+/area/engine/gravity_generator)
 "gHZ" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
@@ -16330,12 +16281,62 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
+"gKX" = (
+/obj/machinery/door/airlock/vault,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/vault,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "gLB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
+"gLG" = (
+/obj/structure/closet/crate{
+	name = "Gold Crate"
+	},
+/obj/item/stack/sheet/mineral/gold{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/item/stack/sheet/mineral/gold{
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/mineral/gold{
+	pixel_x = 1;
+	pixel_y = -2
+	},
+/obj/item/storage/belt/champion,
+/obj/effect/turf_decal/bot_white/left,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "gLN" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -16402,18 +16403,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_master,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
-"gMq" = (
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "gMA" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hor)
@@ -16525,20 +16514,6 @@
 /obj/item/toy/figure/virologist,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"gOE" = (
-/obj/machinery/power/smes/engineering{
-	input_level = 10000;
-	output_attempt = 0;
-	output_level = 5000
-	},
-/obj/structure/cable/orange{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "gOF" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
@@ -16549,19 +16524,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"gOI" = (
-/obj/machinery/power/emitter/anchored{
-	dir = 8;
-	state = 2
-	},
-/obj/structure/cable/orange{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/orange{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "gOO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -16918,6 +16880,15 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"gVE" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "gVO" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/door/poddoor/preopen{
@@ -16940,24 +16911,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/medical/sleeper)
-"gWq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/tcommsat/computer)
 "gWw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -16993,6 +16946,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"gWT" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "gXP" = (
 /obj/effect/spawner/structure/window,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -17190,10 +17149,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
-"hbV" = (
-/obj/machinery/power/port_gen/pacman,
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_smes)
 "hcl" = (
 /obj/machinery/air_sensor/atmos/air_tank,
 /turf/open/floor/engine/air,
@@ -17213,6 +17168,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/warehouse)
+"hcQ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engine_smes)
 "hdg" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel,
@@ -17277,6 +17239,15 @@
 /obj/machinery/porta_turret/ai,
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
+"hec" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "hef" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -17333,21 +17304,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
-"hfL" = (
-/obj/structure/disposalpipe/segment{
+"hfI" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/hallway/primary/central)
 "hfO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17371,6 +17337,21 @@
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"hfT" = (
+/obj/machinery/advanced_airlock_controller{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "hgf" = (
 /obj/effect/turf_decal/pool,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -17401,6 +17382,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"hgV" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "hgW" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall/rust,
@@ -17931,31 +17936,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
-"hrp" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"hrv" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/table,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "hrW" = (
 /obj/structure/sign/departments/science{
 	pixel_y = 32
@@ -18076,15 +18056,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hva" = (
-/obj/structure/particle_accelerator/end_cap{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "hvg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -18252,6 +18223,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"hzV" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "hAd" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -18317,6 +18295,12 @@
 /obj/effect/spawner/backrooms_portal,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"hBm" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hBq" = (
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged3"
@@ -18342,27 +18326,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"hBD" = (
-/obj/structure/safe,
-/obj/item/clothing/head/bearpelt,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/gun/ballistic/revolver/russian,
-/obj/item/ammo_box/a357,
-/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
-/obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "hBH" = (
 /obj/item/stack/ore/slag,
 /turf/open/space/basic,
@@ -18396,16 +18359,6 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hCu" = (
-/obj/machinery/power/smes,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_smes)
 "hCR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -18560,15 +18513,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
-"hFl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/effect/turf_decal/ramp_corner{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "hFt" = (
 /turf/open/water/safe,
 /area/hydroponics/garden)
@@ -18610,17 +18554,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"hFV" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "hFZ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -18642,6 +18575,21 @@
 "hGc" = (
 /turf/open/floor/wood,
 /area/tcommsat/computer)
+"hGr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=BOTTOMRIGHT";
+	location = "RIGHTBOTTOM";
+	name = "navigation beacon (RIGHTBOTTOM)"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "hGy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -18856,26 +18804,6 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"hLz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -27;
-	pixel_y = -34
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/gravity_generator)
 "hLQ" = (
 /obj/machinery/door/morgue/chaplain,
 /turf/open/floor/plasteel/dark,
@@ -18936,10 +18864,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"hNt" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall,
-/area/engine/gravity_generator)
 "hNH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19107,6 +19031,17 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"hQP" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 1;
+	pixel_y = -29
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "hRP" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -19268,13 +19203,6 @@
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"hWp" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/ramp_corner,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "hWs" = (
 /obj/machinery/door/window/northleft{
 	name = "Checkpoint Desk"
@@ -19292,24 +19220,27 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint)
+"hWH" = (
+/obj/machinery/computer/bank_machine,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "hWM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"hWP" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/nuke_storage";
-	dir = 8;
-	name = "Vault APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/nuke_storage)
 "hWV" = (
 /obj/machinery/camera{
 	c_tag = "Research - Main 2";
@@ -19362,6 +19293,39 @@
 "hXS" = (
 /turf/open/floor/plating/rust,
 /area/maintenance/central)
+"hXT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -22;
+	pixel_y = 24
+	},
+/obj/machinery/button/door{
+	id = "enginepashutter";
+	name = "Particle Accelerator Shutter Control";
+	pixel_x = -25;
+	pixel_y = 32;
+	req_access = list("engineering")
+	},
+/obj/machinery/button/door{
+	id = "enginesecurestorage";
+	name = "Secure Storage Control";
+	pixel_x = -25;
+	pixel_y = 40;
+	req_access = list("engineering")
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "hYc" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -19417,12 +19381,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/solars/port/fore)
-"hZj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "hZo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19479,6 +19437,21 @@
 	},
 /turf/open/floor/carpet,
 /area/library)
+"iaU" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_alone{
+	dir = 4
+	},
+/area/engine/engineering)
 "ibk" = (
 /obj/machinery/nanite_chamber,
 /turf/open/floor/plasteel/dark,
@@ -19580,6 +19553,10 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
+"idv" = (
+/obj/effect/turf_decal/bot_white/left,
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
 "idJ" = (
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
@@ -19649,12 +19626,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"ifJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "ifY" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -19669,6 +19640,24 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"igj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "igu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -19711,21 +19700,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"ihV" = (
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "iii" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
@@ -19744,6 +19718,11 @@
 /obj/item/paicard,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"iiz" = (
+/obj/machinery/suit_storage_unit/engine,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "iiD" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge"
@@ -19792,9 +19771,49 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"ijc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "ijq" = (
 /turf/closed/wall,
 /area/security/courtroom)
+"iju" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ijx" = (
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
@@ -19937,21 +19956,27 @@
 "ilP" = (
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"ilZ" = (
+/mob/living/simple_animal/opossum/poppy,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8;
+	pixel_y = -1
+	},
+/obj/effect/mapping_helpers/mail_sorting/engineering/ce_office,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "imd" = (
 /turf/open/floor/plasteel/white/side,
 /area/science/xenobiology)
-"ime" = (
-/obj/machinery/camera/motion{
-	c_tag = "Vault";
-	dir = 8;
-	network = list("vault","ss13")
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "imx" = (
 /obj/structure/closet/secure_closet/freezer/cream_pie,
 /obj/machinery/light_switch{
@@ -20074,12 +20099,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"ipf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "ipr" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port)
+"ips" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "ipy" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
@@ -20143,6 +20180,16 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"iqv" = (
+/obj/machinery/rnd/production/circuit_imprinter,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "iqL" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -20193,15 +20240,6 @@
 /obj/effect/turf_decal/trimline/green,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"isQ" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "isV" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -20251,22 +20289,6 @@
 /obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"itP" = (
-/obj/structure/table/reinforced,
-/obj/machinery/photocopier/faxmachine{
-	department = "Chief Engineer";
-	name = "Chief Engineer's Fax Machine"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/item/toy/figure/ce{
-	pixel_x = -10;
-	pixel_y = -4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "iuk" = (
 /obj/machinery/food_cart,
 /obj/machinery/firealarm{
@@ -20295,19 +20317,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"iuJ" = (
-/obj/machinery/suit_storage_unit/ce,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/computer/security/telescreen{
-	name = "Telecomms/Engineering Monitor";
-	network = list("Telecom","Engine","Engineering");
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "ivd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20353,6 +20362,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"iwn" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Gravity Generator";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/turf/open/floor/engine,
+/area/engine/gravity_generator)
 "ixs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -20532,12 +20557,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
-"iBV" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
-	dir = 1
+"iBJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/closed/wall,
-/area/hallway/primary/central)
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "iCi" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -20614,13 +20643,12 @@
 /obj/structure/closet/crate/internals,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"iEf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/structure/cable{
-	icon_state = "2-4"
+"iED" = (
+/obj/machinery/computer/apc_control{
+	dir = 8
 	},
-/turf/open/floor/wood,
-/area/lawoffice)
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "iEE" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil/random,
@@ -20674,18 +20702,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"iGM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
 "iGX" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -20767,6 +20783,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"iJj" = (
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/nuke_storage";
+	dir = 8;
+	name = "Vault APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/nuke_storage)
 "iJk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
@@ -20895,6 +20923,13 @@
 /obj/item/assembly/flash/handheld,
 /turf/open/floor/plating,
 /area/storage/tech)
+"iLH" = (
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "iLK" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -20950,6 +20985,15 @@
 	initial_gas_mix = "plasma=1000;TEMP=293.15"
 	},
 /area/engine/atmos)
+"iMU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "iNa" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 4
@@ -21099,21 +21143,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"iPk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=BOTTOMRIGHT";
-	location = "RIGHTBOTTOM";
-	name = "navigation beacon (RIGHTBOTTOM)"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "iPw" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
@@ -21293,6 +21322,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"iTj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "iTt" = (
 /obj/item/wrench/medical,
 /turf/open/floor/plating{
@@ -21327,18 +21368,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"iTZ" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/machinery/power/grounding_rod,
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering - Engine Containment West";
-	dir = 4;
-	network = list("ss13","Engine","Engineering")
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "iUd" = (
 /obj/machinery/space_heater,
 /obj/structure/window/reinforced,
@@ -21400,6 +21429,23 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"iWp" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "iWz" = (
 /turf/template_noop,
 /area/maintenance/port/fore)
@@ -21422,12 +21468,6 @@
 	},
 /turf/open/floor/grass,
 /area/medical/genetics)
-"iWQ" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "iXh" = (
 /obj/structure/closet/crate{
 	name = "Surplus Toxins Supplies"
@@ -21463,17 +21503,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"iYc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering Particle Accelerator";
-	dir = 4;
-	network = list("ss13","engine")
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "iYw" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -21487,21 +21516,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"iYy" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "iYH" = (
 /obj/structure/grille,
 /obj/item/shard,
@@ -21576,6 +21590,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"jbx" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/button/door{
+	dir = 8;
+	id = "engsm";
+	name = "Radiation Shutters Control";
+	pixel_y = -24;
+	req_access = list("engineering")
+	},
+/obj/machinery/light{
+	light_color = "#c1caff"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "jbK" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -21629,6 +21657,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint)
+"jdJ" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko{
+	pixel_x = -6;
+	pixel_y = 6
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "jdR" = (
 /obj/structure/cloth_curtain{
 	color = "#99ccff";
@@ -21753,6 +21792,18 @@
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/bar)
+"jhe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "jhk" = (
 /obj/structure/table,
 /obj/item/hand_tele,
@@ -21764,6 +21815,11 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"jhz" = (
+/obj/machinery/gravity_generator/main/station,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
 "jhB" = (
 /obj/machinery/door/airlock/external{
 	name = "AISat External Access"
@@ -21774,6 +21830,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"jhP" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jhT" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Chapel"
@@ -21948,12 +22016,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jjU" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jjV" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
 	dir = 4
@@ -22301,6 +22363,12 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"jqx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "jqN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -22325,6 +22393,10 @@
 /obj/effect/mapping_helpers/mail_sorting/engineering/atmospherics,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"jqW" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/storage_shared)
 "jqX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -22572,21 +22644,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"jxO" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/ramp_middle,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jxT" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -22913,6 +22970,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
+"jDW" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "jEc" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/captain)
@@ -22972,6 +23041,12 @@
 	},
 /turf/open/floor/carpet,
 /area/bridge)
+"jFo" = (
+/obj/machinery/power/emitter{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "jFu" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
@@ -23123,24 +23198,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"jJh" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/engine/engineering";
-	dir = 4;
-	name = "Engine Room APC";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "jJw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -23207,6 +23264,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"jKt" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jKB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -23269,30 +23336,12 @@
 "jMb" = (
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
-"jMh" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
+"jMc" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
+/turf/open/floor/engine,
+/area/engine/engineering)
 "jMn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -23306,17 +23355,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"jMo" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 1;
-	pixel_y = -29
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jMF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -23511,18 +23549,6 @@
 /obj/machinery/status_display,
 /turf/closed/wall,
 /area/maintenance/aft)
-"jQM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jQV" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 8
@@ -23912,6 +23938,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"jZB" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jZF" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -23921,24 +23963,6 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"jZH" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "jZK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
@@ -23974,6 +23998,13 @@
 	},
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tcomms,
 /turf/open/floor/plating,
+/area/tcommsat/computer)
+"kar" = (
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
 /area/tcommsat/computer)
 "kaw" = (
 /obj/structure/window/reinforced{
@@ -24209,6 +24240,19 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"kfR" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "kfT" = (
 /obj/structure/transit_tube/crossing/horizontal,
 /obj/structure/lattice,
@@ -24405,6 +24449,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"kjf" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/nuke_storage)
 "kjs" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -24498,6 +24552,12 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"kkQ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "kkZ" = (
 /turf/open/floor/plasteel,
 /area/escapepodbay)
@@ -24595,6 +24655,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"kmG" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/closet/radiation,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "kmJ" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
 	dir = 8
@@ -24664,6 +24729,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"knw" = (
+/obj/structure/cable/orange{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"knE" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "knF" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
@@ -24671,12 +24752,6 @@
 "koa" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/toilet)
-"koo" = (
-/obj/machinery/light_switch{
-	pixel_x = -28
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/nuke_storage)
 "kop" = (
 /obj/effect/landmark/stationroom/maint/tenxfive,
 /turf/template_noop,
@@ -24710,6 +24785,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"koQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"koW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "kpw" = (
 /obj/structure/sign/warning/pods{
 	pixel_y = 32
@@ -24743,6 +24835,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/freezer,
 /area/maintenance/aft)
+"kqQ" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "kqW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -24801,6 +24907,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"krv" = (
+/obj/machinery/power/smes/engineering{
+	input_level = 10000;
+	output_attempt = 0;
+	output_level = 5000
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "krQ" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -24970,19 +25090,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"kwG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/ramp_middle,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "kwT" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
@@ -25077,6 +25184,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"kzQ" = (
+/obj/machinery/power/apc/auto_name{
+	dir = 8;
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "kzZ" = (
 /obj/item/kirbyplants/photosynthetic,
 /obj/effect/turf_decal/trimline/dark_blue/warning/lower/nobottom{
@@ -25132,32 +25252,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"kCh" = (
-/obj/structure/rack,
-/obj/item/storage/belt/utility{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/storage/belt/utility,
-/obj/item/clothing/head/welding,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "kCs" = (
 /obj/structure/disposaloutlet{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
-"kCI" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "kDd" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/sign/warning/fire{
@@ -25224,10 +25324,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/central)
-"kFg" = (
-/obj/effect/turf_decal/bot_white/right,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "kFl" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 6
@@ -25277,24 +25373,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"kGk" = (
-/obj/machinery/computer/station_alert{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
-"kGx" = (
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "kGU" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -25401,15 +25479,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"kIU" = (
-/obj/structure/table,
-/obj/item/stock_parts/cell/high/plus{
-	pixel_x = 6;
-	pixel_y = 8
-	},
-/obj/item/pen/blue,
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_smes)
 "kIX" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/metal/fifty,
@@ -25487,13 +25556,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"kLV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/machinery/vending/wardrobe/law_wardrobe,
-/turf/open/floor/wood,
-/area/lawoffice)
 "kLY" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -25512,6 +25574,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"kMF" = (
+/obj/effect/turf_decal/bot_white/left,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "kMT" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -25629,6 +25708,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"kOI" = (
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/requests_console{
+	department = "Engineering";
+	departmentType = 4;
+	name = "Engineering RC";
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "kOP" = (
 /obj/item/folder/white,
 /obj/item/stamp/cmo,
@@ -25752,15 +25847,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/freezer,
 /area/maintenance/aft)
-"kQK" = (
-/obj/machinery/field/generator,
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering - Secure Storage";
-	dir = 4;
-	network = list("ss13","Engineering")
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "kQR" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -25809,23 +25895,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"kRH" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Office"
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "kRJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/cable{
@@ -25903,18 +25972,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"kTP" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "kTW" = (
 /obj/machinery/ai/networking{
 	label = "Computer Science";
@@ -25925,6 +25982,13 @@
 	},
 /turf/open/floor/catwalk_floor/telecomms,
 /area/ai_monitored/secondarydatacore)
+"kUe" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "kUh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -26099,6 +26163,9 @@
 /obj/item/clothing/shoes/sneakers/white,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"kXF" = (
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "kXG" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plating,
@@ -26194,6 +26261,10 @@
 "kZs" = (
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
+"kZv" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/r_wall,
+/area/ai_monitored/nuke_storage)
 "kZB" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -26432,22 +26503,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"lew" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "lex" = (
 /obj/machinery/cell_charger,
 /obj/structure/table,
@@ -26468,19 +26523,13 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
-"leG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/mail_sorting/engineering/general,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 2;
-	pixel_y = -1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+"leU" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/chair/office/dark,
+/obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/trimline/engiyellow/warning/lower,
 /turf/open/floor/plasteel,
-/area/engine/foyer)
+/area/engine/storage_shared)
 "lfj" = (
 /obj/structure/chair/wood/wings,
 /obj/effect/landmark/start/chaplain,
@@ -26492,14 +26541,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"lfm" = (
-/obj/structure/tank_dispenser,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "lfS" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip,
@@ -26591,13 +26632,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"lhz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/engine_smes)
 "lia" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26633,29 +26667,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"lim" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Gravity Generator"
-	},
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
-/turf/open/floor/engine,
-/area/engine/gravity_generator)
 "liu" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Air to Ports"
@@ -26787,16 +26798,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"llk" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "llp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -26853,6 +26854,19 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"lmA" = (
+/obj/machinery/power/emitter/anchored{
+	dir = 8;
+	state = 2
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "lmJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -27052,19 +27066,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
-"lqk" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "lqs" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/decal/cleanable/blood/old,
@@ -27119,6 +27120,12 @@
 	},
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
+"lrd" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "lrh" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -27128,6 +27135,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"lrq" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "lrr" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -27387,22 +27403,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
-"lxC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "lxE" = (
 /obj/effect/landmark/start/cook,
 /turf/open/floor/plasteel/cafeteria{
@@ -27433,6 +27433,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"lyf" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "lym" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
@@ -27482,18 +27497,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/storage/tech)
-"lzO" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "lAw" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
@@ -27564,12 +27567,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"lBG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "lBO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -27612,15 +27609,6 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
-"lCw" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering - Entrance";
-	dir = 1;
-	network = list("ss13","Engineering")
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "lCC" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -27649,15 +27637,6 @@
 /obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
-"lDa" = (
-/obj/machinery/computer/secure_data{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "lDd" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/chapel{
@@ -27683,6 +27662,28 @@
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"lDJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"lDP" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/engine,
+/area/engine/gravity_generator)
 "lDW" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
@@ -27748,12 +27749,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"lFR" = (
-/obj/machinery/power/emitter{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "lFV" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm3";
@@ -27773,12 +27768,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"lGb" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "lGl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -27819,13 +27808,6 @@
 /obj/item/storage/box/rxglasses,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"lGP" = (
-/obj/machinery/computer/rdconsole/production,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "lGX" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8
@@ -27909,16 +27891,6 @@
 	},
 /turf/open/floor/plasteel/stairs/goon/wood_stairs_wide,
 /area/library)
-"lJa" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "lJg" = (
 /obj/effect/turf_decal/pool{
 	dir = 4
@@ -28016,6 +27988,21 @@
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
+"lLY" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs2_wide{
+	dir = 1
+	},
+/area/engine/engineering)
 "lMb" = (
 /obj/structure/flora/rock,
 /turf/open/floor/plating/asteroid/airless,
@@ -28067,15 +28054,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"lNn" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "lNo" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -28089,6 +28067,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"lNr" = (
+/obj/item/screwdriver,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "lNs" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
@@ -28215,6 +28197,18 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/fore)
+"lQl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "lQB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28240,18 +28234,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"lQV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "lQX" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -28724,6 +28706,16 @@
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"lZD" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "lZP" = (
 /obj/item/screwdriver,
 /turf/open/floor/plating/airless,
@@ -28774,15 +28766,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"mbt" = (
-/obj/effect/turf_decal/trimline/purple/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
-"mbF" = (
-/obj/machinery/computer/bank_machine,
+"mbg" = (
 /obj/effect/turf_decal/bot_white,
+/obj/structure/filingcabinet,
+/obj/item/folder/documents,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -28795,6 +28782,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
+"mbt" = (
+/obj/effect/turf_decal/trimline/purple/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "mbM" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
@@ -28845,6 +28838,21 @@
 	initial_gas_mix = "n2=1000;TEMP=293.15"
 	},
 /area/engine/atmos)
+"mdg" = (
+/obj/effect/turf_decal/bot_white/right,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "mdj" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 8
@@ -28895,12 +28903,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"mff" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "mfk" = (
 /obj/structure/bed/dogbed/runtime,
 /obj/structure/noticeboard{
@@ -28984,9 +28986,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"mgZ" = (
-/turf/closed/wall/r_wall,
-/area/engine/foyer)
 "mha" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -29021,6 +29020,11 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
+"mhT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mhZ" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall/r_wall,
@@ -29195,6 +29199,11 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"mlq" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mlJ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio_r";
@@ -29258,18 +29267,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/clerk)
-"mmN" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_smes)
 "mmQ" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig"
@@ -29571,6 +29568,28 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"msi" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator and SMES"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "msE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -29619,6 +29638,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
+"mtm" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "mtx" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
@@ -29888,15 +29911,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"myL" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_smes)
 "myW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -29961,12 +29975,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"mzT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "mAb" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -29999,17 +30007,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"mBs" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/holopad,
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "mBt" = (
 /turf/open/floor/engine,
 /area/science/explab)
@@ -30042,6 +30039,18 @@
 /obj/item/weldingtool,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"mBW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mCi" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -30174,15 +30183,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"mDQ" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "mEd" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -30271,13 +30271,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"mFe" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/engiyellow/warning/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "mFj" = (
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
@@ -30407,10 +30400,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/interrogation)
-"mHO" = (
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "mHP" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -30433,14 +30422,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/fore)
-"mIl" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "mIn" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -30466,10 +30447,29 @@
 /obj/machinery/telecomms/server/presets/engineering,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"mIE" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "mJi" = (
 /obj/structure/toilet,
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
+"mJt" = (
+/obj/structure/cable/orange{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mJD" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -30501,6 +30501,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"mJO" = (
+/obj/structure/rack,
+/obj/item/airlock_painter{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/airlock_painter{
+	pixel_x = 3;
+	pixel_y = -6
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "mKf" = (
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
@@ -30538,6 +30553,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"mLI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "mLX" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light{
@@ -30586,18 +30610,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"mNb" = (
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "mNh" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 2
@@ -30614,11 +30626,29 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"mNz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/engine_smes)
 "mNJ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/rnd,
 /turf/open/floor/plating,
 /area/storage/tech)
+"mNS" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mOa" = (
 /obj/structure/chair{
 	dir = 4
@@ -30662,14 +30692,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"mPt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "mPu" = (
 /obj/machinery/computer/message_monitor{
 	dir = 4
@@ -30816,15 +30838,6 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"mRw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/ramp_corner{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "mRB" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -30907,6 +30920,16 @@
 /obj/effect/spawner/structure/solars/solar_96,
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/fore)
+"mTC" = (
+/obj/machinery/disposal/bin/tagger,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "mTT" = (
 /obj/machinery/status_display/ai,
 /turf/closed/wall,
@@ -31141,6 +31164,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"mXG" = (
+/obj/machinery/disposal/bin/tagger,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "mXH" = (
 /obj/machinery/computer/rdconsole/experiment,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
@@ -31451,6 +31481,15 @@
 /obj/effect/landmark/secequipment,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"ndU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "nee" = (
 /obj/machinery/field/generator{
 	anchored = 1;
@@ -31554,6 +31593,16 @@
 /obj/item/reagent_containers/food/condiment/flour,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"nfN" = (
+/obj/machinery/rnd/production/protolathe/department/engineering,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 29
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "ngn" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 4
@@ -31564,6 +31613,20 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"ngP" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/stairs/goon/stairs_wide{
+	dir = 1
+	},
+/area/engine/engineering)
 "ngQ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -31663,6 +31726,9 @@
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/closed/wall,
 /area/medical/chemistry)
+"niQ" = (
+/turf/closed/wall/r_wall,
+/area/engine/foyer)
 "niT" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -31750,6 +31816,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"nlj" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nlm" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -31853,18 +31925,6 @@
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"nlM" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nlP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -31920,18 +31980,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"nnk" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nnr" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -32057,28 +32105,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"nqH" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
-"nqL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "nqO" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/grass,
@@ -32197,6 +32223,25 @@
 "nuh" = (
 /turf/closed/wall,
 /area/quartermaster/sorting)
+"nuI" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "engsm";
+	name = "Radiation Shutters Control";
+	pixel_y = 24;
+	req_access = list("engineering")
+	},
+/obj/machinery/vending/wardrobe/engi_wardrobe,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nuO" = (
 /obj/machinery/light_switch{
 	pixel_x = 24
@@ -32323,6 +32368,24 @@
 /obj/machinery/status_display,
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"nxV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "nya" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder{
@@ -32379,6 +32442,16 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/science/server)
+"nAb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nAq" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -32420,6 +32493,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"nBf" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "nBg" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
 	dir = 1
@@ -32502,6 +32590,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"nDq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nDr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -32534,24 +32637,6 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
-"nDU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "nEr" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
@@ -32878,6 +32963,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"nJY" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 4
+	},
+/obj/structure/chair/office/dark,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "nKe" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -33070,6 +33162,15 @@
 	dir = 4
 	},
 /area/crew_quarters/toilet)
+"nMF" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "nMK" = (
 /obj/structure/ethernet_cable{
 	icon_state = "1-4"
@@ -33444,6 +33545,15 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
+"nVt" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "nWn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -33551,6 +33661,19 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"nYc" = (
+/obj/structure/rack,
+/obj/item/storage/box/lights/mixed{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/lights/mixed{
+	pixel_x = -3;
+	pixel_y = -1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "nYv" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -33851,6 +33974,19 @@
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
+"ofe" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ofh" = (
 /obj/machinery/computer/mech_bay_power_console,
 /turf/open/floor/plasteel,
@@ -34021,6 +34157,16 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/aux_base,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"ojE" = (
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/crew_quarters/heads/chief";
+	dir = 8;
+	name = "CE Office APC";
+	pixel_x = -25
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "ojI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -34506,6 +34652,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"otO" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "otS" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance,
@@ -34528,6 +34684,10 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/crew_quarters/heads/hor)
+"oup" = (
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "ouF" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -34623,6 +34783,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
+"oxj" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "oxk" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -34721,10 +34890,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"oyZ" = (
-/obj/item/screwdriver,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "ozf" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -28
@@ -34761,15 +34926,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"oAk" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "oAz" = (
 /obj/machinery/light_switch{
 	pixel_y = 24
@@ -34814,6 +34970,12 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/clerk)
+"oAV" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "oBd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/carpet,
@@ -34900,17 +35062,6 @@
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"oDP" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "oDZ" = (
 /obj/machinery/camera{
 	c_tag = "Research - Xenobiology Cell 5";
@@ -34986,22 +35137,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"oFJ" = (
-/obj/machinery/power/smes,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/requests_console{
-	department = "Engineering";
-	departmentType = 4;
-	name = "Engineering RC";
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_smes)
 "oFW" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/meter,
@@ -35055,22 +35190,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"oIq" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"oIw" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "oIM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -35078,6 +35197,18 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"oIY" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "oJg" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
@@ -35095,13 +35226,21 @@
 "oJj" = (
 /turf/open/floor/plating/burnt,
 /area/maintenance/starboard)
-"oJG" = (
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
-	dir = 8
+"oJH" = (
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/machinery/vending/coffee,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/engine/engineering)
 "oJL" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
@@ -35183,11 +35322,6 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/engine/atmos)
-"oLM" = (
-/obj/machinery/gravity_generator/main/station,
-/obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "oMy" = (
 /obj/machinery/flasher{
 	id = "AI";
@@ -35248,12 +35382,6 @@
 	},
 /turf/closed/wall,
 /area/crew_quarters/bar)
-"oNy" = (
-/obj/machinery/modular_computer/console/preset/command/ce{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "oNz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -35356,6 +35484,18 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
+"oPP" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/lawoffice";
+	dir = 1;
+	name = "Lawyer's Office APC";
+	pixel_y = 23
+	},
+/turf/open/floor/wood,
+/area/lawoffice)
 "oPQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -35392,12 +35532,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/maintenance/aft)
-"oQc" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "oQk" = (
 /obj/effect/landmark/start/roboticist,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
@@ -35466,6 +35600,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"oRI" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "oRL" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
@@ -35724,23 +35871,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"oWS" = (
-/obj/effect/turf_decal/bot_white/left,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "oWY" = (
 /obj/effect/spawner/lootdrop/mob/kitchen_animal,
 /turf/open/floor/plasteel/showroomfloor,
@@ -35827,6 +35957,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"pau" = (
+/obj/machinery/camera/motion{
+	c_tag = "Vault";
+	dir = 8;
+	network = list("vault","ss13")
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "paM" = (
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -35901,12 +36043,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"pcV" = (
-/obj/structure/cable/orange{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "pdc" = (
 /obj/structure/easel,
 /obj/item/canvas/twentythreeXtwentythree{
@@ -35937,15 +36073,23 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"pdQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+"pdT" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_alone{
+	dir = 8
+	},
 /area/engine/engineering)
 "pei" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -36009,20 +36153,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"phc" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/engine,
-/area/engine/gravity_generator)
 "phg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -36095,17 +36225,6 @@
 "piy" = (
 /turf/open/floor/plating/broken/three,
 /area/maintenance/starboard)
-"piC" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/donkpockets,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "piO" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -36131,6 +36250,17 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
+"pjh" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27;
+	pixel_y = 1
+	},
+/turf/open/floor/engine,
+/area/engine/gravity_generator)
 "pjm" = (
 /obj/structure/closet/secure_closet/atmospherics,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -36205,6 +36335,22 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"pmf" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "pmo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -36369,18 +36515,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/eva,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
-"ppa" = (
-/obj/structure/cable/orange{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ppd" = (
 /obj/machinery/button/door/incinerator_vent_atmos_aux{
 	pixel_x = -8;
@@ -36472,22 +36606,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"pqv" = (
-/obj/effect/turf_decal/bot_white,
-/obj/structure/filingcabinet,
-/obj/item/folder/documents,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "pqQ" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -36540,6 +36658,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"prr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/wood,
+/area/lawoffice)
 "prs" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
@@ -36589,6 +36714,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"prU" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/northleft{
+	name = "Engineering Desk"
+	},
+/obj/item/deskbell/preset/engi{
+	pixel_x = -8;
+	pixel_y = -3
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/mapping_helpers/windoor/access/any/engineering/construction{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/windoor/access/any/engineering/general{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/engine/storage_shared)
 "prZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -36633,16 +36780,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
-"pss" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/power/grounding_rod,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "psu" = (
 /obj/structure/closet/crate,
 /obj/item/toy/figure/miner,
@@ -36809,34 +36946,6 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"pvq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/ramp_corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/rack,
-/obj/item/clothing/glasses/meson{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/clothing/glasses/meson{
-	pixel_y = -1
-	},
-/obj/item/clothing/glasses/meson{
-	pixel_x = -3;
-	pixel_y = -4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "pvr" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/cafeteria,
@@ -36857,27 +36966,6 @@
 	icon_state = "damaged5"
 	},
 /area/space/nearstation)
-"pwa" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "pww" = (
 /turf/closed/wall,
 /area/quartermaster/office)
@@ -37172,27 +37260,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"pCg" = (
-/obj/machinery/door/airlock/vault,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/vault,
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "pCp" = (
 /obj/structure/sign/poster/random{
 	pixel_y = 32
@@ -37219,15 +37286,6 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"pCY" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/tcommsat/computer)
 "pDd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -37437,13 +37495,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"pHX" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/start/station_engineer,
-/obj/effect/turf_decal/trimline/engiyellow/warning/lower,
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "pIm" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -37509,6 +37560,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"pJg" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pJl" = (
 /turf/open/floor/wood,
 /area/library)
@@ -37567,23 +37627,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"pKB" = (
-/obj/machinery/power/apc{
-	areastring = "/area/engine/gravity_generator";
-	name = "Gravity Generator APC";
-	pixel_y = -23
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/engine,
-/area/engine/gravity_generator)
 "pKV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
@@ -37615,6 +37658,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"pLG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pLR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -37825,12 +37874,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"pQu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "pQN" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/minor/kittyears_or_rabbitears,
@@ -37921,15 +37964,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"pSj" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "pSl" = (
 /obj/item/stack/cable_coil/cut/red,
 /turf/open/floor/plasteel/airless{
@@ -38022,25 +38056,6 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
-"pUy" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"pUQ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/button/door{
-	dir = 8;
-	id = "engsm";
-	name = "Radiation Shutters Control";
-	pixel_y = -24;
-	req_access = list("engineering")
-	},
-/obj/machinery/light{
-	light_color = "#c1caff"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "pVt" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/item/t_scanner,
@@ -38064,6 +38079,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"pVz" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "pVC" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -38145,17 +38170,6 @@
 /obj/machinery/field/generator,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"pXu" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "pXz" = (
 /obj/structure/door_assembly/door_assembly_min{
 	anchored = 1
@@ -38275,6 +38289,18 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing)
+"qaR" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "qbc" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -28
@@ -38297,6 +38323,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
+"qbm" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "qbo" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -38343,18 +38373,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"qbI" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"qbF" = (
+/obj/machinery/computer/station_alert{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
+/obj/item/radio/intercom{
+	pixel_x = 29
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
+/area/engine/storage_shared)
 "qce" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -38378,6 +38408,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"qcz" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"qcA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "qcH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -38385,13 +38433,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"qcQ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/plasma,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "qcT" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -38414,6 +38455,10 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"qdg" = (
+/obj/effect/turf_decal/bot_white/right,
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
 "qdJ" = (
 /obj/machinery/status_display,
 /turf/closed/wall,
@@ -38574,9 +38619,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"qgb" = (
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "qgw" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -38785,12 +38827,6 @@
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"qko" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "qkE" = (
 /turf/open/floor/plasteel/white,
 /area/science/explab)
@@ -38876,18 +38912,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"qmB" = (
-/obj/machinery/computer/station_alert{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/item/radio/intercom{
-	pixel_x = 29
-	},
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "qmE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -38936,19 +38960,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"qnR" = (
-/obj/structure/rack,
-/obj/item/storage/box/lights/mixed{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/lights/mixed{
-	pixel_x = -3;
-	pixel_y = -1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "qnS" = (
 /turf/open/floor/plating,
 /area/storage/tech)
@@ -39002,6 +39013,28 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"qoj" = (
+/obj/structure/closet/secure_closet/engineering_chief,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
+"qol" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "qoy" = (
 /obj/machinery/light{
 	dir = 4
@@ -39015,21 +39048,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"qoG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/ramp_middle,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "qoL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
@@ -39239,18 +39257,6 @@
 /obj/machinery/status_display,
 /turf/closed/wall,
 /area/lawoffice)
-"qrt" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "qrD" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
@@ -39356,6 +39362,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"qtC" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "qtI" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
@@ -39456,18 +39477,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"qvx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "qvP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39521,6 +39530,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"qwI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "qwU" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Atmospherics Maintenance"
@@ -39544,13 +39559,6 @@
 "qxi" = (
 /turf/open/floor/plating/asteroid/airless,
 /area/space/nearstation)
-"qxt" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "qxL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -39606,6 +39614,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"qyw" = (
+/obj/machinery/door/poddoor{
+	id = "enginesecurestorage";
+	name = "Secure Storage"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "qyE" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -39731,6 +39752,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"qBw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "qBV" = (
 /obj/machinery/conveyor{
 	dir = 6;
@@ -39845,14 +39887,27 @@
 "qEj" = (
 /turf/open/floor/plasteel,
 /area/security/brig)
-"qEr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/storage_shared)
 "qEt" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"qEA" = (
+/obj/machinery/power/apc{
+	areastring = "/area/engine/gravity_generator";
+	name = "Gravity Generator APC";
+	pixel_y = -23
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/engine,
+/area/engine/gravity_generator)
 "qEG" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -40178,21 +40233,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"qNa" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/stairs/goon/stairs2_wide{
-	dir = 1
-	},
-/area/engine/engineering)
 "qNk" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office"
@@ -40259,6 +40299,26 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"qOC" = (
+/obj/machinery/nuclearbomb/selfdestruct,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "qOP" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -40268,25 +40328,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"qPF" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/ramp_corner{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/table,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/obj/item/melee/sledgehammer,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "qPJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -40302,16 +40343,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"qQe" = (
-/obj/machinery/rnd/production/circuit_imprinter,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "qQh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -40361,6 +40392,18 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
+"qRq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qRr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -40422,20 +40465,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"qSd" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/engine/engine_smes)
-"qSg" = (
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "qSt" = (
 /turf/closed/wall,
 /area/medical/medbay/central)
@@ -40475,6 +40504,21 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"qTe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "qTE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -40521,6 +40565,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"qUN" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qVf" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 6
@@ -40550,6 +40603,14 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"qWb" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "qWl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -40730,12 +40791,35 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"qYJ" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/stairs/goon/stairs_wide{
+	dir = 1
+	},
+/area/engine/engineering)
 "qYR" = (
 /obj/machinery/shower{
 	dir = 1
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
+"qYV" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "qZo" = (
 /obj/effect/landmark/start/assistant,
 /obj/effect/turf_decal/pool,
@@ -40786,16 +40870,6 @@
 	initial_gas_mix = "n2=1000;TEMP=293.15"
 	},
 /area/engine/atmos)
-"qZY" = (
-/obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/crew_quarters/heads/chief";
-	dir = 8;
-	name = "CE Office APC";
-	pixel_x = -25
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "rai" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40876,6 +40950,18 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/carpet,
 /area/bridge)
+"rce" = (
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/item/pen,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "rch" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -40933,14 +41019,18 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"rdS" = (
-/obj/machinery/vending/engivend,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+"rdB" = (
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
 	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -40961,21 +41051,21 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"rec" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "reg" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input{
 	dir = 8
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
+"reD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "rfr" = (
 /obj/structure/closet/secure_closet/brig,
 /obj/machinery/light{
@@ -40998,12 +41088,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"rfV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "rgb" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/main";
@@ -41074,6 +41158,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"rhY" = (
+/obj/structure/table/reinforced,
+/obj/machinery/photocopier/faxmachine{
+	department = "Chief Engineer";
+	name = "Chief Engineer's Fax Machine"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/toy/figure/ce{
+	pixel_x = -10;
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "rio" = (
 /obj/machinery/door/poddoor{
 	id = "trash";
@@ -41116,16 +41216,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/security/prison)
-"rjc" = (
-/obj/machinery/rnd/production/protolathe/department/engineering,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "rjk" = (
 /obj/machinery/status_display/supply{
 	pixel_x = 32
@@ -41274,6 +41364,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/warehouse)
+"rlI" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/plasma,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "rmb" = (
 /obj/structure/ethernet_cable{
 	icon_state = "2-4"
@@ -41318,21 +41415,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
-"rmN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "rmU" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/nuke_storage)
+"rnp" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/hallway/primary/central)
 "rnw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -41641,6 +41732,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/general,
 /turf/open/floor/plating,
 /area/medical/sleeper)
+"rso" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rsE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -41728,6 +41825,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"ruJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rvi" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
@@ -41782,15 +41894,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"rwn" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_smes)
 "rwt" = (
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -41840,10 +41943,7 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"rxR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
+"rxG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
 	},
@@ -41851,28 +41951,10 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
-/obj/machinery/light_switch{
-	pixel_x = -22;
-	pixel_y = 24
-	},
-/obj/machinery/button/door{
-	id = "enginepashutter";
-	name = "Particle Accelerator Shutter Control";
-	pixel_x = -25;
-	pixel_y = 32;
-	req_access = list("engineering")
-	},
-/obj/machinery/button/door{
-	id = "enginesecurestorage";
-	name = "Secure Storage Control";
-	pixel_x = -25;
-	pixel_y = 40;
-	req_access = list("engineering")
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
+/turf/open/floor/circuit,
+/area/ai_monitored/nuke_storage)
 "ryw" = (
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -41891,6 +41973,15 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"ryW" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/tcommsat/computer)
 "rzr" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -41994,19 +42085,18 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"rBu" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/nuke_storage)
 "rBS" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
-"rBT" = (
-/obj/structure/closet/emcloset,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "rCk" = (
 /obj/structure/table,
 /obj/item/camera_film,
@@ -42016,6 +42106,18 @@
 	},
 /turf/open/floor/plasteel/vaporwave,
 /area/storage/art)
+"rCm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rCt" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical{
@@ -42180,6 +42282,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"rFM" = (
+/turf/closed/wall/r_wall,
+/area/engine/storage_shared)
 "rFP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
@@ -42233,6 +42338,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"rGP" = (
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = -22;
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "rGQ" = (
 /obj/structure/table/wood,
 /obj/machinery/airalarm{
@@ -42346,18 +42469,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"rJY" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin{
-	pixel_x = -1;
-	pixel_y = 5
-	},
-/obj/item/pen,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "rKa" = (
 /obj/structure/table,
 /obj/item/assembly/igniter,
@@ -42636,28 +42747,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"rPa" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "rPb" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Two"
@@ -42738,6 +42827,27 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/research)
+"rRb" = (
+/obj/structure/safe,
+/obj/item/clothing/head/bearpelt,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/gun/ballistic/revolver/russian,
+/obj/item/ammo_box/a357,
+/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
+/obj/effect/turf_decal/bot_white/right,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "rRg" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 5
@@ -42799,6 +42909,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"rTl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "rTz" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -42821,18 +42940,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"rTC" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/machinery/power/grounding_rod,
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering - Engine Containment East";
-	dir = 8;
-	network = list("ss13","Engine","Engineering")
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "rTZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -42988,6 +43095,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"rZK" = (
+/turf/closed/wall/r_wall,
+/area/hydroponics)
 "saf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -43016,6 +43126,10 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"sbh" = (
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "sbq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -43131,13 +43245,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
-"seD" = (
-/obj/machinery/power/smes,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_smes)
 "seM" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -43345,6 +43452,24 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"sjd" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/engine/engineering";
+	dir = 4;
+	name = "Engine Room APC";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "sjB" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/decal/cleanable/dirt,
@@ -43410,6 +43535,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"sli" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "slu" = (
 /obj/machinery/door/airlock/maintenance/external{
 	name = "toxins launcher intersection"
@@ -43541,18 +43678,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"snS" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "soh" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -43660,13 +43785,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"srd" = (
-/obj/machinery/vending/coffee,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/tcommsat/computer)
 "sri" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43813,6 +43931,18 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/general,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"svq" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "svz" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor/border_only{
@@ -43832,25 +43962,6 @@
 /obj/machinery/status_display,
 /turf/closed/wall/r_wall,
 /area/science/lab)
-"swn" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "swr" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/airless{
@@ -43960,13 +44071,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"syw" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "syz" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -44094,16 +44198,6 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"szM" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "sAd" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
@@ -44482,10 +44576,6 @@
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"sHR" = (
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "sHS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -44518,18 +44608,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"sIG" = (
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access"
-	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "sIT" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel"
@@ -44598,6 +44676,18 @@
 	},
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"sJF" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Engineer's Desk";
+	departmentType = 3;
+	name = "Chief Engineer RC";
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "sJM" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -44721,12 +44811,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
-"sMn" = (
-/obj/structure/cable/orange{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "sMI" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -45038,9 +45122,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"sSg" = (
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "sSj" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Pure to Ports"
@@ -45116,10 +45197,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
-"sUq" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "sUG" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/stripes/corner{
@@ -45164,12 +45241,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"sVs" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/nuke_storage)
 "sVE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -45290,21 +45361,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"sYW" = (
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "sYX" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -45544,6 +45600,17 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/tcomms,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"teI" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 10
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "teO" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/light/small{
@@ -45552,6 +45619,15 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet)
+"teP" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "teS" = (
 /obj/structure/sign/departments/evac{
 	pixel_y = 32
@@ -45793,6 +45869,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"tja" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/camera{
+	c_tag = "Security Post - Engineering";
+	dir = 8;
+	network = list("ss13","chpt")
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "tjp" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 4
@@ -46129,6 +46217,59 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"tqr" = (
+/obj/item/coin/silver{
+	pixel_x = 7;
+	pixel_y = 12
+	},
+/obj/item/coin/silver{
+	pixel_x = 12;
+	pixel_y = 7
+	},
+/obj/item/coin/silver{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/coin/silver{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/coin/silver{
+	pixel_x = 5;
+	pixel_y = -8
+	},
+/obj/structure/closet/crate{
+	name = "Silver Crate"
+	},
+/obj/effect/turf_decal/bot_white/right,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
+"tqt" = (
+/obj/structure/table/reinforced,
+/obj/item/paper/monitorkey{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/obj/item/stamp/ce{
+	pixel_x = -6;
+	pixel_y = 7
+	},
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = 7;
+	pixel_y = 11
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "tqu" = (
 /obj/structure/table/glass,
 /obj/item/slime_scanner,
@@ -46674,13 +46815,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"tzA" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "tzX" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -46900,32 +47034,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
-"tFP" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Gravity Generator";
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/light_switch{
-	pixel_x = 24
-	},
-/turf/open/floor/engine,
-/area/engine/gravity_generator)
-"tGj" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "tGm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47090,6 +47198,15 @@
 /obj/item/storage/belt/utility,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"tJF" = (
+/obj/machinery/field/generator,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Secure Storage";
+	dir = 4;
+	network = list("ss13","Engineering")
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "tJI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -47180,28 +47297,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"tKw" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Gravity Generator and SMES"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_smes)
 "tKC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -47226,6 +47321,18 @@
 /obj/effect/turf_decal/trimline/green,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"tKT" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "tLf" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower{
@@ -47239,13 +47346,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"tLk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/nuke_storage)
 "tLr" = (
 /obj/machinery/camera{
 	c_tag = "Hallway - Central Southeast 2";
@@ -47320,16 +47420,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"tNf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "tNg" = (
 /obj/machinery/hydroponics/soil,
 /obj/structure/window/reinforced{
@@ -47390,6 +47480,19 @@
 /obj/effect/spawner/lootdrop/coin,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"tPr" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	areastring = "/area/engine/storage_shared";
+	dir = 8;
+	name = "Shared Engineering Storage APC";
+	pixel_x = -25
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "tPw" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -47415,6 +47518,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
+"tPM" = (
+/obj/machinery/computer/rdconsole/production,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "tPQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -47436,35 +47546,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"tQv" = (
-/obj/structure/closet/crate{
-	name = "Gold Crate"
-	},
-/obj/item/stack/sheet/mineral/gold{
-	pixel_x = -1;
-	pixel_y = 5
-	},
-/obj/item/stack/sheet/mineral/gold{
-	pixel_y = 2
-	},
-/obj/item/stack/sheet/mineral/gold{
-	pixel_x = 1;
-	pixel_y = -2
-	},
-/obj/item/storage/belt/champion,
-/obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "tQS" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing)
@@ -47504,21 +47585,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"tRk" = (
-/obj/machinery/advanced_airlock_controller{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "tRo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -47691,6 +47757,26 @@
 	},
 /turf/open/space/basic,
 /area/ai_monitored/turret_protected/aisat_interior)
+"tVt" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
+"tVx" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "tVF" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -47766,6 +47852,28 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"tXe" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/structure/closet/radiation,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
+"tXj" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "tXy" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -47791,6 +47899,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"tYH" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/rack,
+/obj/item/clothing/glasses/meson{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_y = -1
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_x = -3;
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "tYP" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
@@ -47922,6 +48058,15 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"uby" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Hallway - Central East 2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ubP" = (
 /turf/open/indestructible/sound/pool,
 /area/crew_quarters/fitness/recreation)
@@ -48104,16 +48249,6 @@
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"ueP" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "ufa" = (
 /obj/structure/bodycontainer/crematorium{
 	dir = 8;
@@ -48284,6 +48419,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"uip" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "uix" = (
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
@@ -48302,20 +48446,6 @@
 /obj/machinery/vending/games,
 /turf/open/floor/plasteel,
 /area/clerk)
-"uja" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/structure/closet/secure_closet/engineering_welding,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ujh" = (
 /obj/structure/pool_ladder,
 /turf/open/indestructible/sound/pool/end,
@@ -48606,6 +48736,11 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/fore)
+"uqf" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "uqp" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -48635,6 +48770,26 @@
 /obj/structure/cable/white,
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
+"uqV" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=BOTTOMLEFT";
+	location = "BOTTOMMID";
+	name = "navigation beacon (BOTTOMMID)"
+	},
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "urb" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable{
@@ -48731,15 +48886,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"usD" = (
+"usC" = (
 /obj/structure/cable/orange{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -49152,6 +49306,29 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
+"uCb" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
+/turf/open/floor/engine,
+/area/engine/gravity_generator)
 "uCz" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -49201,6 +49378,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"uDm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/tcommsat/computer)
 "uDx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -49228,13 +49423,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"uDE" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/structure/closet/secure_closet/engineering_personal,
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "uEe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -49398,22 +49586,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
-"uFX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/ramp_middle,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "uGh" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -49525,19 +49697,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"uII" = (
-/obj/machinery/power/emitter/anchored{
-	dir = 8;
-	state = 2
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/orange{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "uIQ" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -49590,18 +49749,6 @@
 "uJr" = (
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"uJH" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "uJJ" = (
 /obj/structure/table,
 /obj/machinery/airalarm{
@@ -49610,6 +49757,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
+"uJO" = (
+/obj/structure/tank_dispenser,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "uJQ" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -49746,15 +49901,6 @@
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"uMu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/effect/turf_decal/ramp_corner{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "uMB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrous_output{
 	dir = 8
@@ -49763,11 +49909,28 @@
 	initial_gas_mix = "n2o=1000;TEMP=293.15"
 	},
 /area/engine/atmos)
+"uMO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "uMZ" = (
 /obj/structure/table,
 /obj/item/paper/fluff/holodeck/disclaimer,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"uNH" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "uNK" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -49781,25 +49944,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"uNX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
-"uOi" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "uOr" = (
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged5"
@@ -49906,19 +50050,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"uQJ" = (
-/obj/machinery/vending/tool,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "uQT" = (
 /obj/machinery/computer/teleporter,
 /turf/open/floor/plasteel/dark,
@@ -49975,6 +50106,15 @@
 "uRy" = (
 /turf/open/floor/carpet/black,
 /area/crew_quarters/bar)
+"uRY" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "uSp" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes{
@@ -50071,24 +50211,6 @@
 	initial_gas_mix = "plasma=1000;TEMP=293.15"
 	},
 /area/engine/atmos)
-"uUx" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "uUz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -50169,23 +50291,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"uVZ" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Engine Room"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "uWg" = (
 /obj/machinery/teleport/hub,
 /turf/open/floor/circuit,
@@ -50283,6 +50388,10 @@
 /obj/effect/landmark/stationroom/maint/fivexfour,
 /turf/template_noop,
 /area/maintenance/port/fore)
+"uYa" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "uYd" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/structure/window/reinforced{
@@ -50721,16 +50830,6 @@
 /obj/item/reagent_containers/glass/bottle/epinephrine,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"veZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "vfa" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
@@ -50762,16 +50861,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"vfA" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/machinery/power/grounding_rod,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "vfC" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -50925,14 +51014,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/fore)
-"vkb" = (
-/obj/machinery/suit_storage_unit/engine,
-/obj/structure/cable/orange{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vkv" = (
 /obj/machinery/door/airlock/security{
 	name = "Interrogation"
@@ -50976,18 +51057,18 @@
 /obj/effect/landmark/start/lawyer,
 /turf/open/floor/wood,
 /area/lawoffice)
-"vmd" = (
-/obj/structure/cable{
-	icon_state = "0-8"
+"vlZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/lawoffice";
-	dir = 1;
-	name = "Lawyer's Office APC";
-	pixel_y = 23
+/obj/effect/turf_decal/ramp_middle{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/lawoffice)
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "vmi" = (
 /turf/closed/wall/r_wall,
 /area/medical/storage)
@@ -51116,6 +51197,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"voH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "voN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -51142,24 +51238,6 @@
 "vpk" = (
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"vpq" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
 "vpC" = (
 /obj/structure/sign/poster/official/space_cops{
 	pixel_x = 32
@@ -51185,6 +51263,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"vqi" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "vql" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 10
@@ -51200,13 +51288,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"vqu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vqY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -51250,21 +51331,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"vrO" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_smes)
 "vsp" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -51358,22 +51424,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"vtB" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/ramp_corner{
-	dir = 8
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vtD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -51515,43 +51565,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"vwg" = (
-/obj/structure/cable/orange{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"vwj" = (
-/obj/machinery/advanced_airlock_controller{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "vwr" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -51834,6 +51847,21 @@
 /obj/structure/chair,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"vCn" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/engineering";
+	dir = 8;
+	name = "Engineering Security APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "vCt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/structure/cable{
@@ -51841,21 +51869,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"vCD" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_alone{
-	dir = 4
-	},
-/area/engine/engineering)
 "vCJ" = (
 /obj/docking_port/stationary{
 	dwidth = 3;
@@ -51906,6 +51919,15 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/teleporter,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
+"vDY" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vEE" = (
 /mob/living/carbon/monkey/punpun,
 /turf/open/floor/carpet/black,
@@ -52041,20 +52063,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"vHe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vHz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -52165,11 +52173,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"vKf" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/closet/radiation,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "vKx" = (
 /obj/structure/window/reinforced,
 /obj/machinery/camera{
@@ -52332,6 +52335,22 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"vPi" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access"
+	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"vPr" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "vPx" = (
 /obj/structure/grille,
 /obj/structure/disposalpipe/segment{
@@ -52442,6 +52461,31 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vRc" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command{
+	name = "Chief Engineer's Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "vRn" = (
 /obj/docking_port/stationary/random{
 	dir = 2;
@@ -52508,20 +52552,32 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"vSD" = (
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vSJ" = (
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"vTb" = (
-/obj/machinery/disposal/bin/tagger,
-/obj/structure/disposalpipe/trunk{
+"vSR" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
 /turf/open/floor/plasteel,
-/area/engine/foyer)
+/area/hallway/primary/central)
 "vTr" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -52545,6 +52601,15 @@
 /obj/machinery/telecomms/bus/preset_three,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
+"vTQ" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vUh" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -52634,17 +52699,6 @@
 "vWp" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
-"vWX" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"vXb" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 4
-	},
-/obj/structure/chair/office/dark,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "vXz" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -52894,6 +52948,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"wdU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "wea" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -52959,28 +53025,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"wfM" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "wgg" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 8
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"wgh" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "wgo" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -53246,6 +53296,14 @@
 "wnr" = (
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
+"wns" = (
+/obj/machinery/suit_storage_unit/engine,
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wnt" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -53286,12 +53344,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
-"wnP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "wnV" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light,
@@ -53493,6 +53545,18 @@
 	},
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
+"wsX" = (
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wtb" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -53568,6 +53632,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"wvd" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wvf" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
@@ -53819,18 +53898,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"wzC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "wzH" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 1
@@ -54190,6 +54257,18 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"wFV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wGP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -54250,18 +54329,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"wIx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "wII" = (
 /obj/structure/dresser,
 /turf/open/floor/wood,
@@ -54311,32 +54378,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
-"wJR" = (
-/obj/machinery/power/emitter/anchored{
-	dir = 4;
-	state = 2
-	},
-/obj/structure/cable/orange{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/orange{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "wKa" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"wKk" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "wKn" = (
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice,
@@ -54359,16 +54404,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"wKX" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/obj/effect/landmark/start/station_engineer,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "wKZ" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -54566,6 +54601,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wPt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/gravity_generator)
 "wQb" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -54649,6 +54693,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"wRp" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "wRx" = (
 /obj/structure/table/wood,
 /obj/item/radio/intercom{
@@ -54864,6 +54920,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"wVJ" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/power/rad_collector,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "wVK" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
@@ -54913,41 +54976,6 @@
 	},
 /turf/open/floor/catwalk_floor/telecomms,
 /area/ai_monitored/turret_protected/ai)
-"wWv" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/northleft{
-	name = "Engineering Desk"
-	},
-/obj/item/deskbell/preset/engi{
-	pixel_x = -8;
-	pixel_y = -3
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/mapping_helpers/windoor/access/any/engineering/construction{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/windoor/access/any/engineering/general{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/engine/storage_shared)
-"wWC" = (
-/obj/machinery/door/poddoor{
-	id = "enginesecurestorage";
-	name = "Secure Storage"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "wWJ" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
@@ -55073,20 +55101,14 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"wZy" = (
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access"
+"wZJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
+/obj/effect/turf_decal/ramp_corner{
+	dir = 8
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "wZP" = (
 /obj/machinery/vending/hydronutrients,
@@ -55190,21 +55212,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"xaZ" = (
-/obj/machinery/ore_silo,
-/obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "xbc" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -55265,6 +55272,13 @@
 /obj/item/pool/pool_noodle,
 /turf/open/indestructible/sound/pool/end,
 /area/crew_quarters/fitness/recreation)
+"xbw" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "xbx" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -55341,6 +55355,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"xcy" = (
+/obj/machinery/computer/secure_data{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "xcA" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -55442,6 +55465,25 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"xdX" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/table,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/item/melee/sledgehammer,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "xed" = (
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -55568,38 +55610,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"xgZ" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel/stairs/goon/stairs_wide{
-	dir = 1
-	},
-/area/engine/engineering)
 "xho" = (
 /obj/structure/chair/wood/normal{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"xhK" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Hallway - Central East 2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "xhS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -55614,6 +55630,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"xik" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "xim" = (
 /obj/structure/toilet{
 	dir = 1
@@ -55652,12 +55674,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"xjx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "xjJ" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -55756,6 +55772,13 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
+"xkx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/ramp_corner,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "xkA" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -55852,17 +55875,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"xlG" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/structure/closet/radiation,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/engine/foyer)
 "xmg" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/stripes/line{
@@ -55909,6 +55921,13 @@
 /obj/machinery/vending/sustenance,
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
+"xmM" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "xmO" = (
 /obj/item/hand_labeler,
 /turf/open/floor/plating,
@@ -55955,6 +55974,13 @@
 	},
 /turf/open/floor/catwalk_floor/telecomms,
 /area/ai_monitored/turret_protected/ai)
+"xnD" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "xnG" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -55970,11 +55996,6 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
-"xnN" = (
-/obj/machinery/suit_storage_unit/engine,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "xnQ" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 10
@@ -56124,42 +56145,12 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
-"xpY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "xqf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/trimline/yellow/arrow_cw,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"xqJ" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/stairs/goon/dark_stairs_alone{
-	dir = 8
-	},
-/area/engine/engineering)
 "xqM" = (
 /obj/machinery/light_switch{
 	pixel_x = -23
@@ -56371,17 +56362,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"xvd" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "xvi" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/trunk{
@@ -56400,6 +56380,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"xvU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xwr" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -56505,17 +56497,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
-"xxy" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/button/door{
-	id = "enginesecurestorage";
-	name = "Secure Storage Control";
-	pixel_x = -25;
-	pixel_y = -23;
-	req_access = list("engine_equip")
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "xxK" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -56583,19 +56564,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"xyv" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/landmark/xeno_spawn,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/engine,
-/area/engine/gravity_generator)
 "xyI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56674,13 +56642,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"xzz" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "xzK" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
@@ -56921,12 +56882,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
-"xFR" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "xFT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -57009,12 +56964,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"xIy" = (
-/obj/structure/cable/orange{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "xIB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -57215,13 +57164,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"xMx" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/machinery/power/rad_collector,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "xMI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -57269,39 +57211,27 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"xNF" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Office"
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "xNJ" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"xNS" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering Desk"
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "xNZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -57399,6 +57329,13 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"xPA" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "xPD" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -57604,10 +57541,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"xSO" = (
-/obj/effect/turf_decal/bot_white/left,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "xSP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -57627,6 +57560,19 @@
 /obj/machinery/vending/security,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
+"xTk" = (
+/obj/structure/rack,
+/obj/item/storage/belt/utility{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/belt/utility,
+/obj/item/clothing/head/welding,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "xUh" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/satellite)
@@ -57782,6 +57728,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"xXL" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "xXV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -57811,18 +57764,6 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"xYp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/nuke_storage)
 "xYx" = (
 /obj/structure/table/wood,
 /obj/effect/landmark/event_spawn,
@@ -57865,6 +57806,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
+"yaR" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ybz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
@@ -57872,6 +57827,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"ybA" = (
+/obj/machinery/ore_silo,
+/obj/effect/turf_decal/bot_white/left,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "ybC" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate{
@@ -57979,6 +57949,9 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"ydk" = (
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "ydq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/white,
@@ -58020,6 +57993,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"yed" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "yei" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -58054,6 +58043,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"yeV" = (
+/obj/machinery/modular_computer/console/preset/command/ce{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "yfd" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel,
@@ -58104,6 +58099,15 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"yhn" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Entrance";
+	dir = 1;
+	network = list("ss13","Engineering")
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "yht" = (
 /obj/machinery/meter{
 	layer = 3.4
@@ -58158,6 +58162,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/library)
+"yij" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "yip" = (
 /obj/structure/table,
 /obj/item/reagent_containers/spray/pestspray{
@@ -58202,24 +58213,6 @@
 /obj/effect/spawner/lootdrop/randomfood,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"yjo" = (
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = -22;
-	pixel_y = 24
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "yjJ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -58248,10 +58241,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
-"ykt" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/nuke_storage)
 "ykw" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -58259,6 +58248,20 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
+"ykA" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/engine,
+/area/engine/gravity_generator)
 "ykE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -86962,7 +86965,7 @@ tIb
 fOG
 fOG
 vDp
-dLd
+qBw
 vDp
 vDp
 xkg
@@ -87215,8 +87218,8 @@ atk
 eLP
 imx
 fOG
-vWX
-cPf
+vPr
+qol
 gIJ
 vDp
 vDp
@@ -87470,7 +87473,7 @@ dZN
 chU
 fOG
 gIJ
-cPf
+qol
 gIJ
 ivF
 xSu
@@ -87724,8 +87727,8 @@ eEa
 dnx
 fOG
 gIJ
-bQl
-fki
+qTe
+voH
 vDp
 vDp
 xSu
@@ -87979,7 +87982,7 @@ fOG
 fOG
 fOG
 gIJ
-cPf
+qol
 gIJ
 ivF
 ylr
@@ -88233,7 +88236,7 @@ jlD
 cmK
 fOG
 kYW
-cPf
+qol
 gIJ
 ivF
 xSu
@@ -88486,9 +88489,9 @@ uPG
 jRC
 aCJ
 fOG
-geA
-nDU
-crd
+uqf
+igj
+xPA
 vDp
 xSu
 ylr
@@ -88994,9 +88997,9 @@ uPG
 qFq
 uPG
 akr
-srd
-gWq
-pCY
+kar
+uDm
+ryW
 sIq
 gPK
 iIJ
@@ -92010,7 +92013,7 @@ ylr
 ylr
 ylr
 ylr
-eKw
+rZK
 dMR
 dMR
 dMR
@@ -92267,9 +92270,9 @@ ylr
 ylr
 dMR
 xIW
-kQK
-lFR
-lFR
+tJF
+jFo
+jFo
 dMR
 hiV
 kFs
@@ -92522,8 +92525,8 @@ ylr
 dMR
 xIW
 xIW
-lFR
-lFR
+jFo
+jFo
 dMR
 bhY
 bhY
@@ -92784,10 +92787,10 @@ bvT
 bvT
 bvT
 bvT
-eKw
-eKw
-eKw
-eKw
+rZK
+rZK
+rZK
+rZK
 dFK
 aWv
 nOr
@@ -93028,21 +93031,21 @@ bHj
 bHj
 bHj
 dMR
-qcQ
+rlI
 kie
 kie
 kIX
 bvT
-seD
-cAL
-aGt
-kIU
+iLH
+oRI
+kzQ
+bbe
 bvT
 xSu
 ylr
 xSu
-bSP
-bSP
+dwy
+dwy
 gvx
 hld
 ekF
@@ -93283,20 +93286,20 @@ dMR
 dMR
 dMR
 dMR
-wWC
-wWC
+qyw
+qyw
 dMR
 bvT
-oFJ
-eDD
-rwn
-hbV
+kOI
+tKT
+reD
+oup
 bvT
 xSu
 ylr
 ylr
 xSu
-bSP
+dwy
 khu
 jqS
 foJ
@@ -93521,30 +93524,30 @@ bHj
 vIf
 dMR
 dMR
-wJR
-aiX
-aiX
-aiX
-iTZ
-xMx
-xMx
-xMx
-bxM
+grd
+akY
+akY
+akY
+acV
+wVJ
+wVJ
+wVJ
+dlo
 xdb
-kGx
-vwj
-ihV
-gDg
-fof
-swn
+tVx
+hfT
+nBf
+yaR
+gwr
+bmD
 wOT
-xxy
-bbz
+eIK
+xnD
 bvT
-hCu
-mmN
-vrO
-myL
+azM
+qaR
+lyf
+nMF
 bvT
 hlT
 hlT
@@ -93773,37 +93776,37 @@ ylr
 bHj
 bHj
 dMR
-xIy
+bcP
 mot
-sMn
+cJb
 xdb
 iXL
 iXL
-vfA
+iBJ
 iXL
 iXL
-oIw
+nVt
 iXL
-pSj
+gVE
 dMR
 dMR
 dMR
-gMq
+wsX
 agh
 iGX
 agh
-fMB
-pUy
+dCk
+mlq
 bvT
-lhz
+mNz
 bvT
-tKw
-qSd
+msi
+hcQ
 bvT
-fXg
-eBG
-snS
-abg
+aEx
+vCn
+jDW
+teI
 hlT
 khu
 iOl
@@ -94041,23 +94044,23 @@ mAL
 pzc
 mAL
 rvl
-vKf
+kmG
 nKW
 fkH
-fyC
-dMP
-vqu
-crf
-fFq
-qoG
-fyM
-iYy
-sYW
-kRH
-yjo
-tNf
-xjx
-oQc
+oIY
+mhT
+koW
+qYV
+ngP
+nDq
+jhP
+oJH
+rdB
+xNF
+rGP
+bMq
+ipf
+lrd
 qZx
 khu
 iOl
@@ -94295,23 +94298,23 @@ nee
 pzc
 mAL
 rvl
-gDE
+uYa
 aat
-aFW
-amY
-epv
-lzO
-uOi
-bKe
-kwG
-kTP
-pdQ
-erm
+koQ
+bdt
+cKi
+ggN
+lZD
+lLY
+eKS
+bpj
+jKt
+tXj
 qZx
-fbN
-egv
-vXb
-lDa
+tja
+apM
+nJY
+xcy
 hlT
 khu
 iOl
@@ -94552,14 +94555,14 @@ rvl
 rvl
 dMR
 dMR
-xqJ
+pdT
 dMR
 dMR
 dMR
 dMR
-pvq
-kCI
-cfa
+tYH
+bLw
+bZY
 dMR
 hlT
 hlT
@@ -94802,25 +94805,25 @@ fJu
 fJu
 pzc
 bZW
-hZj
-ifJ
-iYc
-hWp
-duq
-hFl
+cXt
+jqx
+ezY
+xkx
+vlZ
+wZJ
 dMR
-uQJ
-rdS
-rec
-giy
-jMo
+gDG
+eAq
+vDY
+hec
+hQP
 dMR
-vTb
-piC
-rJY
-dRO
-eSk
-mgZ
+mTC
+fAJ
+rce
+jdJ
+bpe
+niQ
 khu
 gOe
 urf
@@ -95058,23 +95061,23 @@ pzc
 bZW
 xwr
 pes
-oyZ
+lNr
 imW
-eIA
-gDE
-xvd
-cNi
+jMc
+uYa
+uNH
+goq
 agh
-lBG
-giy
-szM
-uVZ
-wzC
-chN
-sHR
-wKX
-sUq
-mgZ
+pLG
+hec
+knE
+iWp
+wdU
+fdd
+qbm
+aoY
+dEM
+niQ
 hyJ
 iOl
 aqy
@@ -95314,23 +95317,23 @@ xwr
 oyp
 bMC
 cEU
-hva
-pUQ
+ayZ
+jbx
 dMR
-eUq
+nuI
 agh
-mBs
-nnk
-xpY
-aGy
-biT
-mPt
-jZH
-leG
-lqk
-jMh
+gpf
+fqx
+wFV
+lrq
+diQ
+tVt
+nxV
+aci
+kfR
+hgV
 kbc
-eIS
+uqV
 xae
 dpy
 etr
@@ -95568,21 +95571,21 @@ xwr
 sLe
 imW
 buL
-lGb
-gDE
-xvd
-cNi
+bbY
+uYa
+uNH
+goq
 agh
-lBG
-jQM
-hFV
-uUx
-veZ
-sHR
-fiE
-qgb
-lCw
-mgZ
+pLG
+bHp
+mNS
+iju
+vqi
+qbm
+ilZ
+ydk
+yhn
+niQ
 hyJ
 kmY
 aqy
@@ -95818,27 +95821,27 @@ fJu
 fJu
 pzc
 bZW
-qko
-wnP
-wnP
-mRw
-aTL
-uMu
+xik
+qwI
+qwI
+lDJ
+rTl
+iMU
 dMR
-uja
-syw
-isQ
-blR
+kqQ
+xXL
+pJg
+rCm
 dGI
 dMR
-eFM
-jJh
-rPa
-uDE
-xlG
-mgZ
+mJO
+sjd
+ijc
+hzV
+tXe
+niQ
 khu
-asg
+xvU
 cHw
 uix
 auj
@@ -96076,21 +96079,21 @@ rvl
 rvl
 dMR
 dMR
-vCD
+iaU
 dMR
 dMR
 dMR
 dMR
-hrv
-grO
-cfa
+blT
+nAb
+bZY
 dMR
-fsU
-fsU
-xNS
-fsU
-fsU
-fsU
+rFM
+rFM
+eHx
+rFM
+rFM
+rFM
 dkH
 kmY
 aqy
@@ -96327,24 +96330,24 @@ nee
 pzc
 mAL
 rvl
-gDE
-jjU
-lQV
-pQu
-nlM
-wKk
-xzz
+uYa
+oAV
+dBd
+bWP
+eQw
+vTQ
+qWb
 dMR
-qPF
-blR
-llk
-gOE
-fsU
-kCh
-pwa
-bvA
-rBT
-fsU
+xdX
+rCm
+cvL
+krv
+rFM
+xTk
+gDP
+tPr
+mIE
+rFM
 khu
 kmY
 cLZ
@@ -96581,24 +96584,24 @@ mAL
 pzc
 mAL
 rvl
-vKf
+kmG
 pxl
-dHJ
-ppa
-mIl
-usD
-ezb
-xgZ
-jxO
-oDP
-xFR
-vkb
-fsU
-qQe
-dfB
-mzT
-qnR
-fsU
+rso
+mJt
+dry
+svq
+cvc
+qYJ
+wvd
+ezp
+gWT
+wns
+rFM
+iqv
+jhe
+eOb
+nYc
+rFM
 nQR
 kmY
 jGz
@@ -96823,36 +96826,36 @@ bHj
 dMR
 aYn
 mot
-pcV
+knw
 qKQ
 iXL
 iXL
-pss
+otO
 iXL
 iXL
-lNn
+uRY
 iXL
 kWn
 dMR
 dMR
 dMR
-mNb
+vSD
 agh
-uJH
-fyQ
-wIx
-oIq
-qNa
-uFX
-hfL
+qcz
+qcA
+sli
+yij
+cmN
+yed
+ruJ
 agh
-xnN
-fsU
-rjc
-uNX
-sSg
-bFy
-qEr
+iiz
+rFM
+nfN
+ndU
+kXF
+pVz
+jqW
 khu
 kmY
 jGz
@@ -97077,37 +97080,37 @@ bHj
 vIf
 dMR
 dMR
-gOI
-aiX
-aiX
-aiX
-rTC
-xMx
-xMx
-xMx
-uII
+aLE
+akY
+akY
+akY
+ewo
+wVJ
+wVJ
+wVJ
+lmA
 mot
-sIG
-tRk
-wZy
-vHe
-pXu
-vwg
-qxt
-eDN
-eiM
+vPi
+ats
+qtC
+fZp
+usC
+aID
+xmM
+eLj
+ofe
 dMR
-vtB
-cMV
-wgh
-lfm
-fsU
-lGP
-ciH
-tzA
-pHX
-wWv
-mFe
+jZB
+dNm
+nlj
+uJO
+rFM
+tPM
+mLI
+kUe
+leU
+prU
+aJZ
 cAz
 btE
 fYU
@@ -97348,19 +97351,19 @@ dMR
 myG
 myG
 myG
-lim
+uCb
 myG
 myG
 jvn
-eqj
+vRc
 kHX
 jvn
 jvn
-qSg
-wfM
-nqH
-qmB
-qEr
+xbw
+adN
+oxj
+qbF
+jqW
 khu
 wln
 iln
@@ -97600,21 +97603,21 @@ bHj
 bHj
 bHj
 myG
-hNt
-phc
-hLz
-xyv
+gHG
+ePu
+eyx
+lDP
 myG
-gto
-rxR
-cOH
-aNb
+mXG
+hXT
+tqt
+cOm
 jvn
 jvn
-fsU
-fsU
-fsU
-fsU
+rFM
+rFM
+rFM
+rFM
 uve
 uEO
 dcI
@@ -97854,20 +97857,20 @@ ylr
 xSu
 xSu
 myG
-kFg
-arc
-xSO
-pKB
+qdg
+cub
+idv
+qEA
 myG
-bLM
-rmN
-itP
-qrt
-qZY
-afR
+qoj
+lQl
+rhY
+wRp
+ojE
+mtm
 xSu
 xSu
-bSP
+dwy
 iBp
 nGL
 iOl
@@ -98108,17 +98111,17 @@ ylr
 ylr
 xSu
 myG
-arc
+cub
 gVe
-oLM
-cjR
+jhz
+wPt
 myG
-iuJ
-bNn
-rfV
-bDl
-mff
-afR
+fnT
+uMO
+ips
+sJF
+kkQ
+mtm
 xSu
 xSu
 bDj
@@ -98362,15 +98365,15 @@ ylr
 ylr
 ylr
 myG
-xSO
-arc
-kFg
-cjR
+idv
+cub
+qdg
+wPt
 myG
 jvn
-cXI
-oNy
-kGk
+iED
+yeV
+fnt
 jvn
 jvn
 ylr
@@ -98616,15 +98619,15 @@ ylr
 ylr
 ylr
 myG
-hNt
-aue
-deo
-tFP
+gHG
+ykA
+pjh
+iwn
 myG
 jvn
-afR
-afR
-afR
+mtm
+mtm
+mtm
 jvn
 ylr
 ylr
@@ -99626,11 +99629,11 @@ qAi
 ylr
 ylr
 rmU
-mbF
-hWP
-eYF
-koo
-pqv
+hWH
+iJj
+kjf
+cCC
+mbg
 rmU
 xSu
 xSu
@@ -99880,11 +99883,11 @@ qAi
 ylr
 ylr
 rmU
-eCN
-tLk
-aTV
+mdg
+alG
+qOC
 kst
-oWS
+kMF
 rmU
 ylr
 ylr
@@ -100134,17 +100137,17 @@ qAi
 ylr
 ylr
 rmU
-bOU
-sVs
-xYp
+tqr
+rBu
+rxG
 kUy
-tQv
+gLG
 rmU
 xSu
 ylr
 ylr
 cIr
-iEf
+prr
 dMg
 ibI
 xPK
@@ -100388,20 +100391,20 @@ qAi
 xSu
 xSu
 rmU
-hBD
-ime
-lxC
-mDQ
-xaZ
+rRb
+pau
+eyG
+fln
+ybA
 rmU
 xSu
 xSu
 xSu
 cIr
-vmd
+oPP
 hLr
 sNB
-kLV
+gCa
 cIr
 qrq
 pAH
@@ -100643,9 +100646,9 @@ xSu
 ylr
 rmU
 rmU
-ykt
-pCg
-ykt
+kZv
+gKX
+kZv
 rmU
 rmU
 ylr
@@ -100898,11 +100901,11 @@ ylr
 xSu
 ylr
 eBU
-iGM
+iTj
 eBU
 ylr
 xSu
-iBV
+rnp
 bDj
 bDj
 cIr
@@ -101145,25 +101148,25 @@ tJr
 fpu
 hXS
 ewZ
-cOk
+aYl
 bDj
 bDj
 bDj
 eBU
 eBU
 eBU
-vpq
+dGk
 eBU
 eBU
 eBU
 bDj
-mHO
-oJG
+sbh
+bwn
 tLr
 uNK
 uNK
 uNK
-tGj
+eqj
 voC
 swM
 jJw
@@ -101403,21 +101406,21 @@ aIA
 gSN
 sBb
 jgE
-iWQ
-bsG
+hBm
+teP
 eWk
-qbI
+mBW
 eWk
-oAk
-iWQ
+uip
+hBm
 jgE
 cPC
 cPC
 cPC
 cPC
 yln
-iPk
-qvx
+hGr
+qRq
 jJw
 qoB
 gGv
@@ -101655,12 +101658,12 @@ bDj
 bDj
 bDj
 bDj
-xhK
+uby
 cPC
 cPC
 cPC
 cPC
-qbI
+mBW
 cPC
 cPC
 cPC
@@ -101670,8 +101673,8 @@ xdk
 cPC
 yln
 jJw
-atl
-eNW
+bAH
+hfI
 gGv
 sAd
 jzR
@@ -101904,7 +101907,7 @@ cPC
 iOl
 cPC
 tWc
-ueP
+vSR
 dpq
 ofp
 xWw
@@ -101914,13 +101917,13 @@ cPC
 xdk
 cPC
 cPC
-qbI
+mBW
 cPC
 cPC
 cPC
 yln
 swM
-lJa
+cJA
 swM
 wiz
 gGv
@@ -102158,19 +102161,19 @@ kYt
 eLW
 kYt
 kYt
-hrp
-nqL
+bSD
+brC
 axC
 xxb
 bWN
 dsM
 kYt
-hrp
+bSD
 kYt
 kYt
-lew
+pmf
 dLS
-eOx
+qUN
 vsV
 wiz
 gGv
@@ -102413,7 +102416,7 @@ cPC
 cPC
 cPC
 hDJ
-gFv
+gEX
 xVu
 jjV
 rQI

--- a/_maps/map_files/DonutStation/DonutStation.dmm
+++ b/_maps/map_files/DonutStation/DonutStation.dmm
@@ -3398,25 +3398,6 @@
 /obj/machinery/autolathe,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"bmD" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "bmL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm{
@@ -8715,9 +8696,6 @@
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dwy" = (
-/turf/closed/wall/r_wall,
-/area/hallway/primary/central)
 "dwG" = (
 /obj/structure/closet/secure_closet/detective,
 /obj/item/camera_film,
@@ -9183,13 +9161,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"dGI" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "dGV" = (
 /obj/machinery/mass_driver{
 	dir = 8;
@@ -9571,22 +9542,6 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"dNm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "dNw" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 1
@@ -10766,6 +10721,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"eqV" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "eri" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/randomdrink,
@@ -15931,6 +15891,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"gDd" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "SMES Room"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "gDt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -29568,28 +29550,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"msi" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Gravity Generator and SMES"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_smes)
 "msE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -36141,6 +36101,17 @@
 /obj/effect/spawner/structure/window/hollow/reinforced/end,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"pfy" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pfD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -38100,6 +38071,25 @@
 "pWb" = (
 /turf/closed/wall/r_wall,
 /area/chapel/main)
+"pWc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pWg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -41982,6 +41972,19 @@
 	},
 /turf/open/floor/wood,
 /area/tcommsat/computer)
+"rzq" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "SMES Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "rzr" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -43095,9 +43098,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/tools)
-"rZK" = (
-/turf/closed/wall/r_wall,
-/area/hydroponics)
 "saf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -54623,6 +54623,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
+"wQj" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wQB" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/floor/plating/airless,
@@ -55974,13 +55993,6 @@
 	},
 /turf/open/floor/catwalk_floor/telecomms,
 /area/ai_monitored/turret_protected/ai)
-"xnD" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "xnG" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -57211,23 +57223,6 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"xNF" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Office"
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "xNJ" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -57779,6 +57774,27 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"xYT" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Office"
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "yan" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -92013,7 +92029,7 @@ ylr
 ylr
 ylr
 ylr
-rZK
+lGn
 dMR
 dMR
 dMR
@@ -92787,10 +92803,10 @@ bvT
 bvT
 bvT
 bvT
-rZK
-rZK
-rZK
-rZK
+lGn
+lGn
+lGn
+lGn
 dFK
 aWv
 nOr
@@ -93044,8 +93060,8 @@ bvT
 xSu
 ylr
 xSu
-dwy
-dwy
+bDj
+bDj
 gvx
 hld
 ekF
@@ -93299,7 +93315,7 @@ xSu
 ylr
 ylr
 xSu
-dwy
+bDj
 khu
 jqS
 foJ
@@ -93539,10 +93555,10 @@ hfT
 nBf
 yaR
 gwr
-bmD
+wQj
 wOT
 eIK
-xnD
+eqV
 bvT
 azM
 qaR
@@ -93799,8 +93815,8 @@ dCk
 mlq
 bvT
 mNz
-bvT
-msi
+rzq
+gDd
 hcQ
 bvT
 aEx
@@ -94056,7 +94072,7 @@ nDq
 jhP
 oJH
 rdB
-xNF
+xYT
 rGP
 bMq
 ipf
@@ -95832,7 +95848,7 @@ kqQ
 xXL
 pJg
 rCm
-dGI
+pfy
 dMR
 mJO
 sjd
@@ -97101,7 +97117,7 @@ eLj
 ofe
 dMR
 jZB
-dNm
+pWc
 nlj
 uJO
 rFM
@@ -97870,7 +97886,7 @@ ojE
 mtm
 xSu
 xSu
-dwy
+bDj
 iBp
 nGL
 iOl

--- a/_maps/map_files/DonutStation/DonutStation.dmm
+++ b/_maps/map_files/DonutStation/DonutStation.dmm
@@ -59,6 +59,17 @@
 /obj/machinery/telecomms/bus/preset_four,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
+"abg" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 10
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "abn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -323,6 +334,10 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"afR" = (
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/crew_quarters/heads/chief)
 "afT" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -445,6 +460,13 @@
 /obj/machinery/vending/tool,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"aiX" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/power/tesla_coil,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "ajm" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Biohazard";
@@ -561,17 +583,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"akJ" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "akW" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/window/reinforced{
@@ -723,6 +734,18 @@
 	},
 /turf/open/floor/noslip,
 /area/medical/sleeper)
+"amY" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ana" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -939,6 +962,10 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/central)
+"arc" = (
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
 "arm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -992,10 +1019,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"asd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+"asg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/hallway/primary/central)
 "asm" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/end{
 	dir = 1
@@ -1008,13 +1043,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"asN" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "asP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -1045,6 +1073,13 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
+"atl" = (
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "atm" = (
 /obj/structure/ethernet_cable{
 	icon_state = "4-8"
@@ -1080,13 +1115,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"atR" = (
-/obj/machinery/door/poddoor{
-	id = "enginesecurestorage";
-	name = "Secure Storage"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "atX" = (
 /obj/structure/janitorialcart,
 /obj/item/reagent_containers/glass/bucket,
@@ -1101,6 +1129,20 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"aue" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 28
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/turf/open/floor/engine,
+/area/engine/gravity_generator)
 "auj" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1455,19 +1497,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
-"aBs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aBt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -1521,12 +1550,6 @@
 "aCv" = (
 /turf/closed/mineral/random/high_chance,
 /area/space/nearstation)
-"aCy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "aCH" = (
 /obj/machinery/keycard_auth{
 	pixel_x = -24
@@ -1620,12 +1643,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"aFu" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/nuke_storage)
 "aFL" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
@@ -1651,6 +1668,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"aFW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "aGa" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -1659,6 +1686,19 @@
 "aGn" = (
 /turf/template_noop,
 /area/maintenance/aft)
+"aGt" = (
+/obj/machinery/power/apc/auto_name{
+	dir = 8;
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "aGu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1681,6 +1721,15 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/general,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"aGy" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "aGC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -1946,10 +1995,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"aLF" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "aLL" = (
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/plasteel/grimy,
@@ -1974,15 +2019,6 @@
 	initial_gas_mix = "n2=1000;TEMP=293.15"
 	},
 /area/engine/atmos)
-"aME" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "aMI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -2018,6 +2054,14 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"aNb" = (
+/obj/structure/rack,
+/mob/living/simple_animal/parrot/Poly,
+/obj/machinery/keycard_auth{
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "aNh" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
@@ -2195,12 +2239,6 @@
 /obj/item/lighter,
 /turf/open/floor/carpet,
 /area/security/detectives_office)
-"aQN" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "aQT" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -2271,15 +2309,6 @@
 	dir = 4
 	},
 /area/crew_quarters/dorms)
-"aSo" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "aSB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -2305,31 +2334,32 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"aTH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+"aTL" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"aTV" = (
+/obj/machinery/nuclearbomb/selfdestruct,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 6
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera{
-	c_tag = "Gravity Generator Hall";
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"aTM" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/AI,
-/obj/structure/window/reinforced{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
@@ -2450,13 +2480,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/maintenance/aft)
-"aWc" = (
-/obj/machinery/camera{
-	c_tag = "Gravity Generator";
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "aWf" = (
 /obj/machinery/power/smes/empty,
 /obj/structure/cable{
@@ -2544,18 +2567,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"aXG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "aXH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -2767,6 +2778,12 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
+"bbz" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bbG" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -2961,21 +2978,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"beY" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "bfy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -3200,6 +3202,18 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
+"biT" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "bjl" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -3329,6 +3343,18 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
+"blR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bmr" = (
 /obj/structure/rack,
 /turf/open/floor/plating,
@@ -3618,6 +3644,15 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"bsG" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "bsI" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -3745,6 +3780,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"bvA" = (
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	areastring = "/area/engine/storage_shared";
+	dir = 8;
+	name = "Shared Engineering Storage APC";
+	pixel_x = -25
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "bvG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3862,6 +3910,14 @@
 	},
 /turf/open/floor/wood,
 /area/tcommsat/computer)
+"bxM" = (
+/obj/machinery/power/emitter/anchored{
+	dir = 4;
+	state = 2
+	},
+/obj/structure/cable/orange,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "bxR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 1
@@ -3983,12 +4039,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"bAp" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "bBh" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -4010,21 +4060,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"bBC" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "bBZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4090,6 +4125,18 @@
 "bDj" = (
 /turf/closed/wall,
 /area/hallway/primary/central)
+"bDl" = (
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Chief Engineer's Desk";
+	departmentType = 3;
+	name = "Chief Engineer RC";
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "bDo" = (
 /obj/machinery/recharge_station,
 /obj/machinery/light/small{
@@ -4161,6 +4208,16 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"bFy" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/item/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "bFM" = (
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -4187,32 +4244,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/tcommsat/computer)
-"bGn" = (
-/obj/machinery/door/airlock/security/glass{
-	name = "Security Office"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/security/basic,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "bGy" = (
 /obj/structure/table/glass,
 /obj/structure/cable{
@@ -4358,6 +4389,21 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
+"bKe" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs2_wide{
+	dir = 1
+	},
+/area/engine/engineering)
 "bKm" = (
 /obj/machinery/computer/communications{
 	dir = 8
@@ -4436,6 +4482,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"bLM" = (
+/obj/structure/closet/secure_closet/engineering_chief,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "bLP" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating{
@@ -4492,6 +4545,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/hor)
+"bNn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "bNI" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
@@ -4567,18 +4626,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"bOM" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "bOO" = (
 /obj/machinery/light{
 	dir = 4
@@ -4601,6 +4648,43 @@
 /obj/machinery/vending/hydroseeds/weak,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
+"bOU" = (
+/obj/item/coin/silver{
+	pixel_x = 7;
+	pixel_y = 12
+	},
+/obj/item/coin/silver{
+	pixel_x = 12;
+	pixel_y = 7
+	},
+/obj/item/coin/silver{
+	pixel_x = 4;
+	pixel_y = 8
+	},
+/obj/item/coin/silver{
+	pixel_x = -6;
+	pixel_y = 5
+	},
+/obj/item/coin/silver{
+	pixel_x = 5;
+	pixel_y = -8
+	},
+/obj/structure/closet/crate{
+	name = "Silver Crate"
+	},
+/obj/effect/turf_decal/bot_white/right,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "bPj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -4613,24 +4697,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"bPo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bPq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4641,14 +4707,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"bPr" = (
-/obj/machinery/holopad,
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "bPu" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/mapping_helpers/airlock/abandoned,
@@ -4689,6 +4747,21 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"bQl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "bQv" = (
 /obj/structure/chair{
 	dir = 8
@@ -4757,17 +4830,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"bRW" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"bRZ" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bSc" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -4783,13 +4845,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
-"bSk" = (
-/obj/structure/closet/secure_closet/engineering_welding,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "bSo" = (
 /obj/structure/chair{
 	dir = 8
@@ -4807,6 +4862,9 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"bSP" = (
+/turf/closed/wall/r_wall,
 /area/hallway/primary/central)
 "bSU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -5028,19 +5086,6 @@
 "bXH" = (
 /turf/open/floor/plating/broken/three,
 /area/maintenance/central)
-"bYg" = (
-/obj/structure/rack,
-/obj/item/storage/belt/utility{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/storage/belt/utility,
-/obj/item/clothing/head/welding,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "bYo" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -5108,21 +5153,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"bZR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
 "bZW" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -5260,23 +5290,6 @@
 /obj/item/stack/ore/slag,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"ccq" = (
-/obj/machinery/nuclearbomb/selfdestruct,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
-"ccr" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ccs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5471,6 +5484,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"cfa" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/machinery/light{
+	light_color = "#c1caff"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cfh" = (
 /obj/machinery/light_switch{
 	pixel_y = -24
@@ -5505,13 +5528,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"cfN" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/obj/structure/closet/secure_closet/engineering_personal,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cga" = (
 /obj/machinery/smartfridge/extract/preloaded,
 /turf/open/floor/plasteel/white,
@@ -5595,6 +5611,14 @@
 	icon_state = "damaged2"
 	},
 /area/space/nearstation)
+"chN" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/effect/landmark/start/station_engineer,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "chU" = (
 /obj/structure/closet/crate/wooden/toy,
 /obj/item/grenade/chem_grenade/teargas/moustache,
@@ -5656,6 +5680,15 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
+"ciH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "ciL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -5718,6 +5751,15 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"cjR" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/gravity_generator)
 "cjS" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -5833,15 +5875,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"cmZ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cna" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4
@@ -5966,30 +5999,30 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"cqa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/landmark/start/station_engineer,
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cqe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"crd" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cre" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/engineering,
 /turf/open/floor/plating,
 /area/storage/tech)
+"crf" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "crg" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -6014,18 +6047,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"crL" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "crR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -6102,12 +6123,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ctN" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cuh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
@@ -6237,14 +6252,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"cxA" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "cxB" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -6424,6 +6431,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"cAL" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "cAM" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -6462,11 +6482,6 @@
 "cCh" = (
 /turf/closed/wall/r_wall,
 /area/science/storage)
-"cCy" = (
-/obj/machinery/power/smes,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_smes)
 "cCL" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -6849,32 +6864,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"cIN" = (
-/obj/structure/table/reinforced,
-/obj/machinery/button/door{
-	id = "enginesecurestorage";
-	name = "Secure Storage Control";
-	pixel_x = -8;
-	pixel_y = 24;
-	req_access = list("engineering")
-	},
-/obj/machinery/button/door{
-	id = "enginepashutter";
-	name = "Particle Accelerator Shutter Control";
-	pixel_x = 2;
-	pixel_y = 24;
-	req_access = list("engineering")
-	},
-/obj/machinery/photocopier/faxmachine{
-	department = "Chief Engineer";
-	name = "Chief Engineer's Fax Machine"
-	},
-/obj/machinery/light_switch{
-	pixel_x = 10;
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "cJk" = (
 /turf/closed/wall/r_wall,
 /area/security/main)
@@ -6919,27 +6908,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/experimentation,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"cLl" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/window/northleft{
-	name = "Engineering Desk"
-	},
-/obj/item/deskbell/preset/engi{
-	pixel_x = -8;
-	pixel_y = -3
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/mapping_helpers/windoor/access/any/engineering/construction{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/windoor/access/any/engineering/general{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cLs" = (
 /turf/closed/wall/r_wall,
 /area/science/explab)
@@ -7013,23 +6981,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/fore)
-"cMt" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cMD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -7075,6 +7026,28 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"cMV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cNi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cNq" = (
 /obj/structure/chair/office/dark,
 /turf/open/floor/wood,
@@ -7128,6 +7101,12 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"cOk" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating,
+/area/maintenance/central)
 "cOt" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/disposal";
@@ -7161,6 +7140,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"cOH" = (
+/obj/structure/table/reinforced,
+/obj/item/paper/monitorkey{
+	pixel_x = 6;
+	pixel_y = -4
+	},
+/obj/item/stamp/ce{
+	pixel_x = -6;
+	pixel_y = 7
+	},
+/obj/item/storage/pencil_holder/crew/fancy{
+	pixel_x = 7;
+	pixel_y = 11
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "cOX" = (
 /obj/effect/spawner/lootdrop/donkpockets{
 	pixel_x = -6;
@@ -7177,6 +7172,21 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/tcommsat/computer)
+"cPf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "cPg" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -7285,25 +7295,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"cSB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/landmark/start/station_engineer,
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cSE" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -7573,6 +7564,12 @@
 /obj/item/healthanalyzer,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"cXI" = (
+/obj/machinery/computer/apc_control{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "cXJ" = (
 /obj/machinery/door/airlock/virology/glass{
 	name = "Monkey Pen"
@@ -7844,6 +7841,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"deo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27;
+	pixel_y = 1
+	},
+/turf/open/floor/engine,
+/area/engine/gravity_generator)
 "dep" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/structure/extinguisher_cabinet{
@@ -7886,6 +7894,18 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/science/lab)
+"dfB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "dfE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -8435,28 +8455,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"dqy" = (
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"dqK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
 "drp" = (
 /obj/structure/window/reinforced,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -8478,13 +8476,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/fore)
-"drI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "drZ" = (
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
 	dir = 5
@@ -8622,6 +8613,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"duq" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/ramp_middle{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "duu" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -8711,18 +8714,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
-"dwt" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/nuke_storage)
 "dwu" = (
 /obj/structure/closet/crate{
 	name = "Excess Custodial Supplies"
@@ -8894,17 +8885,6 @@
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"dAC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/item/storage/box/donkpockets,
-/obj/structure/table/glass,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "dAK" = (
 /obj/structure/closet/crate{
 	name = "Target Practice Cutouts"
@@ -9223,6 +9203,12 @@
 "dHD" = (
 /turf/open/floor/plating/rust,
 /area/maintenance/starboard)
+"dHJ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "dHQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -9328,12 +9314,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"dJL" = (
-/obj/machinery/light_switch{
-	pixel_x = 24
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "dJN" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "CloningDoor";
@@ -9442,6 +9422,27 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/ai_monitored/turret_protected/aisat_interior)
+"dLd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "dLi" = (
 /obj/machinery/status_display/ai{
 	pixel_y = -32
@@ -9471,12 +9472,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"dLu" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "dLA" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner/lower{
 	dir = 8
@@ -9569,6 +9564,11 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
+"dMP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "dMR" = (
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
@@ -9760,30 +9760,17 @@
 /obj/structure/sign/warning/vacuum,
 /turf/closed/wall/rust,
 /area/quartermaster/warehouse)
-"dSB" = (
-/obj/structure/cable{
-	icon_state = "2-4"
+"dRO" = (
+/obj/structure/table/glass,
+/obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko{
+	pixel_x = -6;
+	pixel_y = 6
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/light{
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_smes)
-"dSK" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "dSR" = (
 /obj/structure/sign/departments/medbay/alt,
 /turf/closed/wall,
@@ -9939,20 +9926,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"dWS" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "dXc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -10258,26 +10231,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"eei" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/item/reagent_containers/food/drinks/soda_cans/thirteenloko{
-	pixel_x = -6;
-	pixel_y = 6
-	},
-/obj/structure/table/glass,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "eev" = (
 /obj/structure/table,
 /obj/machinery/recharger,
@@ -10303,19 +10256,6 @@
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/science/research)
-"efb" = (
-/obj/effect/landmark/start/station_engineer,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "efc" = (
 /obj/structure/sign/departments/cargo,
 /turf/closed/wall,
@@ -10355,6 +10295,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"egv" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "egB" = (
 /obj/structure/table,
 /obj/item/wallframe/airalarm,
@@ -10511,6 +10460,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"eiM" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "eiQ" = (
 /obj/structure/table,
 /obj/item/clothing/head/soft,
@@ -10641,10 +10602,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"elu" = (
-/obj/structure/closet/crate/goldcrate,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "elw" = (
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
@@ -10685,18 +10642,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"emk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "emA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -10729,15 +10674,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"enu" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "enz" = (
 /obj/effect/turf_decal/trimline/chemorange/filled/line/lower{
 	dir = 1
@@ -10823,6 +10759,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"epv" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "epS" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
@@ -10849,11 +10797,47 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"eqj" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command{
+	name = "Chief Engineer's Office"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "eri" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/lootdrop/randomdrink,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"erm" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ero" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -11187,11 +11171,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"eyH" = (
-/obj/machinery/vending/engivend,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "eyK" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -11207,6 +11186,15 @@
 "eyR" = (
 /turf/closed/wall,
 /area/construction/mining/aux_base)
+"ezb" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ezc" = (
 /obj/effect/turf_decal/trimline/white/filled/corner/lower,
 /obj/effect/turf_decal/trimline/secred/warning/lower/corner/flip,
@@ -11234,13 +11222,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"eAc" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/vending/cola/random,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "eAx" = (
 /obj/machinery/door/airlock/external{
 	name = "External Freight Airlock"
@@ -11316,6 +11297,21 @@
 /obj/machinery/vending/autodrobe/capdrobe,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
+"eBG" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/engineering";
+	dir = 8;
+	name = "Engineering Security APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "eBH" = (
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
@@ -11381,6 +11377,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"eCN" = (
+/obj/effect/turf_decal/bot_white/right,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "eCV" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -11423,6 +11434,18 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"eDD" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "eDH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -11440,6 +11463,21 @@
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
 /area/maintenance/aft)
+"eDN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "eEa" = (
 /obj/effect/landmark/start/clown,
 /obj/structure/disposalpipe/segment{
@@ -11507,6 +11545,21 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"eFM" = (
+/obj/structure/rack,
+/obj/item/airlock_painter{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/airlock_painter{
+	pixel_x = 3;
+	pixel_y = -6
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "eFO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -11551,16 +11604,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"eHb" = (
-/obj/structure/closet/secure_closet/engineering_chief,
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/chief";
-	name = "Chief Engineer's Office APC";
-	pixel_y = -23
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "eHh" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/heads/captain";
@@ -11638,6 +11681,12 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"eIA" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "eIB" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -11659,6 +11708,26 @@
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
+"eIS" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=BOTTOMLEFT";
+	location = "BOTTOMMID";
+	name = "navigation beacon (BOTTOMMID)"
+	},
+/obj/effect/landmark/event_spawn,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "eJx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -11680,6 +11749,9 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"eKw" = (
+/turf/closed/wall/r_wall,
+/area/hydroponics)
 "eKB" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Office"
@@ -11873,6 +11945,16 @@
 "eNH" = (
 /turf/closed/wall,
 /area/science/explab)
+"eNW" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "eOt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -11885,6 +11967,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"eOx" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "eOB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -12000,20 +12091,6 @@
 	},
 /turf/open/floor/catwalk_floor/telecomms,
 /area/ai_monitored/turret_protected/ai)
-"eRk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
 "eRu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -12057,6 +12134,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/solars/port/fore)
+"eSk" = (
+/obj/structure/closet/firecloset,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "eSw" = (
 /obj/machinery/airalarm{
 	dir = 1;
@@ -12083,13 +12171,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"eSX" = (
-/obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/siding/yellow{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
 "eSY" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -12142,6 +12223,25 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"eUq" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "engsm";
+	name = "Radiation Shutters Control";
+	pixel_y = 24;
+	req_access = list("engineering")
+	},
+/obj/machinery/vending/wardrobe/engi_wardrobe,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "eUs" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "hopqueue";
@@ -12193,25 +12293,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"eVM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc/auto_name/north{
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
-"eVV" = (
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/central)
 "eWk" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
 	dir = 8
@@ -12232,22 +12313,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"eWC" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "eWG" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 4
@@ -12283,15 +12348,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"eXD" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "eXF" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel/cafeteria,
@@ -12337,6 +12393,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"eYF" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/nuke_storage)
 "eZg" = (
 /obj/machinery/light/small,
 /turf/open/floor/plating,
@@ -12378,15 +12444,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"eZX" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fat" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecomms Control Room"
@@ -12442,6 +12499,18 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"fbN" = (
+/obj/machinery/vending/wardrobe/sec_wardrobe,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 5
+	},
+/obj/machinery/camera{
+	c_tag = "Security Post - Engineering";
+	dir = 8;
+	network = list("ss13","chpt")
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "fbR" = (
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "outerbrig";
@@ -12480,13 +12549,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"fds" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "fdW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/bed,
@@ -12699,20 +12761,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"fho" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/machinery/light,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fhx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -12821,13 +12869,24 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
-"fiK" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
+"fiE" = (
+/mob/living/simple_animal/opossum/poppy,
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 8;
+	pixel_y = -1
+	},
+/obj/effect/mapping_helpers/mail_sorting/engineering/ce_office,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "fjk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -12853,6 +12912,21 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
+"fki" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "fkv" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -12951,6 +13025,20 @@
 /obj/effect/turf_decal/ramp_corner,
 /turf/open/floor/wood,
 /area/tcommsat/computer)
+"fof" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "foy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/newscaster{
@@ -13003,12 +13091,6 @@
 "fpH" = (
 /turf/closed/wall/r_wall,
 /area/teleporter)
-"fpL" = (
-/obj/structure/cable/orange{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fpS" = (
 /obj/machinery/air_sensor/atmos/carbon_tank,
 /turf/open/floor/engine/co2{
@@ -13094,12 +13176,6 @@
 /obj/effect/turf_decal/trimline/dark_blue/warning/lower/nobottom,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"frz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "frF" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
@@ -13186,6 +13262,9 @@
 	},
 /turf/open/floor/catwalk_floor/telecomms,
 /area/ai_monitored/turret_protected/ai)
+"fsU" = (
+/turf/closed/wall/r_wall,
+/area/engine/storage_shared)
 "ftc" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 4
@@ -13299,15 +13378,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/starboard/fore)
-"fvg" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fvk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -13457,10 +13527,34 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
+"fyC" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "fyF" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"fyM" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "fyP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/layer2{
 	dir = 4
@@ -13471,6 +13565,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
+"fyQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "fyX" = (
 /obj/structure/closet/crate,
 /obj/item/kitchen/fork,
@@ -13521,12 +13621,6 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
-"fAk" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "fAn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -13550,20 +13644,6 @@
 /obj/machinery/telecomms/processor/preset_four,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"fBx" = (
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
-	dir = 1
-	},
-/obj/structure/cable,
-/obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/engine/engineering";
-	name = "Engine Room APC";
-	pixel_y = -23
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fBK" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/closet/crate,
@@ -13685,15 +13765,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"fEh" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fEn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -13758,6 +13829,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"fFq" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/stairs/goon/stairs_wide{
+	dir = 1
+	},
+/area/engine/engineering)
 "fFz" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 1
@@ -14095,13 +14180,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"fLD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "fLH" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge"
@@ -14163,6 +14241,12 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"fMB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "fME" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -14229,15 +14313,6 @@
 "fOG" = (
 /turf/closed/wall,
 /area/crew_quarters/theatre)
-"fOK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "fON" = (
 /turf/template_noop,
 /area/space/nearstation)
@@ -14324,15 +14399,6 @@
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"fQQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "fRi" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -14412,23 +14478,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"fRO" = (
-/obj/machinery/button/door{
-	id = "enginesecurestorage";
-	name = "Secure Storage Control";
-	pixel_x = 7;
-	pixel_y = 25;
-	req_access = list("engine_equip")
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/machinery/light_switch{
-	pixel_x = -10;
-	pixel_y = 27
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fRQ" = (
 /obj/machinery/rnd/production/techfab/department/service,
 /turf/open/floor/plasteel,
@@ -14471,17 +14520,6 @@
 /obj/item/paper/fluff/ruins/thederelict/equipment,
 /turf/open/floor/plasteel/airless,
 /area/space/nearstation)
-"fTp" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fTq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -14600,31 +14638,13 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"fWW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/public/glass{
-	name = "Telecommunications Foyer"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"fXg" = (
+/obj/structure/closet/secure_closet/security/engine,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/area/security/checkpoint/engineering)
 "fXj" = (
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
@@ -14749,42 +14769,12 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"fZK" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/button/door{
-	dir = 8;
-	id = "engsm";
-	name = "Radiation Shutters Control";
-	pixel_y = -24;
-	req_access = list("engineering")
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "fZR" = (
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"gac" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
 "gai" = (
 /obj/effect/landmark/stationroom/maint/fivexfour,
 /turf/template_noop,
@@ -14797,18 +14787,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal)
-"gaD" = (
-/obj/machinery/computer/rdconsole/production{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/structure/sign/warning/enginesafety{
-	pixel_x = 32
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "gaI" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access"
@@ -14880,15 +14858,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
-"gcp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "gcq" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
@@ -14978,6 +14947,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"geA" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "geB" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -15029,15 +15003,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"gfY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ggd" = (
 /obj/structure/closet/crate{
 	name = "Practice Rifles"
@@ -15180,6 +15145,15 @@
 	},
 /turf/open/floor/catwalk_floor/telecomms,
 /area/ai_monitored/turret_protected/ai)
+"giy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "giY" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/medical,
@@ -15492,6 +15466,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"grO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "grP" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Dorms"
@@ -15586,6 +15570,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"gto" = (
+/obj/machinery/disposal/bin/tagger,
+/obj/structure/disposalpipe/trunk{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "gtI" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -15933,15 +15924,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/service/crematorium,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"gAh" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/structure/cable/orange{
-	icon_state = "2-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "gAr" = (
 /obj/machinery/camera{
 	c_tag = "Civilian - Library Lounge";
@@ -16018,6 +16000,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"gDg" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "gDt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -16032,6 +16028,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"gDE" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "gDN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -16144,10 +16144,20 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"gEZ" = (
-/obj/effect/decal/cleanable/dirt,
+"gFv" = (
+/obj/structure/sign/poster/official/pda_ad{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/trimline/white/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
-/area/engine/gravity_generator)
+/area/hallway/primary/central)
 "gFE" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -16392,6 +16402,18 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_master,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/ai_monitored/turret_protected/ai)
+"gMq" = (
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "gMA" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hor)
@@ -16503,6 +16525,20 @@
 /obj/item/toy/figure/virologist,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"gOE" = (
+/obj/machinery/power/smes/engineering{
+	input_level = 10000;
+	output_attempt = 0;
+	output_level = 5000
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "gOF" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
@@ -16513,6 +16549,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
+"gOI" = (
+/obj/machinery/power/emitter/anchored{
+	dir = 8;
+	state = 2
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "gOO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -16891,6 +16940,24 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/medical/sleeper)
+"gWq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/tcommsat/computer)
 "gWw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -17099,24 +17166,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/aft)
-"haY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "hba" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -17141,6 +17190,10 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
+"hbV" = (
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "hcl" = (
 /obj/machinery/air_sensor/atmos/air_tank,
 /turf/open/floor/engine/air,
@@ -17280,6 +17333,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
+"hfL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "hfO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17436,16 +17504,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"hit" = (
-/obj/structure/grille,
-/obj/structure/cable/orange{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "hiu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -17481,18 +17539,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"hjy" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "hjU" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -17678,21 +17724,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
-"hmU" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/structure/table,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/obj/item/melee/sledgehammer,
-/obj/item/melee/sledgehammer,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "hnd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/wood,
@@ -17820,20 +17851,6 @@
 /obj/effect/landmark/start/cargo_technician,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"hpI" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "hpJ" = (
 /obj/machinery/light{
 	dir = 1
@@ -17914,6 +17931,31 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
+"hrp" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"hrv" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/table,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "hrW" = (
 /obj/structure/sign/departments/science{
 	pixel_y = 32
@@ -18034,12 +18076,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hve" = (
-/obj/structure/cable{
+"hva" = (
+/obj/structure/particle_accelerator/end_cap{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
+/turf/open/floor/engine,
+/area/engine/engineering)
 "hvg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -18297,6 +18342,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"hBD" = (
+/obj/structure/safe,
+/obj/item/clothing/head/bearpelt,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
+/obj/item/gun/ballistic/revolver/russian,
+/obj/item/ammo_box/a357,
+/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
+/obj/effect/turf_decal/bot_white/right,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "hBH" = (
 /obj/item/stack/ore/slag,
 /turf/open/space/basic,
@@ -18330,6 +18396,16 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hCu" = (
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "hCR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -18484,6 +18560,15 @@
 /obj/effect/mapping_helpers/airlock/access/all/supply/general,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
+"hFl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "hFt" = (
 /turf/open/water/safe,
 /area/hydroponics/garden)
@@ -18525,6 +18610,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
+"hFV" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "hFZ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -18617,24 +18713,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"hHJ" = (
-/obj/structure/table,
-/obj/item/aiModule/supplied/oxygen,
-/obj/item/aiModule/zeroth/oneHuman,
-/obj/item/aiModule/reset/purge,
-/obj/effect/spawner/lootdrop/aimodule_harmful,
-/obj/item/aiModule/supplied/protectStation,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window/northleft{
-	name = "Secure Board Storage"
-	},
-/obj/effect/mapping_helpers/windoor/access/all/command/ai_master{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "hHP" = (
 /obj/machinery/porta_turret/ai,
 /turf/open/floor/circuit/telecomms/server,
@@ -18747,28 +18825,12 @@
 	},
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
-"hJQ" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "hJT" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"hKh" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering - Entrance";
-	dir = 1;
-	network = list("ss13","Engineering")
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "hKA" = (
 /obj/machinery/space_heater,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -18794,6 +18856,26 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"hLz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -27;
+	pixel_y = -34
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/gravity_generator)
 "hLQ" = (
 /obj/machinery/door/morgue/chaplain,
 /turf/open/floor/plasteel/dark,
@@ -18854,6 +18936,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"hNt" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall,
+/area/engine/gravity_generator)
 "hNH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19128,13 +19214,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/warehouse)
-"hTc" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/siding/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
 "hUs" = (
 /obj/structure/ethernet_cable{
 	icon_state = "0-4"
@@ -19142,13 +19221,6 @@
 /obj/machinery/ai/server_cabinet,
 /turf/open/floor/catwalk_floor/telecomms,
 /area/ai_monitored/secondarydatacore)
-"hUJ" = (
-/obj/machinery/power/smes,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_smes)
 "hVi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -19196,6 +19268,13 @@
 /obj/machinery/chem_master/condimaster,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
+"hWp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/ramp_corner,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "hWs" = (
 /obj/machinery/door/window/northleft{
 	name = "Checkpoint Desk"
@@ -19213,22 +19292,24 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint)
-"hWu" = (
-/obj/machinery/rnd/production/circuit_imprinter,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/item/radio/intercom{
-	pixel_y = -28
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "hWM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
+"hWP" = (
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/nuke_storage";
+	dir = 8;
+	name = "Vault APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/nuke_storage)
 "hWV" = (
 /obj/machinery/camera{
 	c_tag = "Research - Main 2";
@@ -19336,6 +19417,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/solars/port/fore)
+"hZj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "hZo" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -19562,6 +19649,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"ifJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "ifY" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -19618,6 +19711,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"ihV" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "iii" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel,
@@ -19684,25 +19792,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"iiO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-4"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"ijp" = (
-/obj/machinery/power/emitter/anchored{
-	dir = 8;
-	state = 2
-	},
-/obj/structure/cable/orange{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "ijq" = (
 /turf/closed/wall,
 /area/security/courtroom)
@@ -19851,6 +19940,18 @@
 "imd" = (
 /turf/open/floor/plasteel/white/side,
 /area/science/xenobiology)
+"ime" = (
+/obj/machinery/camera/motion{
+	c_tag = "Vault";
+	dir = 8;
+	network = list("vault","ss13")
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "imx" = (
 /obj/structure/closet/secure_closet/freezer/cream_pie,
 /obj/machinery/light_switch{
@@ -19973,16 +20074,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"ioZ" = (
-/obj/structure/safe,
-/obj/item/clothing/head/bearpelt,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
-/obj/item/gun/ballistic/revolver/russian,
-/obj/item/ammo_box/a357,
-/obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "ipr" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating{
@@ -20052,13 +20143,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"iqo" = (
-/obj/structure/grille,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "iqL" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -20097,16 +20181,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
-"isk" = (
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/obj/machinery/power/terminal,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
 "isK" = (
 /obj/item/circuitboard/machine/generator,
 /obj/structure/frame/machine,
@@ -20119,6 +20193,15 @@
 /obj/effect/turf_decal/trimline/green,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"isQ" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "isV" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -20168,6 +20251,22 @@
 /obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"itP" = (
+/obj/structure/table/reinforced,
+/obj/machinery/photocopier/faxmachine{
+	department = "Chief Engineer";
+	name = "Chief Engineer's Fax Machine"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/toy/figure/ce{
+	pixel_x = -10;
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "iuk" = (
 /obj/machinery/food_cart,
 /obj/machinery/firealarm{
@@ -20196,34 +20295,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
+"iuJ" = (
+/obj/machinery/suit_storage_unit/ce,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/computer/security/telescreen{
+	name = "Telecomms/Engineering Monitor";
+	network = list("Telecom","Engine","Engineering");
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "ivd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
-"ivt" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Gravity Generator and SMES"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
 "ivF" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -20240,10 +20330,6 @@
 	},
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
-"ivT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "ivY" = (
 /obj/structure/rack,
 /obj/item/tank/jetpack/carbondioxide,
@@ -20288,28 +20374,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"ixL" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ixO" = (
 /obj/machinery/door/airlock/security{
 	name = "Courtroom Prisoner Access"
@@ -20397,9 +20461,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"iAn" = (
-/turf/open/floor/wood,
-/area/lawoffice)
 "iAu" = (
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
 	dir = 4
@@ -20471,6 +20532,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
+"iBV" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
+	dir = 1
+	},
+/turf/closed/wall,
+/area/hallway/primary/central)
 "iCi" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -20547,6 +20614,13 @@
 /obj/structure/closet/crate/internals,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"iEf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/wood,
+/area/lawoffice)
 "iEE" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil/random,
@@ -20600,6 +20674,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
+"iGM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "iGX" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -21013,6 +21099,21 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
+"iPk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=BOTTOMRIGHT";
+	location = "RIGHTBOTTOM";
+	name = "navigation beacon (RIGHTBOTTOM)"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "iPw" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
@@ -21020,20 +21121,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"iPA" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "iPK" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/disposalpipe/segment{
@@ -21063,16 +21150,6 @@
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
-"iQu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
 "iQw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -21088,28 +21165,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"iQA" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/item/kirbyplants/random,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "iQB" = (
 /obj/machinery/computer/med_data{
 	dir = 8
@@ -21168,20 +21223,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"iRM" = (
-/obj/structure/sign/poster/official/pda_ad{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/trimline/white/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"iSf" = (
-/obj/item/wirecutters,
-/turf/open/space/basic,
-/area/engine/engineering)
 "iSo" = (
 /obj/machinery/disposal/bin/tagger,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
@@ -21286,6 +21327,18 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"iTZ" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/power/grounding_rod,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Engine Containment West";
+	dir = 4;
+	network = list("ss13","Engine","Engineering")
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "iUd" = (
 /obj/machinery/space_heater,
 /obj/structure/window/reinforced,
@@ -21369,6 +21422,12 @@
 	},
 /turf/open/floor/grass,
 /area/medical/genetics)
+"iWQ" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "iXh" = (
 /obj/structure/closet/crate{
 	name = "Surplus Toxins Supplies"
@@ -21398,36 +21457,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"iXI" = (
-/obj/machinery/door/airlock/vault,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/all/command/vault,
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/plating,
-/area/ai_monitored/nuke_storage)
 "iXL" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/airless,
+/area/engine/engineering)
+"iYc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering Particle Accelerator";
+	dir = 4;
+	network = list("ss13","engine")
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "iYw" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -21442,6 +21487,21 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"iYy" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "iYH" = (
 /obj/structure/grille,
 /obj/item/shard,
@@ -21494,22 +21554,6 @@
 /obj/structure/grille/broken,
 /turf/open/space/basic,
 /area/space/nearstation)
-"jaE" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/engineering";
-	dir = 8;
-	name = "Engineering Security APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "jaT" = (
 /obj/machinery/light{
 	dir = 1
@@ -21532,16 +21576,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"jbD" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/structure/closet/secure_closet/engineering_personal,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jbK" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 1
@@ -21560,17 +21594,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"jcf" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/structure/table,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jck" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -21641,36 +21664,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"jeh" = (
-/obj/machinery/ore_silo,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "jei" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"jel" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jes" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"jex" = (
-/obj/machinery/power/smes/fullycharged,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "jeU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -21945,6 +21948,12 @@
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"jjU" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jjV" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
 	dir = 4
@@ -22265,22 +22274,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel,
 /area/janitor)
-"jpz" = (
-/obj/machinery/computer/bank_machine,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/nuke_storage";
-	dir = 1;
-	name = "Vault APC";
-	pixel_y = 23
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "jpD" = (
 /obj/structure/closet/athletic_mixed,
 /obj/item/pool/pool_noodle,
@@ -22299,15 +22292,6 @@
 /obj/item/folder/blue,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"jqa" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "jqr" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /obj/structure/chair/office/light{
@@ -22588,6 +22572,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"jxO" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jxT" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -22713,31 +22712,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"jzy" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/obj/item/crowbar,
-/obj/item/grenade/chem_grenade/smart_metal_foam,
-/obj/item/grenade/chem_grenade/smart_metal_foam,
-/obj/item/stack/sheet/rglass{
-	amount = 30;
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/stack/sheet/plasteel{
-	amount = 10;
-	pixel_x = -2;
-	pixel_y = 2
-	},
-/turf/open/floor/plasteel{
-	dir = 1
-	},
-/area/engine/engineering)
 "jzz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -22795,16 +22769,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"jAC" = (
-/obj/structure/grille,
-/obj/structure/cable/orange{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "jAO" = (
 /obj/structure/table/glass,
 /obj/machinery/light{
@@ -22886,21 +22850,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
-"jBZ" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jCf" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
@@ -23036,10 +22985,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"jFW" = (
-/obj/machinery/vending/wardrobe/law_wardrobe,
-/turf/open/floor/wood,
-/area/lawoffice)
 "jFY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -23086,24 +23031,6 @@
 "jHy" = (
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"jHA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
 "jHI" = (
 /obj/structure/chair{
 	dir = 1
@@ -23196,6 +23123,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"jJh" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/engine/engineering";
+	dir = 4;
+	name = "Engine Room APC";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "jJw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -23324,6 +23269,30 @@
 "jMb" = (
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
+"jMh" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "jMn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -23337,6 +23306,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"jMo" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 1;
+	pixel_y = -29
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jMF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 8
@@ -23357,13 +23337,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"jMK" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "jMW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 10
@@ -23381,13 +23354,6 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"jND" = (
-/obj/machinery/camera{
-	c_tag = "Hallway - Central East 2";
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -23455,13 +23421,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"jPu" = (
-/obj/machinery/power/tesla_coil,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "jPF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -23552,30 +23511,24 @@
 /obj/machinery/status_display,
 /turf/closed/wall,
 /area/maintenance/aft)
+"jQM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jQV" = (
 /obj/machinery/computer/shuttle/mining{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"jRa" = (
-/obj/machinery/button/door{
-	id = "engsm";
-	name = "Radiation Shutters Control";
-	pixel_y = 24;
-	req_access = list("engineering")
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jRh" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -23743,15 +23696,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"jUm" = (
-/obj/machinery/suit_storage_unit/engine,
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/turf/open/floor/plasteel{
-	dir = 1
-	},
-/area/engine/engineering)
 "jUv" = (
 /obj/structure/sign/poster/random{
 	pixel_y = 32
@@ -23810,38 +23754,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"jVz" = (
-/obj/machinery/door/airlock/command{
-	name = "Chief Engineer's Office"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/ce,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "jVI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastleft{
@@ -23967,18 +23879,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"jYI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "jYO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
@@ -24005,27 +23905,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
-"jZl" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jZn" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -24042,19 +23921,28 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"jZH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "jZK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"jZO" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jZW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -24165,18 +24053,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"kbk" = (
-/obj/machinery/power/apc{
-	areastring = "/area/lawoffice";
-	dir = 1;
-	name = "Lawyer's Office APC";
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/floor/wood,
-/area/lawoffice)
 "kbP" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -24322,13 +24198,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/command/ai_sat,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"kfu" = (
-/obj/structure/grille,
-/obj/structure/cable/orange{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "kfA" = (
 /obj/structure/rack,
 /obj/item/gun/energy/ionrifle,
@@ -24527,12 +24396,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"kiI" = (
-/obj/machinery/gravity_generator/main/station,
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/siding/yellow,
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
 "kiM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -24805,12 +24668,15 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
 /area/engine/atmos)
-"knP" = (
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "koa" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/toilet)
+"koo" = (
+/obj/machinery/light_switch{
+	pixel_x = -28
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/nuke_storage)
 "kop" = (
 /obj/effect/landmark/stationroom/maint/tenxfive,
 /turf/template_noop,
@@ -24844,15 +24710,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"kpj" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/sign/poster/contraband/power{
-	pixel_y = 32
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "kpw" = (
 /obj/structure/sign/warning/pods{
 	pixel_y = 32
@@ -25113,6 +24970,19 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"kwG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "kwT" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/engine,
@@ -25166,17 +25036,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"kyG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/highsecurity,
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "kyL" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -25273,12 +25132,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/escapepodbay)
+"kCh" = (
+/obj/structure/rack,
+/obj/item/storage/belt/utility{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/belt/utility,
+/obj/item/clothing/head/welding,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "kCs" = (
 /obj/structure/disposaloutlet{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/space/nearstation)
+"kCI" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "kDd" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/sign/warning/fire{
@@ -25345,6 +25224,10 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/central)
+"kFg" = (
+/obj/effect/turf_decal/bot_white/right,
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
 "kFl" = (
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
 	dir = 6
@@ -25394,18 +25277,23 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
-"kFW" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
+"kGk" = (
+/obj/machinery/computer/station_alert{
+	dir = 8
 	},
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering - Material Storage";
-	network = list("ss13","Engineering")
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
+"kGx" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "kGU" = (
 /obj/structure/cable{
@@ -25513,6 +25401,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"kIU" = (
+/obj/structure/table,
+/obj/item/stock_parts/cell/high/plus{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/pen/blue,
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "kIX" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/metal/fifty,
@@ -25590,10 +25487,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
-"kLS" = (
+"kLV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 8
 	},
+/obj/machinery/vending/wardrobe/law_wardrobe,
 /turf/open/floor/wood,
 /area/lawoffice)
 "kLY" = (
@@ -25854,6 +25752,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/freezer,
 /area/maintenance/aft)
+"kQK" = (
+/obj/machinery/field/generator,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Secure Storage";
+	dir = 4;
+	network = list("ss13","Engineering")
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "kQR" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
@@ -25902,6 +25809,23 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"kRH" = (
+/obj/machinery/door/airlock/security/glass{
+	name = "Security Office"
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "kRJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/cable{
@@ -25964,9 +25888,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"kTi" = (
-/turf/closed/wall,
-/area/engine/gravity_generator)
 "kTy" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
@@ -25982,22 +25903,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"kTO" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Gravity Generator and SMES"
+"kTP" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/engine/engine_smes)
+/area/engine/engineering)
 "kTW" = (
 /obj/machinery/ai/networking{
 	label = "Computer Science";
@@ -26078,13 +25995,6 @@
 /mob/living/simple_animal/pet/axolotl/bop,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
-"kVX" = (
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "kVY" = (
 /obj/structure/chair/stool/bar,
 /obj/effect/landmark/start/assistant,
@@ -26322,12 +26232,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"lab" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "lan" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "robo1"
@@ -26518,15 +26422,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"ldY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "lec" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
@@ -26537,6 +26432,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"lew" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "lex" = (
 /obj/machinery/cell_charger,
 /obj/structure/table,
@@ -26557,6 +26468,19 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/crew_quarters/heads/hop)
+"leG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/mail_sorting/engineering/general,
+/obj/structure/disposalpipe/sorting/mail{
+	dir = 2;
+	pixel_y = -1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "lfj" = (
 /obj/structure/chair/wood/wings,
 /obj/effect/landmark/start/chaplain,
@@ -26568,16 +26492,13 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"lfL" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
+"lfm" = (
+/obj/structure/tank_dispenser,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
+	dir = 4
 	},
-/obj/machinery/power/tesla_coil,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "lfS" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
@@ -26670,6 +26591,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"lhz" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/engine_smes)
 "lia" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -26705,6 +26633,29 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"lim" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
+/turf/open/floor/engine,
+/area/engine/gravity_generator)
 "liu" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Air to Ports"
@@ -26758,13 +26709,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
-"ljK" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/siding/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
 "ljU" = (
 /obj/structure/lattice,
 /obj/structure/transit_tube/diagonal,
@@ -26843,6 +26787,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"llk" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "llp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -27098,6 +27052,19 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
+"lqk" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "lqs" = (
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/decal/cleanable/blood/old,
@@ -27199,13 +27166,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"lsc" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/structure/closet/radiation,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "lsm" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -27427,6 +27387,22 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
+"lxC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "lxE" = (
 /obj/effect/landmark/start/cook,
 /turf/open/floor/plasteel/cafeteria{
@@ -27463,19 +27439,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/storage)
-"lyB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=BOTTOMRIGHT";
-	location = "RIGHTBOTTOM";
-	name = "navigation beacon (RIGHTBOTTOM)"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "lyF" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/wood,
@@ -27519,6 +27482,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/storage/tech)
+"lzO" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "lAw" = (
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
@@ -27589,6 +27564,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"lBG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "lBO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -27631,6 +27612,15 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
+"lCw" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Entrance";
+	dir = 1;
+	network = list("ss13","Engineering")
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "lCC" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -27659,6 +27649,15 @@
 /obj/item/tank/internals/emergency_oxygen,
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/aisat_interior)
+"lDa" = (
+/obj/machinery/computer/secure_data{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "lDd" = (
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/chapel{
@@ -27749,6 +27748,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"lFR" = (
+/obj/machinery/power/emitter{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "lFV" = (
 /obj/machinery/door/airlock{
 	id_tag = "Dorm3";
@@ -27768,6 +27773,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"lGb" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "lGl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -27778,16 +27789,6 @@
 "lGn" = (
 /turf/closed/wall,
 /area/hydroponics)
-"lGq" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "lGu" = (
 /turf/open/floor/plasteel/vaporwave,
 /area/crew_quarters/dorms)
@@ -27818,6 +27819,13 @@
 /obj/item/storage/box/rxglasses,
 /turf/open/floor/plating,
 /area/maintenance/port)
+"lGP" = (
+/obj/machinery/computer/rdconsole/production,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "lGX" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8
@@ -27901,6 +27909,16 @@
 	},
 /turf/open/floor/plasteel/stairs/goon/wood_stairs_wide,
 /area/library)
+"lJa" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "lJg" = (
 /obj/effect/turf_decal/pool{
 	dir = 4
@@ -28049,6 +28067,15 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"lNn" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "lNo" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -28111,13 +28138,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/general,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"lNP" = (
-/obj/structure/grille,
-/obj/structure/cable/orange{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "lNW" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder,
@@ -28195,15 +28215,6 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/fore)
-"lQk" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "lQB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28229,6 +28240,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"lQV" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "lQX" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -28343,29 +28366,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"lTg" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "lTh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -28724,18 +28724,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"lZI" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering - Engine Containment West";
-	dir = 4;
-	network = list("ss13","Engine","Engineering")
-	},
-/obj/machinery/power/rad_collector,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "lZP" = (
 /obj/item/screwdriver,
 /turf/open/floor/plating/airless,
@@ -28792,6 +28780,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"mbF" = (
+/obj/machinery/computer/bank_machine,
+/obj/effect/turf_decal/bot_white,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "mbM" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
@@ -28892,26 +28895,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"mfh" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering Desk"
-	},
-/obj/machinery/door/firedoor/border_only{
+"mff" = (
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "mfk" = (
 /obj/structure/bed/dogbed/runtime,
 /obj/structure/noticeboard{
@@ -28995,6 +28984,9 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"mgZ" = (
+/turf/closed/wall/r_wall,
+/area/engine/foyer)
 "mha" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyer";
@@ -29266,6 +29258,18 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/clerk)
+"mmN" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "mmQ" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig"
@@ -29279,12 +29283,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/basic,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"mnd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "mnt" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
@@ -29426,12 +29424,6 @@
 	},
 /turf/open/floor/carpet/green,
 /area/quartermaster/warehouse)
-"moM" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "moN" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -29512,19 +29504,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"mqo" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "mqq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -29536,17 +29515,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"mqx" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/advanced_airlock_controller{
-	dir = 4;
-	pixel_x = -24
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "mqI" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
@@ -29603,18 +29571,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"mrW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
 "msE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -29932,6 +29888,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"myL" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "myW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/wall/r_wall,
@@ -29996,6 +29961,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"mzT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "mAb" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -30028,6 +29999,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"mBs" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/holopad,
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mBt" = (
 /turf/open/floor/engine,
 /area/science/explab)
@@ -30192,6 +30174,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"mDQ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "mEd" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -30280,6 +30271,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"mFe" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/engiyellow/warning/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mFj" = (
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
@@ -30336,12 +30334,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/kitchen)
-"mGP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "mGS" = (
 /obj/structure/table,
 /turf/open/floor/plasteel/cafeteria,
@@ -30415,6 +30407,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/interrogation)
+"mHO" = (
+/obj/machinery/vending/cola/random,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "mHP" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -30437,6 +30433,14 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/fore)
+"mIl" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mIn" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -30510,21 +30514,6 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/warehouse)
-"mKK" = (
-/obj/machinery/light_switch{
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/structure/table,
-/obj/item/storage/box/lights/mixed{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/lights/mixed,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "mKN" = (
 /obj/effect/landmark/stationroom/maint/threexfive,
 /turf/template_noop,
@@ -30598,12 +30587,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "mNb" = (
-/obj/machinery/field/generator,
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering - Secure Storage";
-	network = list("ss13","Engineering")
+/obj/structure/sign/warning/radiation/rad_area{
+	pixel_y = 32
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "mNh" = (
 /obj/structure/bodycontainer/morgue{
@@ -30669,6 +30662,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
+"mPt" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "mPu" = (
 /obj/machinery/computer/message_monitor{
 	dir = 4
@@ -30691,10 +30692,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mPx" = (
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "mPy" = (
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower,
 /obj/machinery/door/poddoor/preopen{
@@ -30819,6 +30816,15 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"mRw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "mRB" = (
 /obj/structure/rack,
 /obj/item/wrench,
@@ -30915,13 +30921,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"mTX" = (
-/obj/structure/noticeboard{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "mTZ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 4
@@ -31075,19 +31074,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/engineering/external,
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
-"mVN" = (
-/obj/structure/table,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/machinery/camera{
-	c_tag = "Security Post - Engineering";
-	dir = 4;
-	network = list("ss13","chpt")
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "mVO" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
@@ -31215,19 +31201,6 @@
 /obj/effect/turf_decal/trimline/secred/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
-"mYw" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/item/toy/figure/ce,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "mYz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
@@ -31764,22 +31737,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
-"nkL" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/line/lower,
-/obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "nkW" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -31896,6 +31853,18 @@
 /obj/item/stack/cable_coil/cut,
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"nlM" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nlP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -31921,18 +31890,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"nmo" = (
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_y = 32
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "nmC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
@@ -31963,12 +31920,17 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"nne" = (
-/obj/structure/grille,
-/obj/structure/cable/orange{
-	icon_state = "2-8"
+"nnk" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "nnr" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -32095,6 +32057,28 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"nqH" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
+"nqL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "nqO" = (
 /obj/machinery/biogenerator,
 /turf/open/floor/grass,
@@ -32103,15 +32087,6 @@
 /obj/structure/closet/toolcloset,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"nrs" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nrw" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
@@ -32219,32 +32194,9 @@
 /obj/machinery/disposal/bin/tagger,
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
-"ntU" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering - Engine Containment South";
-	dir = 1;
-	network = list("ss13","Engine","Engineering")
-	},
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "nuh" = (
 /turf/closed/wall,
 /area/quartermaster/sorting)
-"nux" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "nuO" = (
 /obj/machinery/light_switch{
 	pixel_x = 24
@@ -32285,15 +32237,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"nvW" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "nwQ" = (
 /obj/structure/chair,
 /turf/open/floor/wood,
@@ -32391,16 +32334,6 @@
 	},
 /turf/open/floor/carpet,
 /area/medical/psych)
-"nyp" = (
-/obj/machinery/vending/wardrobe/engi_wardrobe,
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nzq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 8
@@ -32601,6 +32534,24 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/chapel/main)
+"nDU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "nEr" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical{
@@ -32790,10 +32741,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"nHi" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/wood,
-/area/tcommsat/computer)
 "nHw" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -32905,18 +32852,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"nJo" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering - Engine Containment East";
-	dir = 8;
-	network = list("ss13","Engine","Engineering")
-	},
-/obj/machinery/power/rad_collector,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "nJv" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -32967,22 +32902,6 @@
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/bar)
-"nKv" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
 "nKz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -33017,18 +32936,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"nKV" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/obj/structure/rack,
-/obj/item/airlock_painter{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/airlock_painter,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nKW" = (
 /obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
 	dir = 1
@@ -33061,13 +32968,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/grass,
 /area/hydroponics/garden)
-"nLv" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nLM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 9
@@ -33245,13 +33145,6 @@
 	},
 /turf/open/floor/plating,
 /area/bridge)
-"nOO" = (
-/mob/living/simple_animal/opossum/poppy,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nOQ" = (
 /obj/structure/chair{
 	dir = 1
@@ -33551,23 +33444,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
-"nVx" = (
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"nVy" = (
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "nWn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -33685,10 +33561,6 @@
 "nYA" = (
 /turf/closed/wall/r_wall,
 /area/science/robotics/mechbay)
-"nYD" = (
-/obj/item/screwdriver,
-/turf/open/space/basic,
-/area/engine/engineering)
 "nYE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 8
@@ -33750,15 +33622,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"nZV" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "nZW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -33936,10 +33799,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"ocR" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "odP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -33992,15 +33851,6 @@
 	},
 /turf/open/floor/wood,
 /area/medical/psych)
-"ofb" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "ofh" = (
 /obj/machinery/computer/mech_bay_power_console,
 /turf/open/floor/plasteel,
@@ -34086,32 +33936,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"ogQ" = (
-/obj/machinery/computer/secure_data{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
-"ohE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
 "ohU" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Biohazard";
@@ -34897,6 +34721,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/brig)
+"oyZ" = (
+/obj/item/screwdriver,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "ozf" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -28
@@ -34933,6 +34761,15 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"oAk" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "oAz" = (
 /obj/machinery/light_switch{
 	pixel_y = 24
@@ -35017,27 +34854,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"oCH" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/item/paper_bin{
-	pixel_x = -1;
-	pixel_y = 5
-	},
-/obj/item/pen,
-/obj/structure/table/glass,
-/obj/structure/disposalpipe/sorting/mail/flip{
-	dir = 1
-	},
-/obj/effect/mapping_helpers/mail_sorting/engineering/ce_office,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "oCS" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
@@ -35055,30 +34871,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
-"oDr" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "oDt" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small,
@@ -35108,6 +34900,17 @@
 /mob/living/simple_animal/slime,
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"oDP" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "oDZ" = (
 /obj/machinery/camera{
 	c_tag = "Research - Xenobiology Cell 5";
@@ -35183,6 +34986,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"oFJ" = (
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/requests_console{
+	department = "Engineering";
+	departmentType = 4;
+	name = "Engineering RC";
+	pixel_y = 30
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "oFW" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /obj/machinery/meter,
@@ -35236,6 +35055,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"oIq" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"oIw" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "oIM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -35260,6 +35095,13 @@
 "oJj" = (
 /turf/open/floor/plating/burnt,
 /area/maintenance/starboard)
+"oJG" = (
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+	dir = 8
+	},
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "oJL" = (
 /obj/structure/plasticflaps/opaque,
 /obj/machinery/navbeacon{
@@ -35286,21 +35128,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"oKz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4";
-	tag = ""
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "oKL" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
@@ -35332,15 +35159,6 @@
 /obj/machinery/vending/games,
 /turf/open/floor/wood,
 /area/library)
-"oLy" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	areastring = "/area/engine/gravity_generator";
-	name = "Gravity Generator APC";
-	pixel_y = -23
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "oLF" = (
 /obj/effect/landmark/stationroom/maint/threexthree,
 /turf/template_noop,
@@ -35365,6 +35183,11 @@
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"oLM" = (
+/obj/machinery/gravity_generator/main/station,
+/obj/effect/turf_decal/bot_white,
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
 "oMy" = (
 /obj/machinery/flasher{
 	id = "AI";
@@ -35382,16 +35205,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"oMz" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/power/rad_collector,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "oMD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 1
@@ -35435,6 +35248,12 @@
 	},
 /turf/closed/wall,
 /area/crew_quarters/bar)
+"oNy" = (
+/obj/machinery/modular_computer/console/preset/command/ce{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "oNz" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -35573,6 +35392,12 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/maintenance/aft)
+"oQc" = (
+/obj/structure/table,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/effect/turf_decal/trimline/secred/filled/line/lower,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "oQk" = (
 /obj/effect/landmark/start/roboticist,
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
@@ -35899,6 +35724,23 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"oWS" = (
+/obj/effect/turf_decal/bot_white/left,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "oWY" = (
 /obj/effect/spawner/lootdrop/mob/kitchen_animal,
 /turf/open/floor/plasteel/showroomfloor,
@@ -35931,21 +35773,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"oYt" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "oYI" = (
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = -2;
@@ -35968,30 +35795,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"oYR" = (
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/construction,
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "oZb" = (
 /obj/machinery/disposal/bin/tagger,
 /obj/structure/disposalpipe/trunk{
@@ -36043,13 +35846,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"pba" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "pbi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/machinery/light_switch{
@@ -36089,11 +35885,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
-"pcG" = (
-/obj/machinery/vending/coffee,
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "pcP" = (
 /obj/structure/lattice,
 /obj/structure/sign/warning/docking{
@@ -36110,6 +35901,12 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"pcV" = (
+/obj/structure/cable/orange{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "pdc" = (
 /obj/structure/easel,
 /obj/item/canvas/twentythreeXtwentythree{
@@ -36140,6 +35937,16 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"pdQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pei" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -36202,6 +36009,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"phc" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/engine,
+/area/engine/gravity_generator)
 "phg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -36274,6 +36095,17 @@
 "piy" = (
 /turf/open/floor/plating/broken/three,
 /area/maintenance/starboard)
+"piC" = (
+/obj/structure/table/glass,
+/obj/item/storage/box/donkpockets,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "piO" = (
 /obj/machinery/airalarm{
 	pixel_y = 24
@@ -36339,18 +36171,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"pkv" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "pkJ" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/cmo)
@@ -36549,6 +36369,18 @@
 /obj/effect/mapping_helpers/airlock/access/all/command/eva,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/eva)
+"ppa" = (
+/obj/structure/cable/orange{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ppd" = (
 /obj/machinery/button/door/incinerator_vent_atmos_aux{
 	pixel_x = -8;
@@ -36640,6 +36472,22 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"pqv" = (
+/obj/effect/turf_decal/bot_white,
+/obj/structure/filingcabinet,
+/obj/item/folder/documents,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "pqQ" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 8
@@ -36692,10 +36540,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"prr" = (
-/obj/machinery/power/rad_collector,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "prs" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal/bin,
@@ -36789,6 +36633,16 @@
 /obj/effect/mapping_helpers/airlock/access/all/science/robotics,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
+"pss" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "psu" = (
 /obj/structure/closet/crate,
 /obj/item/toy/figure/miner,
@@ -36955,6 +36809,34 @@
 /obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"pvq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/obj/structure/rack,
+/obj/item/clothing/glasses/meson{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_y = -1
+	},
+/obj/item/clothing/glasses/meson{
+	pixel_x = -3;
+	pixel_y = -4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pvr" = (
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/cafeteria,
@@ -36975,6 +36857,27 @@
 	icon_state = "damaged5"
 	},
 /area/space/nearstation)
+"pwa" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "pww" = (
 /turf/closed/wall,
 /area/quartermaster/office)
@@ -37269,6 +37172,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"pCg" = (
+/obj/machinery/door/airlock/vault,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/command/vault,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "pCp" = (
 /obj/structure/sign/poster/random{
 	pixel_y = 32
@@ -37295,6 +37219,15 @@
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
 /area/maintenance/fore)
+"pCY" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/tcommsat/computer)
 "pDd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -37406,15 +37339,6 @@
 	initial_gas_mix = "o2=1000;TEMP=293.15"
 	},
 /area/engine/atmos)
-"pEz" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "pEM" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -37430,13 +37354,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"pFo" = (
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "pFw" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/effect/turf_decal/tile/green/opposingcorners{
@@ -37485,15 +37402,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"pGw" = (
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 5
-	},
-/obj/machinery/light_switch{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "pGy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37509,22 +37417,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"pHc" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "pHk" = (
 /obj/effect/landmark/start/botanist,
 /obj/structure/disposalpipe/segment{
@@ -37545,6 +37437,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"pHX" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/chair/office/dark,
+/obj/effect/landmark/start/station_engineer,
+/obj/effect/turf_decal/trimline/engiyellow/warning/lower,
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "pIm" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /obj/structure/cable{
@@ -37668,15 +37567,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"pKG" = (
-/obj/machinery/light,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
+"pKB" = (
+/obj/machinery/power/apc{
+	areastring = "/area/engine/gravity_generator";
+	name = "Gravity Generator APC";
+	pixel_y = -23
 	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/engine,
+/area/engine/gravity_generator)
 "pKV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 9
@@ -37881,19 +37788,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/security/prison)
-"pPf" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "pPs" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix{
 	dir = 4
@@ -37931,6 +37825,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"pQu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pQN" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/minor/kittyears_or_rabbitears,
@@ -38021,6 +37921,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"pSj" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "pSl" = (
 /obj/item/stack/cable_coil/cut/red,
 /turf/open/floor/plasteel/airless{
@@ -38113,6 +38022,25 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
+"pUy" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"pUQ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/button/door{
+	dir = 8;
+	id = "engsm";
+	name = "Radiation Shutters Control";
+	pixel_y = -24;
+	req_access = list("engineering")
+	},
+/obj/machinery/light{
+	light_color = "#c1caff"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "pVt" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/item/t_scanner,
@@ -38164,24 +38092,6 @@
 /obj/effect/turf_decal/trimline/secred/warning/lower,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"pWC" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/table,
-/obj/item/clothing/glasses/meson{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "pWL" = (
 /obj/structure/showcase/cyborg/old{
 	dir = 4;
@@ -38231,25 +38141,21 @@
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"pXq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "pXr" = (
 /obj/machinery/field/generator,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"pXu" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pXz" = (
 /obj/structure/door_assembly/door_assembly_min{
 	anchored = 1
@@ -38356,13 +38262,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"qak" = (
-/obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/siding/yellow{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
 "qax" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1
@@ -38444,6 +38343,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"qbI" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qce" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -38474,6 +38385,13 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"qcQ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/plasma,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "qcT" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 1
@@ -38522,16 +38440,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"qej" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/keycard_auth{
-	pixel_x = -24;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "qel" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -38666,6 +38574,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/vacant_room/commissary)
+"qgb" = (
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "qgw" = (
 /obj/effect/mapping_helpers/airlock/abandoned,
 /obj/machinery/door/airlock/maintenance_hatch,
@@ -38874,6 +38785,12 @@
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"qko" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "qkE" = (
 /turf/open/floor/plasteel/white,
 /area/science/explab)
@@ -38947,18 +38864,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"qmf" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "qmo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -38971,6 +38876,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"qmB" = (
+/obj/machinery/computer/station_alert{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/item/radio/intercom{
+	pixel_x = 29
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "qmE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 5
@@ -39019,6 +38936,19 @@
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
+"qnR" = (
+/obj/structure/rack,
+/obj/item/storage/box/lights/mixed{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/lights/mixed{
+	pixel_x = -3;
+	pixel_y = -1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "qnS" = (
 /turf/open/floor/plating,
 /area/storage/tech)
@@ -39085,6 +39015,21 @@
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"qoG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "qoL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
@@ -39265,22 +39210,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/tcommsat/computer)
-"qqN" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
 "qqY" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -39310,6 +39239,18 @@
 /obj/machinery/status_display,
 /turf/closed/wall,
 /area/lawoffice)
+"qrt" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "qrD" = (
 /obj/machinery/mineral/equipment_vendor,
 /obj/effect/turf_decal/trimline/brown/filled/line/lower{
@@ -39317,18 +39258,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"qrF" = (
-/obj/structure/sign/warning/radiation/rad_area{
-	pixel_y = 32
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/structure/cable/orange{
-	icon_state = "2-4"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "qrG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -39483,17 +39412,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/paramedic,
 /turf/open/floor/plasteel,
 /area/medical/paramedic)
-"quW" = (
-/obj/effect/decal/cleanable/cobweb,
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/dark_blue/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "qvf" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -39538,6 +39456,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"qvx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "qvP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39566,13 +39496,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"qws" = (
-/obj/structure/table,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "qwz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/extinguisher_cabinet{
@@ -39621,6 +39544,13 @@
 "qxi" = (
 /turf/open/floor/plating/asteroid/airless,
 /area/space/nearstation)
+"qxt" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "qxL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -39873,18 +39803,6 @@
 "qCt" = (
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"qCM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
 "qCW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -39927,40 +39845,18 @@
 "qEj" = (
 /turf/open/floor/plasteel,
 /area/security/brig)
+"qEr" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/storage_shared)
 "qEt" = (
 /obj/effect/spawner/structure/window/reinforced/shutter,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"qEC" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "qEG" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"qEM" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/power/tesla_coil,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "qEQ" = (
 /obj/structure/table,
 /obj/item/hand_labeler,
@@ -40088,16 +39984,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"qIt" = (
-/obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "qIz" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/assistant,
@@ -40292,6 +40178,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"qNa" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/stairs/goon/stairs2_wide{
+	dir = 1
+	},
+/area/engine/engineering)
 "qNk" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office"
@@ -40358,12 +40259,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"qOM" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "qOP" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -40373,6 +40268,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"qPF" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/table,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/item/melee/sledgehammer,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "qPJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 5
@@ -40388,6 +40302,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"qQe" = (
+/obj/machinery/rnd/production/circuit_imprinter,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "qQh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -40417,16 +40341,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"qQM" = (
-/obj/machinery/rnd/production/protolathe/department/engineering,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "qQQ" = (
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
@@ -40508,6 +40422,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"qSd" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engine_smes)
+"qSg" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "qSt" = (
 /turf/closed/wall,
 /area/medical/medbay/central)
@@ -40637,22 +40565,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"qWx" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "qWy" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Chemistry Lab Maintenance"
@@ -40874,6 +40786,16 @@
 	initial_gas_mix = "n2=1000;TEMP=293.15"
 	},
 /area/engine/atmos)
+"qZY" = (
+/obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/crew_quarters/heads/chief";
+	dir = 8;
+	name = "CE Office APC";
+	pixel_x = -25
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "rai" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -40983,12 +40905,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"rcJ" = (
-/obj/structure/particle_accelerator/end_cap{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "rcK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -41017,9 +40933,16 @@
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"rdI" = (
-/obj/item/weldingtool,
-/turf/open/space/basic,
+"rdS" = (
+/obj/machinery/vending/engivend,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "rdY" = (
 /obj/structure/rack,
@@ -41038,6 +40961,15 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"rec" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "reg" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/mix_input{
 	dir = 8
@@ -41066,6 +40998,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"rfV" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "rgb" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/main";
@@ -41178,6 +41116,16 @@
 	},
 /turf/closed/wall/r_wall,
 /area/security/prison)
+"rjc" = (
+/obj/machinery/rnd/production/protolathe/department/engineering,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 29
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "rjk" = (
 /obj/machinery/status_display/supply{
 	pixel_x = 32
@@ -41370,6 +41318,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/paramedic)
+"rmN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "rmU" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/nuke_storage)
@@ -41759,15 +41719,6 @@
 /obj/machinery/door/airlock/maintenance_hatch,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"rut" = (
-/obj/machinery/power/terminal{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ruG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41831,6 +41782,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"rwn" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "rwt" = (
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
@@ -41843,19 +41803,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"rwZ" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "rxj" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41893,6 +41840,39 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"rxR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light_switch{
+	pixel_x = -22;
+	pixel_y = 24
+	},
+/obj/machinery/button/door{
+	id = "enginepashutter";
+	name = "Particle Accelerator Shutter Control";
+	pixel_x = -25;
+	pixel_y = 32;
+	req_access = list("engineering")
+	},
+/obj/machinery/button/door{
+	id = "enginesecurestorage";
+	name = "Secure Storage Control";
+	pixel_x = -25;
+	pixel_y = 40;
+	req_access = list("engineering")
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
 "ryw" = (
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -42020,6 +42000,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
+"rBT" = (
+/obj/structure/closet/emcloset,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "rCk" = (
 /obj/structure/table,
 /obj/item/camera_film,
@@ -42269,18 +42256,6 @@
 	},
 /turf/open/space/basic,
 /area/engine/atmos)
-"rHy" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "rIh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/northright{
@@ -42371,6 +42346,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"rJY" = (
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/item/pen,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "rKa" = (
 /obj/structure/table,
 /obj/item/assembly/igniter,
@@ -42561,13 +42548,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"rNU" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/chair,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "rOf" = (
 /obj/machinery/door/airlock/medical{
 	name = "Patient Room B"
@@ -42656,6 +42636,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
+"rPa" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "rPb" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Two"
@@ -42732,12 +42734,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"rQN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "rQY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -42825,6 +42821,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"rTC" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/power/grounding_rod,
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engineering - Engine Containment East";
+	dir = 8;
+	network = list("ss13","Engine","Engineering")
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "rTZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
@@ -42880,28 +42888,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"rWe" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "rWo" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = -32
@@ -43030,15 +43016,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
-"sbd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "sbq" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
@@ -43154,6 +43131,13 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"seD" = (
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "seM" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -43257,21 +43241,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
-"shq" = (
-/obj/machinery/computer/apc_control{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	pixel_x = -28
-	},
-/obj/machinery/computer/security/telescreen{
-	name = "Telecomms/Engineering Monitor";
-	network = list("Telecom","Engine","Engineering");
-	pixel_y = 32
-	},
-/obj/item/paper/monitorkey,
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "shs" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43381,13 +43350,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/science/storage)
-"sjM" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/vending/tool,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "sjQ" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/wood,
@@ -43405,15 +43367,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"skz" = (
-/obj/structure/chair/office/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "skC" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
@@ -43483,15 +43436,6 @@
 /obj/machinery/vending/cola/random,
 /turf/open/floor/wood,
 /area/tcommsat/computer)
-"slF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "slJ" = (
 /turf/open/floor/plating/burnt,
 /area/maintenance/port)
@@ -43597,6 +43541,18 @@
 	},
 /turf/open/floor/wood,
 /area/library)
+"snS" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "soh" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -43641,12 +43597,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"spK" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "spM" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Nitrous Oxide Tank";
@@ -43710,6 +43660,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"srd" = (
+/obj/machinery/vending/coffee,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/tcommsat/computer)
 "sri" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -43806,15 +43763,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"stM" = (
-/obj/structure/rack,
-/obj/item/rcl/pre_loaded,
-/obj/item/clothing/glasses/meson{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "stS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -43884,6 +43832,25 @@
 /obj/machinery/status_display,
 /turf/closed/wall/r_wall,
 /area/science/lab)
+"swn" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "swr" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel/airless{
@@ -43986,10 +43953,6 @@
 /obj/effect/spawner/lootdrop/techstorage/service,
 /turf/open/floor/plating,
 /area/storage/tech)
-"sxZ" = (
-/obj/structure/closet/crate/silvercrate,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "syf" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /obj/structure/disposalpipe/segment{
@@ -43997,20 +43960,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"syh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+"syw" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/holopad,
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/nuke_storage)
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "syz" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -44138,6 +44094,16 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"szM" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "sAd" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
@@ -44186,12 +44152,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"sBf" = (
-/obj/structure/filingcabinet,
-/obj/item/folder/documents,
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "sBh" = (
 /obj/machinery/shower{
 	dir = 1
@@ -44294,10 +44254,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"sCT" = (
-/obj/item/wrench,
-/turf/open/space/basic,
-/area/engine/engineering)
 "sCY" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -44526,6 +44482,10 @@
 /obj/structure/closet/secure_closet/hydroponics,
 /turf/open/floor/plasteel,
 /area/hydroponics)
+"sHR" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "sHS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -44559,15 +44519,16 @@
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "sIG" = (
-/obj/structure/tank_dispenser,
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering - Material Storage";
-	network = list("ss13","Engineering")
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access"
 	},
-/obj/effect/turf_decal/bot{
-	dir = 1
+/obj/machinery/atmospherics/pipe/layer_manifold,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "sIT" = (
 /obj/machinery/door/airlock/command{
@@ -44760,6 +44721,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/checkpoint/supply)
+"sMn" = (
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "sMI" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -44861,13 +44828,6 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/detective,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"sOU" = (
-/obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/siding/yellow{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
 "sOV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -44958,13 +44918,6 @@
 /obj/machinery/atmospherics/pipe/manifold/yellow/hidden,
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"sQI" = (
-/obj/structure/closet/crate/solarpanel_small,
-/obj/machinery/light_switch{
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "sQK" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 4
@@ -45085,6 +45038,9 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/science/research)
+"sSg" = (
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "sSj" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Pure to Ports"
@@ -45147,16 +45103,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"sTs" = (
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 5
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "sTU" = (
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
@@ -45170,6 +45116,10 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"sUq" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "sUG" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/turf_decal/stripes/corner{
@@ -45214,6 +45164,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"sVs" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/nuke_storage)
 "sVE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -45334,6 +45290,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
+"sYW" = (
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "sYX" = (
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -45363,15 +45334,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
-"sZF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
 "sZG" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
@@ -45556,15 +45518,6 @@
 /obj/machinery/light/small/built,
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
-"tcT" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "tdW" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 6
@@ -45618,10 +45571,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
-"tfW" = (
-/obj/machinery/power/tesla_coil,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "tge" = (
 /turf/open/floor/carpet,
 /area/hallway/secondary/entry)
@@ -45642,15 +45591,6 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
-"tgQ" = (
-/obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "tgT" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Cryogenics"
@@ -46144,33 +46084,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"toB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
-"toG" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/obj/machinery/power/rad_collector,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "toO" = (
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
@@ -46429,13 +46342,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"tua" = (
-/obj/machinery/power/port_gen/pacman,
-/obj/item/stack/sheet/mineral/plasma{
-	amount = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "tub" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
@@ -46626,19 +46532,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"txy" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 1;
-	pixel_y = -1
-	},
-/obj/effect/mapping_helpers/mail_sorting/engineering/general,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "txK" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/button/door{
@@ -46781,6 +46674,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"tzA" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "tzX" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -47000,6 +46900,32 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/medbay/lobby)
+"tFP" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Gravity Generator";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/machinery/light_switch{
+	pixel_x = 24
+	},
+/turf/open/floor/engine,
+/area/engine/gravity_generator)
+"tGj" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "tGm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47153,13 +47079,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"tIZ" = (
-/obj/structure/grille,
-/obj/structure/cable/orange{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "tJo" = (
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
 	dir = 9
@@ -47261,6 +47180,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"tKw" = (
+/obj/machinery/door/airlock/highsecurity{
+	name = "Gravity Generator and SMES"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/equipment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "tKC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -47298,6 +47239,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"tLk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/nuke_storage)
 "tLr" = (
 /obj/machinery/camera{
 	c_tag = "Hallway - Central Southeast 2";
@@ -47372,6 +47320,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"tNf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "tNg" = (
 /obj/machinery/hydroponics/soil,
 /obj/structure/window/reinforced{
@@ -47478,6 +47436,35 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
+"tQv" = (
+/obj/structure/closet/crate{
+	name = "Gold Crate"
+	},
+/obj/item/stack/sheet/mineral/gold{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/item/stack/sheet/mineral/gold{
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/mineral/gold{
+	pixel_x = 1;
+	pixel_y = -2
+	},
+/obj/item/storage/belt/champion,
+/obj/effect/turf_decal/bot_white/left,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "tQS" = (
 /turf/closed/wall/r_wall,
 /area/science/mixing)
@@ -47485,13 +47472,6 @@
 /obj/structure/door_assembly/door_assembly_mhatch,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"tRe" = (
-/obj/structure/closet/secure_closet/security/engine,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "tRg" = (
 /obj/structure/table,
 /obj/item/assembly/prox_sensor{
@@ -47524,6 +47504,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
+"tRk" = (
+/obj/machinery/advanced_airlock_controller{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "tRo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -47609,14 +47604,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"tSP" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/techstorage/RnD_secure,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "tSY" = (
 /obj/structure/table,
 /obj/item/storage/box/donkpockets{
@@ -48068,24 +48055,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"uel" = (
-/obj/structure/table,
-/obj/item/aiModule/core/full/asimov,
-/obj/item/aiModule/core/freeformcore,
-/obj/effect/spawner/lootdrop/aimodule_harmless,
-/obj/effect/spawner/lootdrop/aimodule_neutral,
-/obj/item/aiModule/core/full/custom,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/window/northleft{
-	name = "Secure Board Storage"
-	},
-/obj/effect/mapping_helpers/windoor/access/all/command/ai_master{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "uep" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 6
@@ -48102,14 +48071,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
-"ueC" = (
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "ueH" = (
 /obj/machinery/button/door{
 	id = "armory";
@@ -48143,6 +48104,16 @@
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"ueP" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "ufa" = (
 /obj/structure/bodycontainer/crematorium{
 	dir = 8;
@@ -48165,11 +48136,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"ufh" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ufG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/landmark/event_spawn,
@@ -48336,6 +48302,20 @@
 /obj/machinery/vending/games,
 /turf/open/floor/plasteel,
 /area/clerk)
+"uja" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 5
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ujh" = (
 /obj/structure/pool_ladder,
 /turf/open/indestructible/sound/pool/end,
@@ -48377,19 +48357,6 @@
 "uku" = (
 /turf/closed/wall,
 /area/science/lab)
-"ukv" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
-	dir = 8
-	},
-/obj/machinery/suit_storage_unit/engine,
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ukE" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -48764,6 +48731,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"usD" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "usF" = (
 /obj/machinery/light{
 	dir = 8
@@ -48820,21 +48799,6 @@
 	},
 /turf/open/floor/plating,
 /area/medical/sleeper)
-"utO" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "uua" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -48967,23 +48931,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/storage/satellite)
-"uww" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
-"uwT" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "uxa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49281,6 +49228,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"uDE" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "uEe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -49290,13 +49244,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/warehouse)
-"uEj" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 9
-	},
-/obj/structure/closet/radiation,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "uEk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
@@ -49451,6 +49398,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
+"uFX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_middle,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "uGh" = (
 /obj/structure/chair/comfy/brown{
 	dir = 8
@@ -49562,6 +49525,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
+"uII" = (
+/obj/machinery/power/emitter/anchored{
+	dir = 8;
+	state = 2
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "uIQ" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -49614,6 +49590,18 @@
 "uJr" = (
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"uJH" = (
+/obj/structure/cable/orange{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "uJJ" = (
 /obj/structure/table,
 /obj/machinery/airalarm{
@@ -49704,10 +49692,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"uKQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "uKU" = (
 /turf/closed/wall,
 /area/medical/storage)
@@ -49762,6 +49746,15 @@
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel,
 /area/escapepodbay)
+"uMu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "uMB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/nitrous_output{
 	dir = 8
@@ -49781,13 +49774,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"uNP" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
 "uNU" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/green/filled/corner/lower{
@@ -49795,6 +49781,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"uNX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
+"uOi" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "uOr" = (
 /turf/open/floor/plasteel/airless{
 	icon_state = "damaged5"
@@ -49830,29 +49835,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"uOX" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering - Airlock";
-	network = list("ss13","Engineering")
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"uPv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/checkpoint/engineering)
 "uPG" = (
 /turf/open/floor/carpet,
 /area/crew_quarters/theatre)
@@ -49924,6 +49906,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"uQJ" = (
+/obj/machinery/vending/tool,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "uQT" = (
 /obj/machinery/computer/teleporter,
 /turf/open/floor/plasteel/dark,
@@ -49996,28 +49991,6 @@
 /obj/effect/landmark/stationroom/maint/tenxten,
 /turf/template_noop,
 /area/space/nearstation)
-"uSU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
 "uSY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 9
@@ -50063,20 +50036,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"uTQ" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/machinery/power/smes/engineering{
-	input_level = 10000;
-	output_attempt = 0;
-	output_level = 5000
-	},
-/obj/structure/cable/orange{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "uUa" = (
 /obj/effect/turf_decal/tile/yellow/opposingcorners,
 /obj/effect/turf_decal/tile/green/opposingcorners{
@@ -50112,6 +50071,24 @@
 	initial_gas_mix = "plasma=1000;TEMP=293.15"
 	},
 /area/engine/atmos)
+"uUx" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "uUz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -50192,6 +50169,23 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"uVZ" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/airlock/engineering{
+	name = "Engine Room"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "uWg" = (
 /obj/machinery/teleport/hub,
 /turf/open/floor/circuit,
@@ -50727,6 +50721,16 @@
 /obj/item/reagent_containers/glass/bottle/epinephrine,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
+"veZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "vfa" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
@@ -50758,6 +50762,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"vfA" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "vfC" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
 	dir = 8
@@ -50817,13 +50831,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"vgq" = (
-/obj/effect/spawner/structure/window/reinforced/shutter,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "vgs" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
@@ -50833,13 +50840,6 @@
 "vgR" = (
 /turf/open/floor/plating,
 /area/maintenance/port)
-"vgS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/lawoffice)
 "vgY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /obj/machinery/power/apc{
@@ -50856,17 +50856,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"vhD" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vhP" = (
 /obj/effect/turf_decal/pool{
 	dir = 4
@@ -50936,18 +50925,13 @@
 	},
 /turf/open/space/basic,
 /area/solar/port/fore)
-"vka" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+"vkb" = (
+/obj/machinery/suit_storage_unit/engine,
+/obj/structure/cable/orange{
+	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 8
-	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
 /turf/open/floor/plasteel,
-/area/engine/engineering)
-"vkg" = (
-/obj/machinery/power/emitter,
-/turf/open/floor/plating,
 /area/engine/engineering)
 "vkv" = (
 /obj/machinery/door/airlock/security{
@@ -50990,6 +50974,18 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/lawyer,
+/turf/open/floor/wood,
+/area/lawoffice)
+"vmd" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/lawoffice";
+	dir = 1;
+	name = "Lawyer's Office APC";
+	pixel_y = 23
+	},
 /turf/open/floor/wood,
 /area/lawoffice)
 "vmi" = (
@@ -51120,28 +51116,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"voE" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=BOTTOMLEFT";
-	location = "BOTTOMMID";
-	name = "navigation beacon (BOTTOMMID)"
-	},
-/obj/effect/landmark/event_spawn,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer4,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/sorting/mail{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/mail_sorting/engineering/general,
-/obj/effect/mapping_helpers/mail_sorting/engineering/ce_office,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "voN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
@@ -51168,16 +51142,24 @@
 "vpk" = (
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"vpn" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 1
+"vpq" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "vpC" = (
 /obj/structure/sign/poster/official/space_cops{
 	pixel_x = 32
@@ -51218,14 +51200,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"vqt" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+"vqu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "vqY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2,
@@ -51270,6 +51250,21 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"vrO" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "vsp" = (
 /obj/machinery/door/airlock/external{
 	name = "Labor Camp Shuttle Airlock";
@@ -51363,6 +51358,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"vtB" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/ramp_corner{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vtD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -51504,6 +51515,43 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"vwg" = (
+/obj/structure/cable/orange{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"vwj" = (
+/obj/machinery/advanced_airlock_controller{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "vwr" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -51601,22 +51649,6 @@
 /obj/item/toy/figure/cmo,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
-"vyt" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vyE" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -51703,27 +51735,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
-"vzP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/requests_console{
-	department = "Engineering";
-	departmentType = 4;
-	name = "Engineering RC";
-	pixel_y = 30
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
 "vAa" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
@@ -51830,6 +51841,21 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"vCD" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_alone{
+	dir = 4
+	},
+/area/engine/engineering)
 "vCJ" = (
 /obj/docking_port/stationary{
 	dwidth = 3;
@@ -51905,16 +51931,6 @@
 /obj/effect/mapping_helpers/mail_sorting/science/toxins,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"vFd" = (
-/obj/machinery/power/emitter/anchored{
-	dir = 4;
-	state = 2
-	},
-/obj/structure/cable/orange{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "vFf" = (
 /obj/machinery/light/small,
 /obj/machinery/camera{
@@ -51945,19 +51961,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"vFu" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8";
-	tag = ""
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_smes)
 "vFA" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8;
@@ -52038,6 +52041,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"vHe" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vHz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -52100,20 +52117,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"vIy" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering - Particle Accelerator";
-	dir = 8;
-	network = list("ss13","Engine","Engineering")
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "vIz" = (
 /obj/machinery/nuclearbomb/beer,
 /turf/open/floor/plating,
@@ -52156,24 +52159,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"vJl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable/orange{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vJX" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"vKf" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/closet/radiation,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "vKx" = (
 /obj/structure/window/reinforced,
 /obj/machinery/camera{
@@ -52330,10 +52326,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"vOX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/turf/open/floor/circuit,
-/area/ai_monitored/nuke_storage)
 "vPe" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -52450,15 +52442,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"vRb" = (
-/obj/machinery/computer/station_alert{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "vRn" = (
 /obj/docking_port/stationary/random{
 	dir = 2;
@@ -52529,6 +52512,16 @@
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/maintenance/central)
+"vTb" = (
+/obj/machinery/disposal/bin/tagger,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "vTr" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -52576,21 +52569,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"vUt" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vUx" = (
 /obj/machinery/power/smes,
 /obj/structure/cable{
@@ -52620,22 +52598,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"vVw" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Chief Engineer's Desk";
-	departmentType = 3;
-	name = "Chief Engineer RC";
-	pixel_x = -32
-	},
-/obj/machinery/modular_computer/console/preset/command/ce{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/heads/chief)
 "vVz" = (
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/airless{
@@ -52672,6 +52634,17 @@
 "vWp" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
+"vWX" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"vXb" = (
+/obj/effect/turf_decal/trimline/secred/filled/line/lower{
+	dir = 4
+	},
+/obj/structure/chair/office/dark,
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "vXz" = (
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
@@ -52710,25 +52683,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"vYC" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 10
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
 "vYJ" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 4
@@ -52857,15 +52811,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"wch" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "wck" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
@@ -53014,12 +52959,28 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"wfM" = (
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "wgg" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 8
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"wgh" = (
+/obj/effect/turf_decal/trimline/dark_blue/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wgo" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -53325,6 +53286,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
+"wnP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "wnV" = (
 /obj/machinery/disposal/bin,
 /obj/machinery/light,
@@ -53377,13 +53344,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"wpm" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "wps" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
@@ -53513,21 +53473,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"wrF" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "wrV" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
@@ -53557,20 +53502,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"wtl" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "wtm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -53690,15 +53621,6 @@
 "wvC" = (
 /turf/closed/wall,
 /area/quartermaster/storage)
-"wvG" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "wvP" = (
 /obj/structure/chair/wood/normal,
 /turf/open/floor/plating,
@@ -53736,15 +53658,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"wwq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "wwH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -53771,13 +53684,6 @@
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
-"wwU" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/plasma,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "wxp" = (
 /obj/machinery/computer/atmos_control{
 	dir = 8
@@ -53913,6 +53819,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"wzC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "wzH" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 1
@@ -53996,15 +53914,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"wAT" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "wAU" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -54179,14 +54088,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"wEp" = (
-/obj/machinery/suit_storage_unit/ce,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
-"wEq" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "wEt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -54276,18 +54177,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/clerk)
-"wFz" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "wFN" = (
 /obj/effect/turf_decal/trimline/white/filled/line/lower{
 	dir = 4
@@ -54335,24 +54224,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"wHi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "wHr" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -54379,28 +54250,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"wIn" = (
+"wIx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"wIv" = (
-/obj/machinery/light,
-/obj/item/kirbyplants/random,
-/obj/effect/turf_decal/trimline/secred/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "wII" = (
@@ -54452,10 +54311,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
+"wJR" = (
+/obj/machinery/power/emitter/anchored{
+	dir = 4;
+	state = 2
+	},
+/obj/structure/cable/orange{
+	icon_state = "2-4"
+	},
+/obj/structure/cable/orange{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "wKa" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"wKk" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wKn" = (
 /obj/structure/table/wood,
 /obj/item/storage/pill_bottle/dice,
@@ -54478,6 +54359,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"wKX" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/effect/landmark/start/station_engineer,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "wKZ" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -54643,11 +54534,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"wOC" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
 "wOE" = (
 /mob/living/simple_animal/hostile/asteroid/hivelord,
 /turf/open/floor/plating/asteroid/airless,
@@ -55027,6 +54913,41 @@
 	},
 /turf/open/floor/catwalk_floor/telecomms,
 /area/ai_monitored/turret_protected/ai)
+"wWv" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/northleft{
+	name = "Engineering Desk"
+	},
+/obj/item/deskbell/preset/engi{
+	pixel_x = -8;
+	pixel_y = -3
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/effect/mapping_helpers/windoor/access/any/engineering/construction{
+	dir = 1
+	},
+/obj/effect/mapping_helpers/windoor/access/any/engineering/general{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/engine/storage_shared)
+"wWC" = (
+/obj/machinery/door/poddoor{
+	id = "enginesecurestorage";
+	name = "Secure Storage"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wWJ" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 1
@@ -55069,13 +54990,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
-"wXY" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "wXZ" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light/small{
@@ -55108,21 +55022,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"wYr" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "wYB" = (
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plasteel,
@@ -55174,6 +55073,21 @@
 /obj/effect/mapping_helpers/airlock/access/all/medical/virology,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"wZy" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/general,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "wZP" = (
 /obj/machinery/vending/hydronutrients,
 /turf/open/floor/plasteel,
@@ -55276,6 +55190,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
+"xaZ" = (
+/obj/machinery/ore_silo,
+/obj/effect/turf_decal/bot_white/left,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
 "xbc" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -55336,13 +55265,6 @@
 /obj/item/pool/pool_noodle,
 /turf/open/indestructible/sound/pool/end,
 /area/crew_quarters/fitness/recreation)
-"xbt" = (
-/obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/siding/yellow{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
 "xbx" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -55501,10 +55423,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/atmos)
-"xdy" = (
-/obj/machinery/power/grounding_rod,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "xdz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -55650,12 +55568,38 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"xgZ" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel/stairs/goon/stairs_wide{
+	dir = 1
+	},
+/area/engine/engineering)
 "xho" = (
 /obj/structure/chair/wood/normal{
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"xhK" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Hallway - Central East 2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "xhS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -55708,6 +55652,12 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
+"xjx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "xjJ" = (
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -55902,6 +55852,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"xlG" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 6
+	},
+/obj/structure/closet/radiation,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/engine/foyer)
 "xmg" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/turf_decal/stripes/line{
@@ -56009,6 +55970,11 @@
 	name = "Holodeck Projector Floor"
 	},
 /area/holodeck/rec_center)
+"xnN" = (
+/obj/machinery/suit_storage_unit/engine,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "xnQ" = (
 /obj/effect/spawner/structure/window/hollow/reinforced/directional{
 	dir = 10
@@ -56062,12 +56028,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"xoH" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "xoM" = (
 /obj/effect/turf_decal/trimline/secred/filled/corner/lower{
 	dir = 8
@@ -56128,17 +56088,6 @@
 /obj/effect/mapping_helpers/airlock/access/any/service/library,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"xpz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "xpC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -56175,12 +56124,42 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/fore)
+"xpY" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "xqf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/effect/turf_decal/trimline/yellow/arrow_cw,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"xqJ" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/stairs/goon/dark_stairs_alone{
+	dir = 8
+	},
+/area/engine/engineering)
 "xqM" = (
 /obj/machinery/light_switch{
 	pixel_x = -23
@@ -56287,14 +56266,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"xsv" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "xsK" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -56400,6 +56371,17 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
+"xvd" = (
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "xvi" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/trunk{
@@ -56495,15 +56477,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"xwW" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "xwY" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/railing,
@@ -56532,6 +56505,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/research)
+"xxy" = (
+/obj/effect/turf_decal/delivery,
+/obj/machinery/button/door{
+	id = "enginesecurestorage";
+	name = "Secure Storage Control";
+	pixel_x = -25;
+	pixel_y = -23;
+	req_access = list("engine_equip")
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "xxK" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -56599,6 +56583,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"xyv" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/landmark/xeno_spawn,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/engine,
+/area/engine/gravity_generator)
 "xyI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -56677,6 +56674,13 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
+"xzz" = (
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "xzK" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower,
 /turf/open/floor/plasteel/white,
@@ -56755,16 +56759,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"xAO" = (
-/obj/structure/grille,
-/obj/structure/cable/orange{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/orange{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "xBa" = (
 /obj/docking_port/stationary{
 	dwidth = 5;
@@ -56794,20 +56788,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"xCh" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/power/terminal,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
 "xCm" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
@@ -56941,6 +56921,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
+"xFR" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "xFT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 8
@@ -57023,6 +57009,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"xIy" = (
+/obj/structure/cable/orange{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "xIB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -57223,12 +57215,12 @@
 /obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"xMH" = (
-/obj/effect/landmark/start/station_engineer,
-/obj/structure/cable{
-	icon_state = "4-8"
+"xMx" = (
+/obj/structure/cable/orange{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/power/rad_collector,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "xMI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
@@ -57281,6 +57273,35 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"xNS" = (
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Engineering Desk"
+	},
+/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower,
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "xNZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -57457,40 +57478,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"xRe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"xRh" = (
-/obj/structure/rack,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/spawner/lootdrop/techstorage/command,
-/obj/machinery/camera/motion{
-	c_tag = "Secure - Vault";
-	dir = 4;
-	network = list("ss13","Secure")
-	},
-/obj/machinery/door/window/eastright{
-	name = "Secure Board Storage"
-	},
-/obj/effect/mapping_helpers/windoor/access/all/engineering/secure_tech{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "xRp" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -57588,15 +57575,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/maintenance/central)
-"xRP" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 6
-	},
-/obj/machinery/computer/station_alert{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "xSe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -57626,6 +57604,10 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"xSO" = (
+/obj/effect/turf_decal/bot_white/left,
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
 "xSP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4{
 	dir = 4
@@ -57641,17 +57623,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"xTf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "xTi" = (
 /obj/machinery/vending/security,
 /turf/open/floor/plasteel/showroomfloor,
@@ -57659,12 +57630,6 @@
 "xUh" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/satellite)
-"xUi" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "xUy" = (
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
@@ -57783,23 +57748,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"xXv" = (
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engineering"
-	},
-/obj/machinery/door/firedoor/border_only,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 8
-	},
-/obj/effect/mapping_helpers/airlock/access/any/engineering/general,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "xXE" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 8
@@ -57863,6 +57811,18 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"xYp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/nuke_storage)
 "xYx" = (
 /obj/structure/table/wood,
 /obj/effect/landmark/event_spawn,
@@ -58094,13 +58054,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"yeX" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/siding/yellow{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
 "yfd" = (
 /obj/machinery/light,
 /turf/open/floor/plasteel,
@@ -58177,43 +58130,6 @@
 "yhE" = (
 /turf/closed/wall,
 /area/space/nearstation)
-"yhK" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engineering - Chief Engineer's Office";
-	network = list("ss13","Engineering")
-	},
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/mob/living/simple_animal/parrot/Poly,
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 2
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
-"yhM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"yhW" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
 "yia" = (
 /obj/structure/chair{
 	dir = 1
@@ -58286,6 +58202,24 @@
 /obj/effect/spawner/lootdrop/randomfood,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"yjo" = (
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/secred/filled/corner/lower{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_x = -22;
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/engineering)
 "yjJ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -58295,19 +58229,6 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/ai_monitored/turret_protected/ai)
-"yjL" = (
-/obj/machinery/camera/motion{
-	c_tag = "Engineering - SMES";
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/light_switch{
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
 "yjX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /obj/structure/cable{
@@ -58327,6 +58248,10 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopods)
+"ykt" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/r_wall,
+/area/ai_monitored/nuke_storage)
 "ykw" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -86782,9 +86707,9 @@ fOG
 fOG
 fOG
 gIJ
-bRW
-haY
-cxA
+gIJ
+nrU
+fEn
 fEn
 fEn
 fEn
@@ -87036,10 +86961,10 @@ eES
 tIb
 fOG
 fOG
-kTi
-twN
-kTi
-kTi
+vDp
+dLd
+vDp
+vDp
 xkg
 gIJ
 vDp
@@ -87290,16 +87215,16 @@ atk
 eLP
 imx
 fOG
-sZF
-vYC
-uSU
-myG
-myG
-myG
-myG
-myG
-myG
-myG
+vWX
+cPf
+gIJ
+vDp
+vDp
+vDp
+vDp
+ylr
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -87544,16 +87469,16 @@ nDr
 dZN
 chU
 fOG
-gEZ
-gEZ
-yhM
-myG
-wFz
-fds
-ivT
-ivT
-frz
-myG
+gIJ
+cPf
+gIJ
+ivF
+xSu
+xSu
+ylr
+xSu
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -87798,16 +87723,16 @@ eLP
 eEa
 dnx
 fOG
-wOC
-gEZ
-aTH
-myG
-fQQ
-qak
-ljK
-eSX
-aCy
-myG
+gIJ
+bQl
+fki
+vDp
+vDp
+xSu
+xSu
+xSu
+xSu
+ylr
 ylr
 ylr
 ylr
@@ -88053,15 +87978,15 @@ fOG
 fOG
 fOG
 fOG
-gEZ
-gac
-kyG
-dSK
-yeX
-gVe
-kiI
-jMK
-myG
+gIJ
+cPf
+gIJ
+ivF
+ylr
+ylr
+xSu
+ylr
+ylr
 ylr
 ylr
 ylr
@@ -88307,15 +88232,15 @@ eDe
 jlD
 cmK
 fOG
-gEZ
-qqN
-myG
-nvW
-sOU
-hTc
-xbt
-aWc
-myG
+kYW
+cPf
+gIJ
+ivF
+xSu
+ylr
+ylr
+ylr
+ylr
 ylr
 ylr
 fTO
@@ -88561,15 +88486,15 @@ uPG
 jRC
 aCJ
 fOG
-uNP
-yhM
-myG
-jex
-xoH
-xoH
-xoH
-oLy
-myG
+geA
+nDU
+crd
+vDp
+xSu
+ylr
+ylr
+ylr
+ylr
 ylr
 akr
 fTO
@@ -88816,7 +88741,7 @@ qFq
 vyJ
 akr
 akr
-fWW
+twN
 akr
 akr
 akr
@@ -89069,9 +88994,9 @@ uPG
 qFq
 uPG
 akr
-nHi
-rby
-sIq
+srd
+gWq
+pCY
 sIq
 gPK
 iIJ
@@ -91828,9 +91753,9 @@ qAi
 qAi
 qAi
 qAi
-ylr
-ylr
-ylr
+xSu
+xSu
+xSu
 lGn
 sHK
 sHK
@@ -92079,19 +92004,19 @@ qAi
 qAi
 ylr
 ylr
-xSu
 ylr
 ylr
 ylr
 ylr
 ylr
-bvT
-bvT
-bvT
-bvT
-bvT
-bvT
-bvT
+ylr
+eKw
+dMR
+dMR
+dMR
+dMR
+dMR
+dMR
 bhY
 bhY
 pHk
@@ -92325,12 +92250,9 @@ ylr
 ylr
 ylr
 ylr
-ylr
-ylr
-ylr
+xSu
 xSu
 ylr
-xSu
 ylr
 ylr
 xSu
@@ -92339,13 +92261,16 @@ ylr
 ylr
 ylr
 ylr
-bvT
-isk
-hUJ
-dSB
-cCy
-nKv
-bvT
+ylr
+ylr
+ylr
+ylr
+dMR
+xIW
+kQK
+lFR
+lFR
+dMR
 hiV
 kFs
 tGm
@@ -92578,28 +92503,28 @@ qEt
 ylr
 ylr
 ylr
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
+ylr
+xSu
 ylr
 ylr
 ylr
-bvT
-xCh
-hUJ
-vFu
-cCy
-dqK
-bvT
+ylr
+xSu
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+dMR
+xIW
+xIW
+lFR
+lFR
+dMR
 bhY
 bhY
 dqp
@@ -92831,38 +92756,38 @@ qEt
 ylr
 ylr
 ylr
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
+ylr
+ylr
+xSu
+ylr
+ylr
+ylr
+ylr
+xSu
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+xSu
+dMR
+xIW
+xIW
+kie
+kie
 bvT
-vzP
-iQu
-eRk
-jHA
-ohE
-hlT
-hlT
-hlT
-hlT
-hlT
-jvn
-jvn
-jvn
-jvn
-jvn
+bvT
+bvT
+bvT
+bvT
+bvT
+eKw
+eKw
+eKw
+eKw
 dFK
 aWv
 nOr
@@ -93084,40 +93009,40 @@ qEt
 ylr
 ylr
 ylr
+ylr
+ylr
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
 bHj
 bHj
 bHj
 bHj
 dMR
-dMR
-dMR
-dMR
-dMR
-dMR
-dMR
-dMR
-vIf
-bHj
-bHj
-bHj
-bHj
+qcQ
+kie
+kie
+kIX
 bvT
-eVM
-mrW
-qCM
-bZR
-yjL
-hlT
-qIt
-jaE
-ogQ
-mVN
-jvn
-shq
-vVw
-vRb
-jvn
-jvn
+seD
+cAL
+aGt
+kIU
+bvT
+xSu
+ylr
+xSu
+bSP
+bSP
 gvx
 hld
 ekF
@@ -93337,41 +93262,41 @@ ylr
 ylr
 ylr
 ylr
+ylr
 bHj
 bHj
 bHj
 dMR
 dMR
 dMR
-lNP
-jPu
-lfL
-lZI
-toG
-mot
-tIZ
-dMR
-lpE
 dMR
 dMR
 dMR
+dMR
+dMR
+dMR
+dMR
+vIf
+dMR
+dMR
+dMR
+dMR
+dMR
+dMR
+wWC
+wWC
+dMR
 bvT
+oFJ
+eDD
+rwn
+hbV
 bvT
-kTO
-bvT
-ivt
-bvT
-hlT
-tRe
-hve
-mnd
-uww
-jvn
-mTX
-skz
-qej
-eHb
-jvn
+xSu
+ylr
+ylr
+xSu
+bSP
 khu
 jqS
 foJ
@@ -93590,42 +93515,42 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
 bHj
-bHj
-bHj
+vIf
 dMR
 dMR
-lNP
-jAC
-kfu
-tfW
-xdy
-xdy
-prr
-mAL
-nne
-xAO
-mot
-tIZ
-mPx
-dMR
-uEj
-aSo
-gfY
-utO
-beY
-pkv
+wJR
+aiX
+aiX
+aiX
+iTZ
+xMx
+xMx
+xMx
+bxM
+xdb
+kGx
+vwj
+ihV
+gDg
+fof
+swn
+wOT
+xxy
+bbz
+bvT
+hCu
+mmN
+vrO
+myL
+bvT
 hlT
-pGw
-uPv
-toB
-qws
-jvn
-cIN
-mYw
-fLD
-stM
-jvn
+hlT
+hlT
+hlT
+hlT
 hhD
 iOl
 cPC
@@ -93844,42 +93769,42 @@ ylr
 ylr
 ylr
 ylr
+ylr
 bHj
 bHj
 dMR
-dMR
-lNP
-kfu
-vFd
+xIy
+mot
+sMn
 xdb
 iXL
 iXL
-uwT
+vfA
 iXL
 iXL
-qOM
-vFd
-mAL
-mrK
-mPx
+oIw
+iXL
+pSj
 dMR
-lsc
-pxl
-xMH
+dMR
+dMR
+gMq
 agh
-gcp
-dGI
+iGX
+agh
+fMB
+pUy
+bvT
+lhz
+bvT
+tKw
+qSd
+bvT
+fXg
+eBG
+snS
+abg
 hlT
-qZx
-qZx
-bGn
-qZx
-jvn
-yhK
-oYt
-jqa
-wEp
-jvn
 khu
 iOl
 cPC
@@ -94097,43 +94022,43 @@ ylr
 ylr
 ylr
 ylr
-bHj
-bHj
+ylr
+ylr
 bHj
 dMR
-mPx
-iqo
-mAL
-mAL
-xOd
-mAL
-hhj
-xOd
-fJu
-mAL
-wch
-iXL
-qOM
+dMR
 mrK
-dMR
-dMR
-dMR
-uOX
-xMH
-agh
-gcp
-nrs
-jBZ
-crL
-vka
-wHi
-wIv
-jvn
-kHX
-jVz
-kHX
-kHX
-jvn
+mAL
+mAL
+xOd
+mAL
+mAL
+xOd
+mAL
+mAL
+xOd
+mAL
+pzc
+mAL
+rvl
+vKf
+nKW
+fkH
+fyC
+dMP
+vqu
+crf
+fFq
+qoG
+fyM
+iYy
+sYW
+kRH
+yjo
+tNf
+xjx
+oQc
+qZx
 khu
 iOl
 hty
@@ -94351,11 +94276,11 @@ ylr
 ylr
 ylr
 ylr
-bHj
+ylr
+ylr
 bHj
 dMR
-dMR
-mPx
+mAL
 mrK
 mAL
 nee
@@ -94368,26 +94293,26 @@ fJu
 fJu
 nee
 pzc
-mrK
-nVy
-mqx
-aXG
-emk
-fTp
-vhD
-wIn
-vhD
-dWS
-xpz
-hjy
-oKz
-eyH
-bZW
-tgQ
-oDr
-pEz
-fBx
-dMR
+mAL
+rvl
+gDE
+aat
+aFW
+amY
+epv
+lzO
+uOi
+bKe
+kwG
+kTP
+pdQ
+erm
+qZx
+fbN
+egv
+vXb
+lDa
+hlT
 khu
 iOl
 aqy
@@ -94605,11 +94530,11 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
 bHj
-bHj
-dMR
-mPx
-mPx
+lpE
+mAL
 mrK
 mAL
 fJu
@@ -94619,29 +94544,29 @@ hhj
 fJu
 fJu
 fJu
-nYD
+fJu
 fJu
 pzc
-mrK
-dMR
-dMR
-dMR
-dMR
-rvl
-rvl
-rvl
-rvl
-sTs
-pxl
-ctN
-eWC
-sjM
 bZW
-ccr
-pXq
-moM
-fvg
+rvl
+rvl
 dMR
+dMR
+xqJ
+dMR
+dMR
+dMR
+dMR
+pvq
+kCI
+cfa
+dMR
+hlT
+hlT
+qZx
+qZx
+hlT
+hlT
 khu
 iOl
 aqy
@@ -94859,10 +94784,10 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
 bHj
-bHj
-lpE
-mAL
+dMR
 mAL
 mrK
 mAL
@@ -94876,26 +94801,26 @@ fJu
 fJu
 fJu
 pzc
-ntU
-dMR
-qrF
-rwZ
-sbd
-sbd
-sbd
-iiO
-rvl
-rvl
-fEh
-ctN
-qWx
 bZW
-bZW
-ccr
-cSB
-agh
-pKG
+hZj
+ifJ
+iYc
+hWp
+duq
+hFl
 dMR
+uQJ
+rdS
+rec
+giy
+jMo
+dMR
+vTb
+piC
+rJY
+dRO
+eSk
+mgZ
 khu
 gOe
 urf
@@ -95113,10 +95038,10 @@ ylr
 ylr
 ylr
 ylr
-bHj
+ylr
+ylr
 bHj
 dMR
-spK
 mAL
 mrK
 mAL
@@ -95130,26 +95055,26 @@ hhj
 hhj
 nee
 pzc
-aYn
-kVX
-slF
+bZW
+xwr
 pes
+oyZ
 imW
-imW
-imW
-gAh
-ldY
-wtl
-eZX
-lQk
-rWe
-lTg
-jZl
-nKW
-eei
-aQN
-wEq
-dMR
+eIA
+gDE
+xvd
+cNi
+agh
+lBG
+giy
+szM
+uVZ
+wzC
+chN
+sHR
+wKX
+sUq
+mgZ
 hyJ
 iOl
 aqy
@@ -95367,16 +95292,16 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
 bHj
-bHj
-dMR
+vIf
 cpp
-mAL
 mrK
 mAL
 fJu
 fJu
-sCT
+fJu
 mAL
 mAL
 mAL
@@ -95384,28 +95309,28 @@ fJu
 fJu
 fJu
 pzc
-mAL
-ocR
+bZW
 xwr
 oyp
 bMC
 cEU
-rcJ
-imW
-fZK
+hva
+pUQ
 dMR
-jRa
-bPr
-fho
-dMR
-iQA
-txy
-oCH
-enu
-mqo
-oYR
+eUq
+agh
+mBs
+nnk
+xpY
+aGy
+biT
+mPt
+jZH
+leG
+lqk
+jMh
 kbc
-voE
+eIS
 xae
 dpy
 etr
@@ -95621,10 +95546,10 @@ ylr
 ylr
 ylr
 ylr
-bHj
+ylr
+ylr
 bHj
 dMR
-kpj
 mAL
 mrK
 mAL
@@ -95637,29 +95562,29 @@ mAL
 fJu
 fJu
 fJu
-vqt
-iXL
-vgq
-cmZ
+pzc
+bZW
+xwr
 sLe
 imW
 buL
-wAT
-wXY
-wwq
-iPA
-wvG
-wrF
-qEC
-cMt
-rHy
-nOO
-dAC
-aQN
-hKh
-dMR
+lGb
+gDE
+xvd
+cNi
+agh
+lBG
+jQM
+hFV
+uUx
+veZ
+sHR
+fiE
+qgb
+lCw
+mgZ
 hyJ
-iOl
+kmY
 aqy
 uix
 rGO
@@ -95875,10 +95800,10 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
 bHj
-bHj
-lpE
-mAL
+dMR
 mAL
 mrK
 mAL
@@ -95888,32 +95813,32 @@ fJu
 fJu
 fJu
 hhj
-iSf
+fJu
 fJu
 fJu
 pzc
-mAL
-dMR
-nmo
-bOM
-vIy
-tcT
-eXD
-nZV
-dMR
-dMR
-kFW
-iGX
-jcf
 bZW
-vpn
-agh
-cqa
-agh
-ufh
+qko
+wnP
+wnP
+mRw
+aTL
+uMu
 dMR
+uja
+syw
+isQ
+blR
+dGI
+dMR
+eFM
+jJh
+rPa
+uDE
+xlG
+mgZ
 khu
-xRe
+asg
 cHw
 uix
 auj
@@ -96129,45 +96054,45 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
 bHj
-bHj
-dMR
-mPx
-mPx
+lpE
+mAL
 mrK
 mAL
 fJu
 fJu
 fJu
-rdI
+fJu
 fJu
 hhj
 fJu
 fJu
 fJu
 pzc
-mAL
-dMR
-dMR
-dMR
-dMR
-dMR
-dMR
-dMR
-dMR
-nyp
-nKW
-iGX
-pWC
 bZW
-nKV
-asd
-drI
-agh
-wEq
+rvl
+rvl
 dMR
+dMR
+vCD
+dMR
+dMR
+dMR
+dMR
+hrv
+grO
+cfa
+dMR
+fsU
+fsU
+xNS
+fsU
+fsU
+fsU
 dkH
-iOl
+kmY
 aqy
 uix
 uUg
@@ -96383,11 +96308,11 @@ ylr
 ylr
 ylr
 ylr
-bHj
+ylr
+ylr
 bHj
 dMR
-dMR
-mPx
+mAL
 mrK
 mAL
 nee
@@ -96401,27 +96326,27 @@ fJu
 nee
 pzc
 mAL
-mPx
+rvl
+gDE
+jjU
+lQV
+pQu
+nlM
+wKk
+xzz
 dMR
-vkg
-vkg
-kie
-kie
-kIX
-dMR
-fRO
-asd
-akJ
-hmU
-bZW
-mKK
-aat
-pPf
-bSk
-nLv
-dMR
+qPF
+blR
+llk
+gOE
+fsU
+kCh
+pwa
+bvA
+rBT
+fsU
 khu
-iOl
+kmY
 cLZ
 teY
 teY
@@ -96637,45 +96562,45 @@ ylr
 ylr
 ylr
 ylr
-bHj
-bHj
+ylr
+ylr
 bHj
 dMR
-mPx
-iqo
+dMR
+mrK
 mAL
-hhj
+mAL
 igc
 mAL
-fJu
+mAL
 igc
-hhj
 mAL
-xwW
-iXL
-kWn
 mAL
-mPx
-dMR
-vkg
-vkg
-kie
-kie
-kie
-atR
-wOT
-agh
-hpI
-pFo
-dMR
-dMR
-bZW
-mfh
-bZW
-bZW
-dMR
+igc
+mAL
+pzc
+mAL
+rvl
+vKf
+pxl
+dHJ
+ppa
+mIl
+usD
+ezb
+xgZ
+jxO
+oDP
+xFR
+vkb
+fsU
+qQe
+dfB
+mzT
+qnR
+fsU
 nQR
-iOl
+kmY
 jGz
 fYU
 xuE
@@ -96892,44 +96817,44 @@ ylr
 ylr
 ylr
 ylr
+ylr
 bHj
 bHj
 dMR
-dMR
-nne
-tIZ
-ijp
+aYn
+mot
+pcV
 qKQ
 iXL
 iXL
-ofb
+pss
 iXL
+iXL
+lNn
 iXL
 kWn
-ijp
-mAL
-mAL
-mPx
+dMR
+dMR
 dMR
 mNb
-xIW
-xIW
-kie
-kie
-atR
-wOT
 agh
-wYr
-jbD
-cfN
-bZW
-pba
-vUt
-bYg
-qmf
-bZW
+uJH
+fyQ
+wIx
+oIq
+qNa
+uFX
+hfL
+agh
+xnN
+fsU
+rjc
+uNX
+sSg
+bFy
+qEr
 khu
-iOl
+kmY
 jGz
 fYU
 dLL
@@ -97146,44 +97071,44 @@ ylr
 ylr
 ylr
 ylr
+ylr
+ylr
 bHj
-bHj
-bHj
+vIf
 dMR
 dMR
-nne
-hit
-tIZ
-tfW
-xdy
-xdy
-prr
-mAL
-lNP
-kfu
-mAL
-mPx
-mPx
+gOI
+aiX
+aiX
+aiX
+rTC
+xMx
+xMx
+xMx
+uII
+mot
+sIG
+tRk
+wZy
+vHe
+pXu
+vwg
+qxt
+eDN
+eiM
 dMR
-xIW
-xIW
-xIW
-wwU
-dJL
-atR
-hJQ
-nVx
-bBC
-vyt
-aME
-xXv
-jZO
-mGP
-agh
-dLu
-cLl
-khu
-iOl
+vtB
+cMV
+wgh
+lfm
+fsU
+lGP
+ciH
+tzA
+pHX
+wWv
+mFe
+cAz
 btE
 fYU
 xzn
@@ -97401,21 +97326,13 @@ ylr
 ylr
 ylr
 ylr
+ylr
 bHj
 bHj
 bHj
 dMR
 dMR
 dMR
-nne
-jPu
-qEM
-nJo
-oMz
-mot
-kfu
-dMR
-lpE
 dMR
 dMR
 dMR
@@ -97423,19 +97340,27 @@ dMR
 dMR
 dMR
 dMR
+vIf
 dMR
 dMR
 dMR
 dMR
-fiK
-ixL
-bZW
-dMR
-jel
-rQN
-wpm
-xRP
-bZW
+myG
+myG
+myG
+lim
+myG
+myG
+jvn
+eqj
+kHX
+jvn
+jvn
+qSg
+wfM
+nqH
+qmB
+qEr
 khu
 wln
 iln
@@ -97656,40 +97581,40 @@ gbh
 ylr
 ylr
 ylr
+ylr
+ylr
 bHj
 bHj
 bHj
 bHj
-dMR
-dMR
-dMR
-dMR
-dMR
-dMR
-dMR
-dMR
-dMR
 bHj
 bHj
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-dMR
-uTQ
-rut
-vJl
-aLF
-dMR
-gaD
-qQM
-hWu
-dMR
-dMR
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+bHj
+myG
+hNt
+phc
+hLz
+xyv
+myG
+gto
+rxR
+cOH
+aNb
+jvn
+jvn
+fsU
+fsU
+fsU
+fsU
 uve
 uEO
 dcI
@@ -97911,20 +97836,14 @@ gbh
 ylr
 ylr
 ylr
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
+ylr
+ylr
+xSu
+ylr
+ylr
+ylr
+ylr
+xSu
 ylr
 ylr
 ylr
@@ -97932,17 +97851,23 @@ ylr
 ylr
 ylr
 ylr
-ylr
-ocR
-fpL
-xsv
-efb
-tua
-dMR
-dMR
-dMR
-dMR
-dMR
+xSu
+xSu
+myG
+kFg
+arc
+xSO
+pKB
+myG
+bLM
+rmN
+itP
+qrt
+qZY
+afR
+xSu
+xSu
+bSP
 iBp
 nGL
 iOl
@@ -98166,34 +98091,34 @@ gbh
 ylr
 ylr
 ylr
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
-bHj
 ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-ocR
-agh
-fkH
-lab
-sQI
-dMR
 xSu
+ylr
+ylr
+ylr
+ylr
+xSu
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+xSu
+myG
+arc
+gVe
+oLM
+cjR
+myG
+iuJ
+bNn
+rfV
+bDl
+mff
+afR
 xSu
 xSu
 bDj
@@ -98421,33 +98346,33 @@ ylr
 ylr
 ylr
 xSu
-ylr
-xSu
-ylr
-xSu
-ylr
 xSu
 ylr
 ylr
 ylr
+xSu
+xSu
 ylr
 ylr
 ylr
-rmU
-rmU
-rmU
-rmU
-rmU
 ylr
 ylr
 ylr
-dMR
-sIG
-ukv
-jUm
-jzy
-dMR
 ylr
+ylr
+ylr
+myG
+xSO
+arc
+kFg
+cjR
+myG
+jvn
+cXI
+oNy
+kGk
+jvn
+jvn
 ylr
 xSu
 bDj
@@ -98681,28 +98606,28 @@ qAi
 qAi
 qAi
 qAi
-ylr
-ylr
-ylr
-ylr
-ylr
-rmU
-rmU
-aTM
-xRh
-tSP
-rmU
-rmU
-ylr
-ylr
-dMR
-dMR
-dMR
-dMR
-dMR
-dMR
-ylr
 xSu
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+ylr
+myG
+hNt
+aue
+deo
+tFP
+myG
+jvn
+afR
+afR
+afR
+jvn
+ylr
+ylr
 eBU
 eBU
 cPC
@@ -98939,24 +98864,24 @@ qAi
 ylr
 ylr
 ylr
-rmU
-rmU
-xUi
-kUy
-kUy
-kUy
-knP
-rmU
-rmU
 ylr
 ylr
 ylr
-xSu
-xSu
-xSu
+ylr
+ylr
+myG
+myG
+myG
+myG
+myG
+myG
+ylr
+ylr
 ylr
 ylr
 xSu
+ylr
+ylr
 eBU
 cPC
 dfE
@@ -99193,23 +99118,23 @@ qAi
 ylr
 ylr
 ylr
-rmU
-sxZ
-uKQ
-vOX
-ccq
-kst
-bAp
-hHJ
-rmU
-ylr
-ylr
 ylr
 ylr
 ylr
 ylr
 ylr
 xSu
+ylr
+ylr
+ylr
+ylr
+xSu
+ylr
+ylr
+ylr
+ylr
+xSu
+ylr
 eBU
 eBU
 cPC
@@ -99444,25 +99369,25 @@ ewZ
 rJj
 ewZ
 qAi
-ylr
-ylr
-ylr
+xSu
+xSu
 rmU
-jpz
-yhW
-aFu
-syh
-kUy
-knP
-sBf
+rmU
+rmU
+rmU
+rmU
+rmU
 rmU
 ylr
-xSu
-ylr
-xSu
-xSu
 ylr
 ylr
+ylr
+xSu
+ylr
+ylr
+ylr
+ylr
+xSu
 ylr
 eBU
 cPC
@@ -99700,16 +99625,16 @@ iTP
 qAi
 ylr
 ylr
-ylr
 rmU
-elu
-knP
-kUy
-dwt
-kUy
-knP
-uel
+mbF
+hWP
+eYF
+koo
+pqv
 rmU
+xSu
+xSu
+xSu
 cIr
 cIr
 cIr
@@ -99950,20 +99875,20 @@ hGJ
 fpu
 vaz
 sGv
-ewZ
+vSJ
 qAi
 ylr
 ylr
+rmU
+eCN
+tLk
+aTV
+kst
+oWS
+rmU
 ylr
-rmU
-rmU
-jeh
-knP
-dwt
-knP
-ioZ
-rmU
-rmU
+ylr
+xSu
 cIr
 kVH
 pom
@@ -100208,18 +100133,18 @@ ewZ
 qAi
 ylr
 ylr
+rmU
+bOU
+sVs
+xYp
+kUy
+tQv
+rmU
+xSu
 ylr
 ylr
-rmU
-rmU
-rmU
-iXI
-rmU
-rmU
-rmU
 cIr
-kbk
-vgS
+iEf
 dMg
 ibI
 xPK
@@ -100460,28 +100385,28 @@ wra
 sIr
 ewZ
 qAi
-ylr
-ylr
-ylr
-ylr
-ylr
-ylr
-eBU
-nkL
-eBU
-ylr
-ylr
+xSu
+xSu
+rmU
+hBD
+ime
+lxC
+mDQ
+xaZ
+rmU
+xSu
+xSu
+xSu
 cIr
-jFW
-iAn
+vmd
 hLr
 sNB
-kLS
+kLV
 cIr
 qrq
 pAH
 yln
-swM
+vZT
 jjK
 gGv
 sAd
@@ -100714,18 +100639,18 @@ mta
 ewZ
 mRB
 qAi
+xSu
+ylr
+rmU
+rmU
+ykt
+pCg
+ykt
+rmU
+rmU
 ylr
 ylr
-ylr
-ylr
-bDj
-eBU
-eBU
-nkL
-eBU
-eBU
-bDj
-cIr
+xSu
 cIr
 wJj
 vlY
@@ -100735,7 +100660,7 @@ ofi
 tJo
 eaP
 kmY
-cPC
+cDY
 ioM
 iEQ
 iEQ
@@ -100968,18 +100893,18 @@ ewZ
 qQQ
 dEX
 qAi
-qEt
-qEt
-qEt
-qAi
+ylr
+ylr
+xSu
+ylr
+eBU
+iGM
+eBU
+ylr
+xSu
+iBV
 bDj
-quW
-eWk
-bPo
-eWk
-fAk
-eAc
-pcG
+bDj
 cIr
 cIr
 qwz
@@ -101220,25 +101145,25 @@ tJr
 fpu
 hXS
 ewZ
-ewZ
-ewZ
-ewZ
-ewZ
-ewZ
-aIA
-gSN
-sBb
-cPC
-nux
-cPC
-cPC
-cPC
-dqy
+cOk
+bDj
+bDj
+bDj
+eBU
+eBU
+eBU
+vpq
+eBU
+eBU
+eBU
+bDj
+mHO
+oJG
 tLr
 uNK
 uNK
 uNK
-uNK
+tGj
 voC
 swM
 jJw
@@ -101474,25 +101399,25 @@ aLU
 fpu
 vHI
 ptk
-ewZ
-blf
-eVV
-vSJ
-ewZ
-jqY
-bDj
-lGq
-cPC
-nux
-cPC
-cPC
+aIA
+gSN
+sBb
+jgE
+iWQ
+bsG
+eWk
+qbI
+eWk
+oAk
+iWQ
+jgE
 cPC
 cPC
 cPC
 cPC
 yln
-lyB
-vZT
+iPk
+qvx
 jJw
 qoB
 gGv
@@ -101726,27 +101651,27 @@ nMg
 wvo
 fpu
 fpu
-qAi
-qAi
-qAi
-qAi
-qAi
-qAi
-qAi
-qAi
 bDj
-rNU
+bDj
+bDj
+bDj
+xhK
 cPC
-jYI
-ekF
 cPC
 cPC
 cPC
+qbI
+cPC
+cPC
+cPC
+cPC
+cPC
+xdk
 cPC
 yln
 jJw
-qoB
-fOK
+atl
+eNW
 gGv
 sAd
 jzR
@@ -101979,23 +101904,23 @@ cPC
 iOl
 cPC
 tWc
-asN
-xdk
+ueP
+dpq
 ofp
 xWw
 rAT
 fjk
 cPC
-jND
-bRZ
+xdk
 cPC
 cPC
+qbI
 cPC
-dIl
+cPC
 cPC
 yln
 swM
-swM
+lJa
 swM
 wiz
 gGv
@@ -102233,19 +102158,19 @@ kYt
 eLW
 kYt
 kYt
-kYt
-xTf
+hrp
+nqL
 axC
 xxb
 bWN
 dsM
 kYt
+hrp
 kYt
-aBs
 kYt
-kYt
+lew
 dLS
-pHc
+eOx
 vsV
 wiz
 gGv
@@ -102488,14 +102413,14 @@ cPC
 cPC
 cPC
 hDJ
-iRM
+gFv
 xVu
 jjV
 rQI
 yeR
 jjV
 tqN
-ueC
+qoB
 eTx
 awa
 gGv


### PR DESCRIPTION
# Document the changes in your pull request

I think the engineering is UGLY so i want to make it BETTER
- Moves grav generator to Engineering
- Splits it into more areas
- Uses condensed SMES style like Gax/Mini
- Uses smaller Box Vault
- Slightly shortens lawyer room that's weirdly shaped
- Removes old grav generator area and makes it maint

![image](https://github.com/user-attachments/assets/e27aeb97-bbf5-46f5-9c32-df0b9457fc44)
![image](https://github.com/user-attachments/assets/56398135-1586-4f2c-968b-834000402dc6)



# Why is this good for the game?

Better looking = Better Functioning = Better Life

# Changelog

:cl:
mapping: DonutStation Engineering has been completely redone
/:cl:
