### PR TITLE
FIX ghost pda notifcations pref again (biomu moment)

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -450,7 +450,7 @@ GLOBAL_LIST_EMPTY(species_list)
 				if(prefs.toggles & DISABLE_ARRIVALRATTLE)
 					continue
 			if(DEADCHAT_PDA)
-				if(prefs.chat_toggles & CHAT_GHOSTPDA)
+				if(!(prefs.chat_toggles & CHAT_GHOSTPDA))
 					continue
 
 		if(isobserver(M))


### PR DESCRIPTION
you reversed it (making disabling ghost pda pref, allowing you to hear pda dchat)



# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:

bugfix: FIX ghost pda notifcations pref again (biomu moment)
/:cl:
