### PR TITLE
Config setting for Backrooms to determine roundstart spawn or not

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -555,3 +555,8 @@
 /datum/config_entry/flag/demos_enabled
 
 /datum/config_entry/flag/toast_notification_on_init
+
+/// Whether the backrooms will spawn at roundstart or not. This is a very intensive process that can tack an extra 30+ seconds to roundstart
+/// and creates an extra z-level full of mobs that will add extra load to the server. Only enable this if you're sure you want it. Or optimize it for me.
+/datum/config_entry/flag/backrooms_enabled
+	default = FALSE

--- a/code/controllers/subsystem/backrooms.dm
+++ b/code/controllers/subsystem/backrooms.dm
@@ -1,7 +1,7 @@
 SUBSYSTEM_DEF(backrooms)
 	name = "Backrooms Procedural Generation"
 	init_order = INIT_ORDER_BACKROOMS
-	flags = SS_TICKER | SS_BACKGROUND
+	flags = SS_TICKER | SS_BACKGROUND | SS_NO_FIRE
 
 	var/noNeed = FALSE
 
@@ -31,7 +31,6 @@ SUBSYSTEM_DEF(backrooms)
 		noNeed = TRUE
 	
 	if(noNeed)
-		flags |= SS_NO_FIRE
 		return SS_INIT_NO_NEED
 
 	pick_theme()
@@ -41,7 +40,7 @@ SUBSYSTEM_DEF(backrooms)
 	return SS_INIT_SUCCESS
 
 /datum/controller/subsystem/backrooms/stat_entry(msg)
-	if(noNeed)
+	if(noNeed || !CONFIG_GET(flag/backrooms_enabled))
 		msg = "DISABLED"
 	else if(!noNeed && !initialized)
 		msg = "Generating..."

--- a/code/controllers/subsystem/backrooms.dm
+++ b/code/controllers/subsystem/backrooms.dm
@@ -1,7 +1,9 @@
 SUBSYSTEM_DEF(backrooms)
-	name = "Procedural Generation"
+	name = "Backrooms Procedural Generation"
 	init_order = INIT_ORDER_BACKROOMS
-	flags = SS_NO_FIRE
+	flags = SS_TICKER | SS_BACKGROUND
+
+	var/noNeed = FALSE
 
 	var/datum/map_generator/dungeon_generator/backrooms_generator
 	var/datum/generator_theme/picked_theme = /datum/generator_theme
@@ -16,8 +18,7 @@ SUBSYSTEM_DEF(backrooms)
 		/obj/item/toy/plush/lizard/azeel = 5000
 	)
 
-/datum/controller/subsystem/backrooms/Initialize(timeofday)
-	var/noNeed = FALSE
+/datum/controller/subsystem/backrooms/PreInit()
 #ifdef LOWMEMORYMODE
 	noNeed = TRUE
 #endif
@@ -25,7 +26,12 @@ SUBSYSTEM_DEF(backrooms)
 	noNeed = TRUE
 #endif
 
-	if(noNeed) //we do it this way so things can pass linter while in low memory mode or unit tests
+/datum/controller/subsystem/backrooms/Initialize(timeofday)
+	if(!CONFIG_GET(flag/backrooms_enabled))
+		noNeed = TRUE
+	
+	if(noNeed)
+		flags |= SS_NO_FIRE
 		return SS_INIT_NO_NEED
 
 	pick_theme()
@@ -33,6 +39,15 @@ SUBSYSTEM_DEF(backrooms)
 	SEND_GLOBAL_SIGNAL(COMSIG_BACKROOMS_INITIALIZE)
 	spawn_loot()
 	return SS_INIT_SUCCESS
+
+/datum/controller/subsystem/backrooms/stat_entry(msg)
+	if(noNeed)
+		msg = "DISABLED"
+	else if(!noNeed && !initialized)
+		msg = "Generating..."
+	else
+		msg = "Theme: [picked_theme]"
+	return ..()
 
 /datum/controller/subsystem/backrooms/proc/pick_theme()
 	var/list/themes = typesof(/datum/generator_theme)

--- a/config/config.txt
+++ b/config/config.txt
@@ -463,3 +463,6 @@ MAX_SHUTTLE_SIZE 300
 ## Comment to disable sending a toast notification on the host server when initializations complete.
 ## Even if this is enabled, a notification will only be sent if there are no clients connected.
 TOAST_NOTIFICATION_ON_INIT
+
+## Enable/Disable Backrooms z-level generation at startup
+BACKROOMS_ENABLED


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/f9dcfb90-a140-4b2d-98fd-2f69ff36557d)
this cost biome one of the last few yog lizard tokens in existence

![image](https://github.com/user-attachments/assets/3359d91f-89a2-4c42-a6b3-cbb96f225406)

![image](https://github.com/user-attachments/assets/d04bb956-fe39-47e5-a2b8-35933fcd3df8)
(the default theme doesn't have a flashy name)


# Changelog

<!-- Edit the changelog below to reflect the changes made by this PR, even if the changes are minor - required for every PR that has player-facing changes.
If you add a name after the ':cl:', that name will be used in the changelog. Leave it empty to use your GitHub name. -->

:cl:
rscadd: Config setting to control whether backrooms spawns on roundstart
rscadd: Some stat panel info for backrooms to know whether it's disabled, generating, or completed
tweak: Renamed backrooms subsystem from Procedural Generation to Backrooms Procedural 
/:cl:
