### PR TITLE
Fixes transfer votes not increasing the vote percentage requirement at 2 hours 30 mins

### DIFF
--- a/code/datums/votes/transfer_vote.dm
+++ b/code/datums/votes/transfer_vote.dm
@@ -12,15 +12,12 @@
 	var/transfer_percentage = 60
 	var/result
 
-/datum/vote/transfer_vote/New()
-	. = ..()
-	if(world.time >= 2.5 HOURS)
-		transfer_percentage = 80
-
 /datum/vote/transfer_vote/get_vote_result(list/non_voters)
 	RETURN_TYPE(/list)
 	var/list/winners = list()
 	result = choices_by_ckey.len>0 ? (choices[CHOICE_NO_CALL_SHUTTLE]/(choices[CHOICE_CALL_SHUTTLE]+choices[CHOICE_NO_CALL_SHUTTLE]))*100 : 0
+	if(world.time >= 2.5 HOURS)
+		transfer_percentage = 80
 	if(result<=transfer_percentage)
 		winners += CHOICE_CALL_SHUTTLE
 	else


### PR DESCRIPTION
# Document the changes in your pull request

Turns out New() doesn't work here for some reason. I have no idea why, so I made it work without New()

# Testing
I waited 2.5 hours for this one message:
![image](https://github.com/user-attachments/assets/5a40d2f5-51d9-40ac-95b1-9ffea75afce5)

# Changelog

:cl:
bugfix: Transfer votes will properly use the 80% percentage requirement at 2.5 hours 
/:cl:
