### PR TITLE
Gives Telecomms a request console in donutstation

### DIFF
--- a/_maps/map_files/DonutStation/DonutStation.dmm
+++ b/_maps/map_files/DonutStation/DonutStation.dmm
@@ -1037,6 +1037,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/requests_console{
+	department = "Telecomms Admin";
+	departmentType = 5;
+	name = "Telecomms RC";
+	pixel_y = 30;
+	announcementConsole = 1
+	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
 "arJ" = (


### PR DESCRIPTION
# Document the changes in your pull request

Adds a request console to Telecomms.

# Why is this good for the game?
Network admins usually have one in every other map. It is also useful when there's a telecomms outage and you can't say anything about it because you have no console.

# Testing
![image](https://github.com/user-attachments/assets/5b37157f-04da-4802-91e8-b8a679ac760c)
![image](https://github.com/user-attachments/assets/7003ad28-f94c-46e7-bd51-c6ecd4c7bf79)

# Changelog

:cl:
mapping: There is now a request console in Telecomms on donutstation.
/:cl:
