### PR TITLE
Changes Gax's killroom freezer to the standard freezer used in slime killrooms

### DIFF
--- a/_maps/map_files/GaxStation/GaxStation.dmm
+++ b/_maps/map_files/GaxStation/GaxStation.dmm
@@ -264,9 +264,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "afI" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	on = 1
-	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "agb" = (


### PR DESCRIPTION
Fixes #18567

# Document the changes in your pull request

Changes the freezer used in Gax's xenobio killroom to /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on 

# Why is this good for the game?
The on version of the thermomachine automatically sets the target temperature to the minimum temperature available upon mapload. Other maps also use the on version, rather than mapediting it to be on (which also results in the above not being done).

# Testing
![image](https://github.com/user-attachments/assets/ba42748a-e7e7-4612-9212-123f6238930e)
![image](https://github.com/user-attachments/assets/6e390cc6-bf5c-48ee-b76f-ca4ec59da1a1)

# Changelog

:cl:
tweak: The slime killroom's thermomachine in Gax is now set to freezing temperatures by default.
/:cl:
