### PR TITLE
Makes the NTSL traffic console no longer save on pressing ENTER, replaces x.len with length(x) in the scripting module

### DIFF
--- a/yogstation/code/modules/scripting/Implementations/logic.dm
+++ b/yogstation/code/modules/scripting/Implementations/logic.dm
@@ -29,10 +29,10 @@
 	name = "find"
 
 /datum/n_function/default/find/execute(this_obj, list/params)
-	var/haystack = params.len >= 1 ? params[1] : null
-	var/needle = params.len >= 2 ? params[2] : null
-	var/start  = params.len >= 3 ? params[3] : 1
-	var/end  = params.len >= 4 ? params[4] : 0
+	var/haystack = length(params) >= 1 ? params[1] : null
+	var/needle = length(params) >= 2 ? params[2] : null
+	var/start  = length(params) >= 3 ? params[3] : 1
+	var/end  = length(params) >= 4 ? params[4] : 0
 	if(!haystack || !needle)
 		return
 	if(IS_OBJECT(haystack))
@@ -50,9 +50,9 @@
 	name = "substr"
 
 /datum/n_function/default/substr/execute(this_obj, list/params)
-	var/string = params.len >= 1 ? params[1] : null
-	var/start = params.len >= 2 ? params[2] :  1
-	var/end = params.len >= 3 ? params[3] :  0
+	var/string = length(params) >= 1 ? params[1] : null
+	var/start = length(params) >= 2 ? params[2] :  1
+	var/end = length(params) >= 3 ? params[3] :  0
 	if(istext(string) && isnum(start) && isnum(end))
 		if(start > 0)
 			return copytext(string, start, end)
@@ -62,7 +62,7 @@
 	name = "length"
 
 /datum/n_function/default/length/execute(this_obj, list/params)
-	var/container = params.len >= 1 ? params[1] : null
+	var/container = length(params) >= 1 ? params[1] : null
 	if(container)
 		if(istype(container, /list) || istext(container))
 			return length(container)
@@ -73,7 +73,7 @@
 	name = "lower"
 
 /datum/n_function/default/lower/execute(this_obj, list/params)
-	var/string = params.len >= 1 ? params[1] : null
+	var/string = length(params) >= 1 ? params[1] : null
 	if(istext(string))
 		return lowertext(string)
 
@@ -82,7 +82,7 @@
 	name = "upper"
 
 /datum/n_function/default/upper/execute(this_obj, list/params)
-	var/string = params.len >= 1 ? params[1] : null
+	var/string = length(params) >= 1 ? params[1] : null
 	if(istext(string))
 		return uppertext(string)
 
@@ -91,8 +91,8 @@
 	name = "explode"
 
 /datum/n_function/default/explode/execute(this_obj, list/params)
-	var/string = params.len >= 1 ? params[1] : null
-	var/separator  = params.len >= 2 ? params[2] :  ""
+	var/string = length(params) >= 1 ? params[1] : null
+	var/separator  = length(params) >= 2 ? params[2] :  ""
 	if(istext(string) && (istext(separator) || isnull(separator)))
 		return splittext(string, separator)
 
@@ -111,8 +111,8 @@
 	name = "repeat"
 
 /datum/n_function/default/repeat/execute(this_obj, list/params)
-	var/string = params.len >= 1 ? params[1] : null
-	var/amount = params.len >= 2 ? params[2] : null
+	var/string = length(params) >= 1 ? params[1] : null
+	var/amount = length(params) >= 2 ? params[2] : null
 	if(istext(string) && isnum(amount))
 		var/i
 		var/newstring = ""
@@ -130,7 +130,7 @@
 	name = "reverse"
 
 /datum/n_function/default/reverse/execute(this_obj, list/params)
-	var/string = params.len >= 1 ? params[1] : null
+	var/string = length(params) >= 1 ? params[1] : null
 	if(istext(string))
 		var/newstring = ""
 		var/i
@@ -146,7 +146,7 @@
 	name = "tonum"
 
 /datum/n_function/default/tonum/execute(this_obj, list/params)
-	var/string = params.len >= 1 ? params[1] : null
+	var/string = length(params) >= 1 ? params[1] : null
 	if(istext(string))
 		return text2num(string)
 
@@ -154,7 +154,7 @@
 	name = "proper"
 
 /datum/n_function/default/proper/execute(this_obj, list/params)
-	var/string = params.len >= 1 ? params[1] : null
+	var/string = length(params) >= 1 ? params[1] : null
 	if(!istext(string))
 		return ""
 
@@ -170,7 +170,7 @@
 	name = "max"
 
 /datum/n_function/default/max/execute(this_obj, list/params)
-	if(!params.len)
+	if(!length(params))
 		return FALSE
 
 	var/max = params[1]
@@ -185,7 +185,7 @@
 	name = "min"
 
 /datum/n_function/default/min/execute(this_obj, list/params)
-	if(!params.len)
+	if(!length(params))
 		return FALSE
 
 	var/min = params[1]
@@ -199,22 +199,22 @@
 	name = "prob"
 
 /datum/n_function/default/prob/execute(this_obj, list/params)
-	var/chance = params.len >= 1 ? params[1] : null
+	var/chance = length(params) >= 1 ? params[1] : null
 	return prob(chance)
 
 /datum/n_function/default/randseed
 	name = "randseed"
 
 /datum/n_function/default/randseed/execute(this_obj, list/params)
-	//var/seed = params.len >= 1 ? params[1] : null
+	//var/seed = length(params) >= 1 ? params[1] : null
 	//rand_seed(seed)
 
 /datum/n_function/default/rand
 	name = "rand"
 
 /datum/n_function/default/rand/execute(this_obj, list/params)
-	var/low = params.len >= 1 ? params[1] : null
-	var/high = params.len >= 2 ? params[2] : null
+	var/low = length(params) >= 1 ? params[1] : null
+	var/high = length(params) >= 2 ? params[2] : null
 	if(isnull(low) && isnull(high))
 		return rand()
 
@@ -225,7 +225,7 @@
 	name = "tostring"
 
 /datum/n_function/default/tostring/execute(this_obj, list/params)
-	var/num = params.len >= 1 ? params[1] : null
+	var/num = length(params) >= 1 ? params[1] : null
 	if(isnum(num))
 		return num2text(num)
 
@@ -234,7 +234,7 @@
 	name = "sqrt"
 
 /datum/n_function/default/sqrt/execute(this_obj, list/params)
-	var/num = params.len >= 1 ? params[1] : null
+	var/num = length(params) >= 1 ? params[1] : null
 	if(isnum(num))
 		return sqrt(num)
 
@@ -243,7 +243,7 @@
 	name = "abs"
 
 /datum/n_function/default/abs/execute(this_obj, list/params)
-	var/num = params.len >= 1 ? params[1] : null
+	var/num = length(params) >= 1 ? params[1] : null
 	if(isnum(num))
 		return abs(num)
 
@@ -252,7 +252,7 @@
 	name = "floor"
 
 /datum/n_function/default/floor/execute(this_obj, list/params)
-	var/num = params.len >= 1 ? params[1] : null
+	var/num = length(params) >= 1 ? params[1] : null
 	if(isnum(num))
 		return round(num)
 
@@ -261,7 +261,7 @@
 	name = "ceil"
 
 /datum/n_function/default/ceil/execute(this_obj, list/params)
-	var/num = params.len >= 1 ? params[1] : null
+	var/num = length(params) >= 1 ? params[1] : null
 	if(isnum(num))
 		return round(num)+1
 
@@ -270,7 +270,7 @@
 	name = "round"
 
 /datum/n_function/default/round/execute(this_obj, list/params)
-	var/num = params.len >= 1 ? params[1] : null
+	var/num = length(params) >= 1 ? params[1] : null
 	if(isnum(num))
 		if(num-round(num) < 0.5)
 			return round(num)
@@ -281,9 +281,9 @@
 	name = "clamp"
 
 /datum/n_function/default/clamp/execute(this_obj, list/params)
-	var/num = params.len >= 1 ? params[1] : null
-	var/min = params.len >= 2 ? params[2] : -1
-	var/max = params.len >= 3 ? params[3] : 1
+	var/num = length(params) >= 1 ? params[1] : null
+	var/min = length(params) >= 2 ? params[2] : -1
+	var/max = length(params) >= 3 ? params[3] : 1
 	if(isnum(num) && isnum(min) && isnum(max))
 		if(num <= min)
 			return min
@@ -296,9 +296,9 @@
 	name = "inrange"
 
 /datum/n_function/default/inrange/execute(this_obj, list/params)
-	var/num = params.len >= 1 ? params[1] : null
-	var/min = params.len >= 2 ? params[2] : -1
-	var/max = params.len >= 3 ? params[3] : 1
+	var/num = length(params) >= 1 ? params[1] : null
+	var/min = length(params) >= 2 ? params[2] : -1
+	var/max = length(params) >= 3 ? params[3] : 1
 	if(isnum(num)&&isnum(min)&&isnum(max))
 		return ((min <= num) && (num <= max))
 
@@ -307,7 +307,7 @@
 	name = "sin"
 
 /datum/n_function/default/sin/execute(this_obj, list/params)
-	var/num = params.len >= 1 ? params[1] : null
+	var/num = length(params) >= 1 ? params[1] : null
 	if(isnum(num))
 		return sin(num)
 
@@ -316,7 +316,7 @@
 	name = "cos"
 
 /datum/n_function/default/cos/execute(this_obj, list/params)
-	var/num = params.len >= 1 ? params[1] : null
+	var/num = length(params) >= 1 ? params[1] : null
 	if(isnum(num))
 		return cos(num)
 
@@ -325,7 +325,7 @@
 	name = "asin"
 
 /datum/n_function/default/asin/execute(this_obj, list/params)
-	var/num = params.len >= 1 ? params[1] : null
+	var/num = length(params) >= 1 ? params[1] : null
 	if(isnum(num) && -1 <= num && num <= 1)
 		return arcsin(num)
 
@@ -334,7 +334,7 @@
 	name = "acos"
 
 /datum/n_function/default/acos/execute(this_obj, list/params)
-	var/num = params.len >= 1 ? params[1] : null
+	var/num = length(params) >= 1 ? params[1] : null
 	if(isnum(num) && -1 <= num && num <= 1)
 		return arccos(num)
 
@@ -343,7 +343,7 @@
 	name = "log"
 
 /datum/n_function/default/log/execute(this_obj, list/params)
-	var/num = params.len >= 1 ? params[1] : null
+	var/num = length(params) >= 1 ? params[1] : null
 	if(isnum(num) && 0 < num)
 		return log(num)
 
@@ -352,9 +352,9 @@
 	name = "replace"
 
 /datum/n_function/default/replace/execute(this_obj, list/params)
-	var/text = params.len >= 1 ? params[1] : null
-	var/find = params.len >= 2 ? params[2] : null
-	var/replacement = params.len >= 3 ? params[3] : null
+	var/text = length(params) >= 1 ? params[1] : null
+	var/find = length(params) >= 2 ? params[2] : null
+	var/replacement = length(params) >= 3 ? params[3] : null
 	if(!istext(text) || !istext(find) || !istext(replacement))
 		return
 	var/find_len = length(find)
@@ -362,7 +362,7 @@
 		return text
 
 	var/max_count
-	if(params.len >= 4 && isnum(params[4]))
+	if(length(params) >= 4 && isnum(params[4]))
 		max_count = min(params[4], SCRIPT_MAX_REPLACEMENTS_ALLOWED)
 	else
 		max_count = SCRIPT_MAX_REPLACEMENTS_ALLOWED
@@ -393,7 +393,7 @@
 	name = "sleep"
 
 /datum/n_function/default/sleeps/execute(this_obj, list/params)
-	var/time = params.len >= 1 ? params[1] : null
+	var/time = length(params) >= 1 ? params[1] : null
 	sleep(time)
 
 /datum/n_function/default/timestamp

--- a/yogstation/code/modules/scripting/Implementations/telecomms_translator.dm
+++ b/yogstation/code/modules/scripting/Implementations/telecomms_translator.dm
@@ -72,7 +72,7 @@ GLOBAL_LIST_INIT(allowed_translations, list(
 	returnerrors += scanner.errors
 	returnerrors += parser.errors
 
-	if(returnerrors.len)
+	if(length(returnerrors))
 		return returnerrors
 
 	interpreter = new(program)
@@ -296,13 +296,13 @@ GLOBAL_LIST_INIT(allowed_translations, list(
 
 /datum/n_function/default/signal/execute(this_obj, list/params)
 	var/datum/n_struct/signal/S = new
-	if(params.len >= 1)
+	if(length(params) >= 1)
 		S.properties["content"] = params[1]
-	if(params.len >= 2)
+	if(length(params) >= 2)
 		S.properties["freq"] = params[2]
-	if(params.len >= 3)
+	if(length(params) >= 3)
 		S.properties["source"] = params[3]
-	if(params.len >= 4)
+	if(length(params) >= 4)
 		S.properties["job"] = params[4]
 	return S
 
@@ -349,8 +349,8 @@ GLOBAL_LIST_INIT(allowed_translations, list(
 	interp_type = /datum/n_Interpreter/TCS_Interpreter
 
 /datum/n_function/default/mem/execute(this_obj, list/params, datum/scope/scope, datum/n_Interpreter/TCS_Interpreter/interp)
-	var/address = params.len >= 1 ? params[1] : null
-	var/value = params.len >= 2 ? params[2] : null
+	var/address = length(params) >= 1 ? params[1] : null
+	var/value = length(params) >= 2 ? params[2] : null
 	if(istext(address))
 		var/obj/machinery/telecomms/server/S = interp.Compiler.Holder
 
@@ -360,7 +360,7 @@ GLOBAL_LIST_INIT(allowed_translations, list(
 			S.memory -= address
 			return TRUE
 		else // Setting the value
-			if(S.memory.len >= MAX_MEM_VARS)
+			if(length(S.memory) >= MAX_MEM_VARS)
 				if(!(address in S.memory))
 					return FALSE
 			S.memory[address] = value
@@ -380,8 +380,8 @@ GLOBAL_LIST_INIT(allowed_translations, list(
 	interp_type = /datum/n_Interpreter/TCS_Interpreter
 
 /datum/n_function/default/remote_signal/execute(this_obj, list/params, datum/scope/scope, datum/n_Interpreter/TCS_Interpreter/interp)
-	var/freq = params.len >= 1 ? params[1] : 1459
-	var/code = params.len >= 2 ? params[2] : 30
+	var/freq = length(params) >= 1 ? params[1] : 1459
+	var/code = length(params) >= 2 ? params[2] : 30
 
 	if(isnum(freq) && isnum(code))
 
@@ -418,7 +418,7 @@ GLOBAL_LIST_INIT(allowed_translations, list(
 	interp_type = /datum/n_Interpreter/TCS_Interpreter
 
 /datum/n_function/default/broadcast/execute(this_obj, list/params, datum/scope/scope, datum/n_Interpreter/TCS_Interpreter/interp)
-	if(params.len < 1)
+	if(length(params) < 1)
 		return
 	var/datum/n_struct/signal/script_signal = params[1]
 	if(!istype(script_signal))

--- a/yogstation/code/modules/scripting/Parser/Expressions.dm
+++ b/yogstation/code/modules/scripting/Parser/Expressions.dm
@@ -170,11 +170,11 @@
 			break
 
 
-		if(index>tokens.len) //End of File
+		if(index>length(tokens)) //End of File
 			errors += new /datum/scriptError/EndOfFile()
 			break
 		var/datum/token/ntok
-		if(index+1<=tokens.len)
+		if(index+1<=length(tokens))
 			ntok=tokens[index+1]
 
 		if(istype(curToken, /datum/token/symbol) && curToken.value == "(") //Parse parentheses expression
@@ -274,7 +274,7 @@
 		if(istype(curToken, /datum/token/symbol) && curToken.value == ")")
 			return exp
 		exp.parameters += ParseParamExpression()
-		if(errors.len)
+		if(length(errors))
 			return exp
 		if(curToken.value == "," && istype(curToken, /datum/token/symbol))
 			NextToken()	//skip comma
@@ -302,7 +302,7 @@
 			exp.init_list[A.exp] = A.exp2
 		else
 			exp.init_list += E
-		if(errors.len)
+		if(length(errors))
 			return exp
 		if(curToken.value == "," && istype(curToken, /datum/token/symbol))
 			NextToken() //skip comma

--- a/yogstation/code/modules/scripting/Parser/Keywords.dm
+++ b/yogstation/code/modules/scripting/Parser/Keywords.dm
@@ -77,8 +77,8 @@
 	var/list/L = parser.curBlock.statements
 	var/datum/node/statement/IfStatement/ifstmt
 
-	if(L && L.len)
-		ifstmt = L[L.len] //Get the last statement in the current block
+	if(L && length(L))
+		ifstmt = L[length(L)] //Get the last statement in the current block
 	if(!ifstmt || !istype(ifstmt) || ifstmt.else_if)
 		parser.errors += new /datum/scriptError/ExpectedToken("if statement", parser.curToken)
 		return KW_FAIL
@@ -102,7 +102,7 @@
 	. = KW_PASS
 	var/list/L = parser.curBlock.statements
 	var/datum/node/statement/IfStatement/stmt
-	if(L&&L.len) stmt=L[L.len] //Get the last statement in the current block
+	if(L&&length(L)) stmt=L[length(L)] //Get the last statement in the current block
 	if(!stmt || !istype(stmt) || stmt.else_block) //Ensure that it is an if statement
 		parser.errors += new /datum/scriptError/ExpectedToken("if statement",parser.curToken)
 		return KW_FAIL

--- a/yogstation/code/modules/scripting/Parser/Parser.dm
+++ b/yogstation/code/modules/scripting/Parser/Parser.dm
@@ -22,7 +22,7 @@
 
 ///Sets <curToken> to the next token in the <tokens> list, or null if there are no more tokens.
 /datum/n_Parser/proc/NextToken()
-	if(index >= tokens.len)
+	if(index >= length(tokens))
 		curToken = null
 	else
 		curToken = tokens[++index]
@@ -43,7 +43,7 @@
 
 /datum/n_Parser/nS_Parser/Parse()
 	ASSERT(tokens)
-	for(,index <= tokens.len, index++)
+	for(,index <= length(tokens), index++)
 		curToken = tokens[index]
 		switch(curToken.type)
 			if(/datum/token/keyword)

--- a/yogstation/code/modules/scripting/stack.dm
+++ b/yogstation/code/modules/scripting/stack.dm
@@ -5,16 +5,16 @@
 	contents += value
 
 /datum/stack/proc/Pop()
-	if(!contents.len)
+	if(!length(contents))
 		return null
-	. = contents[contents.len]
+	. = contents[length(contents)]
 	contents.len--
 
 ///returns the item on the top of the stack without removing it
 /datum/stack/proc/Top()
-	if(!contents.len)
+	if(!length(contents))
 		return null
-	return contents[contents.len]
+	return contents[length(contents)]
 
 /datum/stack/proc/Copy()
 	var/datum/stack/new_stack = new()


### PR DESCRIPTION

# Document the changes in your pull request

- This PR makes a special class extending from TextArea that does not save when pressing ENTER for NTSL
- Replaces X.len with length(X)

# Why is this good for the game?

> This PR makes a special class extending from TextArea that does not save when pressing ENTER for NTSL
- This makes it so you will no longer get your text position thingy moved to the very last line of your code if you are holding down ENTER, alongside possibly reducing lag that'd come from pressing it.
- Being jumped to the last line when holding down enter can be very annoying at times, so imo its gud.
> Replaces X.len with length(X)
- Apparently getting the var with length() is faster

# Testing

Tested locally, maybe i'll add a video here later.

# Changelog

:cl:
tweak: Made the NTSL console's script input area no longer save when pressing ENTER
/:cl:
