### PR TITLE
Fixes sentient creature not getting the right candidates

### DIFF
--- a/code/modules/events/ghost_role/sentience.dm
+++ b/code/modules/events/ghost_role/sentience.dm
@@ -47,7 +47,7 @@ GLOBAL_LIST_INIT(high_priority_sentience, typecacheof(list(
 
 /datum/round_event/ghost_role/sentience/spawn_role()
 	var/list/mob/dead/observer/candidates
-	candidates = get_candidates(ROLE_ALIEN, null, ROLE_ALIEN)
+	candidates = get_candidates(ROLE_SENTIENCE, null, ROLE_SENTIENCE)
 
 	// find our chosen mob to breathe life into
 	// Mobs have to be simple animals, mindless, on station, and NOT holograms.


### PR DESCRIPTION
# Document the changes in your pull request

It was getting the candidates of xenomorphs instead of sentient creature, in other words if you had sentient creature enabled you'd never get the notification unless you had xenomorphs enabled.

# Testing
Getting the prompt with sentient creature enabled works:
![image](https://github.com/user-attachments/assets/a0f70def-4645-49b4-bdd0-a0cbaac818aa)
Not getting the prompt while having xenomorphs enabled works:
![image](https://github.com/user-attachments/assets/8fdd0d74-f61b-4c95-9082-37d4bc9b98f9)


# Changelog

:cl:
bugfix: Sentient creature will now respect your antag preferences.
/:cl:
