### PR TITLE
Ice Weavers now drop 2 diamonds instead of 2 uranium

### DIFF
--- a/yogstation/code/modules/mob/living/simple_animal/hostile/mining_mobs/marrow_weaver.dm
+++ b/yogstation/code/modules/mob/living/simple_animal/hostile/mining_mobs/marrow_weaver.dm
@@ -130,6 +130,7 @@
 /mob/living/simple_animal/hostile/asteroid/marrowweaver/ice
 	name = "Frostbite Spider"
 	desc = "A big, angry, venomous ice spider. It likes to snack on bone marrow. Its preferred food source is you."
+	butcher_results = list(/obj/item/stack/ore/diamond = 2, /obj/item/stack/sheet/bone = 3, /obj/item/stack/sheet/sinew = 2, /obj/item/stack/sheet/animalhide/weaver_chitin = 4, /obj/item/reagent_containers/food/snacks/meat/slab/spider = 2)
 	icon_state = "weaver_ice"
 	icon_living = "weaver_ice"
 	icon_aggro = "weaver_ice"


### PR DESCRIPTION
# Document the changes in your pull request

Does what the title says it does

# Why is this good for the game?
Makes more sense for blue icy spiders to drop diamonds than uranium i think

# Testing
Shouldn't need
# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

working on an icemoon page that will include this

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
tweak: ice weavers now drop 2 diamonds instead of 2 uranium
/:cl:
