### PR TITLE
Revert "Bump dompurify from 2.4.1 to 3.2.4 in /tgui (#22981)"

### DIFF
--- a/tgui/packages/tgui-panel/package.json
+++ b/tgui/packages/tgui-panel/package.json
@@ -4,7 +4,7 @@
   "version": "4.3.0",
   "dependencies": {
     "common": "workspace:*",
-    "dompurify": "^3.2.4",
+    "dompurify": "^2.3.1",
     "inferno": "^7.4.8",
     "tgui": "workspace:*",
     "tgui-dev-server": "workspace:*",

--- a/tgui/packages/tgui/package.json
+++ b/tgui/packages/tgui/package.json
@@ -6,7 +6,7 @@
     "@popperjs/core": "^2.9.3",
     "common": "workspace:*",
     "dateformat": "^4.5.1",
-    "dompurify": "^3.2.4",
+    "dompurify": "^2.3.1",
     "inferno": "^7.4.8",
     "inferno-vnode-flags": "^7.4.8",
     "js-yaml": "^4.1.0",

--- a/tgui/yarn.lock
+++ b/tgui/yarn.lock
@@ -2567,13 +2567,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/trusted-types@npm:^2.0.7":
-  version: 2.0.7
-  resolution: "@types/trusted-types@npm:2.0.7"
-  checksum: 8e4202766a65877efcf5d5a41b7dd458480b36195e580a3b1085ad21e948bc417d55d6f8af1fd2a7ad008015d4117d5fdfe432731157da3c68678487174e4ba3
-  languageName: node
-  linkType: hard
-
 "@types/webpack-env@npm:^1.16.2":
   version: 1.18.0
   resolution: "@types/webpack-env@npm:1.18.0"
@@ -4393,15 +4386,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.2.4":
-  version: 3.2.4
-  resolution: "dompurify@npm:3.2.4"
-  dependencies:
-    "@types/trusted-types": ^2.0.7
-  dependenciesMeta:
-    "@types/trusted-types":
-      optional: true
-  checksum: 7a299cbbfe3b3d189e5fc77ab94ad312807e37fda1e24a927548b76a58a9c98137e612ce8d94a2f6cd3d3db59844f14fca477676b5eae6103568a82142771df6
+"dompurify@npm:^2.3.1":
+  version: 2.4.1
+  resolution: "dompurify@npm:2.4.1"
+  checksum: 1169177465b3cbb25a44322937fba549f6c4e1a91b83245d144471be26619c835cccf0f8e20aa78c25ac11a06efd17cc1b9db9cacadceb78a4c08a1029eafee5
   languageName: node
   linkType: hard
 
@@ -9458,7 +9446,7 @@ resolve@^2.0.0-next.3:
   resolution: "tgui-panel@workspace:packages/tgui-panel"
   dependencies:
     common: "workspace:*"
-    dompurify: ^3.2.4
+    dompurify: ^2.3.1
     inferno: ^7.4.8
     tgui: "workspace:*"
     tgui-dev-server: "workspace:*"
@@ -9528,7 +9516,7 @@ resolve@^2.0.0-next.3:
     "@popperjs/core": ^2.9.3
     common: "workspace:*"
     dateformat: ^4.5.1
-    dompurify: ^3.2.4
+    dompurify: ^2.3.1
     inferno: ^7.4.8
     inferno-vnode-flags: ^7.4.8
     js-yaml: ^4.1.0


### PR DESCRIPTION
Fixes #22984

# Document the changes in your pull request

Reverts #22981

# Why am I reverting before 48 hours have passed?
It broke fancychat (Not surprising after #22982)

# Testing

<details>
<summary>Tgui-dev still works, fancychat works.</summary>
<img src="https://github.com/user-attachments/assets/e8a152bd-2089-4d7a-8c76-aeb658959922"/>
</details>
<details>
<summary>Hot updating</summary>
<img src="https://github.com/user-attachments/assets/b80d2328-c670-44fa-9862-9f57013d1612"/>
</details>

# Changelog

:cl:
bugfix: Fancychat no longer bluescreens.
/:cl:
