### PR TITLE
Gives Clowns + Mimes roundstart access to maints

### DIFF
--- a/code/modules/jobs/job_types/clown.dm
+++ b/code/modules/jobs/job_types/clown.dm
@@ -12,8 +12,7 @@
 
 	alt_titles = list("Entertainer", "Comedian", "Jester", "Improv Artist")
 
-	added_access = list(ACCESS_MAINT_TUNNELS)
-	base_access = list(ACCESS_SERVICE, ACCESS_THEATRE)
+	base_access = list(ACCESS_SERVICE, ACCESS_THEATRE, ACCESS_MAINT_TUNNELS)
 
 	paycheck = PAYCHECK_MINIMAL
 	paycheck_department = ACCOUNT_SRV

--- a/code/modules/jobs/job_types/mime.dm
+++ b/code/modules/jobs/job_types/mime.dm
@@ -12,8 +12,7 @@
 
 	alt_titles = list("Mute Entertainer", "Silent Jokester", "Pantomimist")
 
-	added_access = list(ACCESS_MAINT_TUNNELS)
-	base_access = list(ACCESS_SERVICE, ACCESS_THEATRE)
+	base_access = list(ACCESS_SERVICE, ACCESS_THEATRE, ACCESS_MAINT_TUNNELS)
 	paycheck = PAYCHECK_MINIMAL
 	paycheck_department = ACCOUNT_SRV
 


### PR DESCRIPTION
# Document the changes in your pull request

Changes mimes/clowns having skeleton crew maint access to base level access

# Why is this good for the game?

its funny

# Changelog

:cl:

tweak: Adjusts clown/mime access  

/:cl:
