### PR TITLE
Disables split personality trauma

### DIFF
--- a/code/_globalvars/lists/poll_ignore.dm
+++ b/code/_globalvars/lists/poll_ignore.dm
@@ -44,7 +44,7 @@ GLOBAL_LIST_INIT(poll_ignore_desc, list(
 	POLL_IGNORE_PYROSLIME = "Slime",
 	POLL_IGNORE_SHADE = "Shade",
 	POLL_IGNORE_IMAGINARYFRIEND = "Imaginary Friend",
-	POLL_IGNORE_SPLITPERSONALITY = "Split Personality",
+	// POLL_IGNORE_SPLITPERSONALITY = "Split Personality",
 	POLL_IGNORE_CONTRACTOR_SUPPORT = "Contractor Support Unit",
 	POLL_IGNORE_RAGINMAGES = "Raging Mages"
 ))

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -182,11 +182,11 @@
 // 	if(_codeword)
 // 		codeword = _codeword
 // 	else
-// 		codeword = pick(strings("ion_laws.json", "ionabstract")\
-// 			| strings("ion_laws.json", "ionobjects")\
-// 			| strings("ion_laws.json", "ionadjectives")\
-// 			| strings("ion_laws.json", "ionthreats")\
-// 			| strings("ion_laws.json", "ionfood")\
+// 		codeword = pick(strings("ion_laws.json", "ionabstract")
+// 			| strings("ion_laws.json", "ionobjects")
+// 			| strings("ion_laws.json", "ionadjectives")
+// 			| strings("ion_laws.json", "ionthreats")
+// 			| strings("ion_laws.json", "ionfood")
 // 			| strings("ion_laws.json", "iondrinks"))
 
 // /datum/brain_trauma/severe/split_personality/brainwashing/on_gain()

--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -1,242 +1,242 @@
-#define OWNER 0
-#define STRANGER 1
+// #define OWNER 0
+// #define STRANGER 1
 
-/datum/brain_trauma/severe/split_personality
-	name = "Split Personality"
-	desc = "Patient's brain is split into two personalities, which randomly switch control of the body."
-	scan_desc = "complete lobe separation"
-	gain_text = span_warning("You feel like your mind was split in two.")
-	lose_text = span_notice("You feel alone again.")
-	var/current_controller = OWNER
-	var/initialized = FALSE //to prevent personalities deleting themselves while we wait for ghosts
-	var/mob/living/split_personality/stranger_backseat //there's two so they can swap without overwriting
-	var/mob/living/split_personality/owner_backseat
+// /datum/brain_trauma/severe/split_personality
+// 	name = "Split Personality"
+// 	desc = "Patient's brain is split into two personalities, which randomly switch control of the body."
+// 	scan_desc = "complete lobe separation"
+// 	gain_text = span_warning("You feel like your mind was split in two.")
+// 	lose_text = span_notice("You feel alone again.")
+// 	var/current_controller = OWNER
+// 	var/initialized = FALSE //to prevent personalities deleting themselves while we wait for ghosts
+// 	var/mob/living/split_personality/stranger_backseat //there's two so they can swap without overwriting
+// 	var/mob/living/split_personality/owner_backseat
 
-/datum/brain_trauma/severe/split_personality/on_gain()
-	var/mob/living/M = owner
-	if(M.stat == DEAD || !M.client) //No use assigning people to a corpse or braindead
-		qdel(src)
-		return
-	..()
-	make_backseats()
-	get_ghost()
+// /datum/brain_trauma/severe/split_personality/on_gain()
+// 	var/mob/living/M = owner
+// 	if(M.stat == DEAD || !M.client) //No use assigning people to a corpse or braindead
+// 		qdel(src)
+// 		return
+// 	..()
+// 	make_backseats()
+// 	get_ghost()
 
-/datum/brain_trauma/severe/split_personality/proc/make_backseats()
-	stranger_backseat = new(owner, src)
-	var/datum/action/cooldown/spell/personality_commune/stranger_spell = new(src)
-	stranger_spell.Grant(stranger_backseat)
-	stranger_backseat.copy_languages(owner)
+// /datum/brain_trauma/severe/split_personality/proc/make_backseats()
+// 	stranger_backseat = new(owner, src)
+// 	var/datum/action/cooldown/spell/personality_commune/stranger_spell = new(src)
+// 	stranger_spell.Grant(stranger_backseat)
+// 	stranger_backseat.copy_languages(owner)
 
-	owner_backseat = new(owner, src)
-	var/datum/action/cooldown/spell/personality_commune/owner_spell = new(src)
-	owner_spell.Grant(owner_backseat)
-	owner_backseat.copy_languages(owner)
-
-
-/datum/brain_trauma/severe/split_personality/proc/get_ghost()
-	set waitfor = FALSE
-	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as [owner]'s split personality?", ROLE_PAI, null, null, 75, stranger_backseat, POLL_IGNORE_SPLITPERSONALITY)
-	if(LAZYLEN(candidates))
-		var/mob/dead/observer/C = pick(candidates)
-		stranger_backseat.key = C.key
-		log_game("[key_name(stranger_backseat)] became [key_name(owner)]'s split personality.")
-		message_admins("[ADMIN_LOOKUPFLW(stranger_backseat)] became [ADMIN_LOOKUPFLW(owner)]'s split personality.")
-	else
-		qdel(src)
-
-/datum/brain_trauma/severe/split_personality/on_life()
-	if(owner.stat == DEAD)
-		if(current_controller != OWNER)
-			switch_personalities(TRUE)
-		qdel(src)
-	else if(prob(3))
-		switch_personalities()
-	..()
-
-/datum/brain_trauma/severe/split_personality/on_lose()
-	if(current_controller != OWNER) //it would be funny to cure a guy only to be left with the other personality, but it seems too cruel
-		switch_personalities(TRUE)
-	QDEL_NULL(stranger_backseat)
-	QDEL_NULL(owner_backseat)
-	..()
-
-/datum/brain_trauma/severe/split_personality/proc/switch_personalities(reset_to_owner = FALSE)
-	if(QDELETED(owner)|| QDELETED(stranger_backseat) || QDELETED(owner_backseat))
-		return
-
-	var/mob/living/split_personality/current_backseat
-	var/mob/living/split_personality/new_backseat
-	if(current_controller == STRANGER || reset_to_owner)
-		current_backseat = owner_backseat
-		new_backseat = stranger_backseat
-	else
-		current_backseat = stranger_backseat
-		new_backseat = owner_backseat
-
-	if(!current_backseat.client) //Make sure we never switch to a logged off mob.
-		return
-
-	log_game("[key_name(current_backseat)] assumed control of [key_name(owner)] due to [src]. (Original owner: [current_controller == OWNER ? owner.key : current_backseat.key])")
-	to_chat(owner, span_userdanger("You feel your control being taken away... your other personality is in charge now!"))
-	to_chat(current_backseat, span_userdanger("You manage to take control of your body!"))
-
-	//Body to backseat
-
-	var/h2b_id = owner.computer_id
-	var/h2b_ip= owner.lastKnownIP
-	owner.computer_id = null
-	owner.lastKnownIP = null
-
-	new_backseat.ckey = owner.ckey
-
-	new_backseat.name = owner.name
-
-	if(owner.mind)
-		new_backseat.mind = owner.mind
-
-	if(!new_backseat.computer_id)
-		new_backseat.computer_id = h2b_id
-
-	if(!new_backseat.lastKnownIP)
-		new_backseat.lastKnownIP = h2b_ip
-
-	if(reset_to_owner && new_backseat.mind)
-		new_backseat.ghostize(FALSE)
-
-	//Backseat to body
-
-	var/s2h_id = current_backseat.computer_id
-	var/s2h_ip= current_backseat.lastKnownIP
-	current_backseat.computer_id = null
-	current_backseat.lastKnownIP = null
-
-	owner.ckey = current_backseat.ckey
-	owner.mind = current_backseat.mind
-
-	if(!owner.computer_id)
-		owner.computer_id = s2h_id
-
-	if(!owner.lastKnownIP)
-		owner.lastKnownIP = s2h_ip
-
-	current_controller = !current_controller
+// 	owner_backseat = new(owner, src)
+// 	var/datum/action/cooldown/spell/personality_commune/owner_spell = new(src)
+// 	owner_spell.Grant(owner_backseat)
+// 	owner_backseat.copy_languages(owner)
 
 
-/mob/living/split_personality
-	name = "split personality"
-	real_name = "unknown conscience"
-	var/mob/living/carbon/body
-	var/datum/brain_trauma/severe/split_personality/trauma
+// /datum/brain_trauma/severe/split_personality/proc/get_ghost()
+// 	set waitfor = FALSE
+// 	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as [owner]'s split personality?", ROLE_PAI, null, null, 75, stranger_backseat, POLL_IGNORE_SPLITPERSONALITY)
+// 	if(LAZYLEN(candidates))
+// 		var/mob/dead/observer/C = pick(candidates)
+// 		stranger_backseat.key = C.key
+// 		log_game("[key_name(stranger_backseat)] became [key_name(owner)]'s split personality.")
+// 		message_admins("[ADMIN_LOOKUPFLW(stranger_backseat)] became [ADMIN_LOOKUPFLW(owner)]'s split personality.")
+// 	else
+// 		qdel(src)
 
-/mob/living/split_personality/Initialize(mapload, _trauma)
-	if(iscarbon(loc))
-		body = loc
-		name = body.real_name
-		real_name = body.real_name
-		trauma = _trauma
-	return ..()
+// /datum/brain_trauma/severe/split_personality/on_life()
+// 	if(owner.stat == DEAD)
+// 		if(current_controller != OWNER)
+// 			switch_personalities(TRUE)
+// 		qdel(src)
+// 	else if(prob(3))
+// 		switch_personalities()
+// 	..()
 
-/mob/living/split_personality/Life(seconds_per_tick = SSMOBS_DT, times_fired)
-	if(QDELETED(body))
-		qdel(src) //in case trauma deletion doesn't already do it
+// /datum/brain_trauma/severe/split_personality/on_lose()
+// 	if(current_controller != OWNER) //it would be funny to cure a guy only to be left with the other personality, but it seems too cruel
+// 		switch_personalities(TRUE)
+// 	QDEL_NULL(stranger_backseat)
+// 	QDEL_NULL(owner_backseat)
+// 	..()
 
-	if((body.stat == DEAD && trauma.owner_backseat == src))
-		trauma.switch_personalities()
-		qdel(trauma)
+// /datum/brain_trauma/severe/split_personality/proc/switch_personalities(reset_to_owner = FALSE)
+// 	if(QDELETED(owner)|| QDELETED(stranger_backseat) || QDELETED(owner_backseat))
+// 		return
 
-	//if one of the two ghosts, the other one stays permanently
-	if(!body.client && trauma.initialized)
-		trauma.switch_personalities()
-		qdel(trauma)
+// 	var/mob/living/split_personality/current_backseat
+// 	var/mob/living/split_personality/new_backseat
+// 	if(current_controller == STRANGER || reset_to_owner)
+// 		current_backseat = owner_backseat
+// 		new_backseat = stranger_backseat
+// 	else
+// 		current_backseat = stranger_backseat
+// 		new_backseat = owner_backseat
 
-	..()
+// 	if(!current_backseat.client) //Make sure we never switch to a logged off mob.
+// 		return
 
-/mob/living/split_personality/Login()
-	. = ..()
-	if(!. || !client)
-		return FALSE
-	to_chat(src, span_notice("As a split personality, you cannot do anything but observe. However, you will eventually gain control of your body, switching places with the current personality."))
-	to_chat(src, span_warning("<b>Do not commit suicide or put the body in a deadly position. Behave like you care about it as much as the owner.</b>"))
+// 	log_game("[key_name(current_backseat)] assumed control of [key_name(owner)] due to [src]. (Original owner: [current_controller == OWNER ? owner.key : current_backseat.key])")
+// 	to_chat(owner, span_userdanger("You feel your control being taken away... your other personality is in charge now!"))
+// 	to_chat(current_backseat, span_userdanger("You manage to take control of your body!"))
 
-/mob/living/split_personality/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
-	to_chat(src, span_warning("You cannot speak, your other self is controlling your body!"))
-	return FALSE
+// 	//Body to backseat
 
-/mob/living/split_personality/emote(act, m_type = null, message = null, intentional = FALSE, is_keybind = FALSE)
-	return FALSE
+// 	var/h2b_id = owner.computer_id
+// 	var/h2b_ip= owner.lastKnownIP
+// 	owner.computer_id = null
+// 	owner.lastKnownIP = null
 
-///////////////BRAINWASHING////////////////////
+// 	new_backseat.ckey = owner.ckey
 
-/datum/brain_trauma/severe/split_personality/brainwashing
-	name = "Split Personality"
-	desc = "Patient's brain is split into two personalities, which randomly switch control of the body."
-	scan_desc = "complete lobe separation"
-	gain_text = ""
-	lose_text = span_notice("You are free of your brainwashing.")
-	can_gain = FALSE
-	var/codeword
-	var/objective
+// 	new_backseat.name = owner.name
 
-/datum/brain_trauma/severe/split_personality/brainwashing/New(obj/item/organ/brain/B, _permanent, _codeword, _objective)
-	..()
-	if(_codeword)
-		codeword = _codeword
-	else
-		codeword = pick(strings("ion_laws.json", "ionabstract")\
-			| strings("ion_laws.json", "ionobjects")\
-			| strings("ion_laws.json", "ionadjectives")\
-			| strings("ion_laws.json", "ionthreats")\
-			| strings("ion_laws.json", "ionfood")\
-			| strings("ion_laws.json", "iondrinks"))
+// 	if(owner.mind)
+// 		new_backseat.mind = owner.mind
 
-/datum/brain_trauma/severe/split_personality/brainwashing/on_gain()
-	..()
-	var/mob/living/split_personality/traitor/traitor_backseat = stranger_backseat
-	traitor_backseat.codeword = codeword
-	traitor_backseat.objective = objective
+// 	if(!new_backseat.computer_id)
+// 		new_backseat.computer_id = h2b_id
 
-/datum/brain_trauma/severe/split_personality/brainwashing/make_backseats()
-	stranger_backseat = new /mob/living/split_personality/traitor(owner, src, codeword, objective)
-	owner_backseat = new(owner, src)
+// 	if(!new_backseat.lastKnownIP)
+// 		new_backseat.lastKnownIP = h2b_ip
 
-/datum/brain_trauma/severe/split_personality/brainwashing/get_ghost()
-	set waitfor = FALSE
-	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as [owner]'s brainwashed mind?", null, null, null, 75, stranger_backseat)
-	if(LAZYLEN(candidates))
-		var/mob/dead/observer/C = pick(candidates)
-		stranger_backseat.key = C.key
-	else
-		qdel(src)
+// 	if(reset_to_owner && new_backseat.mind)
+// 		new_backseat.ghostize(FALSE)
 
-/datum/brain_trauma/severe/split_personality/brainwashing/on_life()
-	return //no random switching
+// 	//Backseat to body
 
-/datum/brain_trauma/severe/split_personality/brainwashing/handle_hearing(datum/source, list/hearing_args)
-	if(HAS_TRAIT(owner, TRAIT_DEAF) || owner == hearing_args[HEARING_SPEAKER])
-		return
-	var/message = hearing_args[HEARING_MESSAGE]
-	if(findtext(message, codeword))
-		hearing_args[HEARING_MESSAGE] = replacetext(message, codeword, span_warning("[codeword]"))
-		addtimer(CALLBACK(src, TYPE_PROC_REF(/datum/brain_trauma/severe/split_personality, switch_personalities)), 10)
+// 	var/s2h_id = current_backseat.computer_id
+// 	var/s2h_ip= current_backseat.lastKnownIP
+// 	current_backseat.computer_id = null
+// 	current_backseat.lastKnownIP = null
 
-/datum/brain_trauma/severe/split_personality/brainwashing/handle_speech(datum/source, list/speech_args)
-	if(findtext(speech_args[SPEECH_MESSAGE], codeword))
-		speech_args[SPEECH_MESSAGE] = "" //oh hey did you want to tell people about the secret word to bring you back?
+// 	owner.ckey = current_backseat.ckey
+// 	owner.mind = current_backseat.mind
 
-/mob/living/split_personality/traitor
-	name = "split personality"
-	real_name = "unknown conscience"
-	var/objective
-	var/codeword
+// 	if(!owner.computer_id)
+// 		owner.computer_id = s2h_id
 
-/mob/living/split_personality/traitor/Login()
-	. = ..()
-	if(!. || !client)
-		return FALSE
-	to_chat(src, span_notice("As a brainwashed personality, you cannot do anything yet but observe. However, you may gain control of your body if you hear the special codeword, switching places with the current personality."))
-	to_chat(src, span_notice("Your activation codeword is: <b>[codeword]</b>"))
-	if(objective)
-		to_chat(src, span_notice("Your master left you an objective: <b>[objective]</b>. Follow it at all costs when in control."))
+// 	if(!owner.lastKnownIP)
+// 		owner.lastKnownIP = s2h_ip
 
-#undef OWNER
-#undef STRANGER
+// 	current_controller = !current_controller
+
+
+// /mob/living/split_personality
+// 	name = "split personality"
+// 	real_name = "unknown conscience"
+// 	var/mob/living/carbon/body
+// 	var/datum/brain_trauma/severe/split_personality/trauma
+
+// /mob/living/split_personality/Initialize(mapload, _trauma)
+// 	if(iscarbon(loc))
+// 		body = loc
+// 		name = body.real_name
+// 		real_name = body.real_name
+// 		trauma = _trauma
+// 	return ..()
+
+// /mob/living/split_personality/Life(seconds_per_tick = SSMOBS_DT, times_fired)
+// 	if(QDELETED(body))
+// 		qdel(src) //in case trauma deletion doesn't already do it
+
+// 	if((body.stat == DEAD && trauma.owner_backseat == src))
+// 		trauma.switch_personalities()
+// 		qdel(trauma)
+
+// 	//if one of the two ghosts, the other one stays permanently
+// 	if(!body.client && trauma.initialized)
+// 		trauma.switch_personalities()
+// 		qdel(trauma)
+
+// 	..()
+
+// /mob/living/split_personality/Login()
+// 	. = ..()
+// 	if(!. || !client)
+// 		return FALSE
+// 	to_chat(src, span_notice("As a split personality, you cannot do anything but observe. However, you will eventually gain control of your body, switching places with the current personality."))
+// 	to_chat(src, span_warning("<b>Do not commit suicide or put the body in a deadly position. Behave like you care about it as much as the owner.</b>"))
+
+// /mob/living/split_personality/say(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
+// 	to_chat(src, span_warning("You cannot speak, your other self is controlling your body!"))
+// 	return FALSE
+
+// /mob/living/split_personality/emote(act, m_type = null, message = null, intentional = FALSE, is_keybind = FALSE)
+// 	return FALSE
+
+// ///////////////BRAINWASHING////////////////////
+
+// /datum/brain_trauma/severe/split_personality/brainwashing
+// 	name = "Split Personality"
+// 	desc = "Patient's brain is split into two personalities, which randomly switch control of the body."
+// 	scan_desc = "complete lobe separation"
+// 	gain_text = ""
+// 	lose_text = span_notice("You are free of your brainwashing.")
+// 	can_gain = FALSE
+// 	var/codeword
+// 	var/objective
+
+// /datum/brain_trauma/severe/split_personality/brainwashing/New(obj/item/organ/brain/B, _permanent, _codeword, _objective)
+// 	..()
+// 	if(_codeword)
+// 		codeword = _codeword
+// 	else
+// 		codeword = pick(strings("ion_laws.json", "ionabstract")\
+// 			| strings("ion_laws.json", "ionobjects")\
+// 			| strings("ion_laws.json", "ionadjectives")\
+// 			| strings("ion_laws.json", "ionthreats")\
+// 			| strings("ion_laws.json", "ionfood")\
+// 			| strings("ion_laws.json", "iondrinks"))
+
+// /datum/brain_trauma/severe/split_personality/brainwashing/on_gain()
+// 	..()
+// 	var/mob/living/split_personality/traitor/traitor_backseat = stranger_backseat
+// 	traitor_backseat.codeword = codeword
+// 	traitor_backseat.objective = objective
+
+// /datum/brain_trauma/severe/split_personality/brainwashing/make_backseats()
+// 	stranger_backseat = new /mob/living/split_personality/traitor(owner, src, codeword, objective)
+// 	owner_backseat = new(owner, src)
+
+// /datum/brain_trauma/severe/split_personality/brainwashing/get_ghost()
+// 	set waitfor = FALSE
+// 	var/list/mob/dead/observer/candidates = pollCandidatesForMob("Do you want to play as [owner]'s brainwashed mind?", null, null, null, 75, stranger_backseat)
+// 	if(LAZYLEN(candidates))
+// 		var/mob/dead/observer/C = pick(candidates)
+// 		stranger_backseat.key = C.key
+// 	else
+// 		qdel(src)
+
+// /datum/brain_trauma/severe/split_personality/brainwashing/on_life()
+// 	return //no random switching
+
+// /datum/brain_trauma/severe/split_personality/brainwashing/handle_hearing(datum/source, list/hearing_args)
+// 	if(HAS_TRAIT(owner, TRAIT_DEAF) || owner == hearing_args[HEARING_SPEAKER])
+// 		return
+// 	var/message = hearing_args[HEARING_MESSAGE]
+// 	if(findtext(message, codeword))
+// 		hearing_args[HEARING_MESSAGE] = replacetext(message, codeword, span_warning("[codeword]"))
+// 		addtimer(CALLBACK(src, TYPE_PROC_REF(/datum/brain_trauma/severe/split_personality, switch_personalities)), 10)
+
+// /datum/brain_trauma/severe/split_personality/brainwashing/handle_speech(datum/source, list/speech_args)
+// 	if(findtext(speech_args[SPEECH_MESSAGE], codeword))
+// 		speech_args[SPEECH_MESSAGE] = "" //oh hey did you want to tell people about the secret word to bring you back?
+
+// /mob/living/split_personality/traitor
+// 	name = "split personality"
+// 	real_name = "unknown conscience"
+// 	var/objective
+// 	var/codeword
+
+// /mob/living/split_personality/traitor/Login()
+// 	. = ..()
+// 	if(!. || !client)
+// 		return FALSE
+// 	to_chat(src, span_notice("As a brainwashed personality, you cannot do anything yet but observe. However, you may gain control of your body if you hear the special codeword, switching places with the current personality."))
+// 	to_chat(src, span_notice("Your activation codeword is: <b>[codeword]</b>"))
+// 	if(objective)
+// 		to_chat(src, span_notice("Your master left you an objective: <b>[objective]</b>. Follow it at all costs when in control."))
+
+// #undef OWNER
+// #undef STRANGER

--- a/code/modules/antagonists/horror/horror.dm
+++ b/code/modules/antagonists/horror/horror.dm
@@ -717,9 +717,9 @@
 		to_chat(src, span_notice("This host lacks enough brain function to control."))
 		return
 
-	if(victim.has_trauma_type(/datum/brain_trauma/severe/split_personality))
-		to_chat(src, span_notice("This host's brain lobe separation makes it too complex for you to control."))
-		return
+	// if(victim.has_trauma_type(/datum/brain_trauma/severe/split_personality))
+	// 	to_chat(src, span_notice("This host's brain lobe separation makes it too complex for you to control."))
+	// 	return
 
 	if(bonding)
 		bonding = FALSE

--- a/code/modules/spells/spell_types/self/personality_commune.dm
+++ b/code/modules/spells/spell_types/self/personality_commune.dm
@@ -1,56 +1,56 @@
-// This can probably be changed to use mind linker at some point
-/datum/action/cooldown/spell/personality_commune
-	name = "Personality Commune"
-	desc = "Sends thoughts to your alternate consciousness."
-	button_icon_state = "telepathy"
-	cooldown_time = 0 SECONDS
-	spell_requirements = NONE
+// // This can probably be changed to use mind linker at some point
+// /datum/action/cooldown/spell/personality_commune
+// 	name = "Personality Commune"
+// 	desc = "Sends thoughts to your alternate consciousness."
+// 	button_icon_state = "telepathy"
+// 	cooldown_time = 0 SECONDS
+// 	spell_requirements = NONE
 
-	/// Fluff text shown when a message is sent to the pair
-	var/fluff_text = span_boldnotice("You hear an echoing voice in the back of your head...")
-	/// The message to send to the corresponding person on cast
-	var/to_send
+// 	/// Fluff text shown when a message is sent to the pair
+// 	var/fluff_text = span_boldnotice("You hear an echoing voice in the back of your head...")
+// 	/// The message to send to the corresponding person on cast
+// 	var/to_send
 
-/datum/action/cooldown/spell/personality_commune/New(Target)
-	. = ..()
-	if(!istype(target, /datum/brain_trauma/severe/split_personality))
-		stack_trace("[type] was created on a target that isn't a /datum/brain_trauma/severe/split_personality, this doesn't work.")
-		qdel(src)
+// /datum/action/cooldown/spell/personality_commune/New(Target)
+// 	. = ..()
+// 	// if(!istype(target, /datum/brain_trauma/severe/split_personality))
+// 	// 	stack_trace("[type] was created on a target that isn't a /datum/brain_trauma/severe/split_personality, this doesn't work.")
+// 	// 	qdel(src)
 
-/datum/action/cooldown/spell/personality_commune/is_valid_target(atom/cast_on)
-	return isliving(cast_on)
+// /datum/action/cooldown/spell/personality_commune/is_valid_target(atom/cast_on)
+// 	return isliving(cast_on)
 
-/datum/action/cooldown/spell/personality_commune/before_cast(atom/cast_on)
-	. = ..()
-	if(. & SPELL_CANCEL_CAST)
-		return
+// /datum/action/cooldown/spell/personality_commune/before_cast(atom/cast_on)
+// 	. = ..()
+// 	if(. & SPELL_CANCEL_CAST)
+// 		return
 
-	var/datum/brain_trauma/severe/split_personality/trauma = target
-	if(!istype(trauma)) // hypothetically impossible but you never know
-		return . | SPELL_CANCEL_CAST
+// 	// var/datum/brain_trauma/severe/split_personality/trauma = target
+// 	// if(!istype(trauma)) // hypothetically impossible but you never know
+// 	// 	return . | SPELL_CANCEL_CAST
 
-	to_send = tgui_input_text(cast_on, "What would you like to tell your other self?", "Commune")
-	if(QDELETED(src) || QDELETED(trauma)|| QDELETED(cast_on) || QDELETED(trauma.owner) || !can_cast_spell())
-		return . | SPELL_CANCEL_CAST
-	if(!to_send)
-		reset_cooldown()
-		return . | SPELL_CANCEL_CAST
+// 	to_send = tgui_input_text(cast_on, "What would you like to tell your other self?", "Commune")
+// 	if(QDELETED(src) || QDELETED(trauma)|| QDELETED(cast_on) || QDELETED(trauma.owner) || !can_cast_spell())
+// 		return . | SPELL_CANCEL_CAST
+// 	if(!to_send)
+// 		reset_cooldown()
+// 		return . | SPELL_CANCEL_CAST
 
-// Pillaged and adapted from telepathy code
-/datum/action/cooldown/spell/personality_commune/cast(mob/living/cast_on)
-	. = ..()
-	var/datum/brain_trauma/severe/split_personality/trauma = target
+// // Pillaged and adapted from telepathy code
+// /datum/action/cooldown/spell/personality_commune/cast(mob/living/cast_on)
+// 	. = ..()
+// 	var/datum/brain_trauma/severe/split_personality/trauma = target
 
-	var/user_message = span_boldnotice("You concentrate and send thoughts to your other self:")
-	var/user_message_body = span_notice("[to_send]")
+// 	var/user_message = span_boldnotice("You concentrate and send thoughts to your other self:")
+// 	var/user_message_body = span_notice("[to_send]")
 
-	to_chat(cast_on, "[user_message] [user_message_body]")
+// 	to_chat(cast_on, "[user_message] [user_message_body]")
 
-	trauma.owner.balloon_alert(trauma.owner, "you hear a voice")
-	to_chat(trauma.owner, "[fluff_text] [user_message_body]")
+// 	trauma.owner.balloon_alert(trauma.owner, "you hear a voice")
+// 	to_chat(trauma.owner, "[fluff_text] [user_message_body]")
 
-	log_directed_talk(cast_on, trauma.owner, to_send, LOG_SAY, "[name]")
-	for(var/dead_mob in GLOB.dead_mob_list)
-		if(!isobserver(dead_mob))
-			continue
-		to_chat(dead_mob, "[FOLLOW_LINK(dead_mob, cast_on)] [span_boldnotice("[cast_on] [name]:")] [span_notice("\"[to_send]\" to")] [span_name("[trauma]")]")
+// 	log_directed_talk(cast_on, trauma.owner, to_send, LOG_SAY, "[name]")
+// 	for(var/dead_mob in GLOB.dead_mob_list)
+// 		if(!isobserver(dead_mob))
+// 			continue
+// 		to_chat(dead_mob, "[FOLLOW_LINK(dead_mob, cast_on)] [span_boldnotice("[cast_on] [name]:")] [span_notice("\"[to_send]\" to")] [span_name("[trauma]")]")


### PR DESCRIPTION
# Document the changes in your pull request

This trauma is 90% one awful person taking control of you and messing things up until you remove them, and 10% them going afk because they're new and clicked 'yes' by accident.

# Why is this good for the game?

less frustrations with game mechanics

# Changelog

:cl:

rscdel: Disables split personality 

/:cl:
