### PR TITLE
Update turdis workflow to Ubuntu 22.04

### DIFF
--- a/.github/workflows/turdis.yml
+++ b/.github/workflows/turdis.yml
@@ -151,7 +151,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt install libstdc++6:i386 gcc-multilib g++-7 g++-7-multilib zlib1g:i386 libssl1.1 libssl1.1:i386
+          sudo apt install libstdc++6:i386 gcc-multilib g++-11 g++-11-multilib zlib1g:i386 libssl1.1 libssl1.1:i386
 
       - name: Restore Cache BYOND
         uses: actions/cache@v4

--- a/.github/workflows/turdis.yml
+++ b/.github/workflows/turdis.yml
@@ -151,7 +151,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt install libstdc++6:i386 gcc-multilib g++-11 g++-11-multilib zlib1g:i386 libssl3 libssl1.1:i386
+          sudo apt install libstdc++6:i386 gcc-multilib g++-11 g++-11-multilib zlib1g:i386 libssl3 libssl3:i386
 
       - name: Restore Cache BYOND
         uses: actions/cache@v4

--- a/.github/workflows/turdis.yml
+++ b/.github/workflows/turdis.yml
@@ -151,7 +151,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt install libstdc++6:i386 gcc-multilib g++-8 g++-8-multilib zlib1g:i386 libssl3 libssl3:i386
+          sudo apt install libstdc++6:i386 gcc-multilib g++-9 g++-9-multilib zlib1g:i386 libssl3 libssl3:i386
 
       - name: Restore Cache BYOND
         uses: actions/cache@v4

--- a/.github/workflows/turdis.yml
+++ b/.github/workflows/turdis.yml
@@ -151,7 +151,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt install libstdc++6:i386 gcc-multilib g++-11 g++-11-multilib zlib1g:i386 libssl1.1 libssl1.1:i386
+          sudo apt install libstdc++6:i386 gcc-multilib g++-11 g++-11-multilib zlib1g:i386 libssl3 libssl1.1:i386
 
       - name: Restore Cache BYOND
         uses: actions/cache@v4

--- a/.github/workflows/turdis.yml
+++ b/.github/workflows/turdis.yml
@@ -151,7 +151,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt install libstdc++6:i386 gcc-multilib g++-9 g++-9-multilib zlib1g:i386 libssl3 libssl3:i386
+          sudo apt install libstdc++6:i386 gcc-multilib g++-7 g++-7-multilib zlib1g:i386 libssl3 libssl3:i386
 
       - name: Restore Cache BYOND
         uses: actions/cache@v4

--- a/.github/workflows/turdis.yml
+++ b/.github/workflows/turdis.yml
@@ -151,7 +151,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt install libstdc++6:i386 gcc-multilib g++-11 g++-11-multilib zlib1g:i386 libssl3 libssl3:i386
+          sudo apt install libstdc++6:i386 gcc-multilib g++-8 g++-8-multilib zlib1g:i386 libssl3 libssl3:i386
 
       - name: Restore Cache BYOND
         uses: actions/cache@v4

--- a/.github/workflows/turdis.yml
+++ b/.github/workflows/turdis.yml
@@ -82,7 +82,7 @@ jobs:
 
   compile:
     name: Compile All Maps
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -114,7 +114,7 @@ jobs:
   find_all_maps:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     name: Find Maps to Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       maps: ${{ steps.map_finder.outputs.maps }}
     steps:
@@ -128,7 +128,7 @@ jobs:
           echo "maps={\"paths\":[$(cat maps_output.txt)]}" >> $GITHUB_OUTPUT
   test:
     name: Compile and Run Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [find_all_maps]
     strategy:
       fail-fast: false

--- a/.github/workflows/turdis.yml
+++ b/.github/workflows/turdis.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   lint:
     name: Lints
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
# Document the changes in your pull request

Updates turdis workflow to Ubuntu 22.04 because of https://github.com/actions/runner-images/issues/11101 which has essentially bricked it.

# Testing
I have no idea if this works or not, but it probably does (I hope).

# Changelog

Not player-facing.

:cl:
/:cl:
