### PR TITLE
adds a single tile under the airlock to nanites on ice meta

### DIFF
--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -54342,8 +54342,8 @@
 	name = "Reception Window"
 	},
 /obj/machinery/door/window/brigdoor/eastright{
-	name = "Head of Personnel's Desk";
-	dir = 1
+	dir = 1;
+	name = "Head of Personnel's Desk"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
@@ -69556,6 +69556,31 @@
 /obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom,
 /turf/open/floor/plasteel,
 /area/engine/atmos/distro)
+"tXz" = (
+/obj/machinery/door/airlock/research{
+	name = "Nanite Laboratory"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/mapping_helpers/airlock/access/any/science/general,
+/turf/open/floor/plasteel/dark,
+/area/science/nanite)
 "tXJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -85132,31 +85157,6 @@
 "yhp" = (
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
-"yhs" = (
-/obj/machinery/door/airlock/research{
-	name = "Nanite Laboratory"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/mapping_helpers/airlock/access/any/science/general,
-/turf/open/floor/plating,
-/area/science/nanite)
 "yhz" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -246749,7 +246749,7 @@ uoH
 tme
 tme
 vTj
-yhs
+tXz
 vTj
 tme
 tme


### PR DESCRIPTION
# Document the changes in your pull request

Adds a single floor tile to ice meta that was missing under the door of the nanites room that has bothered me since 2 years ago

# Why is this good for the game?
its ugly and needs a floor tile

# Testing
erm, its a floor tile, i could boot it up in a local instance but its just a floor tile, dont be mad but i didnt test it

# Spriting
N/A

# Wiki Documentation
N/A

# Changelog

:cl:
mapping: Fixed a tile being plating instead of floor tile in nanites on IceMeta
/:cl:
