### PR TITLE
Removes halloween holiday colors

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -518,7 +518,6 @@
 		"https://www.youtube.com/watch?v=fixc63xMXeY", // Plok Boss Theme - HD Remastered
 		"https://www.youtube.com/watch?v=bRLML36HnzU" // Monster Mash
 		)
-	holiday_colors = list(COLOR_MOSTLY_PURE_ORANGE, COLOR_PRISONER_BLACK)
 
 /datum/holiday/halloween/shouldCelebrate(dd, mm, yy, ww, ddd)
 	. = ..()


### PR DESCRIPTION
# Document the changes in your pull request

Removes halloween colors so every single decal will no longer be orange and grey
# Why is this good for the game?
Doesn't look "spooky" it just looks ugly and bad to have every trimline on the station be the exact same two colors
# Testing
One line change, pretty positive it works as intended

# Spriting
<!-- If you are adding new sprites to the game please add a picture of the sprite in its relative context, ie. Clothing on a mob. -->

# Wiki Documentation

<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
rscdel: halloween holiday colors
/:cl:
