### PR TITLE
Fixes a code comment regarding clock cult power stockpiling

### DIFF
--- a/code/__DEFINES/clockcult.dm
+++ b/code/__DEFINES/clockcult.dm
@@ -46,7 +46,7 @@ GLOBAL_LIST_EMPTY(all_scripture)
 #define SCRIPTURE_APPLICATION "Application"
 
 //Various costs related to power.
-///The max power in W that the cult can stockpile
+///The max power in kJ that the cult can stockpile
 #define MAX_CLOCKWORK_POWER 50000
 /// Scripts will unlock if the total power reaches this amount
 #define SCRIPT_UNLOCK_THRESHOLD 25000


### PR DESCRIPTION
Fixes #9208

# Document the changes in your pull request

W --> J --> W --> kJ

# Why is this good for the game?
Clock cult power measurement was changed in #7052 to be in joules. In this comment, it was erroneously made into J rather than kJ (50MJ in J is 50000000J, 50MJ in kJ is 50000, resulting in #9208). Then, in #9306 it was made into watts again? Hopefully this PR puts this to an end.

# Testing
No.

# Changelog

Not player facing change.

:cl:
/:cl:
