### PR TITLE
Grinder will no longer allow you to swap containers while operating

### DIFF
--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -136,6 +136,9 @@
 		return TRUE
 
 	if (istype(I, /obj/item/reagent_containers) && !(I.item_flags & ABSTRACT) && I.is_open_container())
+		if(operating)
+			to_chat(user, span_warning("[src] is operating!"))
+			return
 		var/obj/item/reagent_containers/B = I
 		. = TRUE //no afterattack
 		if(!user.transferItemToLoc(B, src))


### PR DESCRIPTION
Fixes #22544

# Document the changes in your pull request

Checks whether the all in one grinder is operating before swapping containers.

# Testing

https://github.com/user-attachments/assets/d29b880c-8ca4-4bfd-9de8-f6e01c14b5a8



# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
bugfix: All-in-one grinder will no longer allow you to swap containers while it is operating.
/:cl:
