### PR TITLE
FIX FLUX FROM ROUND EVENT NOT EXPLODING

### DIFF
--- a/code/modules/events/anomaly/anomaly.dm
+++ b/code/modules/events/anomaly/anomaly.dm
@@ -16,7 +16,7 @@
 	announce_when = ANOMALY_ANNOUNCE_HARMFUL_TIME
 	var/area/impact_area
 	var/datum/anomaly_placer/placer = new()
-	var/obj/effect/anomaly/anomaly_path = /obj/effect/anomaly/flux
+	var/obj/effect/anomaly/anomaly_path = /obj/effect/anomaly/flux/explosion
 	///The admin-chosen spawn location.
 	var/turf/spawn_location
 


### PR DESCRIPTION
I HATE YOU MOLTI 


# Testing
the path of the old flux uses the type that wont explode


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:

bugfix: FIX FLUX ROUND EVENT NOT EXPLODING
/:cl:
