### PR TITLE
Adds lactose intolerance

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -985,3 +985,35 @@
 	if(!old_limb.is_organic_limb())
 		cybernetics_level--
 		update_mood()
+
+/datum/quirk/lactose_intolerance
+	name = "Lactose Intolerance"
+	desc = "You don't tolerate milk or other dairy products. Racist."
+	icon = "utensils"
+	gain_text = span_danger("You suddenly feel intolerant towards milk.")
+	lose_text = span_notice("You feel like you could drink milk again.")
+	medical_record_text = "Patient is lactose intolerant."
+	value = -1
+
+/datum/quirk/lactose_intolerance/check_quirk(datum/preferences/prefs)
+	var/datum/species/species_type = prefs.read_preference(/datum/preference/choiced/species)
+	if(initial(species_type.toxic_food) & DAIRY)
+		return "You're already lactose intolerant!"
+	species_type = new species_type()
+	if((TRAIT_POWERHUNGRY in species_type.inherent_traits) || (TRAIT_NOHUNGER in species_type.inherent_traits))
+		return "You don't eat food!"
+	return FALSE
+
+/datum/quirk/lactose_intolerance/add()
+	if(!ishuman(quirk_holder))
+		return
+	var/mob/living/carbon/carbon_holder = quirk_holder
+	var/datum/species/spec = carbon_holder.dna.species
+	spec.toxic_food |= DAIRY
+	RegisterSignal(carbon_holder, COMSIG_SPECIES_GAIN, PROC_REF(on_species_gain))
+
+/datum/quirk/lactose_intolerance/remove()
+	UnregisterSignal(quirk_holder, COMSIG_SPECIES_GAIN)
+
+/datum/quirk/lactose_intolerance/proc/on_species_gain(datum/source, datum/species/new_species)
+	new_species.toxic_food |= DAIRY // no escape from your terrible fate

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -988,7 +988,7 @@
 
 /datum/quirk/lactose_intolerance
 	name = "Lactose Intolerance"
-	desc = "You don't tolerate milk or other dairy products. Racist."
+	desc = "You don't tolerate milk or other dairy products."
 	icon = "utensils"
 	gain_text = span_danger("You suddenly feel intolerant towards milk.")
 	lose_text = span_notice("You feel like you could drink milk again.")

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -26,7 +26,7 @@
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard
 	skinned_type = /obj/item/stack/sheet/animalhide/lizard
 	exotic_bloodtype = "L"
-	disliked_food = SUGAR | VEGETABLES
+	toxic_food = parent_type::toxic_food | DAIRY
 	liked_food = MEAT | GRILLED | SEAFOOD | MICE | FRUIT
 	inert_mutation = FIREBREATH
 	deathsound = 'sound/voice/lizard/deathsound.ogg'

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -201,7 +201,7 @@
 /datum/reagent/consumable/milk/on_mob_life(mob/living/carbon/M)
 	. = ..()
 	if(M.dna?.species?.toxic_food & DAIRY)
-		M.adjust_disgust(5)
+		M.adjust_disgust(min(volume / 2, 5))
 
 /datum/reagent/consumable/milk/coconut
 	name = "Coconut Milk"

--- a/code/modules/reagents/chemistry/reagents/drink_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drink_reagents.dm
@@ -198,6 +198,11 @@
 	glass_desc = "White and nutritious goodness!"
 	default_container = /obj/item/reagent_containers/food/condiment/milk
 
+/datum/reagent/consumable/milk/on_mob_life(mob/living/carbon/M)
+	. = ..()
+	if(M.dna?.species?.toxic_food & DAIRY)
+		M.adjust_disgust(5)
+
 /datum/reagent/consumable/milk/coconut
 	name = "Coconut Milk"
 	description = "An opaque white liquid produced by the mammary glands of a coconut... wait what?"


### PR DESCRIPTION
# Document the changes in your pull request

![image](https://github.com/user-attachments/assets/ec77be81-e770-4c33-a875-4323cd8f8a12)

Adds a minor negative quirk, and makes lizards lactose intolerant instead of not liking vegetables and sugar.

# Testing

![image](https://github.com/user-attachments/assets/23a82e1b-1c84-4977-b5cc-4a1ce77371db)

# Wiki Documentation

Add to list of negative quirks - 
https://wiki.yogstation.net/wiki/Quirks#Negative_Quirks

Name: Lactose Intolerance
Balance: -1
Entry Description: "You don't tolerate milk or other dairy products."
Gameplay Effects: "Eating or drinking any dairy will cause a substantial mood decrease and eventually vomiting."

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
rscadd: Adds lactose intolerance quirk
tweak: Lizards are now lactose intolerant instead of not liking vegetables and sugar
/:cl:
