### PR TITLE
Refactors timed actions + hydraulic clamp fix

### DIFF
--- a/code/__DEFINES/dcs/signals/signals_mob/signals_mob.dm
+++ b/code/__DEFINES/dcs/signals/signals_mob/signals_mob.dm
@@ -134,6 +134,8 @@
 ///from base of /mob/living/start_pulling: (atom/movable/AM, state, force)
 #define COMSIG_MOB_PULL "mob_pull"
 	#define COMPONENT_BLOCK_PULL (1<<0) // blocks pulling
+///from base of /obj/item/pickup: (obj/item/item)
+#define COMSIG_MOB_PICKUP_ITEM "mob_pickup_item"
 ///Mob is trying to open the wires of a target [/atom], from /datum/wires/interactable(): (atom/target)
 #define COMSIG_TRY_WIRES_INTERACT "try_wires_interact"
 	#define COMPONENT_CANT_INTERACT_WIRES (1<<0)

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -333,21 +333,12 @@ GLOBAL_LIST_EMPTY(species_list)
 			return
 		LAZYSET(user.do_afters, interaction_key, current_interaction_count + 1)
 
-	var/atom/user_loc = user.loc
-	var/atom/target_loc = target?.loc
-
-	var/drifting = FALSE
-	if(!user.Process_Spacemove() && user.inertia_dir)
-		drifting = TRUE
-
-	var/holding = user.get_active_held_item()
-
 	if(!(timed_action_flags & IGNORE_SLOWDOWNS))
 		delay *= user.action_speed_modifier * user.do_after_coefficent() //yogs: darkspawn
 
 	var/datum/progressbar/progbar
 	if(progress)
-		progbar = new(user, delay, target || user)
+		progbar = new(user, delay, target || user, timed_action_flags, extra_checks)
 
 	SEND_SIGNAL(user, COMSIG_DO_AFTER_BEGAN)
 
@@ -357,24 +348,7 @@ GLOBAL_LIST_EMPTY(species_list)
 	while (world.time < endtime)
 		stoplag(1)
 
-		if(!QDELETED(progbar))
-			progbar.update(world.time - starttime)
-
-		if(drifting && !user.inertia_dir)
-			drifting = FALSE
-			user_loc = user.loc
-
-		if(QDELETED(user) \
-			|| (!(timed_action_flags & IGNORE_USER_LOC_CHANGE) && !drifting && user.loc != user_loc) \
-			|| (!(timed_action_flags & IGNORE_HELD_ITEM) && user.get_active_held_item() != holding) \
-			|| (!(timed_action_flags & IGNORE_INCAPACITATED) && HAS_TRAIT(user, TRAIT_INCAPACITATED)) \
-			|| (extra_checks && !extra_checks.Invoke()))
-			. = FALSE
-			break
-
-		if(target && (user != target) && \
-			(QDELETED(target) \
-			|| (!(timed_action_flags & IGNORE_TARGET_LOC_CHANGE) && target.loc != target_loc)))
+		if(QDELETED(progbar) || !progbar.update(world.time - starttime))
 			. = FALSE
 			break
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -743,8 +743,9 @@
  * * The forced flag indicates whether this was a forced move, which skips many checks of regular movement.
  * * The old_locs is an optional argument, in case the moved movable was present in multiple locations before the movement.
  * * momentum_change represents whether this movement is due to a "new" force if TRUE or an already "existing" force if FALSE
+ * * interrupting will cancel any do_after progress bars that should be canceled by moving.
  **/
-/atom/movable/proc/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE)
+/atom/movable/proc/Moved(atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE, interrupting = TRUE)
 	SHOULD_CALL_PARENT(TRUE)
 
 	if (!inertia_moving && momentum_change)
@@ -755,7 +756,7 @@
 	if (!moving_diagonally && client_mobs_in_contents)
 		update_parallax_contents()
 
-	SEND_SIGNAL(src, COMSIG_MOVABLE_MOVED, old_loc, movement_dir, forced, old_locs, momentum_change)
+	SEND_SIGNAL(src, COMSIG_MOVABLE_MOVED, old_loc, movement_dir, forced, old_locs, momentum_change, interrupting)
 
 	if(old_loc)
 		SEND_SIGNAL(old_loc, COMSIG_ATOM_ABSTRACT_EXITED, src, movement_dir)

--- a/code/game/mecha/equipment/mecha_equipment.dm
+++ b/code/game/mecha/equipment/mecha_equipment.dm
@@ -148,7 +148,7 @@
 	if(!chassis)
 		return FALSE
 	set_ready_state(FALSE)
-	. = do_after(chassis.occupant, equip_cooldown * check_eva(), target, extra_checks = CALLBACK(src, PROC_REF(do_after_checks), target, chassis.loc))
+	. = do_after(chassis.occupant, equip_cooldown * check_eva(), target, extra_checks = CALLBACK(src, PROC_REF(do_after_checks), target))
 	set_ready_state(TRUE)
 	if(!.)
 		return
@@ -158,16 +158,14 @@
 /obj/item/mecha_parts/mecha_equipment/proc/do_after_mecha(atom/target, delay)
 	if(!chassis)
 		return
-	return do_after(chassis.occupant, delay * check_eva(), target, extra_checks = CALLBACK(src, PROC_REF(do_after_checks), target, chassis.loc))
+	return do_after(chassis.occupant, delay * check_eva(), target, extra_checks = CALLBACK(src, PROC_REF(do_after_checks), target))
 
-/obj/item/mecha_parts/mecha_equipment/proc/do_after_checks(atom/target, atom/old_loc)
+/obj/item/mecha_parts/mecha_equipment/proc/do_after_checks(atom/target)
 	if(!chassis)
-		return FALSE
-	if(chassis.loc != old_loc || chassis.inertia_dir)
 		return FALSE
 	if(src != chassis.selected)
 		return FALSE
-	if(!(chassis.omnidirectional_attacks || (get_dir(chassis, target) & chassis.dir)))
+	if(target && !(chassis.omnidirectional_attacks || (get_dir(chassis, target) & chassis.dir)))
 		return FALSE
 	return TRUE
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -537,6 +537,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /obj/item/proc/pickup(mob/user)
 	SHOULD_CALL_PARENT(TRUE)
 	SEND_SIGNAL(src, COMSIG_ITEM_PICKUP, user)
+	SEND_SIGNAL(user, COMSIG_MOB_PICKUP_ITEM, src)
 	item_flags |= IN_INVENTORY
 
 // called when "found" in pockets and storage items. Returns 1 if the search should end.

--- a/code/modules/modular_computers/computers/item/computer.dm
+++ b/code/modules/modular_computers/computers/item/computer.dm
@@ -656,8 +656,8 @@
 	. = ..()
 	UnregisterSignal(user, COMSIG_MOVABLE_MOVED)
 
-/obj/item/modular_computer/proc/parent_moved()
-	SEND_SIGNAL(src, COMSIG_MOVABLE_MOVED)
+/obj/item/modular_computer/proc/parent_moved(datum/source, atom/old_loc, movement_dir, forced, list/old_locs, momentum_change = TRUE, interrupting = TRUE)
+	SEND_SIGNAL(src, COMSIG_MOVABLE_MOVED, old_loc, movement_dir, forced, old_locs, momentum_change, interrupting)
 
 /obj/item/modular_computer/proc/uplink_check(mob/living/M, code)
 	return SEND_SIGNAL(src, COMSIG_NTOS_CHANGE_RINGTONE, M, code) & COMPONENT_STOP_RINGTONE_CHANGE


### PR DESCRIPTION
Refactors timed actions to use signals to interrupt progress and save time over checking everything 10 times per second, and to fix a few bugs.

:cl: 
bugfix: Fixed hydraulic clamp being able to pry doors from a distance
bugfix: Fixed timed actions in exosuits being interrupted by drifting through space
/:cl:
