### PR TITLE
Krokodil addicts now shown as zombie on crew monitor

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -223,7 +223,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 				species = "Slime"
 			if (isethereal(tracked_mob))
 				species = "Ethereal"
-			if (iszombie(tracked_mob))
+			if (iszombie(tracked_mob) || is_species(tracked_mob, /datum/species/krokodil_addict))
 				species = "Zombie"
 			if (issnail(tracked_mob))
 				species = "Snail"


### PR DESCRIPTION


# Document the changes in your pull request
Krokodil addicts now shown as zombie on crew monitor

# Why is this good for the game?
Unknown icon is weird

# Testing
tested on local




# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
rscadd: Krokodil addicts now shown as zombie on crew monitor
/:cl:
