### PR TITLE
fix no damage projectiles from damaging stuffs with integrity

### DIFF
--- a/code/game/atom/_atom.dm
+++ b/code/game/atom/_atom.dm
@@ -424,7 +424,7 @@
 	if(uses_integrity)
 		playsound(src, P.hitsound, 50, 1)
 		visible_message(span_danger("[src] is hit by \a [P]!"), null, null, COMBAT_MESSAGE_RANGE)
-		if(!QDELETED(src)) //Bullet on_hit effect might have already destroyed this object
+		if(!QDELETED(src) && !P.nodamage) //Bullet on_hit effect might have already destroyed this object
 			take_damage(P.damage * P.demolition_mod, P.damage_type, P.armor_flag, 0, turn(P.dir, 180), P.armour_penetration)
 
 ///Return true if we're inside the passed in atom


### PR DESCRIPTION
example of this issue: rad collector being damaged by rad particles



# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:

bugfix: fix no damage projectiles from damaging stuffs with integrity
/:cl:
