### PR TITLE
Fixes the tar king altar never spawning + slightly more tar

### DIFF
--- a/yogstation/code/datums/mapgen/JungleGen.dm
+++ b/yogstation/code/datums/mapgen/JungleGen.dm
@@ -28,7 +28,7 @@
 						),
 
 		BIOME_TOXIC = list(	
-						LOW_HUMIDITY = /datum/biome/jungleland/toxic_pit,
+						LOW_HUMIDITY = /datum/biome/jungleland/tar_wastes,
 						MED_HUMIDITY = /datum/biome/jungleland/toxic_pit,
 						HIGH_HUMIDITY = /datum/biome/jungleland/jungle
 						)
@@ -253,7 +253,7 @@
 	var/toxic_string = rustg_dbp_generate("[toxic_seed]","60","75","[world.maxx]","-0.05","1.1")
 	var/list/humid_strings = list()
 	humid_strings[HIGH_HUMIDITY] = rustg_dbp_generate("[humid_seed]","60","75","[world.maxx]","-0.1","1.1")
-	humid_strings[MED_HUMIDITY] = rustg_dbp_generate("[humid_seed]","60","75","[world.maxx]","-0.3","-0.1")
+	humid_strings[MED_HUMIDITY] = rustg_dbp_generate("[humid_seed]","60","75","[world.maxx]","-0.35","-0.1")
 
 	for(var/t in turfs) //Go through all the turfs and generate them
 		var/turf/gen_turf = t

--- a/yogstation/code/datums/ruins/jungle.dm
+++ b/yogstation/code/datums/ruins/jungle.dm
@@ -69,6 +69,18 @@
 	suffix = "tar_enchant.dmm"	
 	cost = 5
 
+/**
+ * Megafauna
+ */
+/datum/map_template/ruin/jungle/all/tar_king_phylactery
+	name = "Tar King's Phylactery"
+	id = "jungle-tar-king"
+	description = "In this place lies the core of this world's cancer. \
+		Resting deep within the obsidian, sealed under an altar untouched by time, it awaits the day it will finally take form."
+	suffix = "jungleland_tar_king.dmm"
+	always_place = TRUE
+	cost = 0
+
 ////////////////////////////////////////////////////////////////////////////////////
 //-------------------------------Jungle biome-------------------------------------//
 ////////////////////////////////////////////////////////////////////////////////////
@@ -280,15 +292,3 @@
 	suffix = "jungleland_barren_nest.dmm"	
 	allow_duplicates = TRUE 
 	always_place = TRUE
-
-/**
- * Megafauna
- */
-/datum/map_template/ruin/jungle/tar/tar_king_phylactery
-	name = "Tar King's Phylactery"
-	id = "jungle-tar-king"
-	description = "In this place lies the core of this world's cancer. \
-		Resting deep within the obsidian, sealed under an altar untouched by time, it awaits the day it will finally take form."
-	suffix = "jungleland_tar_king.dmm"
-	always_place = TRUE
-	cost = 0


### PR DESCRIPTION
I never quite figured out how jungleland spawning works, but it seems to be unable to spawn the tar king altar after biomes are placed
During a previous jungleland pr, i had intended to make it only ever spawn in the tar biome, however, this wasn't working and I didn't catch it at the time

I've also made the tar biome slightly larger to compensate for it being the only source of jungleland mobs

# Testing
![image](https://github.com/user-attachments/assets/46a68148-e839-46ff-b7f9-ca08395134d1)

:cl:
bugfix: Fixes the tar king altar never spawning
tweak: Makes the tar biome slightly more common
/:cl:
