### PR TITLE
fix unable to research ai tech using ruin type rnd console

### DIFF
--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -91,5 +91,5 @@
 ///This determines how many general points that the ruin_tech techweb gets, since they don't utilize servers
 #define RUIN_GENERATION_PER_TICK 70
 
-///This determines how many nanites points that the ruin_tech techweb gets, since they lack research tools.
-#define NANITES_RESEARCH_RUIN_PER_TICK 10
+///This determines how many nanites/AI points that the ruin_tech techweb gets, since they lack research tools.
+#define NANITES_AI_RESEARCH_RUIN_PER_TICK 10

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -91,7 +91,7 @@ SUBSYSTEM_DEF(research)
 			science_tech.remove_stored_point_type(i, boost_amt)
 	science_tech.add_point_list(bitcoins)
 	//add RUIN_GENERATION_PER_TICK even without any servers, for things like freeminers
-	ruin_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = RUIN_GENERATION_PER_TICK, TECHWEB_POINT_TYPE_NANITES = NANITES_RESEARCH_RUIN_PER_TICK))
+	ruin_tech.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = RUIN_GENERATION_PER_TICK, TECHWEB_POINT_TYPE_NANITES = NANITES_AI_RESEARCH_RUIN_PER_TICK, TECHWEB_POINT_TYPE_AI = NANITES_AI_RESEARCH_RUIN_PER_TICK))
 	last_income = world.time
 
 /datum/controller/subsystem/research/proc/calculate_server_coefficient()	//Diminishing returns.

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -783,6 +783,7 @@
 	link_on_init = FALSE
 	authorization_override = TRUE
 	hacked = TRUE
+	circuit = /obj/item/circuitboard/machine/mechfab/ruin
 
 /obj/machinery/mecha_part_fabricator/ruin/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1129,8 +1129,7 @@
 	name = "Rack Creator (Machine Board)"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
 	build_path = /obj/machinery/rack_creator
-	req_components = list(
-		/obj/item/stock_parts/manipulator = 2,
+	req_components = list(/obj/item/stock_parts/manipulator = 2)
 	var/unlocked = FALSE
 
 /obj/item/circuitboard/machine/rack_creator/multitool_act(mob/living/user, obj/item/I)

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -1131,7 +1131,6 @@
 	build_path = /obj/machinery/rack_creator
 	req_components = list(
 		/obj/item/stock_parts/manipulator = 2,
-		/obj/item/reagent_containers/glass/beaker = 2)
 	var/unlocked = FALSE
 
 /obj/item/circuitboard/machine/rack_creator/multitool_act(mob/living/user, obj/item/I)

--- a/code/game/objects/items/circuitboards/machine_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/machine_circuitboards.dm
@@ -984,6 +984,10 @@
 		/obj/item/stock_parts/micro_laser = 1,
 		/obj/item/stack/sheet/glass = 1)
 
+/obj/item/circuitboard/machine/mechfab/ruin
+	desc = "This board is unofficial, and can be linked experimental R&D console, do not lose this because it's very expensive to accquire."
+	build_path = /obj/machinery/mecha_part_fabricator/ruin
+
 /obj/item/circuitboard/machine/monkey_recycler
 	name = "Monkey Recycler (Machine Board)"
 	greyscale_colors = CIRCUIT_COLOR_SCIENCE
@@ -1128,6 +1132,17 @@
 	req_components = list(
 		/obj/item/stock_parts/manipulator = 2,
 		/obj/item/reagent_containers/glass/beaker = 2)
+	var/unlocked = FALSE
+
+/obj/item/circuitboard/machine/rack_creator/multitool_act(mob/living/user, obj/item/I)
+	. = ..()
+	user.visible_message(span_notice("[user] fiddles with [src]."), span_notice( "You fiddle with [src]."))
+	if(I.use_tool(src, user, 2 SECONDS, volume = 75))
+		var/datum/effect_system/spark_spread/p = new /datum/effect_system/spark_spread
+		p.set_up(6, 1, user)
+		p.start()
+		unlocked = !unlocked
+		to_chat(user, span_notice("You changed [src] to [unlocked? "unofficial type" : "official type"]."))
 
 /obj/item/circuitboard/machine/plort
 	name = "Plort Redemption Machine (Machine Board)"

--- a/code/modules/mob/living/silicon/ai/decentralized/systech/rack_creator.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/systech/rack_creator.dm
@@ -18,9 +18,15 @@
 
 	var/datum/component/remote_materials/rmat
 	var/efficiency_coeff = 1
-
+	var/datum/techweb/stored_research
 
 /obj/machinery/rack_creator/Initialize(mapload)
+	var/obj/item/circuitboard/machine/rack_creator/rack_creator = circuit
+	if(rack_creator.unlocked)
+		stored_research = SSresearch.ruin_tech
+		desc += " This one is unofficial, you shouldn't let the NT officicals see this."
+	else
+		stored_research = SSresearch.science_tech
 	rmat = AddComponent(/datum/component/remote_materials, "rackcreator", mapload)
 	rmat.set_local_size(200000)
 	RefreshParts()
@@ -104,7 +110,7 @@
 				materials_string += "[M.name]: [D.materials[mat] / efficiency_coeff]"
 			else
 				materials_string += ", [M.name]: [D.materials[mat] / efficiency_coeff]"
-		data["possible_ram"] += list(list("name" = D.name, "capacity" = D.capacity, "cost" = materials_string,"id" = D.id, "unlocked" = SSresearch.science_tech.isDesignResearchedID(D.id) ? TRUE : FALSE))
+		data["possible_ram"] += list(list("name" = D.name, "capacity" = D.capacity, "cost" = materials_string,"id" = D.id, "unlocked" = stored_research.isDesignResearchedID(D.id) ? TRUE : FALSE))
 
 	data["unlocked_ram"] = 1
 	data["unlocked_cpu"] = 1
@@ -192,23 +198,23 @@
 		if(1)
 			. = TRUE
 		if(2)
-			. = SSresearch.science_tech.isNodeResearchedID("ai_cpu_2")
+			. = stored_research.isNodeResearchedID("ai_cpu_2")
 		if(3)
-			. = SSresearch.science_tech.isNodeResearchedID("ai_cpu_3")
+			. = stored_research.isNodeResearchedID("ai_cpu_3")
 
 		if(4)
-			. = SSresearch.science_tech.isNodeResearchedID("ai_cpu_4")
+			. = stored_research.isNodeResearchedID("ai_cpu_4")
 
 /obj/machinery/rack_creator/proc/slotUnlockedRAM(slot_number)
 	switch(slot_number)
 		if(1)
 			. = TRUE
 		if(2)
-			. = SSresearch.science_tech.isNodeResearchedID("ai_ram_2")
+			. = stored_research.isNodeResearchedID("ai_ram_2")
 		if(3)
-			. = SSresearch.science_tech.isNodeResearchedID("ai_ram_3")
+			. = stored_research.isNodeResearchedID("ai_ram_3")
 		if(4)
-			. = SSresearch.science_tech.isNodeResearchedID("ai_ram_4")
+			. = stored_research.isNodeResearchedID("ai_ram_4")
 
 
 /obj/machinery/rack_creator/ui_act(action, params)
@@ -252,7 +258,7 @@
 			var/ram_type = params["ram_type"]
 			if(!ram_type)
 				return
-			var/datum/design/ram/D = SSresearch.science_tech.isDesignResearchedID(ram_type)
+			var/datum/design/ram/D = stored_research.isDesignResearchedID(ram_type)
 			if(!D)
 				return
 			if(slotUnlockedRAM(ram_expansions.len + 1))

--- a/code/modules/mob/living/silicon/ai/decentralized/systech/rack_creator.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/systech/rack_creator.dm
@@ -21,19 +21,18 @@
 	var/datum/techweb/stored_research
 
 /obj/machinery/rack_creator/Initialize(mapload)
-	. = ..()
+	rmat = AddComponent(/datum/component/remote_materials, "rackcreator", mapload)
+	rmat.set_local_size(200000)
+	RefreshParts()
+	return ..()
+
+/obj/machinery/rack_creator/RefreshParts()
 	var/obj/item/circuitboard/machine/rack_creator/rack_creator = circuit
 	if(rack_creator.unlocked)
 		stored_research = SSresearch.ruin_tech
 		desc += " This one is unofficial, you shouldn't let the NT officicals see this."
 	else
 		stored_research = SSresearch.science_tech
-	rmat = AddComponent(/datum/component/remote_materials, "rackcreator", mapload)
-	rmat.set_local_size(200000)
-	RefreshParts()
-
-
-/obj/machinery/rack_creator/RefreshParts()
 	calculate_efficiency()
 
 /obj/machinery/rack_creator/proc/calculate_efficiency()

--- a/code/modules/mob/living/silicon/ai/decentralized/systech/rack_creator.dm
+++ b/code/modules/mob/living/silicon/ai/decentralized/systech/rack_creator.dm
@@ -21,6 +21,7 @@
 	var/datum/techweb/stored_research
 
 /obj/machinery/rack_creator/Initialize(mapload)
+	. = ..()
 	var/obj/item/circuitboard/machine/rack_creator/rack_creator = circuit
 	if(rack_creator.unlocked)
 		stored_research = SSresearch.ruin_tech
@@ -30,7 +31,6 @@
 	rmat = AddComponent(/datum/component/remote_materials, "rackcreator", mapload)
 	rmat.set_local_size(200000)
 	RefreshParts()
-	return ..()
 
 
 /obj/machinery/rack_creator/RefreshParts()


### PR DESCRIPTION
* fix #22425

i forgot about this because back then ai tech was still a testmerge thing


# Testing
![image](https://github.com/user-attachments/assets/d4b7e7c2-e74c-4d6f-866f-749bb165edf2)



# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
 
bugfix: fix unable to research ai tech using ruin type rnd console
bugfix: fix mech fab ruin type unable to be rebuilt
tweak: Allows rack creator to be able to link to ruin research tech by multitooling the rack creator board
tweak: rack creator no longer requires beakers because it doesn't store any chems
/:cl:
