### PR TITLE
Fix ratvar chameleon uniform not appearing

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -332,7 +332,7 @@
 /obj/item/clothing/under/chameleon/ratvar
 	name = "ratvarian engineer's jumpsuit"
 	desc = "A tough jumpsuit woven from alloy threads. It can take on the appearance of other jumpsuits."
-	worn_icon = 'icons/mob/clothing/uniform/uniform.dmi'
+	worn_icon = 'icons/mob/clothing/uniform/engineering.dmi'
 	greyscale_colors = null
 	greyscale_config = null
 	greyscale_config_inhand_left = null


### PR DESCRIPTION
# Document the changes in your pull request

The sprite was moved from uniform.dmi into engineering.dmi by #21997, but the icon path wasn't changed, leading it to show no sprite.

# Testing
![image](https://github.com/user-attachments/assets/9754d14b-b23e-4cd0-9f10-64dbc8fa836f)
![image](https://github.com/user-attachments/assets/9ba0a720-8e21-4eb0-9292-97c58b0cc1bf)

# Changelog

:cl:
bugfix: Ratvar chameleon uniform now has a sprite again.
/:cl:
