### PR TITLE
Fixes a few mentor bugs

### DIFF
--- a/code/modules/admin/holder2.dm
+++ b/code/modules/admin/holder2.dm
@@ -122,6 +122,8 @@ GLOBAL_PROTECT(href_token)
 
 		if (deadmined)
 			activate()
+		if(C.mentor_datum)
+			C.mentor_position = C.mentor_datum.position
 		owner = C
 		ip_cache = C.address
 		cid_cache = C.computer_id

--- a/yogstation/code/datums/world_topic.dm
+++ b/yogstation/code/datums/world_topic.dm
@@ -93,8 +93,8 @@ GLOBAL_VAR_INIT(mentornoot, FALSE)
 	if(!add_mhelp_query.Execute())
 		message_admins("Failed insert mhelp into mhelp DB. Check the SQL error logs for more details.")
 	qdel(add_mhelp_query)
-	if(ckey in SSYogs.mentortickets)
-		var/datum/mentorticket/T = SSYogs.mentortickets[ckey]
+	if(C.ckey in SSYogs.mentortickets)
+		var/datum/mentorticket/T = SSYogs.mentortickets[C.ckey]
 		T.log += "<b>[from]:</b> [msg]"
 	to_chat(C, "<font color='purple'>Mentor PM from-<b>[discord_mentor_link(from, from_id)]</b>: [msg]</font>", confidential = TRUE)
 	var/show_char_recip = !C.is_mentor() && CONFIG_GET(flag/mentors_mobname_only)

--- a/yogstation/code/datums/world_topic.dm
+++ b/yogstation/code/datums/world_topic.dm
@@ -94,8 +94,8 @@ GLOBAL_VAR_INIT(mentornoot, FALSE)
 		message_admins("Failed insert mhelp into mhelp DB. Check the SQL error logs for more details.")
 	qdel(add_mhelp_query)
 	if(ckey in SSYogs.mentortickets)
-			var/datum/mentorticket/T = SSYogs.mentortickets[ckey]
-			T.log += "<b>[from]:</b> [msg]"
+		var/datum/mentorticket/T = SSYogs.mentortickets[ckey]
+		T.log += "<b>[from]:</b> [msg]"
 	to_chat(C, "<font color='purple'>Mentor PM from-<b>[discord_mentor_link(from, from_id)]</b>: [msg]</font>", confidential = TRUE)
 	var/show_char_recip = !C.is_mentor() && CONFIG_GET(flag/mentors_mobname_only)
 	for(var/client/X in GLOB.mentors | GLOB.permissions.admins)

--- a/yogstation/code/datums/world_topic.dm
+++ b/yogstation/code/datums/world_topic.dm
@@ -86,6 +86,16 @@ GLOBAL_VAR_INIT(mentornoot, FALSE)
 		SEND_SOUND(C, sound('sound/misc/nootnoot.ogg'))
 	else
 		SEND_SOUND(C, sound('sound/items/bikehorn.ogg'))
+	var/datum/DBQuery/add_mhelp_query = SSdbcore.NewQuery(
+		"INSERT INTO `[format_table_name("mentor_interactions")]` (round_id, ckey, ckey_mentor, target_ckey, target_mentor, message) VALUES (:round, :send, :smentor, :receive, :rmentor, :msg);",
+		list("round" = GLOB.round_id, "send" = from, "smentor" = TRUE, "receive" = C.ckey, "rmentor" = C.is_mentor(), "msg" = msg)
+	)
+	if(!add_mhelp_query.Execute())
+		message_admins("Failed insert mhelp into mhelp DB. Check the SQL error logs for more details.")
+	qdel(add_mhelp_query)
+	if(ckey in SSYogs.mentortickets)
+			var/datum/mentorticket/T = SSYogs.mentortickets[ckey]
+			T.log += "<b>[from]:</b> [msg]"
 	to_chat(C, "<font color='purple'>Mentor PM from-<b>[discord_mentor_link(from, from_id)]</b>: [msg]</font>", confidential = TRUE)
 	var/show_char_recip = !C.is_mentor() && CONFIG_GET(flag/mentors_mobname_only)
 	for(var/client/X in GLOB.mentors | GLOB.permissions.admins)

--- a/yogstation/code/modules/mentor/mentor_verbs.dm
+++ b/yogstation/code/modules/mentor/mentor_verbs.dm
@@ -64,9 +64,8 @@ GLOBAL_PROTECT(mentor_verbs)
 
 			if(C.is_afk())
 				msg += " (AFK)"
-		else
-			msg += span_info("Mentorhelps are also sent to Discord. If no mentors are available in game mentorhelp anyways and a mentor on Discord may see it and respond.")
 		msg += "\n"
+	msg += span_info("Mentorhelps are also sent to Discord. If no mentors are available in game mentorhelp anyways and a mentor on Discord may see it and respond.")
 
 	to_chat(src, msg, confidential=TRUE)
 

--- a/yogstation/code/modules/mentor/mentorpm.dm
+++ b/yogstation/code/modules/mentor/mentorpm.dm
@@ -90,7 +90,7 @@
 		
 	var/datum/DBQuery/add_mhelp_query = SSdbcore.NewQuery(
 		"INSERT INTO `[format_table_name("mentor_interactions")]` (round_id, ckey, ckey_mentor, target_ckey, target_mentor, message) VALUES (:round, :send, :smentor, :receive, :rmentor, :msg);",
-		list("round" = GLOB.round_id, "send" = ckey, "smentor" = is_mentor(), "receive" = discord_id ? whom : C.ckey, "rmentor" = C.is_mentor(), "msg" = msg)
+		list("round" = GLOB.round_id, "send" = ckey, "smentor" = is_mentor(), "receive" = discord_id ? whom : C.ckey, "rmentor" = discord_id ? TRUE : C.is_mentor(), "msg" = msg)
 	)
 	if(!add_mhelp_query.Execute())
 		message_admins("Failed insert mhelp into mhelp DB. Check the SQL error logs for more details.")

--- a/yogstation/code/modules/mentor/mentorpm.dm
+++ b/yogstation/code/modules/mentor/mentorpm.dm
@@ -90,7 +90,7 @@
 		
 	var/datum/DBQuery/add_mhelp_query = SSdbcore.NewQuery(
 		"INSERT INTO `[format_table_name("mentor_interactions")]` (round_id, ckey, ckey_mentor, target_ckey, target_mentor, message) VALUES (:round, :send, :smentor, :receive, :rmentor, :msg);",
-		list("round" = GLOB.round_id, "send" = ckey, "smentor" = is_mentor(), "receive" = C.ckey, "rmentor" = C.is_mentor(), "msg" = msg)
+		list("round" = GLOB.round_id, "send" = ckey, "smentor" = is_mentor(), "receive" = discord_id ? discord_id : C.ckey, "rmentor" = C.is_mentor(), "msg" = msg)
 	)
 	if(!add_mhelp_query.Execute())
 		message_admins("Failed insert mhelp into mhelp DB. Check the SQL error logs for more details.")

--- a/yogstation/code/modules/mentor/mentorpm.dm
+++ b/yogstation/code/modules/mentor/mentorpm.dm
@@ -90,7 +90,7 @@
 		
 	var/datum/DBQuery/add_mhelp_query = SSdbcore.NewQuery(
 		"INSERT INTO `[format_table_name("mentor_interactions")]` (round_id, ckey, ckey_mentor, target_ckey, target_mentor, message) VALUES (:round, :send, :smentor, :receive, :rmentor, :msg);",
-		list("round" = GLOB.round_id, "send" = ckey, "smentor" = is_mentor(), "receive" = discord_id ? discord_id : C.ckey, "rmentor" = C.is_mentor(), "msg" = msg)
+		list("round" = GLOB.round_id, "send" = ckey, "smentor" = is_mentor(), "receive" = discord_id ? whom : C.ckey, "rmentor" = C.is_mentor(), "msg" = msg)
 	)
 	if(!add_mhelp_query.Execute())
 		message_admins("Failed insert mhelp into mhelp DB. Check the SQL error logs for more details.")


### PR DESCRIPTION
Fixes #22794

# Document the changes in your pull request

Fixes mentorwho overreminding people that "Mentorhelps are also sent to Discord. If no mentors are available in game mentorhelp anyways and a mentor on Discord may see it and respond." multiplied per mentor that's on.

Fixes messaging discord mentors not showing the message being sent to them.

Fixes mentor-maintainers/issue hunters' OOC tag becoming [] after readminning, deadminning, and rementoring.

Fixes discord mentor messages not being recorded in mhelp database and mentor tickets.

# Testing
Mentorwho:
![image](https://github.com/user-attachments/assets/5fd1c129-50ba-4cb5-9b11-5bb609e7595f)

Sending messages to discord mentors:
![image](https://github.com/user-attachments/assets/10a6fe03-c23e-451d-aeb4-cae286bae2c0)

OOC tag:
![image](https://github.com/user-attachments/assets/a9b816e7-787b-49c9-b497-a31e5673f97d)

Mentor tickets:
![image](https://github.com/user-attachments/assets/326cddbb-1995-4112-b229-6d1a9c73b908)

# Changelog

:cl:
bugfix: Mentorwho will no longer remind you that mentorhelps are also sent to discord multiplied by the amount of mentors that are on the server.
bugfix: You can now see your messages to mentors on discord again.
bugfix: Mentor-maintainers/issue hunters' OOC tag will no longer evaporate into [] after readminning, deadminning, and rementoring.
bugfix: Discord mentor messages are now recorded in mhelp database and mentor tickets.
/:cl:
