### PR TITLE
Heads update properly

### DIFF
--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -175,7 +175,7 @@
 	if(!get_bodypart(BODY_ZONE_HEAD)) //Decapitated
 		return
 
-	if(client && hud_used?.inv_slots[TOBITSHIFT(ITEM_SLOT_BACK) + 1])
+	if(client && hud_used?.inv_slots[TOBITSHIFT(ITEM_SLOT_HEAD) + 1])
 		var/atom/movable/screen/inventory/inv = hud_used.inv_slots[TOBITSHIFT(ITEM_SLOT_HEAD) + 1]
 		inv.update_appearance(UPDATE_ICON)
 


### PR DESCRIPTION
# Document the changes in your pull request

This got fucked when I removed non-bitflag inventory slots, just a minor copy paste error. I noticed it now so here's a fix for it.

# Changelog

:cl:
bugfix: Your head inventory slot icon now updates even if you don't have a backpack slot icon.
/:cl:
