### PR TITLE
Fix cannot click off mobs to let go in combat mode and throw mobs when in grab mode

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -120,7 +120,7 @@
 		UnarmedAttack(A, FALSE, modifiers)
 		return
 	
-	if(grab_mode && pulled(A))
+	if(grab_mode && pulled(A) && !in_throw_mode)
 		return
 
 	if(in_throw_mode)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -366,7 +366,7 @@
 
 	if(istype(AM) && Adjacent(AM))
 		start_pulling(AM)
-	else if(!combat_mode)
+	else if(!in_throw_mode)
 		stop_pulling()
 	return TRUE
 


### PR DESCRIPTION
fix #22702, fix #22701


# Testing
![GARABB](https://github.com/user-attachments/assets/8671b43c-2237-47ff-a06f-e58c343de0ba)



# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:

bugfix: Fix cannot click off mobs to let go in combat mode and throw mobs when in grab mode
/:cl:
