### PR TITLE
[BOX/GAX FUSION] fixes two mapping errors

### DIFF
--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -35477,6 +35477,11 @@
 /obj/effect/mapping_helpers/airlock/access/all/security/brig,
 /turf/open/floor/plasteel,
 /area/security/prison)
+"rgz" = (
+/obj/machinery/paystand,
+/obj/item/paper/guides/jobs/security/paystand_setup,
+/turf/open/floor/plasteel,
+/area/security/warden)
 "rgP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4{
 	dir = 4
@@ -46679,14 +46684,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"wFZ" = (
-/obj/machinery/light_switch{
-	pixel_x = 24
-	},
-/obj/machinery/paystand,
-/obj/item/paper/guides/jobs/security/paystand_setup,
-/turf/open/floor/plasteel,
-/area/security/warden)
 "wGe" = (
 /obj/machinery/processor,
 /turf/open/floor/plasteel/cafeteria{
@@ -71956,7 +71953,7 @@ vVo
 hlo
 vNC
 xMn
-wFZ
+rgz
 pYB
 bVZ
 czC

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -27442,6 +27442,24 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
+"gVc" = (
+/obj/machinery/rnd/production/protolathe/department/engineering,
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 26
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering - Foyer - Shared Storage";
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
 "gVn" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -48015,21 +48033,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison/hallway)
-"osD" = (
-/obj/machinery/rnd/production/protolathe/department/engineering,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 26
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering - Foyer - Shared Storage";
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "osE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer4,
 /obj/structure/disposalpipe/segment{
@@ -107413,7 +107416,7 @@ kHt
 cnG
 akB
 dXX
-osD
+gVc
 fpn
 raI
 cfb


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/64f835a9-0e58-411f-bde2-a2bf9b7388ab)

![chrome_e3TRp3JQ2D](https://github.com/user-attachments/assets/e6aa0cad-5808-499f-a9ec-49610ebff608)
![image](https://github.com/user-attachments/assets/035f120e-bda7-4038-93f7-e2f45007219c)


# Changelog

:cl:
mapping: Box shared engi storage has a light now
mapping: GaxStation warden office no longer has two lightswitches
/:cl:
