### PR TITLE
Fixes syndicate icemoon commander not being able to access doors

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -648,7 +648,7 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	)
 	skill_points = EXP_MID
 	outfit = /datum/outfit/syndicate_empty/SBC/assault/captain
-	id_access_list = list(150,151)
+	id_access_list = list(ACCESS_SYNDICATE_LEADER)
 
 /datum/outfit/syndicate_empty/SBC/assault/captain
 	name = "Syndicate Battlecruiser Captain"
@@ -787,7 +787,7 @@ GLOBAL_LIST_EMPTY(servant_golem_users)
 	)
 	skill_points = EXP_MID
 	outfit = /datum/outfit/syndicate_empty/icemoon_base/captain
-	id_access_list = list(150,151)
+	id_access_list = list(ACCESS_SYNDICATE_LEADER)
 
 /datum/outfit/syndicate_empty/icemoon_base/captain
 	name = "Syndicate Icemoon Outpost Commander"


### PR DESCRIPTION
# Document the changes in your pull request

Gives the commander their access back. Also fixes the SBC captain access since those weren't updated.

# Why is this good for the game?
Welding your way out of your room is not a fun way to start as a commander.

# Testing
![image](https://github.com/user-attachments/assets/0ac24e33-7574-4d79-a36f-3da2c63b8941)

# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
bugfix: Fixed syndicate icemoon commander's access
/:cl:
