### PR TITLE
Adds a blindness preference dropdown for the blindness quirk

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -55,7 +55,7 @@
 	job_blacklist = list("Captain", "Head of Personnel", "Research Director", "Chief Medical Officer", "Chief Engineer", "Head of Security", "Security Officer", "Warden")
 
 /datum/quirk/blindness/add()
-	var/blindness_preference = quirk_holder.client.prefs.read_preference(/datum/preference/choiced/blindness_choice)
+	var/blindness_preference = quirk_holder.client.prefs.read_preference(/datum/preference/choiced/blindness_choice) == "Random" ? pick("Echolocation", "Complete blindness") : quirk_holder.client.prefs.read_preference(/datum/preference/choiced/blindness_choice)
 	quirk_holder.become_blind(ROUNDSTART_TRAIT)
 	if(blindness_preference == "Echolocation")
 		quirk_holder.AddComponent(/datum/component/echolocation) //add when echolocation is fixed

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -55,8 +55,10 @@
 	job_blacklist = list("Captain", "Head of Personnel", "Research Director", "Chief Medical Officer", "Chief Engineer", "Head of Security", "Security Officer", "Warden")
 
 /datum/quirk/blindness/add()
+	var/blindness_preference = quirk_holder.client.prefs.read_preference(/datum/preference/choiced/blindness_choice)
 	quirk_holder.become_blind(ROUNDSTART_TRAIT)
-	quirk_holder.AddComponent(/datum/component/echolocation) //add when echolocation is fixed
+	if(blindness_preference == "Echolocation")
+		quirk_holder.AddComponent(/datum/component/echolocation) //add when echolocation is fixed
 
 /datum/quirk/blindness/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder

--- a/code/modules/client/preferences/blindness_choice.dm
+++ b/code/modules/client/preferences/blindness_choice.dm
@@ -1,0 +1,22 @@
+/datum/preference/choiced/blindness_choice
+	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	savefile_key = "blindness"
+	savefile_identifier = PREFERENCE_CHARACTER
+
+/datum/preference/choiced/blindness_choice/create_default_value()
+	return "Echolocation"
+
+/datum/preference/choiced/blindness_choice/init_possible_values()
+	return list(
+		"Echolocation",
+		"Complete blindness",
+		"Random",
+	)
+
+/datum/preference/choiced/blindness_choice/is_accessible(datum/preferences/preferences)
+	if(!..(preferences))
+		return FALSE
+	return preferences.all_quirks.Find("Blind")
+
+/datum/preference/choiced/blindness_choice/apply_to_human(mob/living/carbon/human/target, value)
+	return

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/blindness_choice.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/blindness_choice.tsx
@@ -1,6 +1,6 @@
 import { FeatureChoiced, FeatureDropdownInput } from "../base";
 
-export const blindness_choice: FeatureChoiced = {
+export const blindness: FeatureChoiced = {
   name: "Blindness",
   component: FeatureDropdownInput,
 };

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/blindness_choice.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/blindness_choice.tsx
@@ -1,0 +1,6 @@
+import { FeatureChoiced, FeatureDropdownInput } from "../base";
+
+export const blindness_choice: FeatureChoiced = {
+  name: "Blindness",
+  component: FeatureDropdownInput,
+};

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -2245,6 +2245,7 @@
 #include "code\modules\client\preferences\assets.dm"
 #include "code\modules\client\preferences\auto_fit_viewport.dm"
 #include "code\modules\client\preferences\balloon_alerts.dm"
+#include "code\modules\client\preferences\blindness_choice.dm"
 #include "code\modules\client\preferences\chapel_choice.dm"
 #include "code\modules\client\preferences\clerk_choice.dm"
 #include "code\modules\client\preferences\clothing.dm"


### PR DESCRIPTION
# Document the changes in your pull request

Adds a preference to choose between the old blind quirk functionality (complete blindness) and echolocation.

# Why is this good for the game?
While echolocation is nice, it doesn't work well for fast moving situations, such as mining or other combat. 

Echolocation is useful for any station role which doesn't involve combat, since you can still do your job with slight differences (medical using first aid analyser and knowledge, engineering, atmos, science, and cargo with some difficulty) and keep awareness of where you are without much problems. 

It doesn't work well for any combat, such as arresting someone as security (Yes, I know that blindness is on the quirk blacklist, but I'm using this as an example for promoted security), trying to fight multiple fauna as a miner (while trying to avoid getting hit or swarmed, e.g. legions), or trying to kill your target as an antagonist.

Having old blindness as a preference option means that mining, security, or antagonists are semi-reasonable to play, with the tradeoff being able to see far less than you would with echolocation (Echolocation gives you 3 tiles range, while old blindness gives you 1), as well as anyone who wants to play with old blindness can do so anyway.

# Testing
Random option working:

https://github.com/user-attachments/assets/a34ba8dc-5ba7-4ab7-9e00-b35d900da254


<details>
<summary>Blindness dropdown in character preferences menu</summary>
<img src="https://github.com/user-attachments/assets/27c9d50e-e143-4b03-a4d7-1e829df5145a"/>
</details>
<details>
<summary>Non-echolocation blindness working</summary>
<img src="https://github.com/user-attachments/assets/439be46a-0828-4ad9-a40f-81fd91b93b30"/>
</details>
<details>
<summary>Echolocation blindness working</summary>
<img src="https://github.com/user-attachments/assets/45cc0518-0ea4-43b2-a863-406167550726"/>
</details>

# Wiki Documentation

[Quirks](https://wiki.yogstation.net/wiki/Quirks):
- Blindness quirk entry will need to reference that players can choose between echolocation and complete blindness.

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
rscadd: Added a preference option to choose between old blindness and echolocation
/:cl:
