### PR TITLE
Reenables night shift lighting in the config

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -524,7 +524,7 @@ ROUNDSTART_TRAITS
 #DISABLE_HUMAN_MOOD
 
 ## Enable night shifts ##
-#ENABLE_NIGHT_SHIFTS
+ENABLE_NIGHT_SHIFTS
 
 ## Enable randomized shift start times##
 #RANDOMIZE_SHIFT_TIME


### PR DESCRIPTION
# Document the changes in your pull request

Reenables night shift lighting subsystem in the config (even though I remember it working in the past but it's been disabled all this time?).

# Why is this good for the game?
We used to have this previously, although for unknown reasons it stopped on the server, no idea what that was about.

# Testing
<details>
<summary>Night shift lighting working (Ministation)</summary>
<img src="https://github.com/user-attachments/assets/513abd6d-9ff1-4e78-9108-d487a6acec50"/>
</details>
<details>
<summary>Night shift lighting turning on</summary>
<img src="https://github.com/user-attachments/assets/ce084b75-310c-424d-b893-64ecf565db0a" />
</details>
<details>
<summary>Night shift lighting disabling due to emergency</summary>
<img src="https://github.com/user-attachments/assets/2ee572f7-2dd4-4105-a346-01456fa83362"/>
</details>
<details>
<summary>Night shift reenabling due to emergency subsiding</summary>
<img src="https://github.com/user-attachments/assets/587ebf94-7bf9-4d69-a3b0-00a933d31243"/>
</details>
<details>
<summary>Night shift lighting turning off</summary>
<img src="https://github.com/user-attachments/assets/401ce2a2-972e-4f61-a21e-471716ef0f6f"/>
</details>



# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
bugfix: Night shift lighting will now operate again.
/:cl:
