### PR TITLE
Fixes hop's skirt

### DIFF
--- a/code/modules/clothing/under/jobs/command.dm
+++ b/code/modules/clothing/under/jobs/command.dm
@@ -66,7 +66,7 @@
 	item_state = "b_suit"
 	can_adjust = TRUE
 
-/obj/item/clothing/under/rank/command/civilian/head_of_personnel/skirt
+/obj/item/clothing/under/rank/command/head_of_personnel/skirt
 	name = "head of personnel's jumpskirt"
 	desc = "It's a jumpskirt worn by someone who works in the position of \"Head of Personnel\"."
 	icon_state = "hop_skirt"


### PR DESCRIPTION
# Document the changes in your pull request

For whatever reason, HoP's skirt had 'civilian' in its type path in command.dm, and this was not repeated in other parts of the code. This caused issues, such as it not showing in HoP's vendor and it causing issues with the turtle neck. This PR removes 'civilian' from its typepath, fixing the issues.

# Why is this good for the game?

Fixes #22909

# Testing

Skirt now shows in the vendor:
![image](https://github.com/user-attachments/assets/186b2a2d-c5ae-46f2-972b-3a198db53a20)

Turtleneck skirt has worn sprites:
![image](https://github.com/user-attachments/assets/cee0bc1d-f557-4644-8fc1-913edfcb8e4f)
![image](https://github.com/user-attachments/assets/cfbb2778-88ca-4403-a141-348a95bf096f)
![image](https://github.com/user-attachments/assets/99331bc0-6464-4c4f-a408-b3dd76c63473)

Something that I noticed while testing this: sometimes, when switching to the turtleneck's alt for the first time, the uniform's worn sprite would turn invisible for a second before becoming the alt sprite. I do not know why it does this, but it does not stay invisible so I guess it isn't too much of a problem.

# Changelog

:cl:
bugfix: HoP's skirt now shows in their vendor and turtleneck skirt has worn sprites
/:cl:
