### PR TITLE
[BOX] Fixes escape pod camera names

### DIFF
--- a/_maps/map_files/YogStation/YogStation.dmm
+++ b/_maps/map_files/YogStation/YogStation.dmm
@@ -9494,7 +9494,7 @@
 /area/crew_quarters/toilet)
 "buX" = (
 /obj/machinery/camera{
-	c_tag = "Arrivals Escape Pod 2";
+	c_tag = "Arrivals Escape Pod 1";
 	dir = 8
 	},
 /obj/machinery/light/small,
@@ -23210,7 +23210,7 @@
 /area/science/misc_lab)
 "fuj" = (
 /obj/machinery/camera{
-	c_tag = "Arrivals Escape Pod 1";
+	c_tag = "Arrivals Escape Pod 2";
 	dir = 8
 	},
 /obj/machinery/light/small,


### PR DESCRIPTION
# Document the changes in your pull request
It was mentioned that the cameras were mislabeled, so I took a gander and lo and behold they were
(top is escape pod 1 and bottom is escape pod 2)

# Testing
if need can do

# Changelog
:cl:
mapping: On Boxstation, the cameras for escape pod 1 and 2 are now correctly labelled
/:cl:
