### PR TITLE
[ALL MAPS] Adds vox breathing masks and nitrogen tanks to cloning

### DIFF
--- a/_maps/map_files/DonutStation/DonutStation.dmm
+++ b/_maps/map_files/DonutStation/DonutStation.dmm
@@ -22216,6 +22216,8 @@
 	dir = 1;
 	network = list("ss13","Medical")
 	},
+/obj/item/clothing/mask/breath/vox,
+/obj/item/tank/internals/emergency_oxygen/vox,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "jnO" = (

--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -24218,6 +24218,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
+/obj/item/clothing/mask/breath/vox,
+/obj/item/tank/internals/emergency_oxygen/vox,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "lzE" = (

--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -27510,6 +27510,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 4
 	},
+/obj/item/tank/internals/emergency_oxygen/vox,
+/obj/item/clothing/mask/breath/vox,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "iej" = (

--- a/_maps/map_files/ManateeStation/ManateeStation.dmm
+++ b/_maps/map_files/ManateeStation/ManateeStation.dmm
@@ -32565,6 +32565,8 @@
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 4
 	},
+/obj/item/clothing/mask/breath/vox,
+/obj/item/tank/internals/emergency_oxygen/vox,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "jmj" = (

--- a/_maps/map_files/MiniStation/MiniStation.dmm
+++ b/_maps/map_files/MiniStation/MiniStation.dmm
@@ -1473,6 +1473,8 @@
 /obj/item/clothing/head/helmet/space/plasmaman,
 /obj/item/tank/internals/plasmaman/belt/full,
 /obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath/vox,
+/obj/item/tank/internals/emergency_oxygen/vox,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "ajb" = (

--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -69245,6 +69245,8 @@
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 9
 	},
+/obj/item/tank/internals/emergency_oxygen/vox,
+/obj/item/clothing/mask/breath/vox,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "vZc" = (


### PR DESCRIPTION
# Document the changes in your pull request

Adds vox breathing masks and nitrogen tanks to cloning.
Yes, I know that they can't be cloned but I have no idea where else they can go and there are zero other ways of acquiring vox breath masks except the ones vox start out with, meaning if they lose them somehow, they can't replace it.

# Why is this good for the game?
Vox masks aren't printable via protolathe or anywhere else. This gives them a way to actually replace their masks and tanks if they lose them somehow e.g. vox is stripped in maint by traitor and they can't find their mask or tank on revival.

# Testing
On ministation:
![image](https://github.com/user-attachments/assets/3e159a96-7704-4c43-ba49-613c1f572dc4)

Rest can be seen in mapdiffbot (if it doesn't get angry for some reason).

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
mapping: Adds vox masks and nitrogen tanks to cloning.
/:cl:
