### PR TITLE
Makes supermatter bin fireproof

### DIFF
--- a/code/game/objects/items/theft_tools.dm
+++ b/code/game/objects/items/theft_tools.dm
@@ -201,6 +201,7 @@
 	name = "supermatter bin"
 	desc = "A tiny receptacle that releases an inert hyper-noblium mix upon sealing, allowing a sliver of a supermatter crystal to be safely stored."
 	var/obj/item/nuke_core/supermatter_sliver/sliver
+	resistance_flags = FIRE_PROOF
 
 /obj/item/nuke_core_container/supermatter/Destroy()
 	QDEL_NULL(sliver)


### PR DESCRIPTION
# Document the changes in your pull request

Makes the supermatter bin (the box for the supermatter sliver objective) fireproof.

# Why is this good for the game?
The only way of completing your objective being burnt by the supermatter you are getting it from should not happen.

# Testing
![image](https://github.com/user-attachments/assets/7c595c55-2073-463f-8ee4-92c5aee47536)
(The box is in the middle tile)

# Wiki Documentation

Don't think this is covered in any wiki pages that I could find.

# Changelog

:cl:
tweak: The supermatter bin for the supermatter sliver extraction objective is now fireproof.
/:cl:
