### PR TITLE
Suit storage unit and ADSU tweaks, bugfixes

### DIFF
--- a/code/game/machinery/decontamination.dm
+++ b/code/game/machinery/decontamination.dm
@@ -8,6 +8,7 @@
 	max_integrity = 300
 	circuit = /obj/item/circuitboard/machine/decontamination_unit
 	layer = OBJ_LAYER
+	interaction_flags_machine = INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN | INTERACT_MACHINE_OFFLINE
 								// if you add more storage slots, update cook() to clear their radiation too.
 
 	var/max_n_of_items = 53
@@ -390,6 +391,8 @@
 			locked = !locked
 			. = TRUE
 		if("uv")
+			if(!is_operational())
+				return
 			var/mob/living/mob_occupant = occupant
 			if(!occupant && !contents.len)
 				return
@@ -471,6 +474,9 @@
 		return
 	if(panel_open)
 		to_chat(user, span_warning("Close the panel first!"))
+		return
+	if(locked)
+		to_chat(user, span_warning("It's locked!"))
 		return
 	if(uv)
 		to_chat(user, span_warning("You cannot open the gate while the cycle is running!"))

--- a/code/game/machinery/decontamination.dm
+++ b/code/game/machinery/decontamination.dm
@@ -148,10 +148,10 @@
 	say("The decontamination process is completed, thank you for your patience.")
 	playsound(src, 'sound/machines/decon/decon-open.ogg', 50, TRUE)
 	if(mob_occupant)
-		visible_message(span_notice("[src]'s gate slides open, ejecting [mob_occupant] out."), span_notice("[src]'s gate slides open, ejecting you out."))
+		visible_message(span_notice("[src]'s door slides open, ejecting [mob_occupant] out."), span_notice("[src]'s gate slides open, ejecting you out."))
 		mob_occupant.radiation = 0
 	else
-		visible_message(span_notice("[src]'s gate slides open. The glowing yellow lights dim to a gentle green."))
+		visible_message(span_notice("[src]'s door slides open. The glowing yellow lights dim to a gentle green."))
 	var/list/things_to_clear = list() //Done this way since using get_all_contents on the SSU itself would include circuitry and such.
 	if(occupant)
 		things_to_clear += occupant

--- a/code/game/machinery/decontamination.dm
+++ b/code/game/machinery/decontamination.dm
@@ -148,7 +148,7 @@
 	say("The decontamination process is completed, thank you for your patience.")
 	playsound(src, 'sound/machines/decon/decon-open.ogg', 50, TRUE)
 	if(mob_occupant)
-		visible_message(span_notice("[src]'s door slides open, ejecting [mob_occupant] out."), span_notice("[src]'s gate slides open, ejecting you out."))
+		visible_message(span_notice("[src]'s door slides open, ejecting [mob_occupant] out."))
 		mob_occupant.radiation = 0
 	else
 		visible_message(span_notice("[src]'s door slides open. The glowing yellow lights dim to a gentle green."))

--- a/code/game/machinery/decontamination.dm
+++ b/code/game/machinery/decontamination.dm
@@ -148,7 +148,7 @@
 	say("The decontamination process is completed, thank you for your patience.")
 	playsound(src, 'sound/machines/decon/decon-open.ogg', 50, TRUE)
 	if(mob_occupant)
-		visible_message(span_notice("[src]'s gate slides open, ejecting you out."))
+		visible_message(span_notice("[src]'s gate slides open, ejecting [mob_occupant] out."), span_notice("[src]'s gate slides open, ejecting you out."))
 		mob_occupant.radiation = 0
 	else
 		visible_message(span_notice("[src]'s gate slides open. The glowing yellow lights dim to a gentle green."))

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -7,6 +7,7 @@
 	density = TRUE
 	max_integrity = 250
 	circuit = /obj/item/circuitboard/machine/suit_storage_unit
+	interaction_flags_machine = INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN | INTERACT_MACHINE_OFFLINE
 
 	var/obj/item/clothing/suit/space/suit = null
 	var/obj/item/clothing/head/helmet/space/helmet = null
@@ -136,13 +137,6 @@
 	if(storage_type)
 		storage = new storage_type(src)
 	update_appearance(UPDATE_ICON)
-
-/obj/machinery/suit_storage_unit/Destroy()
-	QDEL_NULL(suit)
-	QDEL_NULL(helmet)
-	QDEL_NULL(mask)
-	QDEL_NULL(storage)
-	return ..()
 
 /obj/machinery/suit_storage_unit/update_overlays()
 	. = ..()
@@ -443,6 +437,8 @@
 			locked = !locked
 			. = TRUE
 		if("uv")
+			if(!is_operational())
+				return
 			var/mob/living/mob_occupant = occupant
 			if(!helmet && !mask && !suit && !storage && !occupant)
 				return
@@ -478,6 +474,9 @@
 		return
 	if(panel_open)
 		to_chat(user, span_warning("Close the panel first!"))
+		return
+	if(locked)
+		to_chat(user, span_warning("It's locked!"))
 		return
 	if(uv)
 		to_chat(user, span_warning("You cannot open the gate while the cycle is running!"))


### PR DESCRIPTION
* fixes #17194

# Document the changes in your pull request
fix "The advanced decontamination storage unit's gate slides open, ejecting you out." when actually ejecting someone else
rename "gate" to "door"
SSU and ADSU can be interacted if there's no power but you still need power to operate it
fix being able to open locked SSU/ADSU with altclick
destroyed SSU no longer delete contents inside



# Testing
![image](https://github.com/user-attachments/assets/608ab30f-6aac-4de1-908c-252e4737ce02)
![image](https://github.com/user-attachments/assets/e45e7e87-3a1f-4154-a872-e30e15d796aa)


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
bugfix: fix "The advanced decontamination storage unit's gate slides open, ejecting you out." when actually ejecting someone else
spellcheck: rename "gate" to "door"
tweak: SSU and ADSU can be interacted if there's no power but you still need power to operate it
bugfix: fix being able to open locked SSU/ADSU with altclick
tweak: destroyed SSU no longer delete contents inside
/:cl:
