### PR TITLE
Fixes area issue in legion barracks ruin

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_legionbarracks.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_legionbarracks.dmm
@@ -12,6 +12,7 @@
 "d" = (
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/roman/legionnaire,
+/obj/item/clothing/under/costume/roman,
 /obj/item/clothing/shoes/roman,
 /obj/effect/turf_decal/sand,
 /turf/open/floor/plasteel/lavaland,
@@ -99,6 +100,7 @@
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/roman,
 /obj/item/clothing/shoes/roman,
+/obj/item/clothing/under/costume/roman,
 /obj/effect/turf_decal/sand,
 /turf/open/floor/plasteel/lavaland,
 /area/ruin/unpowered)

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_legionbarracks.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_legionbarracks.dmm
@@ -1,7 +1,7 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
 /turf/closed/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors/explored)
+/area/lavaland/surface/outdoors)
 "b" = (
 /turf/closed/wall/mineral/sandstone,
 /area/ruin/unpowered)
@@ -12,7 +12,6 @@
 "d" = (
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/roman/legionnaire,
-/obj/item/clothing/under/roman,
 /obj/item/clothing/shoes/roman,
 /obj/effect/turf_decal/sand,
 /turf/open/floor/plasteel/lavaland,
@@ -28,7 +27,7 @@
 /area/ruin/unpowered)
 "n" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors/explored)
+/area/lavaland/surface/outdoors)
 "o" = (
 /obj/structure/bed,
 /obj/item/bedsheet/yellow,
@@ -100,7 +99,6 @@
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/roman,
 /obj/item/clothing/shoes/roman,
-/obj/item/clothing/under/roman,
 /obj/effect/turf_decal/sand,
 /turf/open/floor/plasteel/lavaland,
 /area/ruin/unpowered)


### PR DESCRIPTION
Fixes #21428

# Document the changes in your pull request

Changes /area/lavaland/surface/outdoors/explored to /area/lavaland/surface/outdoors in the legion barracks ruin, as it would appear as Lavaland Labor Camp on suit sensors.

Changes path of the roman armour as it was changed at some point?

# Testing
I don't think area changes have any visual indications.

# Changelog

:cl:
mapping: Legion barracks ruin will no longer appear as Lavaland Labor Camp on suit sensors.
mapping: Roman armour in the legion barracks ruin uses the correct path now.
/:cl:
