### PR TITLE
adds back break bow, runes , magic arrow and ranger cloak to wizard and removes embed from break bow

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -403,3 +403,13 @@
 			new /mob/living/simple_animal/hostile/retaliate/goat/plunger(loc)
 		if(40)
 			new /mob/living/simple_animal/hostile/retaliate/goat/suspicious(loc)
+
+/obj/structure/closet/crate/BreakBow
+	name = "BreakBow Crate"
+	desc = "This crate contains a break bow and quiver"
+
+
+/obj/structure/closet/crate/BreakBow/PopulateContents()
+
+			new /obj/item/storage/belt/quiver/unlimited(src)
+			new /obj/item/gun/ballistic/bow/break_bow(src)

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/defensive.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/defensive.dm
@@ -143,3 +143,10 @@
 	item_path = /obj/item/wizard_armour_charge
 	category = "Defensive"
 	cost = 1
+
+/datum/spellbook_entry/item/ranger_cloak
+	name = "Ranger Cloak"
+	desc = "A cape that makes the wearer quickly invisible while standing still, permitting them to dodge ranged attacks. Moving or dodging projectiles reduces the effect."
+	item_path = /obj/item/clothing/neck/cloak/ranger
+	cost = 2
+	category = "Defensive"

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/offensive.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/offensive.dm
@@ -133,3 +133,24 @@
 	item_path = /obj/item/vibro_weapon/wizard
 	category = "Offensive"
 	cost = 3
+
+/datum/spellbook_entry/item/breakbow
+	name = "Break Bow"
+	desc = "A bladed bow that can be split into two swords which attack simultaneously as well as return to their thrower. Comes with a quiver of unlimited, powerful arrows."
+	item_path = /obj/structure/closet/crate/BreakBow
+	category = "Offensive"
+	cost = 2
+
+/datum/spellbook_entry/magic_arrows
+	name = "Summon Magic Arrows"
+	desc =" summons  magic arrows"
+	spell_type = /datum/action/cooldown/spell/conjure_item/arrow/magic
+	category = "Offensive"
+	cost = 1
+
+/datum/spellbook_entry/item/rune_crate
+	name = "Rune Crate"
+	desc = "A wizard specialized in runecrafting, is offering a chest full of runes! The problem is, he mixed them up so you won't know what you will get!"
+	item_path = /obj/structure/closet/crate/magic
+	category = "Offensive"
+	cost = 1

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/offensive.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/offensive.dm
@@ -143,7 +143,7 @@
 
 /datum/spellbook_entry/magic_arrows
 	name = "Summon Magic Arrows"
-	desc =" summons  magic arrows"
+	desc ="A spell that summons a homing arrow in the user's hand, ready to be shot out of a bow that quickly becomes dull after hitting something.Can be quickly casted by pressing the 'quick-equip' key on an empty hand"
 	spell_type = /datum/action/cooldown/spell/conjure_item/arrow/magic
 	category = "Offensive"
 	cost = 1

--- a/code/modules/antagonists/wizard/equipment/spellbook_entries/offensive.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook_entries/offensive.dm
@@ -143,7 +143,7 @@
 
 /datum/spellbook_entry/magic_arrows
 	name = "Summon Magic Arrows"
-	desc ="A spell that summons a homing arrow in the user's hand, ready to be shot out of a bow that quickly becomes dull after hitting something.Can be quickly casted by pressing the 'quick-equip' key on an empty hand"
+	desc ="A spell that summons a homing arrow in the user's hand, ready to be shot out of a bow that quickly becomes dull after hitting something. Can be quickly casted by pressing the 'quick-equip' key on an empty hand"
 	spell_type = /datum/action/cooldown/spell/conjure_item/arrow/magic
 	category = "Offensive"
 	cost = 1

--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -333,7 +333,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/swords_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 10, "embedded_fall_chance" = 10, "embedded_ignore_throwspeed_threshold" = TRUE)
+	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 0, "embedded_fall_chance" = 10, "embedded_ignore_throwspeed_threshold" = TRUE)
 	force = 27 //Total of 54 damage = death in two clicks (probably) PLUS it doesn't care about anti-magic
 	throwforce = 45 //Can't return if it hits anti-magic
 	armour_penetration = 50 //Enchanted blade of fuck you


### PR DESCRIPTION


# Document the changes in your pull request
adds back runes, breakbow, magic arrow and ranger cloak to wizard spell book and removes embed chance of break bow blades
makes rune chest only give 1 chest instead of 2 





# Why is this good for the game?
<!-- Describe why you think this change is good for the game. This section is not required for bugfixes. -->
 meant for wizard to have but they dont have them




# Wiki Documentation

mention that rune chest only gives 1 chest now

# Changelog


:cl:
rscadd: Added break bow, runes  magic arrow and ranger cloak back to wizard spellbook
tweak: removed embed chance on break bow blades 
tweak: rune chest now only gives 1 chest instead of 2
/:cl:
