### PR TITLE
Fix TGUI choice dialog not respecting the default option

### DIFF
--- a/tgui/packages/tgui/interfaces/ListInput.js
+++ b/tgui/packages/tgui/interfaces/ListInput.js
@@ -20,6 +20,7 @@ export const ListInput = (props, context) => {
     title,
     message = '',
     buttons = [],
+    init_value,
     large_buttons,
     timeout,
   } = data;
@@ -40,7 +41,7 @@ export const ListInput = (props, context) => {
 
   // Selected Button
   const [selectedButton, setSelectedButton] = useLocalState(
-    context, 'selected_button', buttons[0]);
+    context, 'selected_button', init_value);
   // Dynamically changes the window height based on the message.
   const windowHeight =
     325 + Math.ceil(message.length / 3) + (large_buttons ? 5 : 0);


### PR DESCRIPTION
# Document the changes in your pull request

Make the TGUI choice dialog show the current/default selection instead of always starting on the first option.

This unifies the behaviour of tgui input with the classic DM input dialog.

# Why is this good for the game?

Now the "adjust suit sensors" dialog actually shows you what your suit sensors are set to, like it used to before the switch to TGUI:

![image](https://github.com/user-attachments/assets/c283455a-2fd3-4951-ab85-0456abdddeb1)

# Testing

Changes compile & run, screenshot above taken with changes.

# Changelog

:cl:
bugfix: Made the suit sensors dialog show your current sensor setting again  
/:cl:
