### PR TITLE
Yogstation mappers suck at door buttons: icemeta edition

### DIFF
--- a/_maps/map_files/IceMeta/IceMeta.dmm
+++ b/_maps/map_files/IceMeta/IceMeta.dmm
@@ -24380,7 +24380,6 @@
 	dir = 8
 	},
 /obj/machinery/door/airlock/command/glass{
-	id_tag = "secondary_aicore_exterior";
 	name = "AI Networking"
 	},
 /obj/effect/mapping_helpers/airlock/access/all/command/ai_sat,


### PR DESCRIPTION
# Document the changes in your pull request
THIS DOOR was set as part of the exterior in the airlock cycle for this room, causing it to annoyingly bolt when the exterior buttons are pressed
![image](https://github.com/user-attachments/assets/77c0d099-6c6f-4351-bc51-bc6c5267a27a)

Should no longer do it now

# Testing
if ask can do

# Changelog
:cl:
bugfix: Fixed the door to enter secondary AI core on IceMeta acting strangely
/:cl:
