### PR TITLE
Fixes the nitrium energy ball reaction not being simulated in the atmospheric simulator computer

### DIFF
--- a/code/modules/atmospherics/gasmixtures/reactions.dm
+++ b/code/modules/atmospherics/gasmixtures/reactions.dm
@@ -516,8 +516,6 @@
 /// Reaction that burns nitrium and plouxium into radballs and partial constituent gases, but also catalyzes the combustion of plasma.
 /datum/gas_reaction/nitro_ball/react(datum/gas_mixture/air, datum/holder)
 	var/turf/open/location = get_holder_turf(holder)
-	if(!location)
-		return NO_REACTION
 
 	var/old_thermal_energy = air.thermal_energy()
 


### PR DESCRIPTION
# Document the changes in your pull request

One last fix before the repository is archived.

# Testing
![image](https://github.com/user-attachments/assets/ffefddea-f87c-4871-af09-3747ae497f0b)

:cl:
bugfix: Fixed nitrium energy ball reactions not simulating in the atmos simulator computer.
/:cl:
