### PR TITLE
Exempting EXP job requirements also exempts you from job connection time requirements

### DIFF
--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -224,6 +224,9 @@
 
 //If the configuration option is set to require players to be logged as old enough to play certain jobs, then this proc checks that they are, otherwise it just returns 1
 /datum/job/proc/player_old_enough(client/C)
+	var/isexempt = C.prefs.db_flags & DB_FLAG_EXEMPT //if we're exempt from job EXP requirements we also should be exempt from account age probably
+	if(isexempt)
+		return TRUE
 	if(available_in_days(C) == 0)
 		return TRUE	//Available in 0 days = available right now = player is old enough to play.
 	return FALSE


### PR DESCRIPTION
# Document the changes in your pull request

Never a problem because we usually don't give people admin when their first connection is today :)

# Changelog

:cl:
tweak: Exempting EXP job requirements also exempts you from job connection time requirements
/:cl:
