### PR TITLE
vox tank can now be printed from autolathe/protolathe(cargo/engi)

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -337,6 +337,15 @@
 	category = list("hacked","Miscellaneous","Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
 
+/datum/design/plasmaman_tank_belt
+	name = "Vox Nitrogen Tank"
+	id = "vox_tank"
+	build_type = AUTOLATHE | PROTOLATHE
+	materials = list(/datum/material/iron = 800)
+	build_path = /obj/item/tank/internals/emergency_oxygen/vox/empty
+	category = list("hacked","Miscellaneous","Equipment")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
+
 /datum/design/metal
 	name = "Metal"
 	id = "metal"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -337,7 +337,7 @@
 	category = list("hacked","Miscellaneous","Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_CARGO
 
-/datum/design/plasmaman_tank_belt
+/datum/design/vox_tank
 	name = "Vox Nitrogen Tank"
 	id = "vox_tank"
 	build_type = AUTOLATHE | PROTOLATHE

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -155,7 +155,7 @@
 	design_ids = list("solarcontrol", "recharger", "powermonitor", "rped", "pacman", "adv_capacitor", "adv_scanning", "emitter", "high_cell", "adv_matter_bin", "scanner_gate",
 	"atmosalerts", "atmos_control", "recycler", "autolathe", "high_micro_laser", "nano_mani", "mesons", "thermomachine", "rad_collector", "tesla_coil", "grounding_rod",
 	"cell_charger", "stack_console", "stack_machine", "conveyor_belt", "conveyor_switch", "reactor_control",
-	"oxygen_tank", "plasma_tank", "emergency_oxygen", "emergency_oxygen_engi", "plasmaman_tank_belt", "electrolyzer", "floorigniter", "crystallizer", "suit_storage_unit",
+	"oxygen_tank", "plasma_tank", "emergency_oxygen", "emergency_oxygen_engi", "plasmaman_tank_belt", "vox_tank", "electrolyzer", "floorigniter", "crystallizer", "suit_storage_unit",
 	"atmos_thermal", "mech_heat_sink", "mech_passive_cooling")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 7500)
 

--- a/yogstation/code/game/objects/items/tanks/tank_types.dm
+++ b/yogstation/code/game/objects/items/tanks/tank_types.dm
@@ -24,3 +24,6 @@
 
 /obj/item/tank/internals/emergency_oxygen/vox/populate_gas()
 	air_contents.set_moles(GAS_N2, (10*ONE_ATMOSPHERE)* volume/(R_IDEAL_GAS_EQUATION*T20C))
+
+/obj/item/tank/internals/emergency_oxygen/vox/empty/populate_gas()
+	return


### PR DESCRIPTION
# Why is this good for game?
it should be able to be printed just like plasmaman tank!!!!

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:

rscadd: vox tank can now be printed from autolathe/protolathe(cargo/engi)
/:cl:
