### PR TITLE
Adds a .NET 9 SDK setup action

### DIFF
--- a/.github/workflows/turdis.yml
+++ b/.github/workflows/turdis.yml
@@ -66,6 +66,10 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
+      - name: Setup .NET SDK
+      - uses: actions/setup-dotnet@v4.2.0
+        with:
+          dotnet-version: 9.x
       - uses: robinraju/release-downloader@v1.9
         with:
           repository: "OpenDreamProject/OpenDream"

--- a/.github/workflows/turdis.yml
+++ b/.github/workflows/turdis.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET SDK
-      - uses: actions/setup-dotnet@v4.2.0
+        uses: actions/setup-dotnet@v4.2.0
         with:
           dotnet-version: 9.x
       - uses: robinraju/release-downloader@v1.9


### PR DESCRIPTION
# Document the changes in your pull request

https://github.com/tgstation/tgstation/pull/88988

will stop opendream lints from failing probably
