### PR TITLE
Makes crew monitor code more sane

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -165,7 +165,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 
 		idcard = tracked_mob.wear_id ? tracked_mob.wear_id.GetID() : null
 
-		var/species
+		var/datum/species/species
 		var/is_irradiated = FALSE
 		var/is_wounded = FALSE
 		var/is_husked = FALSE
@@ -197,40 +197,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			brutedam = round(tracked_mob.getBruteLoss(),1)
 
 			//species check
-			if (ishumanbasic(tracked_mob)) //this should really just pull the species name or something rather than having all these checks
-				species = "Human"
-			if (ispreternis(tracked_mob))
-				species = "Robot"
-			if (isipc(tracked_mob))
-				species = "IPC"
-			if (ispodperson(tracked_mob))
-				species = "Podperson"
-			if (islizard(tracked_mob))
-				species = "Lizard"
-			if (isplasmaman(tracked_mob))
-				species = "Plasmaman"
-			if (ispolysmorph(tracked_mob))
-				species = "Polysmorph"
-			if (ismoth(tracked_mob))
-				species = "Moth"
-			if (isvox(tracked_mob))
-				species = "Vox"
-			if (isflyperson(tracked_mob))
-				species = "Fly"
-			if (iscatperson(tracked_mob))
-				species = "Felinid"
-			if (isskeleton(tracked_mob))
-				species = "Skeleton"
-			if (isjellyperson(tracked_mob))
-				species = "Slime"
-			if (isethereal(tracked_mob))
-				species = "Ethereal"
-			if (iszombie(tracked_mob) || is_species(tracked_mob, /datum/species/krokodil_addict))
-				species = "Zombie"
-			if (issnail(tracked_mob))
-				species = "Snail"
-			if (isabductor(tracked_mob))
-				species = "Alien"
+			species = tracked_mob.dna?.species
 
 			for(var/obj/item/bodypart/part in tracked_mob.bodyparts)
 				if(part.bodypart_disabled == TRUE) //check if has disabled limbs
@@ -300,7 +267,8 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 			"is_bonecrack" = is_bonecrack,
 			"is_disabled" = is_disabled,
 			"is_irradiated" = is_irradiated,
-			"species" = species,
+			"species_icon" = species?.monitor_icon,
+			"species_color" = species?.monitor_color,
 			"life_status" = life_status,
 			"oxydam" = oxydam,
 			"toxdam" = toxdam,

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -18,6 +18,10 @@ GLOBAL_LIST_EMPTY(features_by_species)
 	var/plural_form
 	/// if alien colors are disabled, this is the color that will be used by that race
 	var/default_color = "#FFF"
+	/// The icon this species uses on the crew monitor.
+	var/monitor_icon
+	/// The color of the icon this species uses on the crew monitor.
+	var/monitor_color = "#FFFFFF"
 
 	///A list that contains pixel offsets for various clothing features, if your species is a different shape
 	var/list/offset_features = list(OFFSET_UNIFORM = list(0,0), OFFSET_ID = list(0,0), OFFSET_GLOVES = list(0,0), OFFSET_GLASSES = list(0,0), OFFSET_EARS = list(0,0), OFFSET_SHOES = list(0,0), OFFSET_S_STORE = list(0,0), OFFSET_FACEMASK = list(0,0), OFFSET_HEAD = list(0,0), OFFSET_FACE = list(0,0), OFFSET_BELT = list(0,0), OFFSET_BACK = list(0,0), OFFSET_SUIT = list(0,0), OFFSET_NECK = list(0,0))

--- a/code/modules/mob/living/carbon/human/species_types/IPC.dm
+++ b/code/modules/mob/living/carbon/human/species_types/IPC.dm
@@ -4,6 +4,8 @@
 	name = "IPC" //inherited from the real species, for health scanners and things
 	id = "ipc"
 	say_mod = "states" //inherited from a user's real species
+	monitor_icon = "tv"
+	monitor_color = "#2e46cc"
 	bubble_icon = BUBBLE_ROBOT // beep boop
 	possible_genders = list(PLURAL, NEUTER) // A MERE OBJECT
 	species_traits = list(NOTRANSSTING,NOEYESPRITES,NO_DNA_COPY,NOZOMBIE,MUTCOLORS,NOHUSK,NOBLOOD,NO_UNDERWEAR)

--- a/code/modules/mob/living/carbon/human/species_types/abductors.dm
+++ b/code/modules/mob/living/carbon/human/species_types/abductors.dm
@@ -1,6 +1,8 @@
 /datum/species/abductor
 	name = "Abductor"
 	id = SPECIES_ABDUCTOR
+	monitor_icon = "question-circle"
+	monitor_color = "#d40db9"
 	say_mod = "gibbers"
 	possible_genders = list(PLURAL)
 	species_traits = list(NOBLOOD,NOEYESPRITES)

--- a/code/modules/mob/living/carbon/human/species_types/ethereal.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ethereal.dm
@@ -3,6 +3,8 @@
 /datum/species/ethereal
 	name = "Ethereal"
 	id = SPECIES_ETHEREAL
+	monitor_icon = "sun"
+	monitor_color = "#f0ff66"
 	attack_verbs = list("burn", "sear")
 	attack_sound = 'sound/weapons/etherealhit.ogg'
 	miss_sound = 'sound/weapons/etherealmiss.ogg'

--- a/code/modules/mob/living/carbon/human/species_types/felinid.dm
+++ b/code/modules/mob/living/carbon/human/species_types/felinid.dm
@@ -3,6 +3,8 @@
 	name = "Felinid Human"
 	id = SPECIES_FELINE
 	limbs_id = SPECIES_HUMAN
+	monitor_icon = "paw"
+	monitor_color = "#f52ab4"
 	attack_verbs = list("slash")
 	attack_effect = ATTACK_EFFECT_CLAW
 	attack_sound = 'sound/weapons/slash.ogg'

--- a/code/modules/mob/living/carbon/human/species_types/flypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/flypeople.dm
@@ -2,6 +2,8 @@
 	name = "Flyperson"
 	plural_form = "Flypeople"
 	id = SPECIES_FLYPERSON
+	monitor_icon = "bug"
+	monitor_color = "#039162"
 	say_mod = "buzzes"
 	species_traits = list(NOEYESPRITES, HAS_FLESH, HAS_BONE)
 	inherent_biotypes = MOB_ORGANIC|MOB_HUMANOID|MOB_BUG

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -1,6 +1,8 @@
 /datum/species/human
 	name = "Human"
 	id = SPECIES_HUMAN
+	monitor_icon = "user"
+	monitor_color = "#2ee81a"
 	default_color = "FFFFFF"
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,HAS_FLESH,HAS_BONE)
 	default_features = list("mcolor" = "#FFFFFF", "wings" = "None")

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -3,6 +3,8 @@
 	name = "Jellyperson"
 	plural_form = "Jellypeople"
 	id = SPECIES_JELLYPERSON
+	monitor_icon = "cloud"
+	monitor_color = "#f2505d"
 	default_color = "00FF90"
 	say_mod = "chirps"
 	bubble_icon = BUBBLE_SLIME

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -5,6 +5,8 @@
 	name = "Vuulek"
 	plural_form = "Vuulen"
 	id = SPECIES_LIZARD
+	monitor_icon = "dragon"
+	monitor_color = "#8bf76a"
 	say_mod = "hisses"
 	default_color = "00FF00"
 	species_traits = list(MUTCOLORS,EYECOLOR,DIGITIGRADE,LIPS,HAS_FLESH,HAS_BONE,HAS_TAIL)

--- a/code/modules/mob/living/carbon/human/species_types/mothmen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mothmen.dm
@@ -2,6 +2,8 @@
 	name = "Ex'hai"
 	plural_form = "Ex'hau"
 	id = SPECIES_MOTH
+	monitor_icon = "feather-alt"
+	monitor_color = "#ffebb8"
 	say_mod = "flutters"
 	default_color = "00FF00"
 	species_traits = list(LIPS, NOEYESPRITES,HAS_FLESH,HAS_BONE)

--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -2,6 +2,8 @@
 	name = "Plasmaman"
 	plural_form = "Plasmamen"
 	id = SPECIES_PLASMAMAN
+	monitor_icon = "skull"
+	monitor_color = "#d60b66"
 	say_mod = "rattles"
 	possible_genders = list(PLURAL)
 	meat = /obj/item/stack/sheet/mineral/plasma

--- a/code/modules/mob/living/carbon/human/species_types/polysmorphs.dm
+++ b/code/modules/mob/living/carbon/human/species_types/polysmorphs.dm
@@ -2,6 +2,8 @@
 	//Human xenopmorph hybrid
 	name = "Polysmorph"
 	id = SPECIES_POLYSMORPH
+	monitor_icon = "certificate"
+	monitor_color = "#802496"
 	species_traits = list(NOEYESPRITES, DIGITIGRADE, MUTCOLORS, NOCOLORCHANGE, HAS_FLESH, HAS_BONE, HAS_TAIL)
 	possible_genders = list(FEMALE)
 	inherent_traits = list(TRAIT_ACIDBLOOD, TRAIT_SKINNY)

--- a/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -2,6 +2,8 @@
 	// 2spooky
 	name = "Spooky Scary Skeleton"
 	id = SPECIES_SKELETON
+	monitor_icon = "skull"
+	monitor_color = "#fffcfa"
 	say_mod = "rattles"
 	possible_genders = list(NEUTER)
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/skeleton

--- a/code/modules/mob/living/carbon/human/species_types/snail.dm
+++ b/code/modules/mob/living/carbon/human/species_types/snail.dm
@@ -2,6 +2,8 @@
 	name = "Snailperson"
 	plural_form = "Snailpeople"
 	id = SPECIES_SNAIL
+	monitor_icon = "strikethrough"
+	monitor_color = "#08ccb8"
 	offset_features = list(OFFSET_UNIFORM = list(0,0), OFFSET_ID = list(0,0), OFFSET_GLOVES = list(0,0), OFFSET_GLASSES = list(0,4), OFFSET_EARS = list(0,0), OFFSET_SHOES = list(0,0), OFFSET_S_STORE = list(0,0), OFFSET_FACEMASK = list(0,0), OFFSET_HEAD = list(0,0), OFFSET_FACE = list(0,0), OFFSET_BELT = list(0,0), OFFSET_BACK = list(0,0), OFFSET_SUIT = list(0,0), OFFSET_NECK = list(0,0))
 	default_color = "336600" //vomit green
 	species_traits = list(MUTCOLORS, NO_UNDERWEAR, HAS_FLESH, HAS_BONE)

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -4,6 +4,8 @@
 	// 1spooky
 	name = "High-Functioning Zombie"
 	id = SPECIES_ZOMBIE
+	monitor_icon = "skull"
+	monitor_color = "#186310"
 	say_mod = "moans"
 	possible_genders = list(NEUTER)
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/zombie
@@ -113,6 +115,8 @@
 	name = "Human"
 	id = SPECIES_ZOMBIE_KROKODIL
 	limbs_id = SPECIES_ZOMBIE //They look like zombies
+	monitor_icon = "skull"
+	monitor_color = "#186310"
 	possible_genders = list(PLURAL)
 	species_traits = list(HAS_FLESH, HAS_BONE)
 	inherent_traits = list(TRAIT_EASILY_WOUNDED) //you have no skin

--- a/tgui/packages/tgui/interfaces/CrewConsole.js
+++ b/tgui/packages/tgui/interfaces/CrewConsole.js
@@ -23,77 +23,6 @@ const HEALTH_ICON_BY_LEVEL = [
   'skull-crossbones',
 ];
 
-const speciesmap = {
-  "IPC": {
-    "icon": "tv",
-    "color": "#2e46cc",
-  },
-  "Robot": {
-    "icon": "robot",
-    "color": "#edee1b",
-  },
-  "Felinid": {
-    "icon": "paw",
-    "color": "#f52ab4",
-  },
-  "Moth": {
-    "icon": "feather-alt",
-    "color": "#ffebb8",
-  },
-  "Vox": {
-    "icon": "crow",
-    "color": "#13c230",
-  },
-  "Lizard": {
-    "icon": "dragon",
-    "color": "#8bf76a",
-  },
-  "Polysmorph": {
-    "icon": "certificate",
-    "color": "#802496",
-  },
-  "Podperson": {
-    "icon": "seedling",
-    "color": "#07f58a",
-  },
-  "Plasmaman": {
-    "icon": "skull",
-    "color": "#d60b66",
-  },
-  "Ethereal": {
-    "icon": "sun",
-    "color": "#f0ff66",
-  },
-  "Skeleton": {
-    "icon": "skull",
-    "color": "#fffcfa",
-  },
-  "Slime": {
-    "icon": "cloud",
-    "color": "#f2505d",
-  },
-  "Fly": {
-    "icon": "bug",
-    "color": "#039162",
-  },
-  "Human": {
-    "icon": "user",
-    "color": "#2ee81a",
-  },
-  "Zombie": {
-    "icon": "skull",
-    "color": "#186310",
-  },
-  "Snail": {
-    "icon": "strikethrough",
-    "color": "#08ccb8",
-  },
-  "Alien": {
-    "icon": "question-circle",
-    "color": "#d40db9",
-  },
-};
-
 export const jobIsHead = jobId => jobId % 10 === 0;
 
 export const jobToColor = jobId => {
@@ -252,7 +181,7 @@ export const CrewConsoleContent = (props, context) => {
                   )}
                 </Table.Cell>
                 <Table.Cell collapsing textAlign="center">
-                  {speciesmap[sensor.species] ? <Icon name={speciesmap[sensor.species].icon} color={speciesmap[sensor.species].color} size={1} /> : <Icon name="question" color="#f70505" size={1} />}
+                  {sensor.species_icon ? <Icon name={sensor.species_icon} color={sensor.species_color} size={1} /> : <Icon name="question" color="#f70505" size={1} />}
                 </Table.Cell>
                 <Table.Cell collapsing textAlign="center">
                   {sensor.oxydam !== null ? (

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/plantpeople.dm
@@ -4,6 +4,8 @@
 	// A mutation caused by a human being ressurected in a revival pod. These regain health in light, and begin to wither in darkness.
 	name = "Phytosian"
 	id = SPECIES_PODPERSON // We keep this at pod for compatibility reasons
+	monitor_icon = "seedling"
+	monitor_color = "#07f58a"
 	default_color = "59CE00"
 	species_traits = list(MUTCOLORS, EYECOLOR, HAS_FLESH, HAS_BONE)
 	mutant_bodyparts = list("pod_hair", "pod_flower")

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/preternis/preternis.dm
@@ -2,6 +2,8 @@
 	name = "Preternis"
 	plural_form = "Preterni"
 	id = SPECIES_PRETERNIS
+	monitor_icon = "robot"
+	monitor_color = "#edee1b"
 
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_PRIDE | MIRROR_MAGIC | RACE_SWAP | ERT_SPAWN | SLIME_EXTRACT
 	inherent_traits = list(TRAIT_POWERHUNGRY, TRAIT_RADIMMUNE, TRAIT_MEDICALIGNORE, TRAIT_NO_BLOOD_REGEN)

--- a/yogstation/code/modules/mob/living/carbon/human/species_types/vox.dm
+++ b/yogstation/code/modules/mob/living/carbon/human/species_types/vox.dm
@@ -2,6 +2,8 @@
 	name = "Vox"
 	plural_form = "Vox"
 	id = SPECIES_VOX
+	monitor_icon = "crow"
+	monitor_color = "#13c230"
 	is_dimorphic = FALSE
 	generate_husk_icon = TRUE
 	species_traits = list(EYECOLOR, HAS_TAIL, HAS_FLESH, HAS_BONE, HAIRCOLOR, FACEHAIRCOLOR, MUTCOLORS, MUTCOLORS_SECONDARY) // Robust, but cannot be cloned easily.


### PR DESCRIPTION
The icon and color a species uses on the crew monitor is now stored in the species itself, instead of using a massive if-else chain.

![image](https://github.com/user-attachments/assets/fa6a4d6f-d3c0-4801-bb2e-b2933b50d560)