### PR TITLE
Vox spawn with correct tank/mask pref

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -177,7 +177,7 @@
 	if(outfit_override || outfit)
 		H.equipOutfit(outfit_override ? outfit_override : outfit, visualsOnly)
 
-	H.dna.species.after_equip_job(src, H, visualsOnly)
+	H.dna.species.after_equip_job(src, H, preference_source)
 
 	if(!visualsOnly && announce)
 		announce(H)

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1457,7 +1457,7 @@ GLOBAL_LIST_EMPTY(features_by_species)
 /datum/species/proc/before_equip_job(datum/job/J, mob/living/carbon/human/H)
 	return
 
-/datum/species/proc/after_equip_job(datum/job/J, mob/living/carbon/human/H)
+/datum/species/proc/after_equip_job(datum/job/J, mob/living/carbon/human/H, client/preference_source)
 	H.update_mutant_bodyparts()
 
 // Do species-specific reagent handling here

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/vox.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/vox.dm
@@ -86,20 +86,20 @@
 		soon_added_items += pick(possible_masks)
 	..()
 
-/datum/species/vox/after_equip_job(datum/job/J, mob/living/carbon/human/H, visualsOnly = FALSE) // Don't forget your voxygen tank
+/datum/species/vox/after_equip_job(datum/job/J, mob/living/carbon/human/H, client/preference_source) // Don't forget your voxygen tank
 	if(!H.can_breathe_mask())
 		var/obj/item/clothing/mask/current_mask = H.get_item_by_slot(ITEM_SLOT_MASK)
 		if(!H.equip_to_slot_if_possible(current_mask, ITEM_SLOT_BACKPACK, disable_warning = TRUE))
 			H.put_in_hands(current_mask)
 	var/obj/item/clothing/mask/vox_mask
-	var/mask_pref = H.client?.prefs?.read_preference(/datum/preference/choiced/vox_mask)
+	var/mask_pref = preference_source?.prefs?.read_preference(/datum/preference/choiced/vox_mask)
 	if(mask_pref == "Respirator")
 		vox_mask = new /obj/item/clothing/mask/breath/vox/respirator
 	else
 		vox_mask = new /obj/item/clothing/mask/breath/vox
 	H.equip_to_slot_or_del(vox_mask, ITEM_SLOT_MASK)
 	var/obj/item/tank/internals_tank
-	var/tank_pref = H.client?.prefs?.read_preference(/datum/preference/choiced/vox_tank_type)
+	var/tank_pref = preference_source?.prefs?.read_preference(/datum/preference/choiced/vox_tank_type)
 	if(tank_pref == "Large")
 		internals_tank = new /obj/item/tank/internals/nitrogen
 	else


### PR DESCRIPTION
previously this only worked midround and broke roundstart due to the vox mob not having a client yet during setup

Fixes https://github.com/yogstation13/Yogstation/issues/22805

:cl:
bugfix: Vox spawn with the correct tank and mask at roundstart
/:cl:
