### PR TITLE
adds fluorosurfactant to liquids blacklist

### DIFF
--- a/code/__DEFINES/{yogs_defines}/liquids.dm
+++ b/code/__DEFINES/{yogs_defines}/liquids.dm
@@ -82,5 +82,6 @@
 
 GLOBAL_LIST_INIT(liquid_blacklist, list(
 	/datum/reagent/sorium,
-	/datum/reagent/liquid_dark_matter
+	/datum/reagent/liquid_dark_matter,
+	/datum/reagent/fluorosurfactant
 ))


### PR DESCRIPTION
# Document the changes in your pull request

foam is shitcode so it deletes the entire pool, what if we instead just dont let you do that

# Why is this good for the game?
Nobody can stop my lemonade wave
# Changelog

:cl:
tweak: adds fluorosurfactant to liquids blacklist
/:cl:
