### PR TITLE
Mentor PM Panel

### DIFF
--- a/yogstation/code/modules/mentor/mentor_verbs.dm
+++ b/yogstation/code/modules/mentor/mentor_verbs.dm
@@ -3,6 +3,7 @@ GLOBAL_LIST_INIT(mentor_verbs, list(
 	/client/proc/show_mentor_memo,
 	/client/proc/show_mentor_tickets,
 	/client/proc/cmd_mentor_pm_context,
+	/client/proc/cmd_mentor_pm_panel,
 	/client/proc/dementor
 	))
 GLOBAL_PROTECT(mentor_verbs)

--- a/yogstation/code/modules/mentor/mentorpm.dm
+++ b/yogstation/code/modules/mentor/mentorpm.dm
@@ -1,7 +1,7 @@
 //shows a list of clients we could send PMs to, then forwards our choice to cmd_Mentor_pm
 /client/proc/cmd_mentor_pm_panel()
 	set category = "Mentor"
-	set name = "Mentor PM"
+	set name = "Mentor PM Panel"
 
 	if(!is_mentor())
 		to_chat(src, "<font color='red'>Error: Mentor-PM-Panel: Only Mentors and Admins may use this command.</font>", confidential=TRUE)
@@ -9,10 +9,13 @@
 
 	var/list/client/targets[0]
 	for(var/client/T)
-		targets["[T]"] = T
+		if(T.mob)
+			targets["[T.mob.name]"] = T
+		else
+			targets["[T]"] = T
 
 	var/list/sorted = sortList(targets)
-	var/target = input(src,"To whom shall we send a message?","Mentor PM",null) in sorted|null
+	var/target = input(src,"To whom shall we send a message?","Mentor PM",null) as null|anything in sorted|null
 	cmd_mentor_pm(targets[target],null)
 	SSblackbox.record_feedback("tally", "Mentor_verb", 1, "APM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 


### PR DESCRIPTION
# Document the changes in your pull request

Turns out in #2906, there was a proc that never got a verb. Hence, with a few changes, Mentor PM Panel is now available to mentors.

For reference, I changed the mentor PM panel to only show mob names (and player ckeys when they're in the lobby) since mentors shouldn't really have the same info the admin PM verb would have.

# Why is this good for the game?
MENTORHELP: Player (F): Hey I think [INSERT NAME HERE] is a new player, can you help them?

As the only mentor on, this is difficult to help with the current tools if you're a living player at the time. As a ghost, you can use Orbit menu, Right Click --> Mentor PM Mob, voila. As a living player, it becomes more of a weirder situation. You can either try to search for them in game (questionable, as you're looking for them for an OOC reason in an IC manner), or you can do nothing (Mentors do not do this, except by accident).

With a Mentor PM Panel, this solves the questionability of searching for someone in game for an mhelp, as well as providing a method of helping people when they normally wouldn't be able to (e.g. ghost roles).

# Testing
![image](https://github.com/user-attachments/assets/906df2e3-9e8a-4ae3-a615-14cedab2f2a6)
![image](https://github.com/user-attachments/assets/e1be4b09-e6d0-4bb1-80f1-9ef9a4093d26)

# Changelog

:cl:
rscadd: Added a mentor verb for the Mentor PM Panel from the original mentor PR. 
/:cl:
