### PR TITLE
Personalized Santa gifts!

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -121,11 +121,11 @@
 	if(M.mind && HAS_TRAIT(M.mind, TRAIT_CANNOT_OPEN_PRESENTS))
 		var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 		var/turf/floor = get_turf(src)
-		var/obj/item/I = new /obj/item/a_gift/anything(floor)
-		if(STR.can_be_inserted(I, stop_messages=TRUE))
-			STR.handle_item_insertion(I, prevent_warning=TRUE)
+		var/obj/item/a_gift/anything/personal/new_gift = new(floor)
+		if(STR.can_be_inserted(new_gift, stop_messages=TRUE))
+			STR.handle_item_insertion(new_gift, prevent_warning=TRUE)
 		else
-			qdel(I)
+			qdel(new_gift)
 
 
 /obj/item/storage/backpack/cultpack

--- a/code/modules/clothing/outfits/event.dm
+++ b/code/modules/clothing/outfits/event.dm
@@ -10,7 +10,7 @@
 	gloves = /obj/item/clothing/gloves/color/red
 
 	box = /obj/item/storage/box/survival/engineer
-	backpack_contents = list(/obj/item/a_gift/anything = 5)
+	backpack_contents = list(/obj/item/a_gift/anything/personal = 5)
 
 /datum/outfit/santa/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)


### PR DESCRIPTION
<!-- If this is your first PR, or not, take the time to read our CONTRIBUTING.md file! You can see it here: https://github.com/yogstation13/Yogstation/blob/master/.github/CONTRIBUTING.md
You can remove all headers (Document the changes, Spriting and Wiki documentation) if there is no wiki documentation required but you must still explain what the pr is and why it needs to be added to the game. Directors+ Are immune from this rule in exceptional circumstances. -->

# Document the changes in your pull request

Santa's gifts now fetch a random conscious, cliented, non-Santa crew member and assigns itself to them. If there is no one to choose from, it will be free to claim by anyone, but that shouldn't happen often.

Santa will still be able to see what is inside of the gifts.

<!-- Remove this text and explain what the purpose of your PR is.

Mention if you have tested your changes. If you changed a map, make sure you used the mapmerge tool.
If this is an Issue Correction, you can type "Fixes Issue #169420" to link the PR to the corresponding Issue number #169420.

Prefix the PR title with [admin] if it involves something admin related. 
Prefix the PR title with [s] if you are fixing a game-breaking exploit, so that it is not announced on the Yogstation Discord and the server.

Remember: something that is self-evident to you might not be to others. Explain your rationale fully, even if you feel it goes without saying.-->

# Why is this good for the game?
Minimizes Santa shittery/favoritism. I've always taken issue with Santa being able to see the gifts, as a malicious user could just farm round-breaking gifts and give them to a metafriend. Now Santa has to hunt down people and give them gifts that were actually meant for them instead of just tossing random stuff at people. This also eliminates the phenomenon where people crowd Santa to get powerful items, as now Santa will have to seek out you instead. This also gives further purpose to Santa's teleport, as if he finds where the person works, he can now infiltrate the place of work to get to them faster.
<!-- Describe why you think this change is good for the game. This section is not required for bugfixes. -->

# Testing
![image](https://github.com/user-attachments/assets/2ca9669c-385a-4c44-b65c-106bc14a6aa6)

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
tweak: Santa's gifts now select a random living crew member to be opened by.
/:cl:
