### PR TITLE
Fixes NT diagnostics & troubleshooting app toggle comms button

### DIFF
--- a/tgui/packages/tgui/interfaces/NtosNetMonitor.js
+++ b/tgui/packages/tgui/interfaces/NtosNetMonitor.js
@@ -65,7 +65,7 @@ export const NtosNetMonitor = (props, context) => {
                   icon={config_communication ? 'power-off' : 'times'}
                   content={config_communication ? 'ENABLED' : 'DISABLED'}
                   selected={config_communication}
-                  onClick={() => act('toggle_function', { id: "3" })} />
+                  onClick={() => act('toggle_function', { id: "2" })} />
               )} />
           </LabeledList>
         </Section>


### PR DESCRIPTION
# Document the changes in your pull request

Fixes a minor typo which prevents communication systems from being toggled through the app.

# Testing
![image](https://github.com/user-attachments/assets/9b172d46-e942-4964-8df7-1c76494b5c59)
![image](https://github.com/user-attachments/assets/e6fbaee8-5324-4cd8-8d8e-16d3e00e5f2e)


# Changelog

:cl:
bugfix: Fixes broken toggle comms button in NT diagnostics & troubleshooting app
/:cl:
