### PR TITLE
Fixes a code comment regarding BZ formation

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -396,7 +396,7 @@
 
 	return REACTING
 
-/datum/gas_reaction/bzformation //Formation of BZ by combining plasma and tritium at low pressures. Exothermic.
+/datum/gas_reaction/bzformation //Formation of BZ by combining plasma and N2O at low pressures. Exothermic.
 	priority = BZFORMATION
 	name = "BZ Gas formation"
 	id = "bzformation"


### PR DESCRIPTION
Fixes #20188

# Document the changes in your pull request

Line 399 in [code](https://github.com/yogstation13/Yogstation/tree/51857042a7577f5e4432e3e40dedabb801d21654/code)/[modules](https://github.com/yogstation13/Yogstation/tree/51857042a7577f5e4432e3e40dedabb801d21654/code/modules)/[atmospherics](https://github.com/yogstation13/Yogstation/tree/51857042a7577f5e4432e3e40dedabb801d21654/code/modules/atmospherics)/[gasmixtures](https://github.com/yogstation13/Yogstation/tree/51857042a7577f5e4432e3e40dedabb801d21654/code/modules/atmospherics/gasmixtures)/[reactions.dm](https://github.com/yogstation13/Yogstation/tree/51857042a7577f5e4432e3e40dedabb801d21654/code/modules/atmospherics/gasmixtures/reactions.dm)
"Formation of BZ by combining plasma and tritium at low pressures. Exothermic." --> "Formation of BZ by combining plasma and N2O at low pressures. Exothermic."

# Why is this good for the game?

https://github.com/yogstation13/Yogstation/commit/52870103ee47022be8b1d21ac163965f849d1b48 (https://github.com/tgstation/tgstation/pull/38329) changed the recipe from plasma and tritium to plasma and N2O, without changing the comment.

# Testing
No.

# Changelog

Not player-facing change.

:cl:
/:cl:
