### PR TITLE
[Admin] Limits revive all verb to mobs with minds

### DIFF
--- a/yogstation/code/modules/admin/admin_verbs.dm
+++ b/yogstation/code/modules/admin/admin_verbs.dm
@@ -1,18 +1,21 @@
 /client/proc/rejuv_all()
 	set name = "Revive All"
 	set category = "Admin.Round End"
-	set desc = "Rejuvinate every mob/living."
+	set desc = "Rejuvenate every client with mob attached."
 
 	if(!check_rights(R_ADMIN))
 		return
 
-	var/confirm = alert(src, "Revive all mobs?", "Message", "Yes", "No")
+	var/confirm = alert(src, "Revive all players?", "Message", "Yes", "No")
 	if(confirm != "Yes")
 		return
 
 	var/revive_count = 0
-	for(var/mob/living/M in world)
-		M.revive(TRUE, TRUE)
+	for(var/mob/M in GLOB.player_list)
+		var/mob/living/P = M.mind?.current
+		if(!istype(P, /mob/living))
+			continue
+		P.revive(TRUE, TRUE)
 		revive_count++
 
 	var/fluff_adjective = pick("benevolent","sacred","holy","godly","magnificent","benign","generous","caring") //lol


### PR DESCRIPTION
# Document the changes in your pull request

The revive all verb is now limited to mobs in the player list that have minds. Also fixes spelling of rejuvenate in the description.

# Why is this good for the game?
There are a lot of mobs that fall under /mob/living/ (mainly because of #20555), limiting to players instead is more performance-efficient, since you at most will need to revive <100 mobs instead of 1000 mobs every time the verb is used.

# Testing
![image](https://github.com/user-attachments/assets/f88398b3-43e1-48a7-9c74-aecba0664d6c)

# Changelog

:cl:
tweak: Revive All will only revive mobs with minds.
spellcheck: Rejuvinate --> Rejuvenate
/:cl:
