### PR TITLE
Kill objectives on traitor no longer happen under 10 pop

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -202,7 +202,7 @@
 
 /datum/antagonist/traitor/proc/forge_single_human_objective() //Returns how many objectives are added
 	.=1
-	if(prob(50))
+	if(prob(50) && GLOB.joined_player_list.len >= 10)
 		var/list/active_ais = active_ais()
 		if(active_ais.len && prob(100/GLOB.joined_player_list.len))
 			var/datum/objective/destroy/destroy_objective = new


### PR DESCRIPTION
# Document the changes in your pull request

Traitors no longer get kill objectives of any type when the player count is under 10.

# Why is this good for the game?

No-one has fun when there are 4 crew members and the one traitor has to kill 2 of them.

This is sort of a hashed fix. It is 10 players, not 10 crew -- meaning if there are like 6 ghost roles it can still happen.
Being able to do it with like 6 players as long as there's 1 secoff works too but it's above my coding ability.

# Testing
2 crew
![image](https://github.com/user-attachments/assets/ac88f53d-dea4-4c3d-baca-73d572ea40b7)

Enabled and removed 3 times, no kill objectives.
![image](https://github.com/user-attachments/assets/bd850e9f-1dd1-4ceb-a7a6-292f2a405967)
![image](https://github.com/user-attachments/assets/34b89375-9140-4ea7-8e0e-e7194adab123)
![image](https://github.com/user-attachments/assets/4c748198-f9b9-4a92-aa25-4208b1acac01)

# Changelog

:cl:
tweak: No more murder under 10 players
experimental: Min player number can be changed
/:cl:
