### PR TITLE
Fixes space drugs popping in and out of drugginess

### DIFF
--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -15,7 +15,7 @@
 	overdose_threshold = 30
 
 /datum/reagent/drug/space_drugs/on_mob_life(mob/living/carbon/M)
-	M.set_drugginess(15)
+	M.adjust_drugginess_up_to(3 SECONDS, 15 SECONDS)
 	if(isturf(M.loc) && !isspaceturf(M.loc))
 		if(M.mobility_flags & MOBILITY_MOVE)
 			if(prob(10))
@@ -283,7 +283,7 @@
 
 /datum/reagent/drug/bath_salts/on_mob_metabolize(mob/living/L)
 	..()
-	
+
 	ADD_TRAIT(L, TRAIT_SLEEPIMMUNE, type)
 	if(iscarbon(L))
 		var/mob/living/carbon/human/H = L
@@ -566,7 +566,7 @@
 	L.next_move_modifier *= 0.8
 	L.action_speed_modifier *= 0.5
 	tele_teleport(L)
-	..()	
+	..()
 
 /datum/reagent/drug/red_eye/on_mob_end_metabolize(mob/living/L)
 	L.next_move_modifier *= 1.25
@@ -707,7 +707,7 @@
 	addiction_threshold = 30
 	metabolization_rate = 1.3 * REAGENTS_METABOLISM
 	var/original_eye_color = "000" //so we can return it to normal eye on end metabolism
-	
+
 /datum/reagent/drug/blue_eye/on_mob_metabolize(mob/living/L)
 	..()
 	if(prob(50))


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Space drugs no longer sets your drugginess to a duration of 1.5 seconds, making you stop being druggy for 25% of every tick

Space drugs now give you 3 seconds of drugginess per lifetick, building up to a maximum of 15 excess seconds

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Prefix the PR title with [admin] if it involves something admin related. 
Prefix the PR title with [s] if you are fixing a game-breaking exploit, so that it is not announced on the Yogstation Discord and the server.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->


# Wiki Documentation
Space drugs now give you 3 seconds of drugginess per tick, building up to a maximum of 15 excess seconds
<!-- Remove this text and write all information regarding your changes that should be known and documented through the Yogstation Wiki. 
Important documentation information includes, but is not limited to: any numerical values that have been changed, any images that have to be updated, names of specific pages that will be impacted by your changes. -->

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
bugfix: Space drugs no longer makes you enter and exit drugginess rapidly.
/:cl:
