### PR TITLE
Makes mentorwho explain mhelps are seen in discord too

### DIFF
--- a/yogstation/code/modules/mentor/mentor_verbs.dm
+++ b/yogstation/code/modules/mentor/mentor_verbs.dm
@@ -65,7 +65,7 @@ GLOBAL_PROTECT(mentor_verbs)
 			if(C.is_afk())
 				msg += " (AFK)"
 		else
-			msg += span_info("Mentorhelps are also seen by admins. If no mentors are available in game adminhelp instead and an admin will see it and respond.")
+			msg += span_info("Mentorhelps are also sent to Discord. If no mentors are available in game mentorhelp anyways and a mentor on Discord may see it and respond.")
 		msg += "\n"
 
 	to_chat(src, msg, confidential=TRUE)


### PR DESCRIPTION
# Document the changes in your pull request
One-line text change for the message you get when pressing the mentorwho command:

"Mentorhelps are also seen by admins. If no mentors are available in game adminhelp instead and an admin will see it and respond."
to
"Mentorhelps are also sent to Discord. If no mentors are available in game mentorhelp anyways and a mentor on Discord may see it and respond."



# Why is this good for the game?
Adminwho command explains ahelps are sent to discord, while mentorwho doesn't. This may stop some people (like me in the past) from mhelping because no mentors are on, while many of us pop into the channel to answer stuff pretty often. No we don't always catch every question but it never hurts to ask! You may be surprised with a helpful answer.

Plus if there are only admins on but no mentors, I doubt they wouldn't try to help the other person out, so I don't see how the "adminhelp instead" part of the message makes much sense.


# Testing
only if you can guess what number I'm thinking of

# Changelog
:cl:
tweak: Mentorwho command now explains that mentors can see mhelps in Discord
spellcheck: (Feel free to ask stuff even if no mentor is online, you might get an answer anyways!)
/:cl:
