### PR TITLE
[PORT] Stack traces when a cliented or ckeyed mob is Destroy()ed.

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -23,6 +23,11 @@
   * Returns QDEL_HINT_HARDDEL (don't change this)
   */
 /mob/Destroy()//This makes sure that mobs with clients/keys are not just deleted from the game.
+	if(client)
+		stack_trace("Mob with client has been deleted")
+	else if(ckey)
+		stack_trace("Mob without client but with associated ckey has been deleted.")
+
 	remove_from_mob_list()
 	remove_from_dead_mob_list()
 	remove_from_alive_mob_list()


### PR DESCRIPTION
# Document the changes in your pull request

Ports https://github.com/tgstation/tgstation/pull/72797

# Why is this good for the game?
The ghost role client deletion bug (#22232, #21750, #12331, #22415, and more) is very annoying. Having some form of logging for when clients or mobs with ckeys are destroy()ed would provide actual debugging capability for bad mob transfers.

# Testing
![image](https://github.com/user-attachments/assets/eb00e183-772d-4d70-8c3e-f7afebdfc260)

# Changelog

Not player-facing change

:cl:
/:cl:
