### PR TITLE
healium tweaks p3

### DIFF
--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -54,8 +54,9 @@
 		return
 
 	// Wait a bit before decaying
-	if(world.time - C.timeofdeath < 2 MINUTES)
-		return
+	if(!C.reagents.has_reagent(/datum/reagent/gas/healium))
+		if(world.time - C.timeofdeath < 2 MINUTES)
+			return
 
 	// Properly stored corpses shouldn't create miasma
 	if(istype(C.loc, /obj/structure/closet/crate/coffin)|| istype(C.loc, /obj/structure/closet/body_bag) || istype(C.loc, /obj/structure/bodycontainer))

--- a/code/datums/components/rot.dm
+++ b/code/datums/components/rot.dm
@@ -54,9 +54,8 @@
 		return
 
 	// Wait a bit before decaying
-	if(!C.reagents.has_reagent(/datum/reagent/gas/healium))
-		if(world.time - C.timeofdeath < 2 MINUTES)
-			return
+	if(world.time - C.timeofdeath < 2 MINUTES)
+		return
 
 	// Properly stored corpses shouldn't create miasma
 	if(istype(C.loc, /obj/structure/closet/crate/coffin)|| istype(C.loc, /obj/structure/closet/body_bag) || istype(C.loc, /obj/structure/bodycontainer))
@@ -68,6 +67,10 @@
 
 	// Also no decay if corpse chilled or not organic/undead
 	if(C.bodytemperature <= T0C-10 || (!(C.mob_biotypes & (MOB_ORGANIC & MOB_UNDEAD))))
+		return
+
+	// Healium prevents body from rotting
+	if(C.reagents.has_reagent(/datum/reagent/gas/healium))
 		return
 
 	..()

--- a/code/game/data_huds.dm
+++ b/code/game/data_huds.dm
@@ -171,7 +171,7 @@ Medical HUD! Basic mode needs suit sensors on.
 			return
 		if(tod)
 			var/tdelta = round(world.time - timeofdeath)
-			if(tdelta < (DEFIB_TIME_LIMIT))
+			if(tdelta < (DEFIB_TIME_LIMIT) || reagents.has_reagent(/datum/reagent/gas/healium))
 				holder.icon_state = "huddefib"
 				return
 		holder.icon_state = "huddead"

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -321,6 +321,17 @@
 			gas_reagent.reaction_mob(mob_occupant, VAPOR|BREATH, 2, permeability = 1)
 			air1.adjust_moles(gas_id, -0.1 / efficiency)
 			qdel(gas_reagent)
+		if(C && C.stat == DEAD && C.reagents.has_reagent(/datum/reagent/gas/healium)) // attempts to cycle healium in the body to a reviable state
+			if(!C.can_defib(FALSE))
+				C.reagents.del_reagent(/datum/reagent/gas/healium)
+			else
+				set_on(FALSE)
+				playsound(src, 'sound/machines/cryo_warning.ogg', volume) // Bug the doctors.
+				var/msg = "Dead body has been patched up to a reviable state."
+				if(autoeject) // Eject if configured.
+					msg += " Auto ejecting body now."
+					open_machine()
+				radio.talk_into(src, msg, radio_channel)
 
 	return TRUE
 

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -1,4 +1,4 @@
-8///Max temperature allowed inside the cryotube, should break before reaching this heat
+///Max temperature allowed inside the cryotube, should break before reaching this heat
 #define MAX_TEMPERATURE 4000
 
 /// This is a visual helper that shows the occupant inside the cryo cell.

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -1,4 +1,4 @@
-///Max temperature allowed inside the cryotube, should break before reaching this heat
+8///Max temperature allowed inside the cryotube, should break before reaching this heat
 #define MAX_TEMPERATURE 4000
 
 /// This is a visual helper that shows the occupant inside the cryo cell.
@@ -327,7 +327,7 @@
 			else
 				set_on(FALSE)
 				playsound(src, 'sound/machines/cryo_warning.ogg', volume) // Bug the doctors.
-				var/msg = "Dead body has been patched up to a reviable state."
+				var/msg = "Dead body has been patched up to a revivable state."
 				if(autoeject) // Eject if configured.
 					msg += " Auto ejecting body now."
 					open_machine()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -874,8 +874,9 @@
 /mob/living/carbon/proc/can_defib(careAboutGhost = TRUE) //yogs start
 	if(suiciding || hellbound || HAS_TRAIT(src, TRAIT_HUSK)) //can't revive
 		return FALSE
-	if((world.time - timeofdeath) > DEFIB_TIME_LIMIT) //too late
-		return FALSE
+	if(!reagents.has_reagent(/datum/reagent/gas/healium))
+		if((world.time - timeofdeath) > DEFIB_TIME_LIMIT) //too late
+			return FALSE
 	if((getBruteLoss() >= MAX_REVIVE_BRUTE_DAMAGE) || (getFireLoss() >= MAX_REVIVE_FIRE_DAMAGE) || !can_be_revived()) //too damaged
 		return FALSE
 	if(!getorgan(/obj/item/organ/heart)) //what are we even shocking

--- a/code/modules/reagents/chemistry/reagents/gas_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/gas_reagents.dm
@@ -260,7 +260,7 @@
 			L.adjustBruteLoss(-(L.getBruteLoss() - MAX_REVIVE_FIRE_DAMAGE + 50))
 		if(L.getFireLoss() >= MAX_REVIVE_FIRE_DAMAGE)
 			L.adjustFireLoss(-(L.getFireLoss() - MAX_REVIVE_FIRE_DAMAGE + 50))
-		if(health <= HEALTH_THRESHOLD_DEAD)
+		if(L.health <= HEALTH_THRESHOLD_DEAD)
 			if(L.getOxyLoss())
 				L.adjustOxyLoss(-50)
 			if(L.getToxLoss())

--- a/code/modules/reagents/chemistry/reagents/gas_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/gas_reagents.dm
@@ -255,11 +255,18 @@
 			organs.applyOrganDamage(-20)
 			if(organs.organ_flags & ORGAN_FAILING)
 				organs.organ_flags &= ~ORGAN_FAILING
-	if(L.stat == DEAD)
+	if(L.stat == DEAD) //Healium kicks harder if the body is dead
 		if(L.getBruteLoss() >= MAX_REVIVE_BRUTE_DAMAGE)
 			L.adjustBruteLoss(-(L.getBruteLoss() - MAX_REVIVE_FIRE_DAMAGE + 50))
 		if(L.getFireLoss() >= MAX_REVIVE_FIRE_DAMAGE)
 			L.adjustFireLoss(-(L.getFireLoss() - MAX_REVIVE_FIRE_DAMAGE + 50))
+		if(health <= HEALTH_THRESHOLD_DEAD)
+			if(L.getOxyLoss())
+				L.adjustOxyLoss(-50)
+			if(L.getToxLoss())
+				L.adjustToxLoss(-50)
+			if(L.getCloneLoss())
+				L.adjustCloneLoss(-50)
 	ADD_TRAIT(L, TRAIT_PRESERVED_ORGANS, "healium")
 
 /datum/reagent/gas/healium/on_mob_delete(mob/living/carbon/L)


### PR DESCRIPTION
# Document the changes in your pull request
healium now prevents body from rotting
cryo tube now prorperly heal dead body (with extra check to prevent healium duplication) to a reviable state when healium reagent exists in the body (#22133), broken by (#22188)

# Why is this good for the game?
healium could prevent organs from rotting but not the entire body is whack, allowing doctors to normally defib one without the need of revival surgery (body decayed) if healium exists in the bloodstream

plus bug fix

# Testing
tested on local
![cryooo](https://github.com/user-attachments/assets/404f50e9-8fce-4068-a224-209c805905f0)


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
tweak: healium now prevents body from rotting
bugfix: cryo tube now prorperly heal dead body (with extra check to prevent healium duplication) to a reviable state when healium reagent exists in the body (#22133), broken by (#22188)
/:cl:
