### PR TITLE
Xenobio armblade text change + minor changeling fix

### DIFF
--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -29,6 +29,8 @@
 
 /datum/action/changeling/weapon/proc/check_weapon(mob/user, obj/item/hand_item)
 	if(istype(hand_item, weapon_type))
+		if(istype(hand_item, /obj/item/melee/arm_blade/slime))
+			return
 		user.temporarilyRemoveItemFromInventory(hand_item, TRUE) //DROPDEL will delete the item
 		if(!silent)
 			playsound(user, 'sound/effects/blobattack.ogg', 30, TRUE)
@@ -206,13 +208,19 @@
 			return
 
 		if(A.hasPower())
-			user.visible_message(span_warning("[user] jams [src] into the airlock and starts prying it open!"), span_warning("We start forcing the airlock open."), //yogs modified description
+			if(istype(src, /obj/item/melee/arm_blade/slime))
+				user.visible_message(span_warning("[user] jams [src] into the airlock and starts prying it open!"), span_warning("You start forcing the airlock open."), span_italics("You hear a metal screeching sound."))
+			else
+				user.visible_message(span_warning("[user] jams [src] into the airlock and starts prying it open!"), span_warning("We start forcing the airlock open."), //yogs modified description
 			span_italics("You hear a metal screeching sound."))
 			playsound(A, 'sound/machines/airlock_alien_prying.ogg', 100, 1)
 			if(!do_after(user, 6 SECONDS, A))
 				return
 		//user.say("Heeeeeeeeeerrre's Johnny!")
-		user.visible_message(span_warning("[user] forces the airlock to open with [user.p_their()] [src]!"), span_warning("We force the airlock to open."), //yogs modified description
+		if(istype(src, /obj/item/melee/arm_blade/slime))
+			user.visible_message(span_warning("[user] forces the airlock to open with [user.p_their()] [src]!"), span_warning("We force the airlock to open."), span_italics("You hear a metal screeching sound."))
+		else
+			user.visible_message(span_warning("[user] forces the airlock to open with [user.p_their()] [src]!"), span_warning("We force the airlock to open."), //yogs modified description
 		span_italics("You hear a metal screeching sound."))
 		A.open(2)
 

--- a/code/modules/antagonists/changeling/powers/mutations.dm
+++ b/code/modules/antagonists/changeling/powers/mutations.dm
@@ -218,7 +218,7 @@
 				return
 		//user.say("Heeeeeeeeeerrre's Johnny!")
 		if(istype(src, /obj/item/melee/arm_blade/slime))
-			user.visible_message(span_warning("[user] forces the airlock to open with [user.p_their()] [src]!"), span_warning("We force the airlock to open."), span_italics("You hear a metal screeching sound."))
+			user.visible_message(span_warning("[user] forces the airlock to open with [user.p_their()] [src]!"), span_warning("You force the airlock to open."), span_italics("You hear a metal screeching sound."))
 		else
 			user.visible_message(span_warning("[user] forces the airlock to open with [user.p_their()] [src]!"), span_warning("We force the airlock to open."), //yogs modified description
 		span_italics("You hear a metal screeching sound."))


### PR DESCRIPTION
Fixes #19338

# Document the changes in your pull request

Xenobio armblade: 
We start forcing the airlock open --> You start forcing the airlock open
We force the airlock to open --> You force the airlock to open

Stops changelings from being able to absorb xenobio armblades.

# Why is this good for the game?
I doubt changelings should be able to assimilate foreign matter into their own body. It also would negate the purpose of having the xenobio armblade being stuck to arms.

# Testing
![image](https://github.com/user-attachments/assets/cfcbd430-345c-4f5f-9603-feb82b048ed8)
![image](https://github.com/user-attachments/assets/dc576542-4253-4e28-9eb1-7d464133305e)

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
bugfix: Changelings can no longer assimilate burning green slimecross armblades
spellcheck: Changed the text for forcing open airlocks with xenobio armblades
/:cl:
