### PR TITLE
Makes fall damage interesting

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -265,12 +265,10 @@
 
 /atom/movable/proc/onZImpact(turf/impacted_turf, levels, impact_flags = NONE)
 	SHOULD_CALL_PARENT(TRUE)
+
+	pixel_z += 32
+	animate(src, max((4 - levels) / 10, 0.1) SECONDS, pixel_z = pixel_z - 32)
 	
-	if(!(impact_flags & ZIMPACT_NO_MESSAGE))
-		visible_message(
-			span_danger("[src] crashes into [impacted_turf]!"),
-			span_userdanger("You crash into [impacted_turf]!"),
-		)
 	if(!(impact_flags & ZIMPACT_NO_SPIN))
 		INVOKE_ASYNC(src, PROC_REF(SpinAnimation), 5, 2)
 	SEND_SIGNAL(src, COMSIG_ATOM_ON_Z_IMPACT, impacted_turf, levels)

--- a/code/game/objects/effects/effects.dm
+++ b/code/game/objects/effects/effects.dm
@@ -57,9 +57,6 @@
 /obj/effect/abstract/singularity_act()
 	return
 
-/obj/effect/abstract/has_gravity(turf/T)
-	return FALSE
-
 /obj/effect/dummy/singularity_pull()
 	return
 

--- a/code/game/objects/effects/temporary_visuals/miscellaneous.dm
+++ b/code/game/objects/effects/temporary_visuals/miscellaneous.dm
@@ -546,6 +546,7 @@
 	icon = 'icons/effects/effects_rcd.dmi'
 	icon_state = ""
 	layer = ABOVE_ALL_MOB_LAYER
+	anchored = TRUE
 	var/status = 0
 	var/delay = 0
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1167,6 +1167,26 @@
 
 	return total_bleed_rate
 
+/mob/living/carbon/ZImpactDamage(turf/impacted_turf, levels, impact_flags = NONE)
+	impact_flags |= SEND_SIGNAL(src, COMSIG_LIVING_Z_IMPACT, levels, impacted_turf)
+	if(impact_flags & ZIMPACT_CANCEL_DAMAGE)
+		return impact_flags
+	Knockdown(levels * 3 SECONDS)
+	if(!(impact_flags & ZIMPACT_NO_MESSAGE))
+		visible_message(
+			span_danger("[src] crashes into [impacted_turf] with a sickening noise!"),
+			span_userdanger("You crash into [impacted_turf] with a sickening noise!"),
+		)
+	var/obj/item/bodypart/damaged_limb = pick(bodyparts)
+	if(!damaged_limb)
+		CRASH("[src] has no bodyparts!")
+	var/fall_damage = (levels * 5) ** 1.5
+	if(damaged_limb.can_dismember() && prob(fall_damage * 3) && HAS_TRAIT(src, TRAIT_EASYDISMEMBER))
+		damaged_limb.dismember(BRUTE, FALSE)
+		apply_damage(fall_damage, BRUTE, BODY_ZONE_CHEST, sharpness = SHARP_NONE)
+	else
+		damaged_limb.receive_damage(fall_damage, 0, 0, getarmor(damaged_limb.body_zone, BOMB), TRUE, wound_bonus = 30, sharpness = SHARP_NONE)
+
 /**
   * generate_fake_scars()- for when you want to scar someone, but you don't want to hurt them first. These scars don't count for temporal scarring (hence, fake)
   *

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -38,16 +38,24 @@
 	return ..()
 
 /mob/living/onZImpact(turf/impacted_turf, levels, impact_flags = NONE)
+	impact_flags |= SEND_SIGNAL(impacted_turf, COMSIG_TURF_MOB_FALL, src, levels, impact_flags)
 	if(!isgroundlessturf(impacted_turf))
-		impact_flags |= ZImpactDamage(impacted_turf, levels)
+		impact_flags |= ZImpactDamage(impacted_turf, levels, impact_flags)
 
-	return ..()
+	return ..(impacted_turf, levels, impact_flags)
 
-/mob/living/proc/ZImpactDamage(turf/T, levels)
-	SEND_SIGNAL(T, COMSIG_TURF_MOB_FALL, src)
-	visible_message(span_danger("[src] crashes into [T] with a sickening noise!"))
+/mob/living/proc/ZImpactDamage(turf/impacted_turf, levels, impact_flags)
+	impact_flags |= SEND_SIGNAL(src, COMSIG_LIVING_Z_IMPACT, levels, impacted_turf)
+	if(impact_flags & ZIMPACT_CANCEL_DAMAGE)
+		return impact_flags
+	if(!(impact_flags & ZIMPACT_NO_MESSAGE))
+		visible_message(
+			span_danger("[src] crashes into [impacted_turf] with a sickening noise!"),
+			span_userdanger("You crash into [impacted_turf] with a sickening noise!"),
+		)
 	adjustBruteLoss((levels * 5) ** 1.5)
-	Knockdown(levels * 50)
+	Knockdown(levels * 3 SECONDS)
+	return impact_flags
 
 /mob/living/proc/OpenCraftingMenu()
 	return

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -49,6 +49,10 @@
 		sitting = FALSE
 	update_appearance(UPDATE_ICON_STATE)
 
+/mob/living/simple_animal/pet/cat/ZImpactDamage(turf/T, levels)
+	visible_message(span_notice("[src] lands completely unharmed!"))
+	return ZIMPACT_CANCEL_DAMAGE|ZIMPACT_NO_MESSAGE|ZIMPACT_NO_SPIN
+
 /mob/living/simple_animal/pet/cat/space
 	name = "space cat"
 	desc = "It's a cat... in space!"

--- a/yogstation/code/datums/components/lingering.dm
+++ b/yogstation/code/datums/components/lingering.dm
@@ -27,10 +27,12 @@
 	. = ..()
 	RegisterSignal(parent, COMSIG_ATOM_HITBY, PROC_REF(hitby))
 	RegisterSignal(parent, COMSIG_ATOM_ENTERED, PROC_REF(Entered))
+	RegisterSignal(parent, COMSIG_TURF_MOB_FALL, PROC_REF(kersplash))
 
 /datum/component/lingering/UnregisterFromParent()
 	UnregisterSignal(parent, COMSIG_ATOM_HITBY)
 	UnregisterSignal(parent, COMSIG_ATOM_ENTERED)
+	UnregisterSignal(parent, COMSIG_TURF_MOB_FALL)
 	STOP_PROCESSING(SSobj, src)
 	. = ..()
 	
@@ -48,6 +50,17 @@
 /datum/component/lingering/process(delta_time)
 	if(!affect_stuff(delta_time))
 		STOP_PROCESSING(SSobj, src)
+
+/datum/component/lingering/proc/kersplash(datum/source, atom/movable/fallen_atom, turf/impacted_turf, levels = 1, impact_flags = NONE)
+	fallen_atom.visible_message(
+		span_danger("[fallen_atom] plunges into [parent]!"),
+		span_userdanger("You plunge into [parent]!")
+	)
+	playsound(parent, 'yogstation/sound/effects/splash.ogg', 50, 0)
+	if(isliving(fallen_atom))
+		var/mob/living/cannonball = fallen_atom
+		cannonball.Knockdown(2 SECONDS)
+	return ZIMPACT_CANCEL_DAMAGE
 
 ////////////////////////////////////////////////////////////////////////////////////
 //---------------------------------safety check-----------------------------------//

--- a/yogstation/code/modules/liquids/liquid_effect.dm
+++ b/yogstation/code/modules/liquids/liquid_effect.dm
@@ -175,6 +175,7 @@
 				to_chat(C, span_userdanger("You fall in and swallow some water!"))
 		else
 			to_chat(M, span_userdanger("You fall in the water!"))
+		return ZIMPACT_CANCEL_DAMAGE
 
 /obj/effect/abstract/liquid_turf/Initialize(mapload, datum/liquid_group/group_to_add)
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

Falling down z-levels can now cause dislocations or broken bones (or full dismemberment for IPCs!)

# Why is this good for the game?
It's funny

# Testing

https://github.com/user-attachments/assets/84205037-f712-4ff2-8666-47da1f33ff54

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
tweak: Fall damage can now break bones, or dismember if you're an IPC
tweak: Landing in deep enough liquids prevents fall damage
tweak: Cats are now immune to fall damage
bugfix: Fixed RCD construction effects being affected by gravity
/:cl:
