### PR TITLE
Tesla zaps no longer destroys unanchored tesla coils, they still however can be zapped but they won't receive any power and they can also emit another zap to shock you

### DIFF
--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -89,15 +89,16 @@
 	return ..()
 
 /obj/machinery/power/tesla_coil/tesla_act(power, tesla_flags, shocked_targets, zap_gib = FALSE)
-	if(anchored && !panel_open)
+	if(!panel_open)
+		if(anchored)
+			stored_power += power
+			if(istype(linked_account))
+				linked_account.adjust_money(money_per_zap)
+			if(istype(linked_techweb))
+				linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, research_points_per_zap)
 		obj_flags |= BEING_SHOCKED
-		stored_power += power
 		flick("[base_icon_state]hit", src)
 		playsound(src.loc, 'sound/magic/lightningshock.ogg', 100, 1, extrarange = 5)
-		if(istype(linked_account))
-			linked_account.adjust_money(money_per_zap)
-		if(istype(linked_techweb))
-			linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, research_points_per_zap)
 		addtimer(CALLBACK(src, PROC_REF(reset_shocked)), zap_cooldown)
 		tesla_buckle_check(power)
 	else

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -96,6 +96,8 @@
 				linked_account.adjust_money(money_per_zap)
 			if(istype(linked_techweb))
 				linked_techweb.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, research_points_per_zap)
+		else
+			tesla_zap(src, 3, power, tesla_flags, shocked_targets, zap_gib)
 		obj_flags |= BEING_SHOCKED
 		flick("[base_icon_state]hit", src)
 		playsound(src.loc, 'sound/magic/lightningshock.ogg', 100, 1, extrarange = 5)


### PR DESCRIPTION
# Document the changes in your pull request
Tesla zaps no longer destroys unanchored tesla coils, they still however can be zapped but they won't receive any power and they can also emit another zap to shock you

# Why is this good for the game?
Allows you to be able to build more tesla coils around the tesla ball without them being broken, also you can't cheat this without grounding rod because tesla coils have zap cooldowns, meaning while in cooldown the next tesla zap can shock you

# Testing


https://github.com/user-attachments/assets/c091ccbc-b7d2-466a-aa73-06392bc01d67




# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:

tweak: Tesla zaps no longer destroys unanchored tesla coils, they still however can be zapped but they won't receive any power and they can also emit another zap to shock you
/:cl:
