### PR TITLE
Cybernetic voicebox quirk

### DIFF
--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -436,7 +436,7 @@
 	quality = "regular cybernetic"
 
 /datum/quirk/cyberorgan/voicebox
-	name = "Cybernetic organ (Tongue)"
+	name = "Cybernetic Organ (Tongue)"
 	desc = "Due to a past incident you lost function of your tongue, but now have a robotic voicebox!"
 	organ_list = list(ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/robot)
 	medical_record_text = "During physical examination, patient was found to have a robotic voicebox."

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -434,3 +434,11 @@
 	medical_record_text = "During physical examination, patient was found to have a cybernetic liver."
 	value = 0
 	quality = "regular cybernetic"
+
+/datum/quirk/cyberorgan/voicebox
+	name = "Cybernetic organ (Tongue)"
+	desc = "Due to a past incident you lost function of your tongue, but now have a robotic voicebox!"
+	organ_list = list(ORGAN_SLOT_TONGUE = /obj/item/organ/tongue/robot)
+	medical_record_text = "During physical examination, patient was found to have a robotic voicebox."
+	value = 0
+	quality = "regular cybernetic"


### PR DESCRIPTION
# Document the changes in your pull request

Adds a neutral quirk where your tongue is replaced with a robotic voicebox.

# Why is this good for the game?
Funny quirk which leads to IPCs not being the only ones with robotic voiceboxes. Not much more than that.

# Testing
![image](https://github.com/user-attachments/assets/fd116751-9d67-4570-b99d-8f7df3184255)
![image](https://github.com/user-attachments/assets/a27d8dcf-139e-40e8-a8ef-fe5be1872a7b)

# Wiki Documentation

[Quirks:](https://wiki.yogstation.net/wiki/Quirks)
- New entry in neutral quirks table, Cybernetic organ (Tongue). Replaces tongue with robotic voicebox.

# Changelog

:cl:
rscadd: New neutral quirk: Cybernetic organ (Tongue)
/:cl:
