### PR TITLE
[MINI] Expands Atmos distro, fixes some bad areas and incinerator problems

### DIFF
--- a/_maps/map_files/MiniStation/MiniStation.dmm
+++ b/_maps/map_files/MiniStation/MiniStation.dmm
@@ -756,13 +756,6 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"aeV" = (
-/obj/machinery/atmospherics/pipe/manifold/green/visible,
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "aeZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	external_pressure_bound = 120;
@@ -1520,17 +1513,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ajv" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Unfiltered to Mix";
-	on = 1
-	},
-/obj/effect/turf_decal/siding/thinplating/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "ajx" = (
 /obj/machinery/air_sensor{
 	id_tag = "co2_sensor"
@@ -3971,13 +3953,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"ayI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "ayJ" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -4622,6 +4597,15 @@
 /obj/machinery/light/small,
 /turf/open/floor/engine,
 /area/science/mixing/chamber)
+"aCr" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "aCt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -4774,12 +4758,6 @@
 "aDo" = (
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"aDp" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
 "aDq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -4826,18 +4804,6 @@
 "aDG" = (
 /turf/open/floor/plating,
 /area/maintenance/central)
-"aDM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "aDR" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -4876,15 +4842,6 @@
 "aEh" = (
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
-"aEi" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "aEj" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots{
@@ -5619,13 +5576,6 @@
 "aIO" = (
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
-"aIP" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "aIQ" = (
 /turf/closed/wall,
 /area/medical/morgue)
@@ -5744,25 +5694,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"aJx" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"aJy" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "aJz" = (
 /obj/effect/turf_decal/siding/wood/thin{
 	dir = 8
@@ -6132,17 +6063,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
-"aLY" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "aMf" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -6650,21 +6570,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"aPj" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "aPk" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small{
@@ -7367,15 +7272,6 @@
 	},
 /turf/open/floor/wood/parquet,
 /area/crew_quarters/bar)
-"aTe" = (
-/obj/machinery/atmospherics/components/trinary/mixer/airmix{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line/lower{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "aTf" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -7718,14 +7614,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
-"aUM" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Pure to Mix"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "aUN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
 /turf/open/floor/plasteel,
@@ -8348,15 +8236,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"aYb" = (
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/siding/thinplating{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "aYd" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -9488,12 +9367,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"bIA" = (
-/obj/machinery/camera/autoname{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "bIN" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner/lower,
 /turf/open/floor/plasteel/white,
@@ -9800,6 +9673,13 @@
 /obj/effect/mapping_helpers/windoor/access/all/service/chapel_office,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
+"bQw" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "bQE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 6
@@ -10217,6 +10097,18 @@
 	dir = 5
 	},
 /area/crew_quarters/kitchen)
+"caP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "cbY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -10263,6 +10155,15 @@
 	},
 /turf/open/space/openspace,
 /area/space/nearstation)
+"cdq" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "cdD" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
@@ -10661,25 +10562,6 @@
 	},
 /turf/open/floor/catwalk_floor,
 /area/maintenance/starboard/lower)
-"cnL" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/engine/atmos";
-	dir = 4;
-	name = "Atmospherics Distribution APC";
-	pixel_x = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "coe" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -12043,6 +11925,10 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"ddC" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ddI" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -12328,12 +12214,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"dki" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroid,
-/area/asteroid)
 "dkH" = (
 /obj/machinery/atmospherics/components/binary/dp_vent_pump/layer2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
@@ -12659,6 +12539,10 @@
 /obj/machinery/power/supermatter_crystal/shard/engine,
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"dux" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "duH" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/tcommsat/server";
@@ -13803,9 +13687,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"ehE" = (
-/turf/open/floor/plating/asteroid,
-/area/engine/atmos)
 "ehL" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/plasteel/grimy,
@@ -15418,6 +15299,13 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/open/floor/plating,
 /area/maintenance/starboard/lower)
+"fct" = (
+/obj/effect/turf_decal/siding/thinplating/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "fcW" = (
 /obj/item/deskbell/button/meeting{
 	pixel_x = 25;
@@ -16213,23 +16101,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"fBQ" = (
-/obj/machinery/atmospherics/pipe/simple/purple/visible,
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Incinerator Access"
-	},
-/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/machinery/door/firedoor/border_only,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "fCo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -16520,6 +16391,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"fOu" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "fOy" = (
 /obj/structure/table/wood,
 /obj/item/toy/cards/deck{
@@ -16632,6 +16510,13 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"fTm" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "fTF" = (
 /obj/machinery/light{
 	dir = 1
@@ -16767,12 +16652,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"fXp" = (
-/obj/structure/railing/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid,
-/area/asteroid)
 "fXv" = (
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/carpet,
@@ -18223,13 +18102,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
-"gLy" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
+"gLL" = (
+/obj/item/reagent_containers/glass/bucket/wooden,
+/turf/open/floor/plating/asteroid,
+/area/asteroid)
 "gLQ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -18751,18 +18627,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"hcQ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "N2 to Pure"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "hcR" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/open/floor/plasteel/dark,
@@ -19155,6 +19019,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore/lower)
+"hnH" = (
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/atmos)
 "hnR" = (
 /obj/effect/turf_decal/trimline/blue/filled/line/lower{
 	dir = 1
@@ -20326,12 +20196,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"hZg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating/asteroid,
-/area/asteroid)
 "hZC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
@@ -20546,6 +20410,18 @@
 /obj/machinery/telecomms/bus/preset_one,
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
+"igz" = (
+/obj/structure/railing/corner{
+	dir = 8
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
+"igM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ihc" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
@@ -21021,6 +20897,15 @@
 	},
 /turf/open/floor/circuit/telecomms/server,
 /area/science/server)
+"ixi" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ixk" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -21159,6 +21044,12 @@
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/wood/parquet,
 /area/crew_quarters/bar)
+"iBG" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "iCd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -21458,6 +21349,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing/chamber)
+"iNQ" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible,
+/obj/machinery/door/airlock/atmos/glass{
+	name = "Incinerator Access"
+	},
+/obj/effect/mapping_helpers/airlock/access/all/engineering/atmos,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
 "iOC" = (
 /obj/structure/stairs{
 	dir = 4
@@ -24018,6 +23926,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"kxR" = (
+/obj/machinery/atmospherics/components/trinary/mixer/airmix{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "kyv" = (
 /turf/open/floor/plasteel/chapel,
 /area/hallway/primary/central)
@@ -25391,11 +25305,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
-"luQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/effect/mapping_helpers/teleport_anchor,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "luV" = (
 /obj/machinery/power/apc/highcap{
 	areastring = "/area/ai_monitored/secondarydatacore";
@@ -25769,6 +25678,26 @@
 /obj/structure/curtain,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
+"lIN" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Unfiltered to Mix";
+	on = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "lIT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -25964,6 +25893,11 @@
 	},
 /turf/open/space/openspace,
 /area/space/nearstation)
+"lRi" = (
+/obj/effect/mapping_helpers/teleport_anchor,
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "lRw" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -26573,6 +26507,10 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"mjT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plating/asteroid,
+/area/asteroid)
 "mjZ" = (
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/stripes/corner{
@@ -26835,13 +26773,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/office)
-"mrC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer4,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "mrM" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -28054,12 +27985,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"mZc" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plating/asteroid,
-/area/asteroid)
 "mZe" = (
 /obj/effect/turf_decal/trimline/brown/filled/corner/lower{
 	dir = 1
@@ -29665,6 +29590,11 @@
 	},
 /turf/open/floor/catwalk_floor/telecomms,
 /area/ai_monitored/secondarydatacore)
+"nOL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/effect/spawner/structure/window/reinforced/shutter,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "nOS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 6
@@ -30493,6 +30423,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/secondarydatacore)
+"omy" = (
+/obj/machinery/atmospherics/components/unary/passive_vent{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "omJ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2,
 /turf/open/floor/plasteel/cafeteria{
@@ -31585,6 +31521,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
+"oQv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "oQG" = (
 /turf/closed/wall/r_wall,
 /area/medical/psych)
@@ -32621,13 +32572,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"pwR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/structure/cable{
-	icon_state = "4-8"
+"pxp" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 8
 	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/maintenance/disposal/incinerator)
 "pxq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
@@ -32729,6 +32680,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"pAD" = (
+/obj/machinery/atmospherics/pipe/simple/purple/visible{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "pAU" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -32802,22 +32759,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/storage/primary)
-"pDU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "pEb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -33292,6 +33233,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"pTH" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "pTL" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -34095,6 +34045,18 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"qwi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "N2 to Pure"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "qwD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer2{
 	dir = 4
@@ -34123,10 +34085,6 @@
 /obj/structure/railing,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/ai_upload_foyer)
-"qxk" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plating/asteroid,
-/area/asteroid)
 "qxy" = (
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
 	dir = 1
@@ -34209,6 +34167,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft/lower)
+"qAv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/floor/plating/asteroid,
+/area/asteroid)
 "qBv" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -34235,6 +34199,10 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/engine/atmos/storage)
+"qCE" = (
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "qDo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 6
@@ -35131,6 +35099,12 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"rih" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "riv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
 	dir = 4
@@ -37733,6 +37707,10 @@
 /obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/plasma,
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
+"sJE" = (
+/obj/structure/closet/emcloset,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "sKM" = (
 /obj/structure/table/wood,
 /obj/effect/turf_decal/tile/bar/opposingcorners,
@@ -38888,20 +38866,6 @@
 /obj/machinery/door/firedoor/border_only,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"ttx" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
-/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "tug" = (
 /obj/effect/turf_decal/trimline/purple/filled/line/lower{
 	dir = 1
@@ -38985,6 +38949,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
+"twB" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "txa" = (
 /obj/machinery/computer/shuttle/labor,
 /obj/effect/turf_decal/trimline/secred/filled/line/lower{
@@ -39291,6 +39261,25 @@
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"tFW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/corner/flip{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/engine/atmos";
+	dir = 4;
+	name = "Atmospherics Distribution APC";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "tGf" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -39570,10 +39559,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"tRv" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/asteroid,
-/area/asteroid)
 "tRX" = (
 /obj/structure/chair/comfy/black{
 	dir = 1;
@@ -40104,6 +40089,16 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
+"ukx" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ukK" = (
 /obj/machinery/vending/engivend,
 /obj/effect/turf_decal/bot,
@@ -40324,6 +40319,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
+"upN" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/atmos/warning/lower/nobottom{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "uql" = (
 /obj/machinery/camera/autoname,
 /obj/effect/turf_decal/trimline/green/filled/line/lower{
@@ -41002,6 +41010,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"uIK" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/line/lower{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "uIX" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -41919,6 +41933,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
+"vgj" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "O2 to Pure"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "vgy" = (
 /obj/structure/table/wood,
 /obj/machinery/photocopier/faxmachine{
@@ -42359,6 +42385,14 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/security/processing)
+"vtX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "vui" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -42691,18 +42725,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"vDx" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "O2 to Pure"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "vDE" = (
 /obj/machinery/door/firedoor/border_only,
 /obj/machinery/door/firedoor/border_only{
@@ -42760,6 +42782,25 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"vHf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer2{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "vHu" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -43037,17 +43078,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"vQQ" = (
+/obj/effect/turf_decal/trimline/engiyellow/filled/corner/lower,
+/obj/effect/turf_decal/trimline/blue/filled/corner/lower{
+	dir = 4
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "vRm" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
-"vRs" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/purple/visible{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "vRP" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -45752,6 +45799,16 @@
 /obj/effect/mapping_helpers/windoor/access/all/security/general,
 /turf/open/floor/plasteel/dark,
 /area/security/main)
+"xwg" = (
+/obj/effect/turf_decal/siding/thinplating{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Pure to Mix"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "xwx" = (
 /obj/effect/turf_decal/siding/wood/thin{
 	dir = 1
@@ -46622,12 +46679,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"xVF" = (
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 4
-	},
-/turf/open/floor/engine/airless,
-/area/asteroid)
 "xVR" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -128488,9 +128539,9 @@ jNM
 jNM
 jNM
 jNM
-fXp
-hJe
-oMh
+igz
+eNL
+eNL
 oMh
 oMh
 oMh
@@ -128747,7 +128798,7 @@ axh
 axh
 axh
 axh
-oMh
+eNL
 oMh
 oMh
 oMh
@@ -129004,7 +129055,7 @@ axh
 axh
 axh
 axh
-oMh
+eNL
 oMh
 oMh
 oMh
@@ -129261,7 +129312,7 @@ axh
 axh
 axh
 axh
-oMh
+eNL
 oMh
 oMh
 oMh
@@ -129518,7 +129569,7 @@ axh
 axh
 axh
 axh
-oMh
+eNL
 oMh
 oMh
 oMh
@@ -129775,7 +129826,7 @@ axh
 axh
 axh
 axh
-axh
+eNL
 oMh
 oMh
 oMh
@@ -130032,8 +130083,8 @@ axh
 axh
 axh
 axh
-axh
-axh
+eNL
+hJe
 oMh
 oMh
 oMh
@@ -130289,9 +130340,9 @@ axh
 axh
 axh
 axh
-axh
-axh
-oMh
+eNL
+eNL
+eNL
 oMh
 oMh
 oMh
@@ -130539,9 +130590,7 @@ axh
 axh
 axh
 axh
-qxk
-hZg
-mZc
+axh
 axh
 axh
 axh
@@ -130550,7 +130599,9 @@ axh
 axh
 oMh
 hJe
-oMh
+eNL
+eNL
+eNL
 oMh
 oMh
 oMh
@@ -130796,17 +130847,17 @@ axh
 axh
 axh
 axh
-tRv
-xVF
-dki
 axh
-axh
-axh
-axh
-axh
-axh
-axh
-eNL
+qAv
+mjT
+mjT
+mjT
+mjT
+mjT
+igM
+omy
+hJe
+oMh
 eNL
 hJe
 oMh
@@ -131062,7 +131113,7 @@ apj
 apj
 ano
 apj
-axh
+oMh
 hJe
 eNL
 eNL
@@ -132084,7 +132135,7 @@ apj
 sos
 wDe
 cri
-gLy
+pxp
 aOO
 apj
 aHG
@@ -132850,7 +132901,7 @@ aXB
 aYL
 sJe
 apS
-afP
+apj
 apj
 wHZ
 nfV
@@ -133107,7 +133158,7 @@ aSv
 ppM
 cqT
 wbP
-fBQ
+iNQ
 wuu
 kaF
 saL
@@ -133344,27 +133395,27 @@ gGr
 gGr
 ioM
 asZ
-acw
-aUi
-aSw
-jYr
-alo
-auY
-aUi
-aUi
-axv
-aUi
-aUi
-aUi
-axv
-aUi
-aUi
-aUi
-fvU
-nXK
-vRs
+asZ
+adR
+aKh
+caP
+rih
+aKh
+adR
+adR
+asZ
+adR
+adR
+adR
+asZ
+adR
+adR
+adR
+asZ
+adR
+fOu
 hkB
-afP
+apj
 apj
 apj
 apj
@@ -133600,34 +133651,34 @@ afP
 gGr
 jbx
 tNq
-mrC
-aUM
-luQ
-aGW
-kEA
-jZr
-dnU
-cfF
-cfF
-hcQ
-cfF
-nDn
-cfF
-vDx
-cfF
-qNB
-cfF
-cfF
-crI
-vPS
-hUE
-als
-gFX
-cwb
-snK
-snK
+asZ
+acw
+lRi
+aSw
+jYr
+alo
+auY
+aUi
+aUi
+fvU
+aUi
+aUi
+aUi
+axv
+aUi
+aUi
+aUi
+axv
+nXK
+pAD
+oQv
+afP
+sJE
+afP
 snK
 mvF
+afl
+afl
 eNL
 eNL
 eNL
@@ -133858,35 +133909,35 @@ gGr
 gGr
 eNW
 hti
-aYb
-ajv
-ayI
-pwR
-aCt
-adU
-aOG
-axJ
-aod
-adR
-aXh
-adR
-avR
-tfQ
-jMY
-adR
-adR
-aXh
-adR
-pDU
-afP
-afP
-afP
-gTX
-gTX
-gTX
-gRJ
-hJe
-hJe
+xwg
+fct
+aGW
+kEA
+jZr
+dnU
+cfF
+cfF
+cfF
+nDn
+vtX
+cfF
+qwi
+cfF
+qNB
+cfF
+vgj
+crI
+vPS
+hUE
+als
+gFX
+cwb
+snK
+mvF
+ajD
+ajD
+oMh
+oMh
 oMh
 oMh
 oMh
@@ -134115,34 +134166,34 @@ gGr
 gGr
 sBx
 mnC
-aDp
-aPj
-aDM
-cnL
-aEi
-axu
-aTe
-aLY
-aJx
-aIP
-aIP
-ttx
-aeV
-axu
-axu
-aJy
-bIA
+hnH
+lIN
+upN
+tFW
+aCt
+adU
 adR
 adR
-okU
-bjd
-sre
-sre
-xAA
-axh
-axh
-hJe
-hJe
+adR
+aXh
+aOG
+axJ
+aod
+tfQ
+jMY
+adR
+avR
+aXh
+adR
+vHf
+afP
+afP
+afP
+gTX
+gRJ
+ajD
+aXT
+oMh
 oMh
 oMh
 oMh
@@ -134375,27 +134426,27 @@ ana
 anS
 afP
 acU
-aVk
-aKp
-aZc
-adJ
-amh
-aqB
-aOi
-ilj
-aVk
-atY
-asb
-udm
-aVk
-aVk
-aVk
-aVk
-axx
-afP
-axh
-axh
-qKW
+apS
+twB
+ddC
+ddC
+ddC
+iBG
+adR
+kxR
+axJ
+bQw
+axJ
+axJ
+axJ
+aod
+adR
+adR
+okU
+bjd
+sre
+sre
+xAA
 axh
 oMh
 oMh
@@ -134632,26 +134683,26 @@ ybD
 tNB
 ybD
 ybD
-ybD
-ihc
-ybD
-bNg
-ybD
-tNB
-ybD
-vCS
-ybD
-xwG
-ybD
-vCS
-tcq
+afC
+qCE
+qCE
+dux
+fTm
+ixi
+uIK
+pTH
+ukx
+cdq
+axu
+axu
+vQQ
+pTH
+uIK
+uIK
+aCr
+afP
 axh
 axh
-axh
-axh
-axh
-axh
-sda
 qKW
 oMh
 oMh
@@ -134888,27 +134939,27 @@ aJf
 aBz
 aZT
 aNQ
-ehE
-aNQ
-aYi
-aBz
-aAg
-aNQ
-afa
-aBz
-asW
-aNQ
-afa
-aBz
-asW
-aNQ
+tcq
+acU
+aVk
+nOL
+aVk
+aVk
+aKp
+aZc
+adJ
+amh
+aqB
+aOi
+ilj
+aVk
+atY
+asb
+udm
+axx
+afP
 axh
-sda
-sda
 axh
-sda
-sda
-sda
 qKW
 oMh
 oMh
@@ -135145,28 +135196,28 @@ aVH
 aul
 aVY
 aNQ
-ehE
-aNQ
-aZr
-axo
-aex
-aNQ
-awC
-aQc
-aRl
-aNQ
-aNr
-aJB
-acm
-aNQ
 axh
-sda
-ljY
-sre
-sre
-sre
-sre
-iXo
+axh
+axh
+axh
+axh
+tcq
+ihc
+ybD
+bNg
+ybD
+tNB
+ybD
+vCS
+ybD
+xwG
+ybD
+vCS
+tcq
+axh
+axh
+axh
+qKW
 eNL
 oMh
 oMh
@@ -135402,28 +135453,28 @@ aoJ
 alA
 aoJ
 aNQ
-ehE
-aNQ
-abp
-aen
-abp
-aNQ
-aES
-aNu
-aES
-aNQ
-aFa
-aQq
-aFa
-aNQ
 axh
-sda
-qKW
 axh
 aJt
 aJt
-aJt
-aJt
+axh
+aNQ
+aYi
+aBz
+aAg
+aNQ
+afa
+aBz
+asW
+aNQ
+afa
+aBz
+asW
+aNQ
+ljY
+sre
+sre
+iXo
 eNL
 hJe
 oMh
@@ -135659,25 +135710,25 @@ aNQ
 aNQ
 aNQ
 aNQ
-tcq
-aHm
-aNQ
-aNQ
-aNQ
-aHm
-aNQ
-aNQ
-aNQ
-aNQ
-aNQ
-aNQ
-aNQ
-aNQ
 axh
-sda
+axh
+aJt
+gLL
+axh
+aNQ
+aZr
+axo
+aex
+aNQ
+awC
+aQc
+aRl
+aNQ
+aNr
+aJB
+acm
+aNQ
 qKW
-aJt
-aJt
 aJt
 aJt
 aJt
@@ -135921,20 +135972,20 @@ axh
 axh
 axh
 axh
-axh
-axh
-axh
-axh
-axh
-axh
-axh
-axh
-axh
-axh
-sda
+aNQ
+abp
+aen
+abp
+aNQ
+aES
+aNu
+aES
+aNQ
+aFa
+aQq
+aFa
+aNQ
 qKW
-aJt
-aJt
 aJt
 aJt
 bKk
@@ -136178,20 +136229,20 @@ sda
 sda
 sda
 axh
-axh
-sda
-sda
-sda
-sda
-sda
-axh
-axh
-sda
-sda
-sda
+aHm
+aNQ
+aNQ
+aNQ
+aHm
+aNQ
+aNQ
+aNQ
+aNQ
+aNQ
+aNQ
+aNQ
+aNQ
 qKW
-aJt
-aJt
 aJt
 bKk
 bKk
@@ -136433,6 +136484,7 @@ axh
 axh
 axh
 axh
+sda
 axh
 axh
 axh
@@ -136444,11 +136496,10 @@ axh
 axh
 axh
 axh
-ljY
-sre
-iXo
-aJt
-aJt
+axh
+axh
+axh
+qKW
 aJt
 bKk
 xxb
@@ -136689,23 +136740,23 @@ axh
 axh
 axh
 axh
-aJt
-aJt
-aJt
 axh
+sda
+sda
 axh
+sda
+sda
+sda
 axh
+sda
+sda
 axh
-aJt
-aJt
-aJt
-aJt
-aJt
+sda
+sda
+sda
+axh
+sda
 qKW
-aJt
-aJt
-aJt
-aJt
 aJt
 bKk
 pHR
@@ -136946,23 +136997,23 @@ aJt
 aJt
 aJt
 aJt
-aJt
-aJt
-aJt
-aJt
-aJt
-aJt
-aJt
-aJt
-aJt
-aJt
-aJt
-aJt
-qKW
-aJt
-aJt
-aJt
-aJt
+axh
+axh
+axh
+axh
+axh
+axh
+axh
+axh
+axh
+axh
+axh
+axh
+ljY
+sre
+sre
+sre
+iXo
 aJt
 bKk
 oJj

--- a/_maps/map_files/MiniStation/MiniStation.dmm
+++ b/_maps/map_files/MiniStation/MiniStation.dmm
@@ -23971,13 +23971,6 @@
 /obj/effect/mapping_helpers/airlock/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/port/aft/lower)
-"kzx" = (
-/obj/machinery/keycard_auth{
-	pixel_x = -1;
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/chief)
 "kzK" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
@@ -34694,6 +34687,20 @@
 /area/science/nanite)
 "qUH" = (
 /obj/structure/closet/secure_closet/engineering_chief,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/chief)
+"qVp" = (
+/obj/machinery/keycard_auth{
+	pixel_x = -5;
+	pixel_y = 25
+	},
+/obj/machinery/button/door{
+	id = "atmos";
+	name = "Atmospherics Lockdown";
+	pixel_x = 7;
+	pixel_y = 24;
+	req_access = list("engineering")
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "qVx" = (
@@ -62979,7 +62986,7 @@ aJt
 aJt
 dah
 jYO
-kzx
+qVp
 iqo
 frC
 noa


### PR DESCRIPTION
# Document the changes in your pull request

# Why is this good for the game?
Some concerns were brought up with the original design with the lack of space and awkward angles to connect to the incinerator.

incinerator connector port was also backwards, some areas were messed up, also fixes the outside a little bit. Moves incinerator vent closer to space (ew)

![image](https://github.com/user-attachments/assets/f24dbca7-f06d-4606-aa59-55bdc0a729d2)
![image](https://github.com/user-attachments/assets/80cdcb40-1838-40fb-ad5c-30c223314bbe)


not my best work but it's doable

# Changelog

:cl:
mapping: MiniStation's atmospherics is expanded in front of the tanks
/:cl:
