### PR TITLE
[admin] Changes orbit menu section title to mention that you can see all antagonists as admin

### DIFF
--- a/code/modules/mob/dead/observer/orbit.dm
+++ b/code/modules/mob/dead/observer/orbit.dm
@@ -104,6 +104,7 @@
 	data["ghosts"] = ghosts
 	data["misc"] = misc
 	data["npcs"] = npcs
+	data["is_admin"] = is_admin(user)
 	return data
 
 /datum/orbit_menu/ui_assets()

--- a/tgui/packages/tgui/interfaces/Orbit.js
+++ b/tgui/packages/tgui/interfaces/Orbit.js
@@ -84,6 +84,7 @@ export const Orbit = (props, context) => {
     auto_observe,
     dead,
     ghosts,
+    is_admin,
     misc,
     npcs,
   } = data;
@@ -164,7 +165,7 @@ export const Orbit = (props, context) => {
           </Flex>
         </Section>
         {antagonists.length > 0 && (
-          <Section title="Ghost-Visible Antagonists">
+          <Section title={is_admin ? "Antagonists (Admin view)" : "Ghost-Visible Antagonists"}>
             {sortedAntagonists.map(([name, antags]) => (
               <BasicSection
                 key={name}

--- a/tgui/packages/tgui/interfaces/Orbit.js
+++ b/tgui/packages/tgui/interfaces/Orbit.js
@@ -165,7 +165,7 @@ export const Orbit = (props, context) => {
           </Flex>
         </Section>
         {antagonists.length > 0 && (
-          <Section title={is_admin ? "Antagonists (Admin view)" : "Ghost-Visible Antagonists"}>
+          <Section title={is_admin ? "Antagonists" : "Ghost-Visible Antagonists"}>
             {sortedAntagonists.map(([name, antags]) => (
               <BasicSection
                 key={name}


### PR DESCRIPTION
# Document the changes in your pull request

Changes the section title in the orbit menu from "Ghost-visible antagonists" to "Antagonists" while adminned.

# Why is this good for the game?
There is a difference between being able to see all antagonists and ghost-visible antagonists. For example:
Ghost-visible antagonists: Bloodsucker, changeling, heretic, demon of sin, space ninja
Non-ghost visible antagonists: Traitor, blood brother, monster hunter, zombie, fugitives (and fugitive hunters), obsessed

Admins see all of these as "Ghost-visible antagonists" currently, which some of them may not be.

# Testing
While adminned:
![image](https://github.com/user-attachments/assets/d47b129d-f790-4b6e-9cfd-379b79d1f8fd)
While deadminned | not an admin:
![image](https://github.com/user-attachments/assets/20f4b399-a783-4dcd-b0c7-6c73a74cf3c5)

# Changelog

:cl:
tweak: Admin orbit menu now correctly shows Antagonist section title instead of Ghost-visible antagonists.
/:cl:
