### PR TITLE
[Admin] edits the gamemode panel to show a storyteller's description

### DIFF
--- a/yogstation/code/modules/storytellers/gamemode_subsystem.dm
+++ b/yogstation/code/modules/storytellers/gamemode_subsystem.dm
@@ -894,13 +894,13 @@ SUBSYSTEM_DEF(gamemode)
 
 	var/round_started = SSticker.HasRoundStarted()
 	var/list/dat = list()	
-	dat += "<font color='#888888'><i>Storyteller determines points gained, event chances, and is the entity responsible for rolling events.</i></font>"
 	dat += "<BR><a href='?src=[REF(src)];panel=main;action=halt_storyteller' [halted_storyteller ? "class='linkOn'" : ""]>HALT Storyteller</a> <a href='?src=[REF(src)];panel=main;action=open_stats'>Event Panel</a> <a href='?src=[REF(src)];panel=main;action=set_storyteller'>Set Storyteller</a> <a href='?src=[REF(src)];panel=main'>Refresh</a>"
 	if(storyteller)
 		dat += "<BR>Storyteller: [storyteller.name]"
 		dat += "<BR>Description: [storyteller.desc]"
 	else
 		dat += "<BR><b>No Storyteller Selected</b>"
+	dat += "<font color='#888888'><i>Storyteller determines points gained, event chances, and is the entity responsible for rolling events.</i></font>"
 	dat += "<BR>Active Players: [active_players]   (Head: [head_crew], Sec: [sec_crew], Eng: [eng_crew], Med: [med_crew])"
 	dat += "<BR>Antagonist Count vs Maximum: [total_valid_antags] / [get_antag_cap()]"
 	dat += "<HR>"

--- a/yogstation/code/modules/storytellers/gamemode_subsystem.dm
+++ b/yogstation/code/modules/storytellers/gamemode_subsystem.dm
@@ -893,10 +893,14 @@ SUBSYSTEM_DEF(gamemode)
 		total_valid_antags++
 
 	var/round_started = SSticker.HasRoundStarted()
-	var/list/dat = list()
-	dat += "Storyteller: [storyteller ? "[storyteller.name]" : "None"] "
-	dat += " <a href='?src=[REF(src)];panel=main;action=halt_storyteller' [halted_storyteller ? "class='linkOn'" : ""]>HALT Storyteller</a> <a href='?src=[REF(src)];panel=main;action=open_stats'>Event Panel</a> <a href='?src=[REF(src)];panel=main;action=set_storyteller'>Set Storyteller</a> <a href='?src=[REF(src)];panel=main'>Refresh</a>"
-	dat += "<BR><font color='#888888'><i>Storyteller determines points gained, event chances, and is the entity responsible for rolling events.</i></font>"
+	var/list/dat = list()	
+	dat += "<font color='#888888'><i>Storyteller determines points gained, event chances, and is the entity responsible for rolling events.</i></font>"
+	dat += "<BR><a href='?src=[REF(src)];panel=main;action=halt_storyteller' [halted_storyteller ? "class='linkOn'" : ""]>HALT Storyteller</a> <a href='?src=[REF(src)];panel=main;action=open_stats'>Event Panel</a> <a href='?src=[REF(src)];panel=main;action=set_storyteller'>Set Storyteller</a> <a href='?src=[REF(src)];panel=main'>Refresh</a>"
+	if(storyteller)
+		dat += "<BR>Storyteller: [storyteller.name]"
+		dat += "<BR>Description: [storyteller.desc]"
+	else
+		dat += "<BR><b>No Storyteller Selected</b>"
 	dat += "<BR>Active Players: [active_players]   (Head: [head_crew], Sec: [sec_crew], Eng: [eng_crew], Med: [med_crew])"
 	dat += "<BR>Antagonist Count vs Maximum: [total_valid_antags] / [get_antag_cap()]"
 	dat += "<HR>"


### PR DESCRIPTION
# Testing
edits the gamemode panel to show a storyteller's description
![image](https://github.com/user-attachments/assets/1de6ec19-63e9-4a0a-905e-b8bc51b4e43f)
![image](https://github.com/user-attachments/assets/29ea0d27-3975-4594-96ab-1374a0afe522)

do admins count as players? if not, then there's nothing player facing

:cl:
/:cl:
