### PR TITLE
Add byond version to issue reporting template

### DIFF
--- a/.github/ISSUE_TEMPLATE/00-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/00-bug-report.yml
@@ -55,7 +55,7 @@ body:
   attributes:
     label: BYOND version
     description: You can check this by opening BYOND, clicking the settings button, clicking on "About BYOND...", and the version will be in the lower left corner.
-    placeholder: 123.4567
+    placeholder: "123.4567"
 
 - type: dropdown
   attributes:

--- a/.github/ISSUE_TEMPLATE/00-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/00-bug-report.yml
@@ -51,6 +51,12 @@ body:
     description: Also known as ckey, its the username you use to login on BYOND.
     placeholder: "Player1702"
 
+- type: input
+  attributes:
+    label: BYOND version
+    description: You can check this by opening BYOND, clicking the settings button, clicking on "About BYOND...", and the version will be in the lower left corner.
+    placeholder: 123.4567
+
 - type: dropdown
   attributes:
     label: Was this done on a locally hosted or non-Yogstation hosted server?

--- a/.github/ISSUE_TEMPLATE/00-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/00-bug-report.yml
@@ -56,6 +56,8 @@ body:
     label: BYOND version
     description: You can check this by opening BYOND, clicking the settings button, clicking on "About BYOND...", and the version will be in the lower left corner.
     placeholder: "123.4567"
+  validations:
+    required: true
 
 - type: dropdown
   attributes:


### PR DESCRIPTION
# Document the changes in your pull request

Adds an input box in the issue reporting template for reporters to type their BYOND version in.

# Why is this good for the game?
BYOND issues are fairly common, when they're fixed in later versions, unsurprisingly they're still broken for the previous ones. This leads into people making bug reports of the same issue in different forms (#21711, #21734, 515.1643 in general). Requiring BYOND version in issue reports makes more information available, as you don't need to ask for their BYOND version (which they may not even respond to afterwards).

# Testing
![image](https://github.com/user-attachments/assets/e348fff7-fb62-4a64-8eb8-8ae049ad13ba)

# Changelog

Not (in-game) player facing change

:cl:
/:cl:
