### PR TITLE
Allows foam to spread through density objects

### DIFF
--- a/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
+++ b/code/game/objects/effects/effect_system/fluid_spread/effects_foam.dm
@@ -135,7 +135,7 @@
 	if(!istype(location))
 		return FALSE
 
-	for(var/turf/spread_turf as anything in location.reachableAdjacentTurfs())
+	for(var/turf/spread_turf as anything in location.reachableAdjacentAtmosTurfs())
 		var/obj/effect/particle_effect/fluid/foam/foundfoam = locate() in spread_turf //Don't spread foam where there's already foam!
 		if(foundfoam)
 			continue


### PR DESCRIPTION

# Why is this good for the game?
Attempt to unspace an area with metal foams...? Oh no a fucking chem dispenser is ontop of a spaced tile.. OH NO THE FOAM CANT REACH THAT TILE

Attempt to put out a hot area with resin foam..? Oh no a SAME FUCKING chem dispenser is ontop of THAT STUPID HOT TILE... THE FOAM CANT REACH IT TO remove the HEAT

Now, worry no more, this will change everything. make the job less painful

# Testing

![yes foam](https://github.com/user-attachments/assets/b992e205-fb2c-4efa-8923-4ca3f094ce12)


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
rscadd: Allows foam to spread through density objects
/:cl:
