### PR TITLE
extinguish_turf also includes liquids on the turf

### DIFF
--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -741,6 +741,8 @@
 		qdel(active_hotspot)
 	if(turf_fire)
 		qdel(turf_fire)
+	if(liquids) //extinguish any liquids in our turf
+		liquids.liquid_group.extinguish(src)
 
 /turf/open/proc/set_flammability(new_flammability)
 	if(isnull(new_flammability))

--- a/code/game/turfs/open/_open.dm
+++ b/code/game/turfs/open/_open.dm
@@ -741,7 +741,7 @@
 		qdel(active_hotspot)
 	if(turf_fire)
 		qdel(turf_fire)
-	if(liquids) //extinguish any liquids in our turf
+	if(liquids?.fire_state > LIQUID_FIRE_STATE_NONE) //extinguish any liquids with any level of fire in our turf
 		liquids.liquid_group.extinguish(src)
 
 /turf/open/proc/set_flammability(new_flammability)


### PR DESCRIPTION
<!-- Remove this text and explain what the purpose of your PR is.

stuff like water and firefighting foam will help with turf fires

# Why is this good for the game?
so you can actually deal with them

# Changelog

:cl:
rscadd: you can now use water and firefighting foam to extinguish liquid fires
/:cl:
