### PR TITLE
Makes goliath hide boat able to survive liquid plasma

### DIFF
--- a/code/modules/vehicles/lavaboat.dm
+++ b/code/modules/vehicles/lavaboat.dm
@@ -3,10 +3,10 @@
 
 /obj/vehicle/ridden/lavaboat
 	name = "lava boat"
-	desc = "A boat used for traversing lava."
+	desc = "A boat used for traversing lava and liquid plasma."
 	icon_state = "goliath_boat"
 	icon = 'icons/obj/lavaland/dragonboat.dmi'
-	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF | FREEZE_PROOF
 	can_buckle = TRUE
 	legs_required = 0
 	arms_required = 0
@@ -45,12 +45,6 @@
 	time = 5 SECONDS
 	category = CAT_PRIMAL
 
-/datum/crafting_recipe/plasmaboat
-	name = "Polar Bear Hide Boat"
-	result = /obj/vehicle/ridden/lavaboat/plasma
-	reqs = list(/obj/item/stack/sheet/animalhide/goliath_hide/polar_bear_hide = 3)
-	time = 5 SECONDS
-	category = CAT_PRIMAL
 
 //Dragon Boat
 

--- a/code/modules/vehicles/lavaboat.dm
+++ b/code/modules/vehicles/lavaboat.dm
@@ -45,6 +45,13 @@
 	time = 5 SECONDS
 	category = CAT_PRIMAL
 
+/datum/crafting_recipe/plasmaboat
+	name = "Polar Bear Hide Boat"
+	result = /obj/vehicle/ridden/lavaboat/plasma
+	reqs = list(/obj/item/stack/sheet/animalhide/goliath_hide/polar_bear_hide = 3)
+	time = 5 SECONDS
+	category = CAT_PRIMAL
+
 //Dragon Boat
 
 


### PR DESCRIPTION
Fixes #22752 (technically)

# Document the changes in your pull request

Changes the flags on the goliath hide boat to be usable in liquid plasma rivers.

# Why is this good for the game?
As of current, there is no safe way of crossing plasma rivers without using bluespace shelters or RCDs at all. This way there is a proper one and it is reasonable.

# Testing
![image](https://github.com/user-attachments/assets/2cad8408-170c-4313-afea-13c9e29a5333)
![image](https://github.com/user-attachments/assets/bb618839-23ff-4b3a-9426-9442c9ad409d)

# Changelog

:cl:
tweak: Changes the goliath hide boat to be plasma-proof.
/:cl:
