### PR TITLE
removes halloween filter

### DIFF
--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -80,10 +80,6 @@
 /atom/movable/screen/plane_master/rendering_plate/game_plate/Initialize(mapload, datum/hud/hud_owner)
 	. = ..()
 	add_filter("displacer", 1, displacement_map_filter(render_source = OFFSET_RENDER_TARGET(GRAVITY_PULSE_RENDER_TARGET, offset), size = 10))
-	if(check_holidays(HALLOWEEN))
-		// Makes things a tad greyscale (leaning purple) and drops low colors for vibes
-		// We're basically using alpha as better constant here btw
-		add_filter("spook_color", 2, color_matrix_filter(list(0.75,0.13,0.13,0, 0.13,0.7,0.13,0, 0.13,0.13,0.75,0, -0.06,-0.09,-0.08,1, 0,0,0,0)))
 
 /atom/movable/screen/plane_master/rendering_plate/game_plate/show_to(mob/mymob)
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request
removes halloween filter

# Why is this good for the game?
I've seen only two people say they like it, people don't want to play because of it, and you can barely see things, and it kind of hurts my eyes. Also, undocumented change shouldn't have been in to begin with?

# Testing
I did test it but I forgot to get screenshots, I can go grab some if wanted but it will just be the same image with the filter on and off.



:cl: ktlwjec
rscdel: Halloween filter.
/:cl: