### PR TITLE
[Admin] Makes set minetype verb more understandable

### DIFF
--- a/yogstation/code/modules/admin/admin_verbs.dm
+++ b/yogstation/code/modules/admin/admin_verbs.dm
@@ -108,6 +108,6 @@
 	var/answer = input(src,"Which one do you choose?","Selection","Either") in l
 	if(!answer)
 		return
-	message_admins("[src] the next minetype was picked.")
+	message_admins("[src] set the next minetype to [answer].")
 	log_admin("[src] picked the next minetype.")
 	SSpersistence.SaveMinetype(l[answer])

--- a/yogstation/code/modules/admin/admin_verbs.dm
+++ b/yogstation/code/modules/admin/admin_verbs.dm
@@ -109,5 +109,5 @@
 	if(!answer)
 		return
 	message_admins("[src] set the next minetype to [answer].")
-	log_admin("[src] picked the next minetype.")
+	log_admin("[src] set the next minetype to [answer].")
 	SSpersistence.SaveMinetype(l[answer])


### PR DESCRIPTION
# Document the changes in your pull request

Changes the message admins receive to be more understandable about the minetype and what has been selected.

# Why is this good for the game?
It'd probably be useful to see what you're changing it to.

# Testing
![image](https://github.com/user-attachments/assets/32a3e6e3-cc8c-4d3a-b29c-ecfacaa72e40)

# Changelog

:cl:
tweak: Set next minetype verb is now more clear and actually tells you what minetype is set.
/:cl:
