### PR TITLE
reverts Increases the price of Australian Slime Mutator from 10 TC to 25 TC.

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -2574,10 +2574,10 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			to create a few of the same type of spiders we found on the planets over there. They're a bit tame until you \
 			also give them a bit of sentience though."
 	item = /obj/item/reagent_containers/syringe/spider_extract
-	cost = 25 //yogs - increase price to reduce grief potential
+	cost = 10
 	manufacturer = /datum/corporation/traitor/waffleco
 	restricted_roles = list("Research Director", "Scientist", "Roboticist")
-	include_objectives = list(/datum/objective/hijack, /datum/objective/martyr) //yogs // >Increase price to reduce grief > limit it to hijack only :think:
+	include_objectives = list(/datum/objective/hijack, /datum/objective/martyr) //yogs reduces grief potential
 
 /datum/uplink_item/role_restricted/clowncar
 	name = "Clown Car"


### PR DESCRIPTION
# Document the changes in your pull request
Partially reverts #6222 
Reduces the price of Australicus Slime Mutator to 10tc. Thinking about making it 15, just seeing what people think.

# Why is this good for the game?
I have seen this used once in about 5 years, it may as well just not exist with all the restrictions in place.
Also, original PR was upping the price, fine. But then it was requested to just move it to a hijack restricted item, fine. But the price wasn't changed back.
I think if you manage to roll hijack you should be able to enjoy this instead of then also having to find another traitor for extra tc.

# Testing
simple number change, shouldnt need it

:cl: ktlwjec
tweak: Australicus Slime Mutator reduced to 10TC.
/:cl: