### PR TITLE
Gives security officers assigned to service access to the service hall

### DIFF
--- a/code/modules/jobs/job_types/security_officer.dm
+++ b/code/modules/jobs/job_types/security_officer.dm
@@ -109,7 +109,7 @@ GLOBAL_LIST_INIT(available_depts_sec, list(SEC_DEPT_ENGINEERING, SEC_DEPT_MEDICA
 			minimal_lightup_areas |= GLOB.science_lightup_areas
 		if(SEC_DEPT_SERVICE)
 			ears = /obj/item/radio/headset/headset_sec/alt/department/service
-			dep_access = list(ACCESS_THEATRE, ACCESS_CHAPEL_OFFICE, ACCESS_LIBRARY, ACCESS_BAR, ACCESS_KITCHEN, ACCESS_HYDROPONICS, ACCESS_JANITOR, ACCESS_CLERK)
+			dep_access = list(ACCESS_THEATRE, ACCESS_CHAPEL_OFFICE, ACCESS_LIBRARY, ACCESS_BAR, ACCESS_KITCHEN, ACCESS_HYDROPONICS, ACCESS_JANITOR, ACCESS_CLERK, ACCESS_SERVICE)
 			destination = /area/security/checkpoint/service
 			spawn_point = locate(/obj/effect/landmark/start/depsec/service) in GLOB.department_security_spawns
 			accessory =  /obj/item/clothing/accessory/armband/service


### PR DESCRIPTION
Fixes #21894

# Document the changes in your pull request

Security officers assigned to the Service department now have access to the service hall.

# Why is this good for the game?
Security officers usually have access to all areas of the department they're assigned to (with the exception of toxins storage, R&D servers, and engineering secure storage for the science and engineering officer respectively). With #21265, the service hall was made it's own access type, and only the existing jobs in service were given the access, not any security officers assigned to that department.

# Testing
![image](https://github.com/user-attachments/assets/47b889fb-f68d-4a6a-b232-41fd85580bff)

# Changelog

:cl:
tweak: Security officers assigned to Service now have service hall access.
/:cl:
