### PR TITLE
Removes the ability to perform server rack alchemy

### DIFF
--- a/code/modules/mob/living/silicon/ai/decentralized/systech/rack.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/systech/rack.dm
@@ -13,7 +13,7 @@
 	throwforce = 0
 	throw_speed = 3
 	throw_range = 7
-	materials = list(/datum/material/gold=50, /datum/material/iron=250)
+	materials = list(/datum/material/iron=250)
 
 	var/list/contained_cpus = list()
 	var/contained_ram = 0


### PR DESCRIPTION
Fixes #22570

# Document the changes in your pull request

You can no longer make gold from only iron and glass by deconstructing server racks in a deconstructive analyser.

# Testing
![image](https://github.com/user-attachments/assets/9baac06e-c2d9-43e2-ac7d-a5e95c5cfb3e)

# Changelog

:cl:
bugfix: Removed making gold with server racks only using out of iron and glass
/:cl:
