### PR TITLE
[Admin] VV will no longer give you nuisance alerts about getting anything from the same Z-level if you don't have +FUN

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -802,8 +802,8 @@
 		var/atom/movable/AM = locate(href_list["admingetmovable"])
 		if(QDELETED(AM))
 			return
-		if(!check_rights(R_FUN))
-			if(is_centcom_level(AM.z) && !is_centcom_level(usr.z))
+		if(is_centcom_level(AM.z) && !is_centcom_level(usr.z))
+			if(!check_rights(R_FUN))
 				to_chat(usr, "You cannot get things from the Centcom Z-Level", confidential=TRUE)
 				return
 		AM.forceMove(get_turf(usr))


### PR DESCRIPTION
Fixes #22795

# Document the changes in your pull request

The ifs checking whether it was an item on CC and whether you have +FUN was the wrong way round.

# Testing
Still checks if you're getting something from CC and stops you if you don't have +FUN
![image](https://github.com/user-attachments/assets/508d88ec-534d-45c8-83b5-5d892d2674fa)
Getting things from CC with +FUN still works:
![image](https://github.com/user-attachments/assets/fb0ddf3f-d39d-4d30-a6e1-7c3686befc76)

# Changelog

:cl:
bugfix: VV getting anything on the same Z-level without +FUN will no longer give you nuisance alerts about not having +FUN.
/:cl:
