### PR TITLE
Fixes custom sandwiches and burgers having invisible ingredients if you add more than 1

### DIFF
--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -103,7 +103,6 @@
 		filling_color = rgb(rgbcolor[1], rgbcolor[2], rgbcolor[3], rgbcolor[4])
 
 /obj/item/reagent_containers/food/snacks/customizable/update_snack_overlays(obj/item/reagent_containers/food/snacks/S)
-	. = ..()
 	var/mutable_appearance/filling = mutable_appearance(icon, "[initial(icon_state)]_filling")
 	if(S.filling_color == "#FFFFFF")
 		filling.color = pick("#FF0000","#0000FF","#008000","#FFFF00")


### PR DESCRIPTION


# Document the changes in your pull request

caused by https://github.com/yogstation13/Yogstation/pull/19643
closes https://github.com/yogstation13/Yogstation/issues/19979

# Why is this good for the game?
more chef rp

# Changelog

:cl:
bugfix: fixes custom sandwiches and burgers having invisible ingredients if you add more than 1
/:cl:
