### PR TITLE
Transfer votes

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -141,7 +141,7 @@ SUBSYSTEM_DEF(shuttle)
 	/// Did the supermatter start a cascade event?
 	var/supermatter_cascade = FALSE
 	/// Has any transfer votes been started, ongoing, or finished?
-	var/transfer_votes_done
+	var/transfer_votes_done = 0
 
 /datum/controller/subsystem/shuttle/Initialize(timeofday)
 	order_number = rand(1, 9000)

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -140,6 +140,8 @@ SUBSYSTEM_DEF(shuttle)
 	var/shuttle_loading
 	/// Did the supermatter start a cascade event?
 	var/supermatter_cascade = FALSE
+	/// Has any transfer votes been started, ongoing, or finished?
+	var/transfer_votes_done
 
 /datum/controller/subsystem/shuttle/Initialize(timeofday)
 	order_number = rand(1, 9000)
@@ -239,8 +241,16 @@ SUBSYSTEM_DEF(shuttle)
 				priority_announce("Catastrophic casualties detected: crisis shuttle protocols activated - jamming recall signals across all frequencies.")
 				emergency.request(null, set_coefficient = ALERT_COEFF_AUTOEVAC_CRITICAL)
 				return
-	if(world.time >= 2 HOURS) //auto call the shuttle after 2 hours 
-		emergency_no_recall = TRUE //no recalling after 2 hours
+	if(world.time >= 2 HOURS && transfer_votes_done < 1) 
+		transfer_votes_done += 1
+		if(EMERGENCY_IDLE_OR_RECALLED)
+			SSvote.initiate_vote(/datum/vote/transfer_vote, "automatic crew transfer", forced = TRUE)
+	if(world.time >= 2.5 HOURS && transfer_votes_done < 2)
+		transfer_votes_done += 1
+		if(EMERGENCY_IDLE_OR_RECALLED)
+			SSvote.initiate_vote(/datum/vote/transfer_vote, "automatic crew transfer", forced = TRUE)
+	if(world.time >= 3 HOURS) //auto call the shuttle after 3 hours 
+		emergency_no_recall = TRUE //no recalling after 3 hours
 		if(EMERGENCY_IDLE_OR_RECALLED)
 			var/msg = "Automatically dispatching shuttle due to lack of shift end response."
 			message_admins(msg)

--- a/code/datums/votes/transfer_vote.dm
+++ b/code/datums/votes/transfer_vote.dm
@@ -1,0 +1,43 @@
+#define CHOICE_CALL_SHUTTLE "Call emergency shuttle"
+#define CHOICE_NO_CALL_SHUTTLE "Don't call emergency shuttle"
+
+/datum/vote/transfer_vote
+	name = "Transfer"
+	message = "Vote for whether the emergency shuttle should be called for crew transfer!"
+	default_choices = list(
+		CHOICE_CALL_SHUTTLE,
+		CHOICE_NO_CALL_SHUTTLE
+	)
+	player_startable = FALSE
+	var/transfer_percentage = 60
+	var/result
+
+/datum/vote/transfer_vote/New()
+	. = ..()
+	if(world.time >= 2.5 HOURS)
+		transfer_percentage = 80
+
+/datum/vote/transfer_vote/can_be_initiated(mob/by_who, forced)
+	return TRUE
+
+/datum/vote/transfer_vote/get_vote_result(list/non_voters)
+	RETURN_TYPE(/list)
+	var/list/winners = list()
+	result = choices_by_ckey.len>0 ? (choices[CHOICE_NO_CALL_SHUTTLE]/(choices[CHOICE_CALL_SHUTTLE]+choices[CHOICE_NO_CALL_SHUTTLE]))*100 : 0
+	if(result<=transfer_percentage)
+		winners += CHOICE_CALL_SHUTTLE
+	else
+		winners += CHOICE_NO_CALL_SHUTTLE
+	return winners
+
+/datum/vote/transfer_vote/finalize_vote(winning_option)
+	if(winning_option == CHOICE_CALL_SHUTTLE)
+		priority_announce("Dispatching shuttle for scheduled crew transfer.")
+		message_admins("Shuttle called after successful transfer vote ([result]% voted to stay, requirement is [transfer_percentage]%)")
+		SSshuttle.emergency_no_recall = TRUE //No, you aren't allowed to reverse a vote
+		SSshuttle.emergency.request(null)
+	else
+		message_admins("Transfer vote failed ([result]% voted to stay, requirement is [transfer_percentage]%)")
+
+#undef CHOICE_CALL_SHUTTLE
+#undef CHOICE_NO_CALL_SHUTTLE

--- a/code/datums/votes/transfer_vote.dm
+++ b/code/datums/votes/transfer_vote.dm
@@ -18,6 +18,7 @@
 		transfer_percentage = 80
 
 /datum/vote/transfer_vote/can_be_initiated(mob/by_who, forced)
+	. = ..()
 	return TRUE
 
 /datum/vote/transfer_vote/get_vote_result(list/non_voters)

--- a/code/datums/votes/transfer_vote.dm
+++ b/code/datums/votes/transfer_vote.dm
@@ -17,10 +17,6 @@
 	if(world.time >= 2.5 HOURS)
 		transfer_percentage = 80
 
-/datum/vote/transfer_vote/can_be_initiated(mob/by_who, forced)
-	. = ..()
-	return TRUE
-
 /datum/vote/transfer_vote/get_vote_result(list/non_voters)
 	RETURN_TYPE(/list)
 	var/list/winners = list()

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -924,6 +924,7 @@
 #include "code\datums\votes\map_vote.dm"
 #include "code\datums\votes\restart_vote.dm"
 #include "code\datums\votes\rock_the_vote.dm"
+#include "code\datums\votes\transfer_vote.dm"
 #include "code\datums\votes\wanna_do_vote.dm"
 #include "code\datums\weather\weather.dm"
 #include "code\datums\weather\weather_types\acid_rain.dm"


### PR DESCRIPTION
# Document the changes in your pull request

Adds transfer votes, which will trigger at 2 hours and 2 hours 30 respectively, polling all players on whether to call the emergency shuttle. Moved shuttle autocall to 3 hours.

At 2 hours, percentage required to stay is 60%
At 2 hours 30 mins, percentage required to stay is 80%

# Why is this good for the game?
At the moment, autocall prevents anyone from doing anything past 2 hours, which in my opinion is restrictive if you want to do something past that, or figured out something that you want to do around 1 hour 30 mins, but because it takes an hour to do, you'd have to wait for the next round to do it.

Transfer votes allows all players on the server (including ghosts and dead players) to decide whether to choose whether they want to continue the round or start a new one.

# Testing
<details>
<summary>Shuttle calling after transfer vote</summary>
<img src="https://github.com/user-attachments/assets/07b1044e-84c8-4ef6-858e-04ded64e3dec"/>
</details>
<details>
<summary>Shuttle not calling after transfer vote</summary>
<img src="https://github.com/user-attachments/assets/89fa3813-efdf-4f12-837a-2840937094cd"/>
</details>
<details>
<summary>If no one votes, calls shuttle anyway</summary>
<img src="https://github.com/user-attachments/assets/73909f9c-508e-4af0-bf48-459285012fa7"/>
</details>
<details>
<summary>Vote menu (accessible to ghosts)</summary>
<img src="https://github.com/user-attachments/assets/ecedf019-0518-435e-8ab4-427f9140f6af"/>
</details>
<details>
<summary>Transfer vote in create vote menu (non-admins can't make one)</summary>
<img src="https://github.com/user-attachments/assets/cf6a19bc-d05c-433e-9f6f-3df884e7757a"/>
</details>


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
rscadd: Added crew transfer votes.
tweak: Shuttle autocall will now trigger at 3 hours.
/:cl:
