### PR TITLE
Couple darkspawn bugfixes

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -205,7 +205,7 @@
 
 /datum/species/shadow/darkspawn/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()
-	C.fully_replace_character_name("[C.real_name]", darkspawn_name())
+	C.fully_replace_character_name(null, darkspawn_name())
 
 /datum/species/shadow/darkspawn/spec_updatehealth(mob/living/carbon/human/H)
 	var/datum/antagonist/darkspawn/antag = isdarkspawn(H)

--- a/yogstation/code/modules/storytellers/converted_events/solo/darkspawn.dm
+++ b/yogstation/code/modules/storytellers/converted_events/solo/darkspawn.dm
@@ -16,6 +16,8 @@
 		JOB_SECURITY_OFFICER,
 		JOB_WARDEN,
 		JOB_BRIG_PHYSICIAN,
+		JOB_CHIEF_ENGINEER,
+		JOB_RESEARCH_DIRECTOR
 	)
 	required_enemies = 3
 	enemy_roles = list(
@@ -25,6 +27,7 @@
 		JOB_SECURITY_OFFICER,
 		JOB_WARDEN,
 		JOB_CHAPLAIN,
+		JOB_CHIEF_ENGINEER
 	)
 	base_antags = 2
 	maximum_antags = 4


### PR DESCRIPTION
Forgot to add two other heads to prevented roles
Also, it fully renamed them, which isn't ideal


:cl:
bugfix: Darkspawns can no longer be CE or RD
bugfix: Divulging no longer changes their name on crew manifest
Tweak: Existence of a CE counts as security for the purpose of spawning a darkspawn
/:cl:
