### PR TITLE
Fixes random body preferences menu imploding

### DIFF
--- a/tgui/packages/tgui/interfaces/PreferencesMenu/RandomizationButton.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/RandomizationButton.tsx
@@ -59,6 +59,7 @@ export const RandomizationButton = (props: {
       nochevron
       onSelected={setValue}
       width="auto"
+      menuWidth="auto"
     />
   );
 };


### PR DESCRIPTION
# Document the changes in your pull request

Previously if you pressed the button it did this:
![image](https://github.com/user-attachments/assets/394801c4-ac39-4902-86af-f2e0dda02c68)


Now it doesn't implode.

# Testing
![image](https://github.com/user-attachments/assets/22e7bb2b-5ff4-4b71-b57f-502114419c43)

# Changelog

:cl:
bugfix: Fixed random body menu imploding
/:cl:
