### PR TITLE
Makes faxes emaggable

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_syndicate.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_syndicate.dmm
@@ -5417,7 +5417,8 @@
 	department = "Unidentified";
 	desc = "Used to send black pages to Nanotrasen stations.";
 	name = "Syndicate Fax Machine";
-	req_access = list("syndicate")
+	req_access = list("syndicate");
+	set_obj_flags = "EMAGGED"
 	},
 /obj/item/stamp/chameleon{
 	pixel_x = -6;

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_syndicate.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_syndicate.dmm
@@ -5413,13 +5413,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/syndicate_icemoon/xenobio)
 "CP" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "Unidentified";
-	desc = "Used to send black pages to Nanotrasen stations.";
-	name = "Syndicate Fax Machine";
-	req_access = list("syndicate");
-	set_obj_flags = "EMAGGED"
-	},
 /obj/item/stamp/chameleon{
 	pixel_x = -6;
 	pixel_y = 10
@@ -5431,6 +5424,12 @@
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
+	},
+/obj/machinery/photocopier/faxmachine/syndicate{
+	desc = "Used to send black pages to Nanotrasen stations.";
+	department = "Unidentified";
+	name = "Syndicate Fax Machine";
+	req_access = list("syndicate")
 	},
 /turf/open/floor/wood,
 /area/ruin/syndicate_icemoon/command)

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_syndicate.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_syndicate.dmm
@@ -5425,12 +5425,7 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 9
 	},
-/obj/machinery/photocopier/faxmachine/syndicate{
-	desc = "Used to send black pages to Nanotrasen stations.";
-	department = "Unidentified";
-	name = "Syndicate Fax Machine";
-	req_access = list("syndicate")
-	},
+/obj/machinery/photocopier/faxmachine/syndicate,
 /turf/open/floor/wood,
 /area/ruin/syndicate_icemoon/command)
 "CQ" = (

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -2431,13 +2431,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/hallway)
 "KJ" = (
-/obj/machinery/photocopier/faxmachine{
-	department = "Unidentified";
-	desc = "Used to send black pages to Nanotrasen stations.";
-	name = "Syndicate Fax Machine";
-	req_access = list("syndicate");
-	set_obj_flags = "EMAGGED"
-	},
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -2450,6 +2443,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red/fourcorners,
+/obj/machinery/photocopier/faxmachine/syndicate{
+	desc = "Used to send black pages to Nanotrasen stations.";
+	department = "Unidentified";
+	name = "Syndicate Fax Machine"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/hallway)
 "KS" = (

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -2435,7 +2435,8 @@
 	department = "Unidentified";
 	desc = "Used to send black pages to Nanotrasen stations.";
 	name = "Syndicate Fax Machine";
-	req_access = list("syndicate")
+	req_access = list("syndicate");
+	set_obj_flags = "EMAGGED"
 	},
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,

--- a/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/listeningstation.dmm
@@ -2443,11 +2443,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red/fourcorners,
-/obj/machinery/photocopier/faxmachine/syndicate{
-	desc = "Used to send black pages to Nanotrasen stations.";
-	department = "Unidentified";
-	name = "Syndicate Fax Machine"
-	},
+/obj/machinery/photocopier/faxmachine/syndicate,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/listeningstation/hallway)
 "KS" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -21480,6 +21480,11 @@
 	dir = 9
 	},
 /obj/structure/table/reinforced,
+/obj/machinery/photocopier/faxmachine{
+	department = "Syndicate";
+	destination = "Bridge";
+	hidefromfaxlist = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/syndicate_mothership)
 "crH" = (

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -21480,11 +21480,7 @@
 	dir = 9
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/photocopier/faxmachine{
-	department = "Syndicate";
-	destination = "Bridge";
-	hidefromfaxlist = 1
-	},
+/obj/machinery/photocopier/faxmachine/syndicate_command,
 /turf/open/floor/plasteel/dark,
 /area/centcom/syndicate_mothership)
 "crH" = (

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1830,7 +1830,7 @@
 	send_admin_fax()
 
 /client/proc/send_admin_fax(obj/machinery/photocopier/faxmachine/F)
-	var/syndicate = istype(F) ? F.obj_flags & EMAGGED : FALSE
+	var/syndicate = (F?.obj_flags & EMAGGED)
 	var/inputsubject = input(src, "Please enter a subject", "Outgoing message from [syndicate ? "Syndicate" : "CentCom"]", "") as text|null
 	if(!inputsubject)
 		return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1815,7 +1815,7 @@
 		if(info)
 			info.examine(usr, TRUE)
 
-	else if(href_list["CentcomFaxReply"])
+	else if(href_list["AdminFaxReply"])
 		var/obj/machinery/photocopier/faxmachine/F = locate(href_list["originfax"]) in GLOB.allfaxes
 		if(!istype(F))
 			to_chat(src.owner, span_danger("Unable to locate fax!"))
@@ -1830,20 +1830,21 @@
 	send_admin_fax()
 
 /client/proc/send_admin_fax(obj/machinery/photocopier/faxmachine/F)
-	var/inputsubject = input(src, "Please enter a subject", "Outgoing message from CentCom", "") as text|null
+	var/syndicate = istype(F) ? F.obj_flags & EMAGGED : FALSE
+	var/inputsubject = input(src, "Please enter a subject", "Outgoing message from [syndicate ? "Syndicate" : "CentCom"]", "") as text|null
 	if(!inputsubject)
 		return
 
-	var/inputmessage = input(src, "Please enter the message sent to [istype(F) ? F : "all fax machines"] via secure connection. Supports pen markdown.", "Outgoing message from CentCom", "") as message|null
+	var/inputmessage = input(src, "Please enter the message sent to [istype(F) ? F : "all fax machines"] via secure connection. Supports pen markdown.", "Outgoing message from [syndicate ? "Syndicate" : "CentCom"]", "") as message|null
 	if(!inputmessage)
 		return
 
-	var/inputsigned = input(src, "Please enter CentCom Official name.", "Outgoing message from CentCom", usr?.client?.holder?.admin_signature || "") as text|null
+	var/inputsigned = input(src, "Please enter [syndicate ? "Syndicate" : "CentCom"] Official name.", "Outgoing message from [syndicate ? "Syndicate" : "CentCom"]", usr?.client?.holder?.admin_signature || "") as text|null
 	if(!inputsigned)
 		return
 
 	var/customname = input(src, "Pick a title for the report", "Title") as text|null
-	var/prefix = "<center><b>Nanotrasen Fax Network</b></center><hr><center>RE: [inputsubject]</center><hr>"
+	var/prefix = "<center><b>[syndicate ? "Syndicate" : "Nanotrasen"] Fax Network</b></center><hr><center>RE: [inputsubject]</center><hr>"
 	var/suffix = "<hr><b>Signed:</b> <font face=\"[SIGNFONT]\"><i>[inputsigned]</i></font>"
 
 	inputmessage = parsemarkdown(inputmessage)

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -172,19 +172,11 @@ GLOBAL_LIST_EMPTY(adminfaxes)
 			F.recievefax(rcvdcopy)
 	
 	//message badmins that a fax has arrived
-	switch(destination)
-		if ("Central Command")
-			for(var/client/C in GLOB.permissions.admins) //linked to prayers cause we are running out of legacy toggles
-				if(C.prefs.chat_toggles & CHAT_PRAYER_N_FAX) //if to be moved elsewhere then we must declutter legacy toggles
-					if(C.prefs.toggles & SOUND_PRAYER_N_FAX)//if done then delete these comments
-						SEND_SOUND(sender, sound('sound/effects/admin_fax.ogg'))
-			send_adminmessage(sender, "CENTCOM FAX", rcvdcopy, "AdminFaxReply", "#006100")
-		if ("Syndicate")
-			for(var/client/C in GLOB.permissions.admins)
-				if(C.prefs.chat_toggles & CHAT_PRAYER_N_FAX)
-					if(C.prefs.toggles & SOUND_PRAYER_N_FAX)
-						SEND_SOUND(sender, sound('sound/effects/admin_fax.ogg'))
-			send_adminmessage(sender, "SYNDICATE FAX", rcvdcopy, "AdminFaxReply", "crimson") //Same colour used in redphone
+	for(var/client/C in GLOB.permissions.admins) //linked to prayers cause we are running out of legacy toggles
+		if(C.prefs.chat_toggles & CHAT_PRAYER_N_FAX) //if to be moved elsewhere then we must declutter legacy toggles
+			if(C.prefs.toggles & SOUND_PRAYER_N_FAX)//if done then delete these comments
+				SEND_SOUND(sender, sound('sound/effects/admin_fax.ogg'))
+	send_adminmessage(sender, destination == "Syndicate" ? "SYNDICATE FAX" : "CENTCOM FAX", rcvdcopy, "AdminFaxReply", destination == "Syndicate" ? "crimson" : "#006100")
 	sendcooldown = world.time + 1 MINUTES
 	sleep(5 SECONDS)
 	visible_message("[src] beeps, \"Message transmitted successfully.\"")

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -236,8 +236,6 @@ GLOBAL_LIST_EMPTY(adminfaxes)
 /obj/machinery/photocopier/faxmachine/AltClick(mob/user)
 	if(IsAdminGhost(user))
 		send_admin_fax(src)	
-	else
-		message_admins("Not an admin ghost")
 
 /obj/machinery/photocopier/faxmachine/examine(mob/user)
 	. = ..()

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -254,3 +254,6 @@ GLOBAL_LIST_EMPTY(adminfaxes)
 	playsound(src, "sparks", 100, 1)
 	to_chat(user, span_warning("You short out the security protocols on [src]'s transceiver!"))
 	return TRUE
+
+/obj/machinery/photocopier/faxmachine/syndicate
+	obj_flags = CAN_BE_HIT | EMAGGED

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -174,13 +174,13 @@ GLOBAL_LIST_EMPTY(adminfaxes)
 				if(C.prefs.chat_toggles & CHAT_PRAYER_N_FAX) //if to be moved elsewhere then we must declutter legacy toggles
 					if(C.prefs.toggles & SOUND_PRAYER_N_FAX)//if done then delete these comments
 						SEND_SOUND(sender, sound('sound/effects/admin_fax.ogg'))
-			send_adminmessage(sender, "CENTCOM FAX", rcvdcopy, "CentcomFaxReply", "#006100")
+			send_adminmessage(sender, "CENTCOM FAX", rcvdcopy, "AdminFaxReply", "#006100")
 		if ("Syndicate")
 			for(var/client/C in GLOB.permissions.admins)
 				if(C.prefs.chat_toggles & CHAT_PRAYER_N_FAX)
 					if(C.prefs.toggles & SOUND_PRAYER_N_FAX)
 						SEND_SOUND(sender, sound('sound/effects/admin_fax.ogg'))
-			send_adminmessage(sender, "SYNDICATE FAX", rcvdcopy, "SyndicateFaxReply", "crimson") //Same colour used in redphone
+			send_adminmessage(sender, "SYNDICATE FAX", rcvdcopy, "AdminFaxReply", "crimson") //Same colour used in redphone
 	sendcooldown = world.time + 1 MINUTES
 	sleep(5 SECONDS)
 	visible_message("[src] beeps, \"Message transmitted successfully.\"")
@@ -205,7 +205,8 @@ GLOBAL_LIST_EMPTY(adminfaxes)
 	// give the sprite some time to flick
 	spawn(20)
 		var/obj/item/paper/P = new /obj/item/paper( loc )
-		P.name = "[command_name()] - [customname]"
+		var/syndicate = obj_flags & EMAGGED
+		P.name = syndicate ? "The Syndicate - [customname]" : "[command_name()] - [customname]"
 		
 		var/list/templist = list() // All the stuff we're adding to $written
 		for(var/text in T)
@@ -223,18 +224,20 @@ GLOBAL_LIST_EMPTY(adminfaxes)
 		var/datum/asset/spritesheet/sheet = get_asset_datum(/datum/asset/spritesheet/simple/paper)
 		if (isnull(P.stamps))
 			P.stamps = sheet.css_tag()
-		P.stamps += sheet.icon_tag("stamp-cent")
-		P.stamps += "<br><i>This paper has been verified by the Central Command Quantum Relay.</i><br>"
-		var/mutable_appearance/stampoverlay = mutable_appearance('icons/obj/bureaucracy.dmi', "paper_stamp-cent")
+		P.stamps += syndicate ? sheet.icon_tag("stamp-syndiround") : sheet.icon_tag("stamp-cent")
+		P.stamps += "<br><i>This paper has [syndicate ? "not" : ""] been verified by the Central Command Quantum Relay.</i><br>"
+		var/mutable_appearance/stampoverlay = mutable_appearance('icons/obj/bureaucracy.dmi', syndicate ? "paper_stamp-syndiround" : "paper_stamp-cent")
 		stampoverlay.pixel_x = rand(-2, 2)
 		stampoverlay.pixel_y = rand(-3, 2)
 
-		LAZYADD(P.stamped, "stamp-cent")
+		LAZYADD(P.stamped, syndicate ? "stamp-syndiround" : "stamp-cent")
 		P.add_overlay(stampoverlay)
 
 /obj/machinery/photocopier/faxmachine/AltClick(mob/user)
 	if(IsAdminGhost(user))
-		send_admin_fax(src)		
+		send_admin_fax(src)	
+	else
+		message_admins("Not an admin ghost")
 
 /obj/machinery/photocopier/faxmachine/examine(mob/user)
 	. = ..()

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -96,6 +96,10 @@ GLOBAL_LIST_EMPTY(adminfaxes)
 				authenticated = TRUE
 				auth_name = usr.client.holder.admin_signature
 				return
+			if(obj_flags & EMAGGED)
+				authenticated = TRUE
+				auth_name = "$#%*! - ERROR"
+				return
 			var/obj/item/card/id/id_card = usr.get_idcard(hand_first = TRUE)
 			if (check_access(id_card))
 				authenticated = TRUE

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -255,5 +255,19 @@ GLOBAL_LIST_EMPTY(adminfaxes)
 	to_chat(user, span_warning("You short out the security protocols on [src]'s transceiver!"))
 	return TRUE
 
+///Common syndicate fax machines, comes pre-emagged
 /obj/machinery/photocopier/faxmachine/syndicate
+	department = "Unidentified"
+	desc = "Used to send black pages to Nanotrasen stations."
+	name = "Syndicate Fax Machine"
 	obj_flags = CAN_BE_HIT | EMAGGED
+	req_access = list(ACCESS_SYNDICATE)
+
+///The fax machine in the Syndicate mothership
+/obj/machinery/photocopier/faxmachine/syndicate_command
+	department = "Syndicate"
+	desc = "Used for communication between the different echelons of the Syndicate. It has a note on the side reading <i>'DO NOT MOVE'</i>."
+	destination = "Bridge"
+	hidefromfaxlist = TRUE
+	name = "Syndicate Fax Machine"
+	req_access = list(ACCESS_SYNDICATE)


### PR DESCRIPTION
# Document the changes in your pull request

You can now fax the syndicate with an emagged fax machine. Admins can reply as the syndicate. Emagging a fax machine will also bypass ID restrictions for it.

Made syndicate ghost role faxes emagged by default, in case they somehow lose their redphone (or just want to fax their command reports for no reason).

# Why is this good for the game?
It gives traitors more ways of contacting the syndicate ICly, as the other two options (emagged communication console, redphone) are annoyingly difficult with someone watching, or can be listened into by centcomm.

# Testing
![image](https://github.com/user-attachments/assets/355b9c81-7f41-40d4-bf70-a6d4851f940a)
![image](https://github.com/user-attachments/assets/5086ef50-e1b0-417a-8cfa-afbce3cda32d)

# Wiki Documentation

[Emag:](https://wiki.yogstation.net/wiki/Emag)
New entry, fax machine. Can be used to send faxes to the syndicate.

# Changelog

:cl:
rscadd: You can now emag fax machines.
mapping: Added a fax machine to the syndicate mothership.
bugfix: You can now examine fax machines again.
/:cl:
