### PR TITLE
Health implant no longer creates an empty action button

### DIFF
--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -77,6 +77,7 @@
 
 /obj/item/implant/health
 	name = "health implant"
+	actions_types = null
 	var/healthstring = ""
 
 /obj/item/implant/health/proc/sensehealth()


### PR DESCRIPTION
Fixes #19962

# Document the changes in your pull request

Health implants will no longer give an empty action button.

# Why is this good for the game?
These aren't meant to have an action button, they do not do anything when pressed, and are only there to pass information back to the cloner.

# Testing
![image](https://github.com/user-attachments/assets/b15db8db-c393-40ab-be0b-30acd8389be7)

# Changelog

:cl:
tweak: Health implants no longer have an empty action button.
/:cl:
