### PR TITLE
Adjusts some bloody examine text

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -73,8 +73,10 @@
 		. += "[t_He] [t_has] [gloves.get_examine_string(user)] on [t_his] hands."
 	else if(FR && length(FR.blood_DNA))
 		var/hand_number = get_num_arms(FALSE)
-		if(hand_number)
-			. += span_warning("[t_He] [t_has] [hand_number > 1 ? "" : "a"] blood-stained hand[hand_number > 1 ? "s" : ""]!")
+		if(hand_number && blood_in_hands)
+			. += span_warning("[t_He] [t_has][hand_number > 1 ? "" : " a"] blood-stained hand[hand_number > 1 ? "s" : ""]!")
+		else
+			. += span_warning("[t_He] [t_is] covered in blood!")
 
 	//handcuffed?
 	if(handcuffed)


### PR DESCRIPTION
# Document the changes in your pull request

I noticed that you can have blood on you without your hands actually being bloody (somehow) so I am updating it to check if your *hands* are bloody and report that you are *covered* in blood if not, indicating that a shower or otherwise is better suited to clean you (because washing your hands won't fix it).

Also removed an erroneous space

# Changelog

:cl:
spellcheck: Removed an extra space from blood-stained hands examine
spellcheck: Examining someone who is bloody but does not have bloody hands will now be indicated correctly
/:cl:
