### PR TITLE
fix NTNET quantum relay sprite being invisible when disabled

### DIFF
--- a/code/game/machinery/telecomms/ntnet_relay.dm
+++ b/code/game/machinery/telecomms/ntnet_relay.dm
@@ -70,9 +70,13 @@
 	. = dos_failure
 	dos_failure = new_value
 
-/obj/machinery/ntnet_relay/update_icon_state()
-	icon_state = "bus[is_operational() ? null : "_off"]"
-	return ..()
+/obj/machinery/ntnet_relay/update_overlays()
+	. = ..()
+	if(!is_operational())
+		return
+	var/mutable_appearance/on_overlay
+	on_overlay = mutable_appearance(icon, "[initial(icon_state)]_on")
+	. += on_overlay
 
 /obj/machinery/ntnet_relay/process(seconds_per_tick)
 	if(is_operational())


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/8e5b51b4-6391-4a25-aa23-263634f3e8c6)
![image](https://github.com/user-attachments/assets/4435f534-5376-4a20-8993-2849a7ada919)

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:

bugfix: fix NTNET quantum relay sprite being invisible when disabled
/:cl:
