### PR TITLE
Fix cybernetic organs replacing upgraded cybernetic organs (Quirk and station trait related only)

### DIFF
--- a/code/datums/station_traits/positive_traits.dm
+++ b/code/datums/station_traits/positive_traits.dm
@@ -195,7 +195,7 @@
 	if(cybernetic_type)
 		var/obj/item/organ/cybernetic = new cybernetic_type()
 		// Timer is needed because doing it immediately doesn't REPLACE organs for some unknown reason, so got to do it next tick or whatever.
-		addtimer(CALLBACK(cybernetic, TYPE_PROC_REF(/obj/item/organ, Insert), living_mob), 1)
+		addtimer(CALLBACK(cybernetic, TYPE_PROC_REF(/obj/item/organ, Insert), living_mob, 0, TRUE), 1)
 		return
 
 	if(isAI(living_mob))

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -331,7 +331,7 @@
 	var/obj/item/organ/prosthetic = new organ_type(quirk_holder)
 	var/obj/item/organ/old_part = H.getorganslot(prosthetic.slot)
 	slot_string = prosthetic.slot
-	prosthetic.Insert(H)
+	prosthetic.Insert(H, 0, TRUE)
 	qdel(old_part)
 	H.regenerate_icons()
 

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -253,6 +253,7 @@
 	var/rid = /datum/reagent/medicine/epinephrine
 	var/ramount = 10
 	restartTimer = 5 SECONDS //restarts faster
+	cybernetic_quality = 1
 
 /obj/item/organ/heart/cybernetic/upgraded/on_life()
 	. = ..()

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -106,6 +106,7 @@
 	healing_factor = 2 * STANDARD_ORGAN_HEALING //Can regenerate from damage quicker
 	toxTolerance = 20
 	toxLethality = 0.007
+	cybernetic_quality = 1
 
 /obj/item/organ/liver/cybernetic/upgraded/on_life()
 	. = ..()

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -555,6 +555,7 @@
 	heat_level_1_threshold = 500
 	heat_level_2_threshold = 800
 	heat_level_3_threshold = 1400
+	cybernetic_quality = 1
 
 // ELECTROLYZER LUNGS!!!!!
 /obj/item/organ/lungs/ethereal

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -35,7 +35,10 @@
 	///Do we effect the appearance of our mob. Used to save time in preference code
 	var/visual = TRUE
 
-/obj/item/organ/proc/Insert(mob/living/carbon/M, special = 0, drop_if_replaced = TRUE,special_zone = null)
+	///Quality cybernetic check, see Insert(), the higher the better
+	var/cybernetic_quality = 0
+
+/obj/item/organ/proc/Insert(mob/living/carbon/M, special = 0, cybernetic_check = FALSE, drop_if_replaced = TRUE, special_zone = null)
 	if(!iscarbon(M) || owner == M)
 		return
 
@@ -43,6 +46,9 @@
 		zone = special_zone
 
 	var/obj/item/organ/replaced = M.getorganslot(slot)
+	if(cybernetic_check && replaced.cybernetic_quality > cybernetic_quality) //If true, this won't replace the upgraded cybernetic organs with normal cybernetic one
+		return
+
 	if(replaced && !special_zone)
 		replaced.Remove(M, special = 1)
 		if(drop_if_replaced)

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -106,6 +106,7 @@
 	maxHealth = 3 * STANDARD_ORGAN_THRESHOLD
 	var/nutriment_stashed = 0
 	disgust_metabolism = 2		//Twice as efficient as stabilizing itself
+	cybernetic_quality = 1
 
 /obj/item/organ/stomach/cybernetic/upgraded/on_life()
 	if(owner.nutrition >= NUTRITION_LEVEL_FULL && nutriment_stashed < NUTRI_STASH_MAX)

--- a/sound/standard.md
+++ b/sound/standard.md
@@ -2,7 +2,7 @@ Standard audio file format is:
 Ogg Vorbis on quality 5 preset, 44.1khz sample rate
 Audio which plays with a source and direction (via playsound()) should be downmixed to mono, otherwise byond will do it itself.
 Other sounds can be stereo
-aaa
+
 If you don't know what this means, here's a brief guide on how to do things right in audacity:
 
 Project Rate (Hz) in the bottom right should be set to 44100 before exporting

--- a/sound/standard.md
+++ b/sound/standard.md
@@ -2,7 +2,7 @@ Standard audio file format is:
 Ogg Vorbis on quality 5 preset, 44.1khz sample rate
 Audio which plays with a source and direction (via playsound()) should be downmixed to mono, otherwise byond will do it itself.
 Other sounds can be stereo
-
+aaa
 If you don't know what this means, here's a brief guide on how to do things right in audacity:
 
 Project Rate (Hz) in the bottom right should be set to 44100 before exporting


### PR DESCRIPTION
* fix #22396 also this issue is outdated since the janitor heart is now replaced with a toolset
# Document the changes in your pull request
Fix cybernetic organs replacing upgraded cybernetic organs (Quirk and station trait related only)



# Testing

### Quirk test

![image](https://github.com/user-attachments/assets/0f6687ea-7b2c-42e2-9b31-c9fe81f4154f)

![image](https://github.com/user-attachments/assets/7089d0aa-007a-401f-870c-b8eb9acf2486)

### Station trait test

Assistant gets cybernetic heart for this station trait but i have upgraded cybernetic quirk
![image](https://github.com/user-attachments/assets/9670d754-c74e-4276-9c81-bea544e97399)



https://github.com/user-attachments/assets/b7fdad27-baa4-40ed-b0c6-7252bbcd434a









 







# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:

bugfix: Fix cybernetic organs replacing upgraded cybernetic organs (Quirk and station trait related only)
/:cl:
