### PR TITLE
stops station goals paper spawning on request console

### DIFF
--- a/yogstation/code/controllers/subsystem/yogs.dm
+++ b/yogstation/code/controllers/subsystem/yogs.dm
@@ -90,7 +90,7 @@ SUBSYSTEM_DEF(Yogs)
 		if(istype(C, /obj/machinery/computer/card/minor/ce))
 			account = ACCOUNT_ENG
 
-		else if(istype(C, /obj/machinery/computer/cargo))
+		else if(istype(C, /obj/machinery/computer/cargo) && !istype(C, /obj/machinery/computer/cargo/request))
 			account = ACCOUNT_CAR
 
 		else if(istype(C, /obj/machinery/computer/card/minor/cmo))


### PR DESCRIPTION
# Document the changes in your pull request

Cargo station goals paper spawns on the cargo console and the public request console. This removes it from spawning on the public console.

# Why is this good for the game?
The entire station doesn't need to know that cargo has to get 50 sheets of every ore into the ore silo.
They already get three copies of this paper from other consoles.
It's just a minor annoyance having it there.
No one will notice it is missing, no one likes it there.

# Testing
You can see here it only spawns on the consoles inside cargo now.
![image](https://github.com/user-attachments/assets/6ddff4fa-eeb6-4f16-8efd-7155b2b4c5a5)

:cl: ktlwjec
tweak: Cargo station goals paper no longer spawns over the public request console.
/:cl: