### PR TITLE
[s] Clear flavortext on force species change

### DIFF
--- a/code/modules/antagonists/bloodsuckers/vassal/bloodsucker_conversion.dm
+++ b/code/modules/antagonists/bloodsuckers/vassal/bloodsucker_conversion.dm
@@ -126,6 +126,7 @@
 
 	if(noblood)
 		user.set_species(/datum/species/human, TRUE, TRUE)
+		user.dna.features["flavor_text"] = "";
 		if(user.client?.prefs?.read_preference(/datum/preference/name/backup_human) && !is_banned_from(user.client?.ckey, "Appearance"))
 			user.fully_replace_character_name(user.dna.real_name, user.client.prefs.read_preference(/datum/preference/name/backup_human))
 		else

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -210,6 +210,7 @@ GLOBAL_VAR(changeling_team_objective_type)
 	if(ishuman(C) && ((NO_DNA_COPY in C.dna.species.species_traits) || !C.has_dna() || (NOHUSK in C.dna.species.species_traits)))
 		to_chat(C, span_userdanger("You have been made a human, as your original race had incompatible DNA."))
 		C.set_species(/datum/species/human, TRUE, TRUE)
+		C.dna.features["flavor_text"] = ""
 		if(C.client?.prefs?.read_preference(/datum/preference/name/backup_human) && !is_banned_from(C.client?.ckey, "Appearance"))
 			C.fully_replace_character_name(C.dna.real_name, C.client.prefs.read_preference(/datum/preference/name/backup_human))
 		else

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -173,6 +173,7 @@
 		if(H.dna.species.id != SPECIES_HUMAN)
 			H.set_species(/datum/species/human)
 			H.apply_pref_name(/datum/preference/name/backup_human, preference_source)
+			H.dna.features["flavor_text"] = ""
 	
 	if(forced_species)
 		H.set_species(forced_species)


### PR DESCRIPTION
# Document the changes in your pull request

Removes flavor text from players who are forced human.

# Why is this good for the game?

If a player mentions their species in their flavor text, it gets strange when they are then human.

# Testing
Aquizit has offered to test since my machine doesn't run this version of byond.

# Changelog

:cl:
bugfix: Fixed flavor text pontentially mentioning incorrect details about a character when the game force changes their species.
/:cl:
