### PR TITLE
[MINI] Fixes the issue with AI sat door buttons that was copied from the AI whale

### DIFF
--- a/_maps/map_files/MiniStation/MiniStation.dmm
+++ b/_maps/map_files/MiniStation/MiniStation.dmm
@@ -43895,7 +43895,7 @@
 /area/hallway/primary/central)
 "wqg" = (
 /obj/machinery/doorButtons/access_button{
-	idDoor = "ai_core_airlock_interior";
+	idDoor = "ai_core_airlock_exterior";
 	idSelf = "ai_core_airlock_control";
 	pixel_x = 8;
 	pixel_y = -24;


### PR DESCRIPTION
# Document the changes in your pull request

#22254 also applied to Mini because we here in the mapping business love the buttons Ctrl + C and Ctrl + V

# Testing
if need be

# Changelog
:cl:
bugfix: Fixed AI chamber door buttons on MiniStation, similar to the bug with the AI whale
/:cl:
