### PR TITLE
Allows concealed weapon bay to hide melee mech weaponry

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -342,7 +342,10 @@
 /obj/mecha/examine(mob/user)
 	. = ..()
 	var/hide_weapon = locate(/obj/item/mecha_parts/concealed_weapon_bay) in contents
-	var/hidden_weapon = hide_weapon ? (locate(/obj/item/mecha_parts/mecha_equipment/weapon) in equipment) : null
+	var/obj/item/mecha_parts/mecha_equipment/melee_weapon/hidden_melee_weapon = locate(/obj/item/mecha_parts/mecha_equipment/melee_weapon) in equipment
+	if(hidden_melee_weapon && !(hidden_melee_weapon.mech_flags ~= EXOSUIT_MODULE_COMBAT))
+		hidden_melee_weapon = null
+	var/hidden_weapon = hide_weapon ? (locate(/obj/item/mecha_parts/mecha_equipment/weapon) in equipment)||hidden_melee_weapon : null
 	var/list/visible_equipment = equipment - hidden_weapon
 	if(visible_equipment.len)
 		. += "It's equipped with:"

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -343,7 +343,7 @@
 	. = ..()
 	var/hide_weapon = locate(/obj/item/mecha_parts/concealed_weapon_bay) in contents
 	var/obj/item/mecha_parts/mecha_equipment/melee_weapon/hidden_melee_weapon = locate(/obj/item/mecha_parts/mecha_equipment/melee_weapon) in equipment
-	if(hidden_melee_weapon && !(hidden_melee_weapon.mech_flags ~= EXOSUIT_MODULE_COMBAT))
+	if(hidden_melee_weapon && !(hidden_melee_weapon.mech_flags & EXOSUIT_MODULE_COMBAT))
 		hidden_melee_weapon = null
 	var/hidden_weapon = hide_weapon ? (locate(/obj/item/mecha_parts/mecha_equipment/weapon) in equipment)||hidden_melee_weapon : null
 	var/list/visible_equipment = equipment - hidden_weapon


### PR DESCRIPTION
Fixes #19279

# Document the changes in your pull request

Makes the concealed weapon bay hide any melee mech weaponry (i.e. combat mech weaponry such as swords, rocket fist).

# Why is this good for the game?
Concealed weapon bay should be able to hide these, otherwise it's not much of a concealment, that and it'll lead to people wasting 3 TC if they specifically wanted to ambush people with hidden mech swords.

# Testing

https://github.com/user-attachments/assets/29eec6c3-2e22-4699-9a1d-9b42973c805c


# Changelog

:cl:
tweak: Concealed weapon bay can now hide melee mech weaponry.
/:cl:
